### PR TITLE
Fixes #13208 - Enabled 'Mirror On Sync' for repositories

### DIFF
--- a/app/lib/actions/katello/repository/create.rb
+++ b/app/lib/actions/katello/repository/create.rb
@@ -29,7 +29,8 @@ module Actions
                                         path: path,
                                         download_policy: repository.download_policy,
                                         with_importer: true,
-                                        ostree_branches: repository.ostree_branch_names)
+                                        ostree_branches: repository.ostree_branch_names,
+                                        mirror_on_sync: repository.mirror_on_sync?)
 
             return if create_action.error
 

--- a/app/lib/actions/pulp/repository/create.rb
+++ b/app/lib/actions/pulp/repository/create.rb
@@ -20,6 +20,7 @@ module Actions
           param :download_policy
           param :capsule_id
           param :ostree_branches
+          param :mirror_on_sync
         end
 
         def run
@@ -57,6 +58,7 @@ module Actions
           importer.ssl_client_cert = input[:ssl_client_cert]
           importer.ssl_client_key  = input[:ssl_client_key]
           importer.download_policy = input[:download_policy] if input[:content_type] == ::Katello::Repository::YUM_TYPE
+          importer.remove_missing  = input[:mirror_on_sync] if input[:content_type] == ::Katello::Repository::YUM_TYPE
           importer
         end
 

--- a/app/models/katello/candlepin/content.rb
+++ b/app/models/katello/candlepin/content.rb
@@ -71,6 +71,7 @@ module Katello
           :preserve_metadata => true, #preserve repo metadata when importing from cp
           :unprotected => unprotected?,
           :download_policy => download_policy,
+          :mirror_on_sync => true,
           :content_view_version => product.organization.
                                   library.default_content_view_version
         )

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -64,7 +64,7 @@ module Katello
 
     # rubocop:disable Metrics/ModuleLength
     module InstanceMethods
-      # This module is too long. See https://projects.theforeman.org/issues/12584.
+      # TODO: This module is too long. See https://projects.theforeman.org/issues/12584.
       def last_sync
         last = self.latest_dynflow_sync
         last.nil? ? nil : last.to_s
@@ -185,6 +185,7 @@ module Katello
         {}.tap do |yum_importer_values|
           yum_importer_values[:feed] = self.importer_feed_url(capsule)
           yum_importer_values[:download_policy] = new_download_policy
+          yum_importer_values[:remove_missing] = capsule ? true : self.mirror_on_sync?
           unless capsule
             yum_importer_values[:ssl_ca_cert] = self.feed_ca
             yum_importer_values[:ssl_client_cert] = self.feed_cert
@@ -495,7 +496,7 @@ module Katello
 
       def pulp_update_needed?
         return true if ostree?
-        changeable_attributes = %w(url unprotected checksum_type docker_upstream_name download_policy)
+        changeable_attributes = %w(url unprotected checksum_type docker_upstream_name download_policy mirror_on_sync)
         changeable_attributes << "name" if docker?
         changeable_attributes.any? { |key| previous_changes.key?(key) }
       end

--- a/app/views/katello/api/v2/repositories/show.json.rabl
+++ b/app/views/katello/api/v2/repositories/show.json.rabl
@@ -5,6 +5,7 @@ extends 'katello/api/v2/common/timestamps'
 
 attributes :content_type
 attributes :docker_upstream_name
+attributes :mirror_on_sync
 attributes :unprotected, :full_path, :checksum_type, :container_repository_name
 attributes :download_policy
 attributes :url,

--- a/db/migrate/20160114200145_add_mirror_on_sync_to_repositories.rb
+++ b/db/migrate/20160114200145_add_mirror_on_sync_to_repositories.rb
@@ -1,0 +1,9 @@
+class AddMirrorOnSyncToRepositories < ActiveRecord::Migration
+  class RepositoryMirrorOnSync < ActiveRecord::Base
+    self.table_name = "katello_repositories"
+  end
+  def change
+    add_column :katello_repositories, :mirror_on_sync, :boolean, :default => true, :null => false
+    RepositoryMirrorOnSync.update_all(:mirror_on_sync => false)
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-info.html
@@ -119,7 +119,7 @@
     </div>
 
 
-    <div class="detail" ng-show="repository.content_type == 'yum'">
+    <div class="detail" ng-show="repository.content_type === 'yum'">
       <span class="info-label" translate>Yum Metadata Checksum</span>
       <span class="info-value"
             bst-edit-select="checksumTypeDisplay(repository.checksum_type)"
@@ -127,6 +127,16 @@
             selector="repository.checksum_type"
             options="checksums"
             on-save="save(repository)">
+      </span>
+    </div>
+
+    <div class="detail" ng-show="repository.content_type === 'yum'">
+      <span class="info-label" translate>Mirror on Sync</span>
+      <span class="info-value"
+            bst-edit-checkbox="repository.mirror_on_sync"
+            formatter="booleanToYesNo"
+            on-save="save(repository)"
+            readonly="product.readonly || denied('edit_products', product)">
       </span>
     </div>
 
@@ -159,7 +169,7 @@
       </span>
     </div>
 
-    <div class="detail" ng-if="repository.content_type == 'yum' && !product.redhat">
+    <div class="detail" ng-if="repository.content_type === 'yum' && !product.redhat">
       <span class="info-label" translate>GPG Key</span>
       <span class="info-value"
             bst-edit-select="repository.gpg_key.name"
@@ -230,7 +240,7 @@
       </thead>
 
       <tbody>
-        <tr ng-show="repository.content_type == 'yum'">
+        <tr ng-show="repository.content_type === 'yum'">
           <td translate>Packages</td>
           <td class="align-center">
             <a ui-sref="products.details.repositories.manage-content.packages({productId: product.id, repositoryId: repository.id})">
@@ -238,7 +248,7 @@
             </a>
           </td>
         </tr>
-        <tr ng-show="repository.content_type == 'yum'">
+        <tr ng-show="repository.content_type === 'yum'">
           <td translate>Errata</td>
           <td class="align-center">
             <a ui-sref="errata.index({repositoryId: repository.id})">
@@ -262,7 +272,6 @@
             </a>
           </td>
         </tr>
-
         <tr ng-show="repository.content_type === 'docker'">
             <td translate>Docker Manifests</td>
             <td class="align-center">{{ repository.content_counts.docker_manifest || 0 }}</td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/new-repository.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/new-repository.controller.js
@@ -46,7 +46,7 @@ angular.module('Bastion.repositories').controller('NewRepositoryController',
         }
 
         $scope.repository = new Repository({'product_id': $scope.$stateParams.productId, unprotected: true,
-            'checksum_type': null, 'download_policy': null});
+            'checksum_type': null, 'download_policy': null, 'mirror_on_sync': true});
 
         Repository.repositoryTypes({'creatable': true}, function (data) {
             $scope.repositoryTypes = data;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/views/repository-new.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/views/repository-new.html
@@ -112,6 +112,17 @@
                 ng-options="id as name for (id, name) in downloadPolicies">
         </select>
       </div>
+
+      <div bst-form-group label="{{ 'Mirror On Sync' | translate }}">
+        <input id="mirror_on_sync"
+               name="mirror_on_sync"
+               ng-model="repository.mirror_on_sync"
+               type="checkbox"
+               tabindex="8"/>
+        <h6 translate>
+          Selecting this option will result in contents that are no longer part of the upstream repository being removed during synchronization.
+        </h6>
+      </div>
     </div>
 
     <div bst-form-buttons ng-show="repository.content_type !== undefined"

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -401,6 +401,40 @@ module Katello
       end
     end
 
+    def test_create_with_mirror_on_sync_true
+      mirror_on_sync = true
+      product = MiniTest::Mock.new
+      product.expect(:add_repo, @repository, [
+        'Fedora_Repository',
+        'Fedora Repository',
+        'http://www.google.com',
+        'yum',
+        false,
+        nil,
+        nil,
+        nil
+      ])
+
+      product.expect(:editable?, @product.editable?)
+      product.expect(:gpg_key, nil)
+      product.expect(:organization, @organization)
+      product.expect(:redhat?, false)
+      product.expect(:unprotected?, false)
+      @repository.expects(:mirror_on_sync=).with(mirror_on_sync)
+      assert_sync_task(::Actions::Katello::Repository::Create, @repository, false, true, nil)
+
+      Product.stub(:find, product) do
+        post :create, :name => 'Fedora Repository',
+                      :product_id => @product.id,
+                      :url => 'http://www.google.com',
+                      :content_type => 'yum',
+                      :unprotected => false,
+                      :mirror_on_sync => mirror_on_sync
+        assert_response :success
+        assert_template 'api/v2/repositories/show'
+      end
+    end
+
     def test_create_with_protected_docker
       docker_upstream_name = "busybox"
       product = MiniTest::Mock.new

--- a/test/fixtures/vcr_cassettes/actions/pulp/repository/background_sync/sync.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp/repository/background_sync/sync.yml
@@ -1,559 +1,29 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f5f73e0f-f26d-481e-b7b3-e2757ebb6ae2/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="929atNQ1BNXiBsGxKxJDrf9wv9465j7vAWYvodk0U",
-        oauth_signature="L2iKUAoRrLFkYjnAqXDubzK9LbM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455221364", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:09:24 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '649'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mNWY3M2UwZi1mMjZkLTQ4MWUtYjdiMy1lMjc1N2ViYjZh
-        ZTIvIiwgInRhc2tfaWQiOiAiZjVmNzNlMGYtZjI2ZC00ODFlLWI3YjMtZTI3
-        NTdlYmI2YWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0
-        YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwg
-        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNTZiY2VhNzQ2NTI0NTA2NjUxZmI1MDczIn0sICJpZCI6ICI1NmJjZWE3
-        NDY1MjQ1MDY2NTFmYjUwNzMifQ==
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:09:24 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f5f73e0f-f26d-481e-b7b3-e2757ebb6ae2/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="uw23rdhW60qx0GkG6P1y1LV0qWv6BXn9GwAdSnCwo",
-        oauth_signature="MAOBpaRmt0yZjupMMeQ1RcJaARg%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455221364", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:09:24 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1078'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mNWY3M2UwZi1mMjZkLTQ4MWUtYjdiMy1lMjc1N2ViYjZh
-        ZTIvIiwgInRhc2tfaWQiOiAiZjVmNzNlMGYtZjI2ZC00ODFlLWI3YjMtZTI3
-        NTdlYmI2YWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0xMVQyMDowOToyNFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
-        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVl
-        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgt
-        ZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29y
-        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
-        by0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJv
-        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiY2VhNzQ2NTI0NTA2NjUx
-        ZmI1MDczIn0sICJpZCI6ICI1NmJjZWE3NDY1MjQ1MDY2NTFmYjUwNzMifQ==
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:09:24 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f5f73e0f-f26d-481e-b7b3-e2757ebb6ae2/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="QfpQGWr9jRf4dUjzLqW15DaysPZTFgsufzZLJpdTrQ",
-        oauth_signature="HrSEQKcSNRWC4G%2FsFnnaOF458PI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455221365", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:09:25 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mNWY3M2UwZi1mMjZkLTQ4MWUtYjdiMy1lMjc1N2ViYjZh
-        ZTIvIiwgInRhc2tfaWQiOiAiZjVmNzNlMGYtZjI2ZC00ODFlLWI3YjMtZTI3
-        NTdlYmI2YWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMDowOToyNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMDowOToyNFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMjE0Y2Y0MGYtZDM0ZS00MjRiLWFmYzctZmFiOGU1ZGNm
-        MzE5LyIsICJ0YXNrX2lkIjogIjIxNGNmNDBmLWQzNGUtNDI0Yi1hZmM3LWZh
-        YjhlNWRjZjMxOSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YmNl
-        YTczYzc4MjFiMTNkMGY3ZTEyNSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMTFUMjA6MDk6MjRaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0xMVQyMDowOToy
-        NFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiY2VhNzRjNzgyMWIxNTQ5YWM0ZWNjIiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiY2VhNzQ2NTI0NTA2NjUxZmI1MDczIn0s
-        ICJpZCI6ICI1NmJjZWE3NDY1MjQ1MDY2NTFmYjUwNzMifQ==
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:09:25 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/214cf40f-d34e-424b-afc7-fab8e5dcf319/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="D4wiAnKM54GqrDlCtNZfbMOG0OS3Zliwuny9wZFc0c",
-        oauth_signature="0xF5tg292hmnsEKX9stayE0OYnc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455221365", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:09:25 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8yMTRjZjQwZi1kMzRlLTQyNGItYWZjNy1mYWI4
-        ZTVkY2YzMTkvIiwgInRhc2tfaWQiOiAiMjE0Y2Y0MGYtZDM0ZS00MjRiLWFm
-        YzctZmFiOGU1ZGNmMzE5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0xMVQyMDowOToyNVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMDowOToyNFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI5ZjM0NWJhNi05OTFkLTQyMGItODAzMi04YTRhMmYw
-        NGMxMTUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZjRkYmIyNjktM2VhYi00MWQ2LTkzMTMtYWUxODI1NWNkYWUzIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiOWU0MjYwOGMtMWEwNy00YThiLWIxMTMt
-        MDBiYThkZDg3MGYwIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNWVi
-        OTg2YzYtZmVkMC00ZWU5LTkwMjktNWUzOGFmYzMwNjY0IiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjJlYTEwMzExLTBmNmUtNGY1NS1hMWViLWI1M2E1
-        M2U5Y2JhMyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkYTMyYTIw
-        ZS04YzlhLTRmMDYtODY2Yy02YzQ5NWFmYmUzMzciLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI2NWMwMTE0NC0xMWRkLTRkYTQtOTM1Ni02ZjUy
-        NWJjYmE1OGEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIwM2VhMjUwMy00OGUxLTQ5N2ItYjc5OS0yNzk4YzNmOGMxZDQi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNmNm
-        Y2YwMC04YzVmLTRmZDktYWI3YS1jYTJhYWQwZjE0M2EiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxMWIxMmI1ZC1mMGEz
-        LTQ3NDUtYjI2Ni1mMzc5OTRiMTA0ZDgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjY4OGY5MmNiLTU5N2YtNGFk
-        ZC1hMjI4LTJmMGFlZDAzMDdmZCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
-        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTExVDIwOjA5OjI0
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMTFUMjA6MDk6MjVaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiY2VhNzVjNzgyMWIx
-        NTQ5YWM0ZWNkIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjlmMzQ1YmE2LTk5MWQtNDIwYi04MDMyLThhNGEyZjA0YzEx
-        NSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJmNGRiYjI2OS0zZWFiLTQxZDYtOTMxMy1hZTE4MjU1Y2RhZTMiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI5ZTQyNjA4Yy0xYTA3LTRhOGItYjExMy0wMGJh
-        OGRkODcwZjAiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1ZWI5ODZj
-        Ni1mZWQwLTRlZTktOTAyOS01ZTM4YWZjMzA2NjQiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiMmVhMTAzMTEtMGY2ZS00ZjU1LWExZWItYjUzYTUzZTlj
-        YmEzIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImRhMzJhMjBlLThj
-        OWEtNGYwNi04NjZjLTZjNDk1YWZiZTMzNyIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjY1YzAxMTQ0LTExZGQtNGRhNC05MzU2LTZmNTI1YmNi
-        YTU4YSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjAzZWEyNTAzLTQ4ZTEtNDk3Yi1iNzk5LTI3OThjM2Y4YzFkNCIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE2Y2ZjZjAw
-        LThjNWYtNGZkOS1hYjdhLWNhMmFhZDBmMTQzYSIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjExYjEyYjVkLWYwYTMtNDc0
-        NS1iMjY2LWYzNzk5NGIxMDRkOCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjg4ZjkyY2ItNTk3Zi00YWRkLWEy
-        MjgtMmYwYWVkMDMwN2ZkIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmNlYTc0NjUyNDUwNjY1
-        MWZiNTA4MyJ9LCAiaWQiOiAiNTZiY2VhNzQ2NTI0NTA2NjUxZmI1MDgzIn0=
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:09:25 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/d1730d56-0191-46d9-991b-8f3843e22969/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="tpw1q4XsN1tW2St2OwItjomMuO8Us1dLDsGGWWoDrc",
-        oauth_signature="D4K%2BVVBnp548F4vTKh246%2Faz2Os%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455221365", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:09:25 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kMTczMGQ1Ni0wMTkxLTQ2ZDktOTkxYi04ZjM4NDNlMjI5
-        NjkvIiwgInRhc2tfaWQiOiAiZDE3MzBkNTYtMDE5MS00NmQ5LTk5MWItOGYz
-        ODQzZTIyOTY5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJjZWE3
-        NTY1MjQ1MDY2NTFmYjUwODQifSwgImlkIjogIjU2YmNlYTc1NjUyNDUwNjY1
-        MWZiNTA4NCJ9
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:09:25 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/d1730d56-0191-46d9-991b-8f3843e22969/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="uAiB5LawlQVKDODM9BWAHzrTpFmTQQP4WgIGWt50iKw",
-        oauth_signature="pvJMSgvX%2FcUl7TZM7%2B2chRxgMcs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455221366", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:09:26 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kMTczMGQ1Ni0wMTkxLTQ2ZDktOTkxYi04ZjM4NDNlMjI5
-        NjkvIiwgInRhc2tfaWQiOiAiZDE3MzBkNTYtMDE5MS00NmQ5LTk5MWItOGYz
-        ODQzZTIyOTY5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTExVDIwOjA5OjI2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTExVDIwOjA5OjI1WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        Y2VhNzU2NTI0NTA2NjUxZmI1MDg0In0sICJpZCI6ICI1NmJjZWE3NTY1MjQ1
-        MDY2NTFmYjUwODQifQ==
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:09:26 GMT
-- request:
     method: post
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
-        IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRp
-        c3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwi
-        OiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3Rl
-        Y3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJleHBvcnRfZGlzdHJpYnV0
-        b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBz
-        IjpmYWxzZSwicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIn0sImF1dG9fcHVi
-        bGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1
-        dG9yIn1dfQ==
+        eyJpZCI6IjkiLCJkaXNwbGF5X25hbWUiOiJSSEVMIDcgeDg2XzY0IiwiaW1w
+        b3J0ZXJfdHlwZV9pZCI6Inl1bV9pbXBvcnRlciIsImltcG9ydGVyX2NvbmZp
+        ZyI6eyJmZWVkIjoiZmlsZTovLy92YXIvd3d3L3Rlc3RfcmVwb3Mvem9vIiwi
+        c3NsX2NhX2NlcnQiOm51bGwsInNzbF9jbGllbnRfY2VydCI6bnVsbCwic3Ns
+        X2NsaWVudF9rZXkiOm51bGwsImRvd25sb2FkX3BvbGljeSI6bnVsbCwicmVt
+        b3ZlX21pc3NpbmciOm51bGx9LCJub3RlcyI6eyJfcmVwby10eXBlIjoicnBt
+        LXJlcG8ifSwiZGlzdHJpYnV0b3JzIjpbeyJkaXN0cmlidXRvcl90eXBlX2lk
+        IjoieXVtX2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7InJl
+        bGF0aXZlX3VybCI6InRlc3RfcGF0aCIsImh0dHAiOmZhbHNlLCJodHRwcyI6
+        dHJ1ZSwicHJvdGVjdGVkIjp0cnVlfSwiYXV0b19wdWJsaXNoIjp0cnVlLCJk
+        aXN0cmlidXRvcl9pZCI6IjkifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5
+        dW1fY2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsi
+        ZGVzdGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiI5In0sImF1dG9fcHVibGlz
+        aCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiOV9jbG9uZSJ9LHsiZGlzdHJp
+        YnV0b3JfdHlwZV9pZCI6ImV4cG9ydF9kaXN0cmlidXRvciIsImRpc3RyaWJ1
+        dG9yX2NvbmZpZyI6eyJodHRwIjpmYWxzZSwiaHR0cHMiOmZhbHNlLCJyZWxh
+        dGl2ZV91cmwiOiJ0ZXN0X3BhdGgifSwiYXV0b19wdWJsaXNoIjpmYWxzZSwi
+        ZGlzdHJpYnV0b3JfaWQiOiJleHBvcnRfZGlzdHJpYnV0b3IifV19
     headers:
       Accept:
       - application/json
@@ -561,14 +31,8 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
-        oauth_nonce="dTj08ZWj0G6rkE67FcOwhZihmVAje4CFkvzAGHaNU", oauth_signature="bWZsV7VdxTYYG%2Bc8NfprHa6ONkI%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1455221411", oauth_version="1.0"
-      Pulp-User:
-      - admin
       Content-Length:
-      - '817'
+      - '804'
       User-Agent:
       - Ruby
   response:
@@ -577,13 +41,13 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Thu, 11 Feb 2016 20:10:11 GMT
+      - Tue, 23 Feb 2016 16:47:07 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
-      - '320'
+      - '301'
       Location:
-      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
+      - https://katello-yoda.example.com/pulp/api/v2/repositories/9/
       Connection:
       - close
       Content-Type:
@@ -591,19 +55,18 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiY2VhYTNjNzgyMWIxM2QwZjdlMTJhIn0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUkhFTCA3IHg4
+        Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRkZWQi
+        OiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwg
+        Imxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3Vu
+        dHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNTZj
+        YzhkMGJkZTA0MDMzZjQxZDJhM2IyIn0sICJpZCI6ICI5IiwgIl9ocmVmIjog
+        Ii9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvOS8ifQ==
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:10:11 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:07 GMT
 - request:
     method: post
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/9/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -616,12 +79,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
-        oauth_nonce="B6OWzPP4MAzwG5GY9juD5F299snRKSEkKzDx1hS1S9E", oauth_signature="gMXN%2Fv3QU3WBH0eUl3RiAANYS58%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1455221411", oauth_version="1.0"
-      Pulp-User:
-      - admin
       Content-Length:
       - '53'
       User-Agent:
@@ -632,7 +89,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Thu, 11 Feb 2016 20:10:11 GMT
+      - Tue, 23 Feb 2016 16:47:07 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -645,14 +102,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2I2NWI2ZTlhLThiNTUtNDRiOS05ZTNkLTMyNjRjZDg0ZDE2Ny8iLCAi
-        dGFza19pZCI6ICJiNjViNmU5YS04YjU1LTQ0YjktOWUzZC0zMjY0Y2Q4NGQx
-        NjcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzU1ZGYzM2Y2LTUxYWEtNDA1Ny1iZjdlLTRlNGRmNDg4YzY0ZC8iLCAi
+        dGFza19pZCI6ICI1NWRmMzNmNi01MWFhLTQwNTctYmY3ZS00ZTRkZjQ4OGM2
+        NGQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:10:11 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:07 GMT
 - request:
     method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/b65b6e9a-8b55-44b9-9e3d-3264cd84d167/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/55df33f6-51aa-4057-bf7e-4e4df488c64d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -663,12 +120,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="FmFh1cBn2Jur0U6vKgtNubPqrZz12cDyreIettd40",
-        oauth_signature="aT3i87JuaOxeG0a42UBZUDL%2Bo8U%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455221411", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -677,13 +128,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 20:10:11 GMT
+      - Tue, 23 Feb 2016 16:47:07 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '653'
       Connection:
       - close
       Content-Type:
@@ -693,813 +144,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iNjViNmU5YS04YjU1LTQ0YjktOWUzZC0zMjY0Y2Q4NGQx
-        NjcvIiwgInRhc2tfaWQiOiAiYjY1YjZlOWEtOGI1NS00NGI5LTllM2QtMzI2
-        NGNkODRkMTY3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiY2VhYTM2
-        NTI0NTA2NjUxZmI1MDk3In0sICJpZCI6ICI1NmJjZWFhMzY1MjQ1MDY2NTFm
-        YjUwOTcifQ==
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:10:11 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/b65b6e9a-8b55-44b9-9e3d-3264cd84d167/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="5CiHYLD0gHtnFVcu4RY4HHiZaiHX6biR4282gSIes",
-        oauth_signature="WrKHtumfCCVTExWvZtmvyGJB%2Ft8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455221412", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:10:12 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1090'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iNjViNmU5YS04YjU1LTQ0YjktOWUzZC0zMjY0Y2Q4NGQx
-        NjcvIiwgInRhc2tfaWQiOiAiYjY1YjZlOWEtOGI1NS00NGI5LTllM2QtMzI2
-        NGNkODRkMTY3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0xMVQyMDoxMDoxMloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
-        Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJOT1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
-        bCI6IDAsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        a2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1
-        bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
-        IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiY2Vh
-        YTM2NTI0NTA2NjUxZmI1MDk3In0sICJpZCI6ICI1NmJjZWFhMzY1MjQ1MDY2
-        NTFmYjUwOTcifQ==
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:10:12 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/b65b6e9a-8b55-44b9-9e3d-3264cd84d167/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="KFJeM2becWbQvIUdfzgHvm33gpG7DNePZ685sNmWE",
-        oauth_signature="vSuyZEjJZR7o%2FNcWsmrgsgzLT%2Bg%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455221413", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:10:13 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iNjViNmU5YS04YjU1LTQ0YjktOWUzZC0zMjY0Y2Q4NGQx
-        NjcvIiwgInRhc2tfaWQiOiAiYjY1YjZlOWEtOGI1NS00NGI5LTllM2QtMzI2
-        NGNkODRkMTY3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMDoxMDoxMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMDoxMDoxMloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYzkzY2RhNjUtNjAwOC00ZTg0LWJjZjktMDM2YzI1Mjg2
-        YWY4LyIsICJ0YXNrX2lkIjogImM5M2NkYTY1LTYwMDgtNGU4NC1iY2Y5LTAz
-        NmMyNTI4NmFmOCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YmNl
-        YWEzYzc4MjFiMTNkMGY3ZTEyYiJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMTFUMjA6MTA6MTJaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0xMVQyMDoxMDox
-        MloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiY2VhYTRjNzgyMWIxNTQ5YWM0ZWQ2IiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiY2VhYTM2NTI0NTA2NjUxZmI1MDk3In0s
-        ICJpZCI6ICI1NmJjZWFhMzY1MjQ1MDY2NTFmYjUwOTcifQ==
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:10:13 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/c93cda65-6008-4e84-bcf9-036c25286af8/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Xdh3m5QBMaapvsYOotgpvfwnZbNk0kONK9cU2zI4s",
-        oauth_signature="AaGQKB4EHO8Q3kdP9eQfxEsLgpo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455221413", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:10:13 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3529'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9jOTNjZGE2NS02MDA4LTRlODQtYmNmOS0wMzZj
-        MjUyODZhZjgvIiwgInRhc2tfaWQiOiAiYzkzY2RhNjUtNjAwOC00ZTg0LWJj
-        ZjktMDM2YzI1Mjg2YWY4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0xMVQyMDoxMDoxM1oiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIx
-        NjY0NDZkZC0wZTBjLTRkNDYtOTgyZS0zM2VhYWYyZWFmMTgiLCAibnVtX3By
-        b2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlw
-        ZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGU0YjNj
-        OWQtNThlMy00NDEwLWIxNzktNDUxYmQ2ZGQ0MWUzIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNf
-        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiMWEyNmNjNTMtYmVmYy00YTE0LTljOTQtMjAyY2Y1ZDVm
-        MDNmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3Rl
-        cF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQzMTQ2YTVm
-        LWFmYWItNGI3Yy04MDM3LTdjNGM0NjA4OTZjNiIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVt
-        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJlOTgyNjdjZS01MGU1LTQ3ZmEtOWIyMy1jMGQ4YjFm
-        YTQ1YjkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJz
-        dGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWNjYWU3
-        M2EtZDY5Mi00OTUwLTgzMWItYWI5NjI1NDYyMGMxIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEi
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiM2U0Yjk5NTMtNWUxOS00YTk0LWIzYzgt
-        NzZhZTRlYmVlYTkxIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRh
-        dGEiLCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiNjY2M2U2MDEtNzc0ZS00OTU2LTkwNzYtNDY2YjVm
-        ZDE1ZDlmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
-        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIs
-        ICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogImJlNDk4MzE1LWNjODItNDU3Ny1hNDcxLWRiMWNjNjFiNDU2OCIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
-        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90
-        eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImQ1MjQzMWYxLWRkZDMtNDFiMi1iYWIxLTNmYmQ5ZGYwNjhlNiIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJp
-        bml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        NGY5ZTVmZWMtZWM3Mi00YzdmLWIwYzItMzlhZWUyMjFmNWYzIiwgIm51bV9w
-        cm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0
-        YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwg
-        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNTZiY2VhYTQ2NTI0NTA2NjUxZmI1MGE3In0sICJpZCI6ICI1NmJjZWFh
-        NDY1MjQ1MDY2NTFmYjUwYTcifQ==
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:10:13 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/b65b6e9a-8b55-44b9-9e3d-3264cd84d167/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="pTuxmvQalysdTOS3ACtRbONOSr8ozQjCJu7tPFjS2U",
-        oauth_signature="Cxp4bASYOAC0%2F%2FMkhc7FJZdOs%2FI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455221413", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:10:13 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iNjViNmU5YS04YjU1LTQ0YjktOWUzZC0zMjY0Y2Q4NGQx
-        NjcvIiwgInRhc2tfaWQiOiAiYjY1YjZlOWEtOGI1NS00NGI5LTllM2QtMzI2
-        NGNkODRkMTY3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMDoxMDoxMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMDoxMDoxMloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYzkzY2RhNjUtNjAwOC00ZTg0LWJjZjktMDM2YzI1Mjg2
-        YWY4LyIsICJ0YXNrX2lkIjogImM5M2NkYTY1LTYwMDgtNGU4NC1iY2Y5LTAz
-        NmMyNTI4NmFmOCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YmNl
-        YWEzYzc4MjFiMTNkMGY3ZTEyYiJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMTFUMjA6MTA6MTJaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0xMVQyMDoxMDox
-        MloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiY2VhYTRjNzgyMWIxNTQ5YWM0ZWQ2IiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiY2VhYTM2NTI0NTA2NjUxZmI1MDk3In0s
-        ICJpZCI6ICI1NmJjZWFhMzY1MjQ1MDY2NTFmYjUwOTcifQ==
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:10:13 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/c93cda65-6008-4e84-bcf9-036c25286af8/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="BClpaXHZ2XJGcRx8ESJP50hBlpswTA76gjxf8LkjVo",
-        oauth_signature="etnzWvaLVuBT%2FXVixAbAER4%2FNOs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455221413", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:10:14 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9jOTNjZGE2NS02MDA4LTRlODQtYmNmOS0wMzZj
-        MjUyODZhZjgvIiwgInRhc2tfaWQiOiAiYzkzY2RhNjUtNjAwOC00ZTg0LWJj
-        ZjktMDM2YzI1Mjg2YWY4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0xMVQyMDoxMDoxM1oiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMDoxMDoxM1oiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIxNjY0NDZkZC0wZTBjLTRkNDYtOTgyZS0zM2VhYWYy
-        ZWFmMTgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMGU0YjNjOWQtNThlMy00NDEwLWIxNzktNDUxYmQ2ZGQ0MWUzIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMWEyNmNjNTMtYmVmYy00YTE0LTljOTQt
-        MjAyY2Y1ZDVmMDNmIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDMx
-        NDZhNWYtYWZhYi00YjdjLTgwMzctN2M0YzQ2MDg5NmM2IiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImU5ODI2N2NlLTUwZTUtNDdmYS05YjIzLWMwZDhi
-        MWZhNDViOSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhY2NhZTcz
-        YS1kNjkyLTQ5NTAtODMxYi1hYjk2MjU0NjIwYzEiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIzZTRiOTk1My01ZTE5LTRhOTQtYjNjOC03NmFl
-        NGViZWVhOTEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI2NjYzZTYwMS03NzRlLTQ5NTYtOTA3Ni00NjZiNWZkMTVkOWYi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiZTQ5
-        ODMxNS1jYzgyLTQ1NzctYTQ3MS1kYjFjYzYxYjQ1NjgiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkNTI0MzFmMS1kZGQz
-        LTQxYjItYmFiMS0zZmJkOWRmMDY4ZTYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRmOWU1ZmVjLWVjNzItNGM3
-        Zi1iMGMyLTM5YWVlMjIxZjVmMyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
-        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTExVDIwOjEwOjEz
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMTFUMjA6MTA6MTNaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiY2VhYTVjNzgyMWIx
-        NTQ5YWM0ZWQ3IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjE2NjQ0NmRkLTBlMGMtNGQ0Ni05ODJlLTMzZWFhZjJlYWYx
-        OCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICIwZTRiM2M5ZC01OGUzLTQ0MTAtYjE3OS00NTFiZDZkZDQxZTMiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIxYTI2Y2M1My1iZWZjLTRhMTQtOWM5NC0yMDJj
-        ZjVkNWYwM2YiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0MzE0NmE1
-        Zi1hZmFiLTRiN2MtODAzNy03YzRjNDYwODk2YzYiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiZTk4MjY3Y2UtNTBlNS00N2ZhLTliMjMtYzBkOGIxZmE0
-        NWI5IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFjY2FlNzNhLWQ2
-        OTItNDk1MC04MzFiLWFiOTYyNTQ2MjBjMSIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjNlNGI5OTUzLTVlMTktNGE5NC1iM2M4LTc2YWU0ZWJl
-        ZWE5MSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjY2NjNlNjAxLTc3NGUtNDk1Ni05MDc2LTQ2NmI1ZmQxNWQ5ZiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJlNDk4MzE1
-        LWNjODItNDU3Ny1hNDcxLWRiMWNjNjFiNDU2OCIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ1MjQzMWYxLWRkZDMtNDFi
-        Mi1iYWIxLTNmYmQ5ZGYwNjhlNiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGY5ZTVmZWMtZWM3Mi00YzdmLWIw
-        YzItMzlhZWUyMjFmNWYzIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmNlYWE0NjUyNDUwNjY1
-        MWZiNTBhNyJ9LCAiaWQiOiAiNTZiY2VhYTQ2NTI0NTA2NjUxZmI1MGE3In0=
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:10:14 GMT
-- request:
-    method: delete
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="AUWeNXOdXRHUhKfV11SpMHfzxaWLdB9n9V2dos1jKA",
-        oauth_signature="wNnsqEPxJQuEhC2hZu2fQhDlo7M%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455221414", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: ACCEPTED
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:10:14 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzc3OTZjNTgwLTRiZDQtNDIwYy05ZDU2LTM0YzlmNWIzOGRjZi8iLCAi
-        dGFza19pZCI6ICI3Nzk2YzU4MC00YmQ0LTQyMGMtOWQ1Ni0zNGM5ZjViMzhk
-        Y2YifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:10:14 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/7796c580-4bd4-420c-9d56-34c9f5b38dcf/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="gQNxyLflCDJVTFibDD8HZ1OkEMbfTG285wbxGpw1KPg",
-        oauth_signature="Z6Lp0Ms6%2F8ZjpH0bod%2FX19FbA6g%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455221414", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:10:14 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '651'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83Nzk2YzU4MC00YmQ0LTQyMGMtOWQ1Ni0zNGM5ZjViMzhk
-        Y2YvIiwgInRhc2tfaWQiOiAiNzc5NmM1ODAtNGJkNC00MjBjLTlkNTYtMzRj
-        OWY1YjM4ZGNmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAi
-        c3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
-        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20i
-        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmJjZWFhNjY1MjQ1MDY2NTFmYjUwYTgifSwgImlkIjogIjU2YmNl
-        YWE2NjUyNDUwNjY1MWZiNTBhOCJ9
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:10:14 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/7796c580-4bd4-420c-9d56-34c9f5b38dcf/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="gRg2kjDUuxMmlA4woC1iHpdqYkQGw82TfE2pb2qblUY",
-        oauth_signature="0w3IU0ijAuihX9PxAKGafVygdTc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455221415", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:10:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83Nzk2YzU4MC00YmQ0LTQyMGMtOWQ1Ni0zNGM5ZjViMzhk
-        Y2YvIiwgInRhc2tfaWQiOiAiNzc5NmM1ODAtNGJkNC00MjBjLTlkNTYtMzRj
-        OWY1YjM4ZGNmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTExVDIwOjEwOjE0WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTExVDIwOjEwOjE0WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        Y2VhYTY2NTI0NTA2NjUxZmI1MGE4In0sICJpZCI6ICI1NmJjZWFhNjY1MjQ1
-        MDY2NTFmYjUwYTgifQ==
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:10:15 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ae91b770-e0a0-454d-aeee-b2d186dc3c20/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="1aYQLzbeZFF40OMHuocRSZQ7XwWcPw08OudLaZJjs",
-        oauth_signature="%2FKC8zu2yDFp7PE%2BRgDpvtvMEoew%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455221704", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:15:04 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '641'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hZTkxYjc3MC1lMGEwLTQ1NGQtYWVlZS1iMmQxODZkYzNj
-        MjAvIiwgInRhc2tfaWQiOiAiYWU5MWI3NzAtZTBhMC00NTRkLWFlZWUtYjJk
-        MTg2ZGMzYzIwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
+        aS92Mi90YXNrcy81NWRmMzNmNi01MWFhLTQwNTctYmY3ZS00ZTRkZjQ4OGM2
+        NGQvIiwgInRhc2tfaWQiOiAiNTVkZjMzZjYtNTFhYS00MDU3LWJmN2UtNGU0
+        ZGY0ODhjNjRkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
         bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
-        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogbnVsbCwgInRyYWNlYmFj
-        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBv
-        cnQiOiB7fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
-        QGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJ3
-        YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
-        cmtlci0xQGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQi
-        OiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmNl
-        YmM4NjUyNDUwNjY1MWZiNTBiYiJ9LCAiaWQiOiAiNTZiY2ViYzg2NTI0NTA2
-        NjUxZmI1MGJiIn0=
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6
+        NDc6MDdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        W10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogInJlc2VydmVk
+        X3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5k
+        cSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
+        dmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNv
+        bSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDBiOTg5MDU0ZmM0OGJhMmUzNyJ9LCAiaWQiOiAiNTZj
+        YzhkMGI5ODkwNTRmYzQ4YmEyZTM3In0=
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:15:04 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:07 GMT
 - request:
     method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ae91b770-e0a0-454d-aeee-b2d186dc3c20/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/55df33f6-51aa-4057-bf7e-4e4df488c64d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1510,12 +172,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="92hfFsK95JW1vhhjjyve2E2fYab9HBahGryw0Gy7lw",
-        oauth_signature="ODt7UazQCvNnMOD3ARbcuV6SYJE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455221705", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -1524,13 +180,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 20:15:05 GMT
+      - Tue, 23 Feb 2016 16:47:08 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1076'
+      - '2302'
       Connection:
       - close
       Content-Type:
@@ -1540,125 +196,61 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hZTkxYjc3MC1lMGEwLTQ1NGQtYWVlZS1iMmQxODZkYzNj
-        MjAvIiwgInRhc2tfaWQiOiAiYWU5MWI3NzAtZTBhMC00NTRkLWFlZWUtYjJk
-        MTg2ZGMzYzIwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
-        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
-        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTFUMjA6
-        MTU6MDRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
-        W10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29u
-        dGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
-        IjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9k
-        b25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJp
-        dGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiTk9UX1NUQVJU
-        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNf
-        bGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJJTl9QUk9HUkVTUyJ9
-        LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1ZXVl
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRl
-        di5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Mi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3Ii
-        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmNlYmM4NjUyNDUwNjY1MWZi
-        NTBiYiJ9LCAiaWQiOiAiNTZiY2ViYzg2NTI0NTA2NjUxZmI1MGJiIn0=
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:15:05 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ae91b770-e0a0-454d-aeee-b2d186dc3c20/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="AXvdAGqP1ZF3jG0X4ZT5j1tY8Dj4qNPDBuZWGGrxdg",
-        oauth_signature="iTo5wThhqpXz0blpsa7c4EFR29o%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455221706", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:15:06 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2178'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hZTkxYjc3MC1lMGEwLTQ1NGQtYWVlZS1iMmQxODZkYzNj
-        MjAvIiwgInRhc2tfaWQiOiAiYWU5MWI3NzAtZTBhMC00NTRkLWFlZWUtYjJk
-        MTg2ZGMzYzIwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
-        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTFU
-        MjA6MTU6MDVaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
-        IjogIjIwMTYtMDItMTFUMjA6MTU6MDRaIiwgInRyYWNlYmFjayI6IG51bGws
+        aS92Mi90YXNrcy81NWRmMzNmNi01MWFhLTQwNTctYmY3ZS00ZTRkZjQ4OGM2
+        NGQvIiwgInRhc2tfaWQiOiAiNTVkZjMzZjYtNTFhYS00MDU3LWJmN2UtNGU0
+        ZGY0ODhjNjRkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
+        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNU
+        MTY6NDc6MDdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
+        IjogIjIwMTYtMDItMjNUMTY6NDc6MDdaIiwgInRyYWNlYmFjayI6IG51bGws
         ICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2U4ZjFiMGJhLWU0MDktNGYxNC1hZDhlLTYwMzI3ZTg2YWNiMS8iLCAi
-        dGFza19pZCI6ICJlOGYxYjBiYS1lNDA5LTRmMTQtYWQ4ZS02MDMyN2U4NmFj
-        YjEifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsi
+        c2tzL2VhNTAzNTA4LTFkMmQtNDBhYS04NGQ4LWI4YTZkYTUzMWY3Ny8iLCAi
+        dGFza19pZCI6ICJlYTUwMzUwOC0xZDJkLTQwYWEtODRkOC1iOGE2ZGE1MzFm
+        NzcifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsi
         Y29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
         RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3Rv
         dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
         bV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAs
         ICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNf
-        bGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1ZXVlIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5l
-        eGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTIt
-        OC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
-        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJjZWJjOGM3ODIx
-        YjEzZDBmN2UxMzUifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
-        IjkiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0x
-        MVQyMDoxNTowNFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
-        bXBsZXRlZCI6ICIyMDE2LTAyLTExVDIwOjE1OjA1WiIsICJpbXBvcnRlcl90
-        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
-        bCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
-        dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAw
-        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmJjZWJjOWM3ODIxYjE1
-        NDlhYzRlZTAiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
-        IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
-        ICI1NmJjZWJjODY1MjQ1MDY2NTFmYjUwYmIifSwgImlkIjogIjU2YmNlYmM4
-        NjUyNDUwNjY1MWZiNTBiYiJ9
+        RUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xl
+        ZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
+        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBs
+        ZS5jb20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4
+        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
+        aW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMGJkZTA0MDMzZjQxZDJh
+        M2IzIn0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICI5IiwgInRy
+        YWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMjNUMTY6NDc6
+        MDdaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQi
+        OiAiMjAxNi0wMi0yM1QxNjo0NzowN1oiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6
+        ICJ5dW1faW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1t
+        YXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29t
+        cHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAi
+        YWRkZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRl
+        ZF9jb3VudCI6IDAsICJpZCI6ICI1NmNjOGQwYmRlMDQwMzA4OTc1OGE4NGMi
+        LCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJp
+        dGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90
+        YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBt
+        X2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMGI5
+        ODkwNTRmYzQ4YmEyZTM3In0sICJpZCI6ICI1NmNjOGQwYjk4OTA1NGZjNDhi
+        YTJlMzcifQ==
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:15:06 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:08 GMT
 - request:
     method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/e8f1b0ba-e409-4f14-ad8e-60327e86acb1/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/ea503508-1d2d-40aa-84d8-b8a6da531f77/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1669,12 +261,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="4uATe5i53rE1RoUdRsOwNbtZI14zMAoIuTTOcFR48R0",
-        oauth_signature="tyqzHp6%2FNugLs82tiRB8x6iI4CE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455221706", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -1683,13 +269,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 20:15:06 GMT
+      - Tue, 23 Feb 2016 16:47:08 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '3484'
+      - '6891'
       Connection:
       - close
       Content-Type:
@@ -1699,2612 +285,163 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9lOGYxYjBiYS1lNDA5LTRmMTQtYWQ4ZS02MDMy
-        N2U4NmFjYjEvIiwgInRhc2tfaWQiOiAiZThmMWIwYmEtZTQwOS00ZjE0LWFk
-        OGUtNjAzMjdlODZhY2IxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5
-        IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogbnVs
-        bCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYt
-        MDItMTFUMjA6MTU6MDZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
-        X3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7IjkiOiBbeyJudW1f
-        c3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVw
-        byBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVE
+        dWxwL2FwaS92Mi90YXNrcy9lYTUwMzUwOC0xZDJkLTQwYWEtODRkOC1iOGE2
+        ZGE1MzFmNzcvIiwgInRhc2tfaWQiOiAiZWE1MDM1MDgtMWQyZC00MGFhLTg0
+        ZDgtYjhhNmRhNTMxZjc3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5
+        IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogIjIw
+        MTYtMDItMjNUMTY6NDc6MDhaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
+        dGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDc6MDhaIiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBv
+        cnQiOiB7IjkiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
+        ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAi
+        aW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFh
+        OWRlMWM0LTE0MTYtNDNmMS1hZGFjLTY3NGE1NzQ0YzQ1MSIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
+        OiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBl
+        IjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlODE5NDNlMC1l
+        ZjdmLTRmMTEtOTRjOC1mYjMwNzVmY2M2ZGIiLCAibnVtX3Byb2Nlc3NlZCI6
+        IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
+        c2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVtc190b3Rh
+        bCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJhYzM3YjQyMC02ZTk0LTQ3N2MtYWI4Yy0yODBhZjlhNWIxZTIiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUi
+        OiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5MTRhM2UxNC0xM2QyLTQzMjAt
+        YTQ3Yi03M2YwODgyZTFlNjIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJy
+        YXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAz
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        MGZiNmZjOTQtYTBhZC00Mjk4LTllMjQtYWJmMmFkMmY5MzYyIiwgIm51bV9w
+        cm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlv
+        biI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNv
+        bXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjIwOTM0ZTA4LTYyN2UtNDg0MC1iNjk4
+        LTNmY2E3MzIyNGE5MCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0
+        YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjcwZTk2Mjk3LWEyYzAtNDc5MS05YWM5LWM2NTUxNDY3ZTliMiIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRp
+        b24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJj
+        bG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjllYTMyZjZj
+        LWI0NjItNDRjZC05YTYzLWRhMDBlZGRmZTc0NCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2Vu
+        ZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRl
+        IHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVE
         IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNkMWYyYjFmLTJmMmEtNGIyNC1i
-        OWQxLWE0MTM3YjY5MTUxZSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0
-        cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIs
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjVhOTNmNzU3LTZiMmItNDJhMy04
+        ODhkLTRjMDhhNDY1N2MxMyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxl
+        cyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5Iiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogImM2ZDYyNTE0LWE4ZDQtNDg0Ni1iNzU1LWQxYjYx
+        YmY3YjA2NiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwg
+        InN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiYjg4OGE1YmItMzg4YS00MTc1LWJkOWMtYWVhNTlkZGZk
+        MmM2IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAicXVldWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxl
+        LmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2Vw
+        dGlvbiI6IG51bGwsICJyZXBvX2lkIjogIjkiLCAic3RhcnRlZCI6ICIyMDE2
+        LTAyLTIzVDE2OjQ3OjA4WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDc6MDhaIiwgInRy
+        YWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9k
+        aXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAi
+        U0tJUFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNI
+        RUQiLCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRh
+        IjogIkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAi
+        RklOSVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxp
+        c2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hF
+        RCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6
+        IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICI5IiwgImlkIjogIjU2Y2M4ZDBj
+        ZGUwNDAzMDg5NzU4YTg0ZCIsICJkZXRhaWxzIjogW3sibnVtX3N1Y2Nlc3Mi
+        OiAxLCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRh
+        dGEiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI0OTBlNjBmNS04Y2Q0LTRmNTYtOTI2Ny1lN2My
-        YWI5NGYxY2IiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
-        IjogOCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVw
-        X3R5cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwODViMDkyMi1iMDQ2
-        LTRkYTItYmYyNC1jYWMyNjg3NDUxNWQiLCAibnVtX3Byb2Nlc3NlZCI6IDh9
-        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
-        bmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNf
-        dG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJlODY2NDFhZS1lMzIwLTRmMTEtYjUyZC0zY2JhY2JkZmM1YmMi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRl
-        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6
-        ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDg3M2IwYjMtZjM2MS00OTRh
-        LThjM2YtM2YxMDg5NTViODllIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJu
-        dW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
-        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
-        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjUzY2M3MWI1LWZjNDQtNDc3OC05NGEwLWQ2ZDg2MzNjOGE2NiIsICJu
-        dW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjog
-        Im1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjFkMDIzZDc4LWE4NDUtNGVj
-        YS1hYWI2LTNmMzA4YzlhYzg2ZSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
-        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
-        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        OiAwLCAic3RlcF9pZCI6ICJhYTlkZTFjNC0xNDE2LTQzZjEtYWRhYy02NzRh
+        NTc0NGM0NTEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9u
+        IGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiZTgxOTQzZTAtZWY3Zi00ZjExLTk0YzgtZmIzMDc1ZmNjNmRi
+        IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJk
+        ZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjog
+        InJwbXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWMzN2I0MjAtNmU5NC00NzdjLWFi
+        OGMtMjgwYWY5YTViMWUyIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRh
+        IFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjog
+        MSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        OTE0YTNlMTQtMTNkMi00MzIwLWE0N2ItNzNmMDg4MmUxZTYyIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlv
+        biI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
         cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogImJhNzI2YmMxLTYxZjAtNDQ5MS04N2MwLWE4
-        YzNkYTQyMTRmMiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
-        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmls
-        ZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjgyZDI4ZDg1LTcwY2EtNGZmNS1hZWY3LTZkOTMxMzM1YWU2ZiIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
-        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90
-        eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImIxM2Y4MThkLTlmMmUtNGI3Mi05YTlmLTFlMDIwZDRkYzEzNyIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJp
-        bml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        MGVjODViNWEtNjkxMS00NDQwLTliOTgtNTcwNzE2ZTEzZDQzIiwgIm51bV9w
-        cm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0
-        YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwg
-        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNTZiY2ViYzk2NTI0NTA2NjUxZmI1MGNiIn0sICJpZCI6ICI1NmJjZWJj
-        OTY1MjQ1MDY2NTFmYjUwY2IifQ==
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:15:06 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ae91b770-e0a0-454d-aeee-b2d186dc3c20/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="A8bv7kF1WdtXIX1dPVtan7Rao8TnuSdEHoicadbON4",
-        oauth_signature="Z%2B4fdZaQBvz9C8Kact0Y4hAkvI8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455221707", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:15:07 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2178'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hZTkxYjc3MC1lMGEwLTQ1NGQtYWVlZS1iMmQxODZkYzNj
-        MjAvIiwgInRhc2tfaWQiOiAiYWU5MWI3NzAtZTBhMC00NTRkLWFlZWUtYjJk
-        MTg2ZGMzYzIwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
-        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTFU
-        MjA6MTU6MDVaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
-        IjogIjIwMTYtMDItMTFUMjA6MTU6MDRaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2U4ZjFiMGJhLWU0MDktNGYxNC1hZDhlLTYwMzI3ZTg2YWNiMS8iLCAi
-        dGFza19pZCI6ICJlOGYxYjBiYS1lNDA5LTRmMTQtYWQ4ZS02MDMyN2U4NmFj
-        YjEifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsi
-        Y29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3Rv
-        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
-        bV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAs
-        ICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNf
-        bGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1ZXVlIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5l
-        eGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTIt
-        OC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
-        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJjZWJjOGM3ODIx
-        YjEzZDBmN2UxMzUifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
-        IjkiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0x
-        MVQyMDoxNTowNFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
-        bXBsZXRlZCI6ICIyMDE2LTAyLTExVDIwOjE1OjA1WiIsICJpbXBvcnRlcl90
-        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
-        bCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
-        dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAw
-        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmJjZWJjOWM3ODIxYjE1
-        NDlhYzRlZTAiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
-        IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
-        ICI1NmJjZWJjODY1MjQ1MDY2NTFmYjUwYmIifSwgImlkIjogIjU2YmNlYmM4
-        NjUyNDUwNjY1MWZiNTBiYiJ9
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:15:07 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/e8f1b0ba-e409-4f14-ad8e-60327e86acb1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="0wh7SJUbd8jmEIQ8ZlOmvpcvpNApkQ2lOqDj18k",
-        oauth_signature="EKJy6LjDtlAk6I%2BZSEQrtHMgV0Q%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455221707", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:15:07 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6897'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9lOGYxYjBiYS1lNDA5LTRmMTQtYWQ4ZS02MDMy
-        N2U4NmFjYjEvIiwgInRhc2tfaWQiOiAiZThmMWIwYmEtZTQwOS00ZjE0LWFk
-        OGUtNjAzMjdlODZhY2IxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5
-        IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogIjIw
-        MTYtMDItMTFUMjA6MTU6MDZaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
-        dGFydF90aW1lIjogIjIwMTYtMDItMTFUMjA6MTU6MDZaIiwgInRyYWNlYmFj
-        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBv
-        cnQiOiB7IjkiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
-        ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAi
-        aW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNk
-        MWYyYjFmLTJmMmEtNGIyNC1iOWQxLWE0MTM3YjY5MTUxZSIsICJudW1fcHJv
-        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBl
-        IjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0OTBlNjBmNS04
-        Y2Q0LTRmNTYtOTI2Ny1lN2MyYWI5NGYxY2IiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
-        c2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVtc190b3Rh
-        bCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICIwODViMDkyMi1iMDQ2LTRkYTItYmYyNC1jYWMyNjg3NDUxNWQiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUi
-        OiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlODY2NDFhZS1lMzIwLTRmMTEt
-        YjUyZC0zY2JhY2JkZmM1YmMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
-        bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJy
-        YXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        MDg3M2IwYjMtZjM2MS00OTRhLThjM2YtM2YxMDg5NTViODllIiwgIm51bV9w
-        cm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlv
-        biI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNv
-        bXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjUzY2M3MWI1LWZjNDQtNDc3OC05NGEw
-        LWQ2ZDg2MzNjOGE2NiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1
-        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0
-        YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjog
-        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjFkMDIzZDc4LWE4NDUtNGVjYS1hYWI2LTNmMzA4YzlhYzg2ZSIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRp
-        b24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJj
-        bG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJhNzI2YmMx
-        LTYxZjAtNDQ5MS04N2MwLWE4YzNkYTQyMTRmMiIsICJudW1fcHJvY2Vzc2Vk
-        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2Vu
-        ZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRl
-        IHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjgyZDI4ZDg1LTcwY2EtNGZmNS1h
-        ZWY3LTZkOTMxMzM1YWU2ZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxl
-        cyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5Iiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImIxM2Y4MThkLTlmMmUtNGI3Mi05YTlmLTFlMDIw
-        ZDRkYzEzNyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiMGVjODViNWEtNjkxMS00NDQwLTliOTgtNTcwNzE2ZTEz
-        ZDQzIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAicXVldWUiOiAicmVzZXJ2
-        ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUu
-        Y29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5l
-        eGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwg
-        ImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIjkiLCAic3RhcnRlZCI6
-        ICIyMDE2LTAyLTExVDIwOjE1OjA2WiIsICJfbnMiOiAicmVwb19wdWJsaXNo
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjA6MTU6MDZa
-        IiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjog
-        Inl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxp
-        dGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAi
-        RklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21l
-        dGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29t
-        cHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwg
-        InB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJG
-        SU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVz
-        c2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICI5IiwgImlkIjogIjU2
-        YmNlYmNhYzc4MjFiMTU0OWFjNGVlMSIsICJkZXRhaWxzIjogW3sibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8g
-        bWV0YWRhdGEiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRh
-        ZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzZDFmMmIxZi0yZjJhLTRiMjQtYjlk
-        MS1hNDEzN2I2OTE1MWUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9z
-        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJp
-        YnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAi
-        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiNDkwZTYwZjUtOGNkNC00ZjU2LTkyNjctZTdjMmFi
-        OTRmMWNiIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6
-        IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90
-        eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklO
-        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDg1YjA5MjItYjA0Ni00
-        ZGEyLWJmMjQtY2FjMjY4NzQ1MTVkIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwg
-        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
-        IERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3Rv
-        dGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZTg2NjQxYWUtZTMyMC00ZjExLWI1MmQtM2NiYWNiZGZjNWJjIiwg
-        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAi
-        ZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA4NzNiMGIzLWYzNjEtNDk0YS04
-        YzNmLTNmMTA4OTU1Yjg5ZSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVt
-        X3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21w
-        cyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI1M2NjNzFiNS1mYzQ0LTQ3NzgtOTRhMC1kNmQ4NjMzYzhhNjYiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJt
-        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxZDAyM2Q3OC1hODQ1LTRlY2Et
-        YWFiNi0zZjMwOGM5YWM4NmUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
-        bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBt
-        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJiYTcyNmJjMS02MWYwLTQ0OTEtODdjMC1hOGMz
-        ZGE0MjE0ZjIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVz
-        IiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI4MmQyOGQ4NS03MGNhLTRmZjUtYWVmNy02ZDkzMTMzNWFlNmYiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlw
-        ZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        cyI6IDAsICJzdGVwX2lkIjogIjBmYjZmYzk0LWEwYWQtNDI5OC05ZTI0LWFi
+        ZjJhZDJmOTM2MiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nl
+        c3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxl
+        IiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMTNm
-        ODE4ZC05ZjJlLTRiNzItOWE5Zi0xZTAyMGQ0ZGMxMzciLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
-        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBlYzg1YjVh
-        LTY5MTEtNDQ0MC05Yjk4LTU3MDcxNmUxM2Q0MyIsICJudW1fcHJvY2Vzc2Vk
-        IjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJj
-        ZWJjOTY1MjQ1MDY2NTFmYjUwY2IifSwgImlkIjogIjU2YmNlYmM5NjUyNDUw
-        NjY1MWZiNTBjYiJ9
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:15:07 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/a0262623-7413-4b8a-bc41-91754b2b2d94/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="GlsxI2roxQlVC47YBYXfBGdvqCots7P9eZGIFwySvA",
-        oauth_signature="I%2Be6GV1oEz9F81cTvmLfmBkfLd8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455221707", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:15:07 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '541'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hMDI2MjYyMy03NDEzLTRiOGEtYmM0MS05MTc1NGIyYjJk
-        OTQvIiwgInRhc2tfaWQiOiAiYTAyNjI2MjMtNzQxMy00YjhhLWJjNDEtOTE3
-        NTRiMmIyZDk0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
-        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiBudWxsLCAiX25z
-        IjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3Jl
-        cG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6ICJ3YWl0
-        aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51bGwsICJl
-        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiY2ViY2I2NTI0NTA2
-        NjUxZmI1MGNjIn0sICJpZCI6ICI1NmJjZWJjYjY1MjQ1MDY2NTFmYjUwY2Mi
-        fQ==
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:15:07 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/a0262623-7413-4b8a-bc41-91754b2b2d94/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="8uBY1vlb0Ak7bP3khzsioSLToY860QiKtoVX3DyHAWs",
-        oauth_signature="mEHVGRJenXvVTxVyweHBVbyaYkc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455221708", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:15:08 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '680'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hMDI2MjYyMy03NDEzLTRiOGEtYmM0MS05MTc1NGIyYjJk
-        OTQvIiwgInRhc2tfaWQiOiAiYTAyNjI2MjMtNzQxMy00YjhhLWJjNDEtOTE3
-        NTRiMmIyZDk0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
-        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0x
-        MVQyMDoxNTowN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3Rp
-        bWUiOiAiMjAxNi0wMi0xMVQyMDoxNTowN1oiLCAidHJhY2ViYWNrIjogbnVs
-        bCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9
-        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
-        by0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVk
-        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
-        QGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmNlYmNiNjUy
-        NDUwNjY1MWZiNTBjYyJ9LCAiaWQiOiAiNTZiY2ViY2I2NTI0NTA2NjUxZmI1
-        MGNjIn0=
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:15:08 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/fd05ca00-85c2-4fae-be8b-94813fd22622/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="TRbq5Egyzo1byhJpKUbMLz5gCebZl0q2dh5iZcDy0c",
-        oauth_signature="yzhWdaxmWZSOnUdJ7gPkS4nl%2FkE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455222050", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:20:50 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '539'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mZDA1Y2EwMC04NWMyLTRmYWUtYmU4Yi05NDgxM2ZkMjI2
-        MjIvIiwgInRhc2tfaWQiOiAiZmQwNWNhMDAtODVjMi00ZmFlLWJlOGItOTQ4
-        MTNmZDIyNjIyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
-        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
-        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogbnVsbCwgInRyYWNlYmFj
-        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBv
-        cnQiOiB7fSwgInF1ZXVlIjogIk5vbmUuZHEiLCAic3RhdGUiOiAid2FpdGlu
-        ZyIsICJ3b3JrZXJfbmFtZSI6IG51bGwsICJyZXN1bHQiOiBudWxsLCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmNlZDIyNjUyNDUwNjY1
-        MWZiNTBkZiJ9LCAiaWQiOiAiNTZiY2VkMjI2NTI0NTA2NjUxZmI1MGRmIn0=
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:20:50 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/fd05ca00-85c2-4fae-be8b-94813fd22622/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="XUJISb6QwZYu2W8omaEFNafZbbuoKUzagpU2HZ5c",
-        oauth_signature="xwR6apYftRF85%2B4QJXl%2F7LSYGKE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455222050", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:20:50 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1079'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mZDA1Y2EwMC04NWMyLTRmYWUtYmU4Yi05NDgxM2ZkMjI2
-        MjIvIiwgInRhc2tfaWQiOiAiZmQwNWNhMDAtODVjMi00ZmFlLWJlOGItOTQ4
-        MTNmZDIyNjIyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
-        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
-        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTFUMjA6
-        MjA6NTBaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
-        W10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29u
-        dGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
-        IjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9k
-        b25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJp
-        dGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiTk9UX1NUQVJU
-        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3Rh
-        dGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRl
-        bXNfbGVmdCI6IDF9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJOT1RfU1RBUlRF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04
-        LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndv
-        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVs
-        bG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmNlZDIyNjUyNDUwNjY1
-        MWZiNTBkZiJ9LCAiaWQiOiAiNTZiY2VkMjI2NTI0NTA2NjUxZmI1MGRmIn0=
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:20:50 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/fd05ca00-85c2-4fae-be8b-94813fd22622/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="mQGziFdgEP5SH87MFxyTuNa1m6lkni1NuqaIWurA7d0",
-        oauth_signature="2ReO7toEgPTfkqS7MsWxfZVs7%2Bs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455222051", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:20:51 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2178'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mZDA1Y2EwMC04NWMyLTRmYWUtYmU4Yi05NDgxM2ZkMjI2
-        MjIvIiwgInRhc2tfaWQiOiAiZmQwNWNhMDAtODVjMi00ZmFlLWJlOGItOTQ4
-        MTNmZDIyNjIyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
-        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTFU
-        MjA6MjA6NTFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
-        IjogIjIwMTYtMDItMTFUMjA6MjA6NTBaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzJhYTE4NWEwLWUwNGUtNGIwMC1iNGQxLWE3YzhjNWJiMzg1ZS8iLCAi
-        dGFza19pZCI6ICIyYWExODVhMC1lMDRlLTRiMDAtYjRkMS1hN2M4YzViYjM4
-        NWUifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsi
-        Y29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3Rv
-        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
-        bV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAs
-        ICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNf
-        bGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1ZXVlIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5l
-        eGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTIt
-        OC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
-        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJjZWQyMWM3ODIx
-        YjEzZDBmN2UxM2EifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
-        IjkiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0x
-        MVQyMDoyMDo1MFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
-        bXBsZXRlZCI6ICIyMDE2LTAyLTExVDIwOjIwOjUwWiIsICJpbXBvcnRlcl90
-        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
-        bCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
-        dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAw
-        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmJjZWQyMmM3ODIxYjE1
-        NDlhYzRlZWEiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
-        IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
-        ICI1NmJjZWQyMjY1MjQ1MDY2NTFmYjUwZGYifSwgImlkIjogIjU2YmNlZDIy
-        NjUyNDUwNjY1MWZiNTBkZiJ9
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:20:51 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/2aa185a0-e04e-4b00-b4d1-a7c8c5bb385e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Coyfwsp6ESyawML4TmryrtdvOMGxHjEDDUnaGDR1Nc",
-        oauth_signature="NjITIzFOD9PawUgswgQtimQlvxY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455222051", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:20:51 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3507'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8yYWExODVhMC1lMDRlLTRiMDAtYjRkMS1hN2M4
-        YzViYjM4NWUvIiwgInRhc2tfaWQiOiAiMmFhMTg1YTAtZTA0ZS00YjAwLWI0
-        ZDEtYTdjOGM1YmIzODVlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5
-        IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogbnVs
-        bCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYt
-        MDItMTFUMjA6MjA6NTFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
-        X3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7IjkiOiBbeyJudW1f
-        c3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVw
-        byBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNlODY5OWVkLTYyYzgtNGM2OS05
-        MTQ2LTZlMTgxN2RmNjc3YyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0
-        cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIyNWI1MTUxZi1iMGJmLTQyOWItYjk4OC0yN2Ey
-        ZDdlZGYwZTgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
-        IjogOCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVw
-        X3R5cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJJ
-        Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYThkZWQ4MS01
-        NTNjLTQ0NWUtYTUwNS1lOGM4YzRhNmM3NDAiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
-        c2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiYjFlNTUwYjgtOTk5MC00M2MxLWJlMGEtZGMyMjBi
-        YWEzNThiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
-        IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVw
-        X3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNkNTk5MzRh
-        LTY2M2ItNGU1YS05NzkwLWJmZjZjMzRlMzY4NCIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI4MGNiYzFiNC1kMzIyLTQ0YTQtOWFhNy03NDIz
-        YmE3MTI3MjAiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwg
-        InN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJk
-        NTExYzAxZS02NTU3LTRjN2MtOTAwMS01ZjU5ODlmZDkzNjkiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xv
-        c2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyOGY1OTQ3
-        Zi0yOGVmLTRlZjUtYmRjNy05ZDk2OTJjNDg1MzUiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdl
-        bmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0
-        ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
-        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDdmYTY3YzItYzY1Ni00
-        ZjIyLTg1OGQtZmEzYWYwZmZiZDg3IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
-        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
-        IGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rv
-        cnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZWQyNjMxOTYtZTY0NS00OGFmLTk1
-        NTAtNjg4YTM3OGI3MDVmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3Rpbmdz
-        IEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0
-        YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2Y2I3ZTg3NS01NzcwLTRhYzYtYmQx
-        Yi03ZWUzMzU1MDUxMWEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1
-        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1k
-        ZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3Jr
-        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
-        LTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9y
-        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJjZWQyMjY1MjQ1MDY2NTFm
-        YjUwZWYifSwgImlkIjogIjU2YmNlZDIyNjUyNDUwNjY1MWZiNTBlZiJ9
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:20:51 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/fd05ca00-85c2-4fae-be8b-94813fd22622/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="qAFuv384NLC49WSbutAIWeiR7bUDPv4asLxMtWjr8g",
-        oauth_signature="RphOyp4whL50IaL%2BH9X3ddsmXCc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455222052", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:20:52 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2178'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mZDA1Y2EwMC04NWMyLTRmYWUtYmU4Yi05NDgxM2ZkMjI2
-        MjIvIiwgInRhc2tfaWQiOiAiZmQwNWNhMDAtODVjMi00ZmFlLWJlOGItOTQ4
-        MTNmZDIyNjIyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
-        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTFU
-        MjA6MjA6NTFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
-        IjogIjIwMTYtMDItMTFUMjA6MjA6NTBaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzJhYTE4NWEwLWUwNGUtNGIwMC1iNGQxLWE3YzhjNWJiMzg1ZS8iLCAi
-        dGFza19pZCI6ICIyYWExODVhMC1lMDRlLTRiMDAtYjRkMS1hN2M4YzViYjM4
-        NWUifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsi
-        Y29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3Rv
-        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
-        bV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAs
-        ICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNf
-        bGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1ZXVlIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5l
-        eGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTIt
-        OC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
-        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJjZWQyMWM3ODIx
-        YjEzZDBmN2UxM2EifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
-        IjkiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0x
-        MVQyMDoyMDo1MFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
-        bXBsZXRlZCI6ICIyMDE2LTAyLTExVDIwOjIwOjUwWiIsICJpbXBvcnRlcl90
-        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
-        bCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
-        dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAw
-        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmJjZWQyMmM3ODIxYjE1
-        NDlhYzRlZWEiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
-        IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
-        ICI1NmJjZWQyMjY1MjQ1MDY2NTFmYjUwZGYifSwgImlkIjogIjU2YmNlZDIy
-        NjUyNDUwNjY1MWZiNTBkZiJ9
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:20:52 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/2aa185a0-e04e-4b00-b4d1-a7c8c5bb385e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="LgRp4mDBk2pVZNZItHWsdju7bbYH02ZRqNykiSiloIo",
-        oauth_signature="BHKcRILEPLYIbImg%2BjgD8ACgnNU%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455222052", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:20:52 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6897'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8yYWExODVhMC1lMDRlLTRiMDAtYjRkMS1hN2M4
-        YzViYjM4NWUvIiwgInRhc2tfaWQiOiAiMmFhMTg1YTAtZTA0ZS00YjAwLWI0
-        ZDEtYTdjOGM1YmIzODVlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5
-        IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogIjIw
-        MTYtMDItMTFUMjA6MjA6NTFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
-        dGFydF90aW1lIjogIjIwMTYtMDItMTFUMjA6MjA6NTFaIiwgInRyYWNlYmFj
-        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBv
-        cnQiOiB7IjkiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
-        ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAi
-        aW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNl
-        ODY5OWVkLTYyYzgtNGM2OS05MTQ2LTZlMTgxN2RmNjc3YyIsICJudW1fcHJv
-        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBl
-        IjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyNWI1MTUxZi1i
-        MGJmLTQyOWItYjk4OC0yN2EyZDdlZGYwZTgiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
-        c2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVtc190b3Rh
-        bCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICIwYThkZWQ4MS01NTNjLTQ0NWUtYTUwNS1lOGM4YzRhNmM3NDAiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUi
-        OiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMWU1NTBiOC05OTkwLTQzYzEt
-        YmUwYS1kYzIyMGJhYTM1OGIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
-        bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJy
-        YXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        M2Q1OTkzNGEtNjYzYi00ZTVhLTk3OTAtYmZmNmMzNGUzNjg0IiwgIm51bV9w
-        cm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlv
-        biI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNv
-        bXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjgwY2JjMWI0LWQzMjItNDRhNC05YWE3
-        LTc0MjNiYTcxMjcyMCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1
-        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0
-        YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjog
-        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImQ1MTFjMDFlLTY1NTctNGM3Yy05MDAxLTVmNTk4OWZkOTM2OSIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRp
-        b24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJj
-        bG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI4ZjU5NDdm
-        LTI4ZWYtNGVmNS1iZGM3LTlkOTY5MmM0ODUzNSIsICJudW1fcHJvY2Vzc2Vk
-        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2Vu
-        ZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRl
-        IHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA3ZmE2N2MyLWM2NTYtNGYyMi04
-        NThkLWZhM2FmMGZmYmQ4NyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxl
-        cyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5Iiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImVkMjYzMTk2LWU2NDUtNDhhZi05NTUwLTY4OGEz
-        NzhiNzA1ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiNmNiN2U4NzUtNTc3MC00YWM2LWJkMWItN2VlMzM1NTA1
-        MTFhIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAicXVldWUiOiAicmVzZXJ2
-        ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUu
-        Y29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5l
-        eGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwg
-        ImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIjkiLCAic3RhcnRlZCI6
-        ICIyMDE2LTAyLTExVDIwOjIwOjUxWiIsICJfbnMiOiAicmVwb19wdWJsaXNo
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjA6MjA6NTFa
-        IiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjog
-        Inl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxp
-        dGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAi
-        RklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21l
-        dGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29t
-        cHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwg
-        InB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJG
-        SU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVz
-        c2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICI5IiwgImlkIjogIjU2
-        YmNlZDIzYzc4MjFiMTU0OWFjNGVlYiIsICJkZXRhaWxzIjogW3sibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8g
-        bWV0YWRhdGEiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRh
-        ZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzZTg2OTllZC02MmM4LTRjNjktOTE0
-        Ni02ZTE4MTdkZjY3N2MiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9z
-        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJp
-        YnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAi
-        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiMjViNTE1MWYtYjBiZi00MjliLWI5ODgtMjdhMmQ3
-        ZWRmMGU4IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6
-        IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90
-        eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklO
-        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGE4ZGVkODEtNTUzYy00
-        NDVlLWE1MDUtZThjOGM0YTZjNzQwIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwg
-        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
-        IERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3Rv
-        dGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYjFlNTUwYjgtOTk5MC00M2MxLWJlMGEtZGMyMjBiYWEzNThiIiwg
-        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAi
-        ZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNkNTk5MzRhLTY2M2ItNGU1YS05
-        NzkwLWJmZjZjMzRlMzY4NCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVt
-        X3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21w
-        cyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI4MGNiYzFiNC1kMzIyLTQ0YTQtOWFhNy03NDIzYmE3MTI3MjAiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJt
-        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkNTExYzAxZS02NTU3LTRjN2Mt
-        OTAwMS01ZjU5ODlmZDkzNjkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
-        bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBt
-        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIyOGY1OTQ3Zi0yOGVmLTRlZjUtYmRjNy05ZDk2
-        OTJjNDg1MzUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVz
-        IiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICIwN2ZhNjdjMi1jNjU2LTRmMjItODU4ZC1mYTNhZjBmZmJkODciLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlw
-        ZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlZDI2
-        MzE5Ni1lNjQ1LTQ4YWYtOTU1MC02ODhhMzc4YjcwNWYiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
-        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjZjYjdlODc1
-        LTU3NzAtNGFjNi1iZDFiLTdlZTMzNTUwNTExYSIsICJudW1fcHJvY2Vzc2Vk
-        IjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJj
-        ZWQyMjY1MjQ1MDY2NTFmYjUwZWYifSwgImlkIjogIjU2YmNlZDIyNjUyNDUw
-        NjY1MWZiNTBlZiJ9
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:20:52 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/e8029c79-0969-482b-8881-e873c193ea2a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="zl49Es4uYL9WOIOstEBvgM8dSS1ZhErolQHJY24XUdI",
-        oauth_signature="jPOPowXwtrDT9FZ%2BY%2FW2Ka598qM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455222052", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:20:52 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '541'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lODAyOWM3OS0wOTY5LTQ4MmItODg4MS1lODczYzE5M2Vh
-        MmEvIiwgInRhc2tfaWQiOiAiZTgwMjljNzktMDk2OS00ODJiLTg4ODEtZTg3
-        M2MxOTNlYTJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
-        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiBudWxsLCAiX25z
-        IjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3Jl
-        cG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6ICJ3YWl0
-        aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51bGwsICJl
-        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiY2VkMjQ2NTI0NTA2
-        NjUxZmI1MGYwIn0sICJpZCI6ICI1NmJjZWQyNDY1MjQ1MDY2NTFmYjUwZjAi
-        fQ==
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:20:52 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/e8029c79-0969-482b-8881-e873c193ea2a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="gWxjEr5NevbfFAgFj7kngvzll6aG46eh3XJWrqNjw",
-        oauth_signature="xxaMhmhIUvNKYGl7zF4oDdsKoLw%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455222053", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:20:53 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '680'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lODAyOWM3OS0wOTY5LTQ4MmItODg4MS1lODczYzE5M2Vh
-        MmEvIiwgInRhc2tfaWQiOiAiZTgwMjljNzktMDk2OS00ODJiLTg4ODEtZTg3
-        M2MxOTNlYTJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
-        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0x
-        MVQyMDoyMDo1M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3Rp
-        bWUiOiAiMjAxNi0wMi0xMVQyMDoyMDo1M1oiLCAidHJhY2ViYWNrIjogbnVs
-        bCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9
-        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
-        by0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVk
-        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
-        QGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmNlZDI0NjUy
-        NDUwNjY1MWZiNTBmMCJ9LCAiaWQiOiAiNTZiY2VkMjQ2NTI0NTA2NjUxZmI1
-        MGYwIn0=
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:20:53 GMT
-- request:
-    method: post
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IjkiLCJkaXNwbGF5X25hbWUiOiJSSEVMIDcgeDg2XzY0IiwiaW1w
-        b3J0ZXJfdHlwZV9pZCI6Inl1bV9pbXBvcnRlciIsImltcG9ydGVyX2NvbmZp
-        ZyI6eyJmZWVkIjoiZmlsZTovLy92YXIvd3d3L3Rlc3RfcmVwb3Mvem9vIiwi
-        c3NsX2NhX2NlcnQiOm51bGwsInNzbF9jbGllbnRfY2VydCI6bnVsbCwic3Ns
-        X2NsaWVudF9rZXkiOm51bGwsImRvd25sb2FkX3BvbGljeSI6bnVsbH0sIm5v
-        dGVzIjp7Il9yZXBvLXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMi
-        Olt7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJk
-        aXN0cmlidXRvcl9jb25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRo
-        IiwiaHR0cCI6ZmFsc2UsImh0dHBzIjp0cnVlLCJwcm90ZWN0ZWQiOnRydWV9
-        LCJhdXRvX3B1Ymxpc2giOnRydWUsImRpc3RyaWJ1dG9yX2lkIjoiOSJ9LHsi
-        ZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9jbG9uZV9kaXN0cmlidXRvciIs
-        ImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRv
-        cl9pZCI6IjkifSwiYXV0b19wdWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiI5X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBlX2lkIjoiZXhwb3J0
-        X2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7Imh0dHAiOmZh
-        bHNlLCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6InRlc3RfcGF0aCJ9
-        LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRvcl9pZCI6ImV4cG9y
-        dF9kaXN0cmlidXRvciJ9XX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
-        oauth_nonce="barhb4Jk9vxKRg5PlEXddHEeycZHsC8AZXxOmvs33k", oauth_signature="KbhK5%2Fi48FAPwP22imNwFiJw8E4%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1455222098", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '782'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:21:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '301'
-      Location:
-      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/9/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUkhFTCA3IHg4
-        Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRkZWQi
-        OiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwg
-        Imxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3Vu
-        dHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        Y2VkNTJjNzgyMWIxM2QwZjdlMTNlIn0sICJpZCI6ICI5IiwgIl9ocmVmIjog
-        Ii9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvOS8ifQ==
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:21:38 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/75b3534a-fb90-42e3-b5f5-43d71f08ca62/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="sBajhsC9JgyjoLA1TD8SJjBy8CHLlH8bD8y6fS43Y",
-        oauth_signature="x0l1tHRBWk5k4zDLgsjpGBaBUUM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455222099", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:21:39 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '539'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83NWIzNTM0YS1mYjkwLTQyZTMtYjVmNS00M2Q3MWYwOGNh
-        NjIvIiwgInRhc2tfaWQiOiAiNzViMzUzNGEtZmI5MC00MmUzLWI1ZjUtNDNk
-        NzFmMDhjYTYyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
-        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
-        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogbnVsbCwgInRyYWNlYmFj
-        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBv
-        cnQiOiB7fSwgInF1ZXVlIjogIk5vbmUuZHEiLCAic3RhdGUiOiAid2FpdGlu
-        ZyIsICJ3b3JrZXJfbmFtZSI6IG51bGwsICJyZXN1bHQiOiBudWxsLCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmNlZDUzNjUyNDUwNjY1
-        MWZiNTEwMyJ9LCAiaWQiOiAiNTZiY2VkNTM2NTI0NTA2NjUxZmI1MTAzIn0=
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:21:39 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/75b3534a-fb90-42e3-b5f5-43d71f08ca62/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="q1mDtojRwGgj1yTBdJPoBS5CRGZHCDssyfe8emEc",
-        oauth_signature="6l5hDT87XkxYUgv2JykfOfEdx8g%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455222099", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:21:39 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1079'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83NWIzNTM0YS1mYjkwLTQyZTMtYjVmNS00M2Q3MWYwOGNh
-        NjIvIiwgInRhc2tfaWQiOiAiNzViMzUzNGEtZmI5MC00MmUzLWI1ZjUtNDNk
-        NzFmMDhjYTYyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
-        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
-        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTFUMjA6
-        MjE6MzlaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
-        W10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29u
-        dGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
-        IjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9k
-        b25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJp
-        dGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiTk9UX1NUQVJU
-        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
-        dGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJOT1RfU1RBUlRF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04
-        LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndv
-        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVs
-        bG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmNlZDUzNjUyNDUwNjY1
-        MWZiNTEwMyJ9LCAiaWQiOiAiNTZiY2VkNTM2NTI0NTA2NjUxZmI1MTAzIn0=
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:21:39 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/75b3534a-fb90-42e3-b5f5-43d71f08ca62/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="RAK7eFAFrQANLDl15BlofYd9p3d1KjopOca9GHg",
-        oauth_signature="bilttO%2F6085CEU5BZVCiWY7WqXI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455222100", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:21:40 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2178'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83NWIzNTM0YS1mYjkwLTQyZTMtYjVmNS00M2Q3MWYwOGNh
-        NjIvIiwgInRhc2tfaWQiOiAiNzViMzUzNGEtZmI5MC00MmUzLWI1ZjUtNDNk
-        NzFmMDhjYTYyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
-        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTFU
-        MjA6MjE6MzlaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
-        IjogIjIwMTYtMDItMTFUMjA6MjE6MzlaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzZmNjA4NWQwLTA3OTYtNDkwZS1hNzZkLWMwOWYyYjY1MTY3Yi8iLCAi
-        dGFza19pZCI6ICI2ZjYwODVkMC0wNzk2LTQ5MGUtYTc2ZC1jMDlmMmI2NTE2
-        N2IifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsi
-        Y29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3Rv
-        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
-        bV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAs
-        ICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNf
-        bGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1ZXVlIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5l
-        eGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTIt
-        OC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
-        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJjZWQ1MmM3ODIx
-        YjEzZDBmN2UxM2YifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
-        IjkiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0x
-        MVQyMDoyMTozOVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
-        bXBsZXRlZCI6ICIyMDE2LTAyLTExVDIwOjIxOjM5WiIsICJpbXBvcnRlcl90
-        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
-        bCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
-        dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAw
-        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmJjZWQ1M2M3ODIxYjE1
-        NDlhYzRlZjQiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
-        IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
-        ICI1NmJjZWQ1MzY1MjQ1MDY2NTFmYjUxMDMifSwgImlkIjogIjU2YmNlZDUz
-        NjUyNDUwNjY1MWZiNTEwMyJ9
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:21:40 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/6f6085d0-0796-490e-a76d-c09f2b65167b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="P1tgq8jSMHty7GyApgcmA7AVo7UlgekaC5ZS62xKaDU",
-        oauth_signature="9lN5GFuiWM%2F%2BW4KS8fiZUbSFPtU%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455222100", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:21:40 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3497'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82ZjYwODVkMC0wNzk2LTQ5MGUtYTc2ZC1jMDlm
-        MmI2NTE2N2IvIiwgInRhc2tfaWQiOiAiNmY2MDg1ZDAtMDc5Ni00OTBlLWE3
-        NmQtYzA5ZjJiNjUxNjdiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5
-        IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogbnVs
-        bCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYt
-        MDItMTFUMjA6MjE6NDBaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
-        X3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7IjkiOiBbeyJudW1f
-        c3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVw
-        byBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQ5MTkwNmJmLTQ0ZTQtNDQ0OC05
-        N2NlLTUwNTQwMTEzMTkwYyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0
-        cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJjYjFkODVlZC05M2E3LTQ4YTMtOGUxYy1iYjI1
-        MTE3YzNjYjIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
-        IjogOCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVw
-        X3R5cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0ZTg5ZDZkNy1mOGU4
-        LTQ1Y2QtODNiNy02NTM4ZDQ4NmFlZDIiLCAibnVtX3Byb2Nlc3NlZCI6IDh9
-        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
-        bmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNf
-        dG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIxODU5ZTNmMy01M2NjLTRiYTctYTA4OC0yNWVmYWM0MTgxMWMi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRl
-        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6
-        ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjU4YzBhMzYtMmYwMC00NmQx
-        LThhZTItOGQyMDIxNTMyOTM0IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJu
-        dW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
-        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
-        IjogMywgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogImQ2YjA0YjdlLTg2YTUtNDVmNi1hODZmLTI2YjgwMWQwOGI4NyIs
-        ICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
-        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBl
-        IjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5P
-        VF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdiM2U4YTI4LWYw
-        YTAtNGExNS04NmY0LTE0N2MwZDYwOGQxZSIsICJudW1fcHJvY2Vzc2VkIjog
-        MH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2lu
-        ZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFS
-        VEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjUxZjE5Mjc5LTUxMDMtNDIz
-        OC05NjYwLTJjMTg4Y2JmMjU3ZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBz
-        cWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyMDkz
+        NGUwOC02MjdlLTQ4NDAtYjY5OC0zZmNhNzMyMjRhOTAiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0
+        YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJhN2VhNDk2Zi1lZWMxLTRjOWQtYTA2OS05
-        MzQ3OTkwZGRiMDkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8g
-        d2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVt
-        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJmY2MyMjM4MC0yM2U1LTQwMDQtYjIyMS1lOTcxMzdi
-        NjM4NGUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjQ4ZjI2MDBhLTJkN2MtNGE2My05OWM5LWFiZGI3YzE4
-        MGIxMSIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5leGFtcGxl
-        LmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5l
-        eGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjU2YmNlZDUzNjUyNDUwNjY1MWZiNTExMyJ9LCAi
-        aWQiOiAiNTZiY2VkNTM2NTI0NTA2NjUxZmI1MTEzIn0=
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:21:40 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/75b3534a-fb90-42e3-b5f5-43d71f08ca62/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="ulafYwJFG7tEKrbKhb4daGVwYjFib9O3Hkpr8vZL2Y",
-        oauth_signature="5q2V1SoHYcqwBKwBqnBL99H7zPg%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455222101", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:21:41 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2178'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83NWIzNTM0YS1mYjkwLTQyZTMtYjVmNS00M2Q3MWYwOGNh
-        NjIvIiwgInRhc2tfaWQiOiAiNzViMzUzNGEtZmI5MC00MmUzLWI1ZjUtNDNk
-        NzFmMDhjYTYyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
-        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTFU
-        MjA6MjE6MzlaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
-        IjogIjIwMTYtMDItMTFUMjA6MjE6MzlaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzZmNjA4NWQwLTA3OTYtNDkwZS1hNzZkLWMwOWYyYjY1MTY3Yi8iLCAi
-        dGFza19pZCI6ICI2ZjYwODVkMC0wNzk2LTQ5MGUtYTc2ZC1jMDlmMmI2NTE2
-        N2IifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsi
-        Y29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3Rv
-        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
-        bV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAs
-        ICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNf
-        bGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1ZXVlIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5l
-        eGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTIt
-        OC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
-        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJjZWQ1MmM3ODIx
-        YjEzZDBmN2UxM2YifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
-        IjkiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0x
-        MVQyMDoyMTozOVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
-        bXBsZXRlZCI6ICIyMDE2LTAyLTExVDIwOjIxOjM5WiIsICJpbXBvcnRlcl90
-        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
-        bCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
-        dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAw
-        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmJjZWQ1M2M3ODIxYjE1
-        NDlhYzRlZjQiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
-        IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
-        ICI1NmJjZWQ1MzY1MjQ1MDY2NTFmYjUxMDMifSwgImlkIjogIjU2YmNlZDUz
-        NjUyNDUwNjY1MWZiNTEwMyJ9
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:21:41 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/6f6085d0-0796-490e-a76d-c09f2b65167b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="vN5lDuFXjorSOFpvP32llMyKadgVO2wpAEBMv9BjHOw",
-        oauth_signature="37NSeQKk7V%2BFHjNQ%2FW4pIH1GQc4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455222101", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:21:41 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6897'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82ZjYwODVkMC0wNzk2LTQ5MGUtYTc2ZC1jMDlm
-        MmI2NTE2N2IvIiwgInRhc2tfaWQiOiAiNmY2MDg1ZDAtMDc5Ni00OTBlLWE3
-        NmQtYzA5ZjJiNjUxNjdiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5
-        IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogIjIw
-        MTYtMDItMTFUMjA6MjE6NDBaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
-        dGFydF90aW1lIjogIjIwMTYtMDItMTFUMjA6MjE6NDBaIiwgInRyYWNlYmFj
-        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBv
-        cnQiOiB7IjkiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
-        ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAi
-        aW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQ5
-        MTkwNmJmLTQ0ZTQtNDQ0OC05N2NlLTUwNTQwMTEzMTkwYyIsICJudW1fcHJv
-        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBl
-        IjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI3MGU5NjI5Ny1hMmMwLTQ3OTEtOWFjOS1j
+        NjU1MTQ2N2U5YjIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0
+        YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVt
+        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI5ZWEzMmY2Yy1iNDYyLTQ0Y2QtOWE2My1kYTAwZWRkZmU3
+        NDQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0
+        ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAx
+        LCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1
+        YTkzZjc1Ny02YjJiLTQyYTMtODg4ZC00YzA4YTQ2NTdjMTMiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJw
+        dWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjYjFkODVlZC05
-        M2E3LTQ4YTMtOGUxYy1iYjI1MTE3YzNjYjIiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
-        c2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVtc190b3Rh
-        bCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI0ZTg5ZDZkNy1mOGU4LTQ1Y2QtODNiNy02NTM4ZDQ4NmFlZDIiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUi
-        OiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxODU5ZTNmMy01M2NjLTRiYTct
-        YTA4OC0yNWVmYWM0MTgxMWMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
-        bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJy
-        YXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        YjU4YzBhMzYtMmYwMC00NmQxLThhZTItOGQyMDIxNTMyOTM0IiwgIm51bV9w
-        cm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlv
-        biI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNv
-        bXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImQ2YjA0YjdlLTg2YTUtNDVmNi1hODZm
-        LTI2YjgwMWQwOGI4NyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1
-        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0
-        YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjog
-        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjdiM2U4YTI4LWYwYTAtNGExNS04NmY0LTE0N2MwZDYwOGQxZSIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRp
-        b24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJj
-        bG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjUxZjE5Mjc5
-        LTUxMDMtNDIzOC05NjYwLTJjMTg4Y2JmMjU3ZCIsICJudW1fcHJvY2Vzc2Vk
-        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2Vu
-        ZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRl
-        IHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE3ZWE0OTZmLWVlYzEtNGM5ZC1h
-        MDY5LTkzNDc5OTBkZGIwOSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxl
-        cyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5Iiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImZjYzIyMzgwLTIzZTUtNDAwNC1iMjIxLWU5NzEz
-        N2I2Mzg0ZSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiNDhmMjYwMGEtMmQ3Yy00YTYzLTk5YzktYWJkYjdjMTgw
-        YjExIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAicXVldWUiOiAicmVzZXJ2
-        ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUu
-        Y29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5l
-        eGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwg
-        ImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIjkiLCAic3RhcnRlZCI6
-        ICIyMDE2LTAyLTExVDIwOjIxOjQwWiIsICJfbnMiOiAicmVwb19wdWJsaXNo
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjA6MjE6NDBa
-        IiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjog
-        Inl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxp
-        dGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAi
-        RklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21l
-        dGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29t
-        cHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwg
-        InB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJG
-        SU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVz
-        c2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICI5IiwgImlkIjogIjU2
-        YmNlZDU0Yzc4MjFiMTU0OWFjNGVmNSIsICJkZXRhaWxzIjogW3sibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8g
-        bWV0YWRhdGEiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRh
-        ZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0OTE5MDZiZi00NGU0LTQ0NDgtOTdj
-        ZS01MDU0MDExMzE5MGMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9z
-        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJp
-        YnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAi
-        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiY2IxZDg1ZWQtOTNhNy00OGEzLThlMWMtYmIyNTEx
-        N2MzY2IyIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6
-        IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90
-        eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklO
-        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGU4OWQ2ZDctZjhlOC00
-        NWNkLTgzYjctNjUzOGQ0ODZhZWQyIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwg
-        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
-        IERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3Rv
-        dGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMTg1OWUzZjMtNTNjYy00YmE3LWEwODgtMjVlZmFjNDE4MTFjIiwg
-        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAi
-        ZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI1OGMwYTM2LTJmMDAtNDZkMS04
-        YWUyLThkMjAyMTUzMjkzNCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVt
-        X3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21w
-        cyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJkNmIwNGI3ZS04NmE1LTQ1ZjYtYTg2Zi0yNmI4MDFkMDhiODciLCAibnVt
-        X3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJt
-        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3YjNlOGEyOC1mMGEwLTRhMTUt
-        ODZmNC0xNDdjMGQ2MDhkMWUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
-        bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBt
-        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI1MWYxOTI3OS01MTAzLTQyMzgtOTY2MC0yYzE4
-        OGNiZjI1N2QiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVz
-        IiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICJhN2VhNDk2Zi1lZWMxLTRjOWQtYTA2OS05MzQ3OTkwZGRiMDkiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlw
-        ZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmY2My
-        MjM4MC0yM2U1LTQwMDQtYjIyMS1lOTcxMzdiNjM4NGUiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
-        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQ4ZjI2MDBh
-        LTJkN2MtNGE2My05OWM5LWFiZGI3YzE4MGIxMSIsICJudW1fcHJvY2Vzc2Vk
-        IjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJj
-        ZWQ1MzY1MjQ1MDY2NTFmYjUxMTMifSwgImlkIjogIjU2YmNlZDUzNjUyNDUw
-        NjY1MWZiNTExMyJ9
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjNmQ2MjUxNC1h
+        OGQ0LTQ4NDYtYjc1NS1kMWI2MWJmN2IwNjYiLCAibnVtX3Byb2Nlc3NlZCI6
+        IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRp
+        bmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9y
+        ZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI4ODhhNWJiLTM4OGEt
+        NDE3NS1iZDljLWFlYTU5ZGRmZDJjNiIsICJudW1fcHJvY2Vzc2VkIjogMX1d
+        fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQwYjk4
+        OTA1NGZjNDhiYTJlNDcifSwgImlkIjogIjU2Y2M4ZDBiOTg5MDU0ZmM0OGJh
+        MmU0NyJ9
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:21:41 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/257edee5-1874-4d1c-bba5-dd42307d44c0/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="GzjgrlvrV99ssOImhi5g3bCvUM29ZjdDFQxWXTM2Y",
-        oauth_signature="cirhQh3w68lcpjyE%2BYltcgm24L0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455222101", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:21:41 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '541'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yNTdlZGVlNS0xODc0LTRkMWMtYmJhNS1kZDQyMzA3ZDQ0
-        YzAvIiwgInRhc2tfaWQiOiAiMjU3ZWRlZTUtMTg3NC00ZDFjLWJiYTUtZGQ0
-        MjMwN2Q0NGMwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
-        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiBudWxsLCAiX25z
-        IjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3Jl
-        cG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6ICJ3YWl0
-        aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51bGwsICJl
-        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiY2VkNTU2NTI0NTA2
-        NjUxZmI1MTE0In0sICJpZCI6ICI1NmJjZWQ1NTY1MjQ1MDY2NTFmYjUxMTQi
-        fQ==
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:21:41 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/257edee5-1874-4d1c-bba5-dd42307d44c0/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="yi1Jn4WGX4DxBk66qCSIOLNrbQ6wvdz3BFv8IzHI",
-        oauth_signature="7ATM2QljtTKeiTsS3PzX0QrKYhs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1455222102", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 20:21:42 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '680'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yNTdlZGVlNS0xODc0LTRkMWMtYmJhNS1kZDQyMzA3ZDQ0
-        YzAvIiwgInRhc2tfaWQiOiAiMjU3ZWRlZTUtMTg3NC00ZDFjLWJiYTUtZGQ0
-        MjMwN2Q0NGMwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
-        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0x
-        MVQyMDoyMTo0MVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3Rp
-        bWUiOiAiMjAxNi0wMi0xMVQyMDoyMTo0MVoiLCAidHJhY2ViYWNrIjogbnVs
-        bCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9
-        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
-        by0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVk
-        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
-        QGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmNlZDU1NjUy
-        NDUwNjY1MWZiNTExNCJ9LCAiaWQiOiAiNTZiY2VkNTU2NTI0NTA2NjUxZmI1
-        MTE0In0=
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 20:21:42 GMT
-- request:
-    method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IjkiLCJkaXNwbGF5X25hbWUiOiJSSEVMIDcgeDg2XzY0IiwiaW1w
-        b3J0ZXJfdHlwZV9pZCI6Inl1bV9pbXBvcnRlciIsImltcG9ydGVyX2NvbmZp
-        ZyI6eyJmZWVkIjoiZmlsZTovLy92YXIvd3d3L3Rlc3RfcmVwb3Mvem9vIiwi
-        c3NsX2NhX2NlcnQiOm51bGwsInNzbF9jbGllbnRfY2VydCI6bnVsbCwic3Ns
-        X2NsaWVudF9rZXkiOm51bGwsImRvd25sb2FkX3BvbGljeSI6bnVsbH0sIm5v
-        dGVzIjp7Il9yZXBvLXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMi
-        Olt7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJk
-        aXN0cmlidXRvcl9jb25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRo
-        IiwiaHR0cCI6ZmFsc2UsImh0dHBzIjp0cnVlLCJwcm90ZWN0ZWQiOnRydWV9
-        LCJhdXRvX3B1Ymxpc2giOnRydWUsImRpc3RyaWJ1dG9yX2lkIjoiOSJ9LHsi
-        ZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9jbG9uZV9kaXN0cmlidXRvciIs
-        ImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRv
-        cl9pZCI6IjkifSwiYXV0b19wdWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiI5X2Nsb25lIn1dfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '601'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Fri, 12 Feb 2016 19:05:57 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '301'
-      Location:
-      - https://katello-burrito.example.com/pulp/api/v2/repositories/9/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUkhFTCA3IHg4
-        Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRkZWQi
-        OiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwg
-        Imxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3Vu
-        dHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZTJkMTU2NzdjNzQyZDA2Y2NjZTYzIn0sICJpZCI6ICI5IiwgIl9ocmVmIjog
-        Ii9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvOS8ifQ==
-    http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:05:57 GMT
-- request:
-    method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/9/actions/sync/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
-        Ijp0cnVlfX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '53'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: ACCEPTED
-    headers:
-      Date:
-      - Fri, 12 Feb 2016 19:05:57 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2EwM2Q5NzNiLTFiMzgtNGY5ZS05MGQ0LWE0YTRjOGQwYTIxMi8iLCAi
-        dGFza19pZCI6ICJhMDNkOTczYi0xYjM4LTRmOWUtOTBkNC1hNGE0YzhkMGEy
-        MTIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:05:57 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/a03d973b-1b38-4f9e-90d4-a4a4c8d0a212/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 12 Feb 2016 19:05:57 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '539'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hMDNkOTczYi0xYjM4LTRmOWUtOTBkNC1hNGE0YzhkMGEy
-        MTIvIiwgInRhc2tfaWQiOiAiYTAzZDk3M2ItMWIzOC00ZjllLTkwZDQtYTRh
-        NGM4ZDBhMjEyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
-        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
-        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogbnVsbCwgInRyYWNlYmFj
-        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBv
-        cnQiOiB7fSwgInF1ZXVlIjogIk5vbmUuZHEiLCAic3RhdGUiOiAid2FpdGlu
-        ZyIsICJ3b3JrZXJfbmFtZSI6IG51bGwsICJyZXN1bHQiOiBudWxsLCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmUyZDE1MzQ0NzFlNDAw
-        NzBiMGM2ZSJ9LCAiaWQiOiAiNTZiZTJkMTUzNDQ3MWU0MDA3MGIwYzZlIn0=
-    http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:05:57 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/a03d973b-1b38-4f9e-90d4-a4a4c8d0a212/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 12 Feb 2016 19:05:58 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2308'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hMDNkOTczYi0xYjM4LTRmOWUtOTBkNC1hNGE0YzhkMGEy
-        MTIvIiwgInRhc2tfaWQiOiAiYTAzZDk3M2ItMWIzOC00ZjllLTkwZDQtYTRh
-        NGM4ZDBhMjEyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
-        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTJU
-        MTk6MDU6NThaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
-        IjogIjIwMTYtMDItMTJUMTk6MDU6NTdaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzgyOTZkZjg1LWU5YjctNDNmNS1iMDg3LTliZTg5NDY5Njc5OC8iLCAi
-        dGFza19pZCI6ICI4Mjk2ZGY4NS1lOWI3LTQzZjUtYjA4Ny05YmU4OTQ2OTY3
-        OTgifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsi
-        Y29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3Rv
-        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
-        bV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAs
-        ICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xl
-        ZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
-        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJy
-        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRlbGxvLWJ1cnJpdG8uZXhh
-        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25h
-        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1idXJy
-        aXRvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZiZTJkMTU2NzdjNzQy
-        ZDA2Y2NjZTY0In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICI5
-        IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMTJU
-        MTk6MDU6NTdaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21w
-        bGV0ZWQiOiAiMjAxNi0wMi0xMlQxOTowNTo1OFoiLCAiaW1wb3J0ZXJfdHlw
-        ZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGws
-        ICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In19LCAiYWRkZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmJlMmQxNjY3N2M3NDRhNGU5
-        YTczZTgiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0
-        ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZTJkMTUzNDQ3MWU0MDA3MGIwYzZlIn0sICJpZCI6ICI1NmJlMmQxNTM0NDcx
-        ZTQwMDcwYjBjNmUifQ==
-    http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:05:58 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/8296df85-e9b7-43f5-b087-9be894696798/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 12 Feb 2016 19:05:58 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '650'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84Mjk2ZGY4NS1lOWI3LTQzZjUtYjA4Ny05YmU4
-        OTQ2OTY3OTgvIiwgInRhc2tfaWQiOiAiODI5NmRmODUtZTliNy00M2Y1LWIw
-        ODctOWJlODk0Njk2Nzk4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5
-        IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogbnVs
-        bCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogbnVsbCwg
-        InRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9n
-        cmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNl
-        X3dvcmtlci0wQGthdGVsbG8tYnVycml0by5leGFtcGxlLmNvbS5kcSIsICJz
-        dGF0ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
-        c291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVycml0by5leGFtcGxlLmNvbSIs
-        ICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjU2YmUyZDE2MzQ0NzFlNDAwNzBiMGM3ZSJ9LCAiaWQiOiAiNTZiZTJk
-        MTYzNDQ3MWU0MDA3MGIwYzdlIn0=
-    http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:05:58 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/a03d973b-1b38-4f9e-90d4-a4a4c8d0a212/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 12 Feb 2016 19:05:58 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2308'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hMDNkOTczYi0xYjM4LTRmOWUtOTBkNC1hNGE0YzhkMGEy
-        MTIvIiwgInRhc2tfaWQiOiAiYTAzZDk3M2ItMWIzOC00ZjllLTkwZDQtYTRh
-        NGM4ZDBhMjEyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
-        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTJU
-        MTk6MDU6NThaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
-        IjogIjIwMTYtMDItMTJUMTk6MDU6NTdaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzgyOTZkZjg1LWU5YjctNDNmNS1iMDg3LTliZTg5NDY5Njc5OC8iLCAi
-        dGFza19pZCI6ICI4Mjk2ZGY4NS1lOWI3LTQzZjUtYjA4Ny05YmU4OTQ2OTY3
-        OTgifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsi
-        Y29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3Rv
-        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
-        bV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAs
-        ICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xl
-        ZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
-        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJy
-        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRlbGxvLWJ1cnJpdG8uZXhh
-        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25h
-        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1idXJy
-        aXRvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZiZTJkMTU2NzdjNzQy
-        ZDA2Y2NjZTY0In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICI5
-        IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMTJU
-        MTk6MDU6NTdaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21w
-        bGV0ZWQiOiAiMjAxNi0wMi0xMlQxOTowNTo1OFoiLCAiaW1wb3J0ZXJfdHlw
-        ZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGws
-        ICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In19LCAiYWRkZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmJlMmQxNjY3N2M3NDRhNGU5
-        YTczZTgiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0
-        ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZTJkMTUzNDQ3MWU0MDA3MGIwYzZlIn0sICJpZCI6ICI1NmJlMmQxNTM0NDcx
-        ZTQwMDcwYjBjNmUifQ==
-    http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:05:58 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/8296df85-e9b7-43f5-b087-9be894696798/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 12 Feb 2016 19:05:58 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6897'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84Mjk2ZGY4NS1lOWI3LTQzZjUtYjA4Ny05YmU4
-        OTQ2OTY3OTgvIiwgInRhc2tfaWQiOiAiODI5NmRmODUtZTliNy00M2Y1LWIw
-        ODctOWJlODk0Njk2Nzk4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5
-        IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogIjIw
-        MTYtMDItMTJUMTk6MDU6NThaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
-        dGFydF90aW1lIjogIjIwMTYtMDItMTJUMTk6MDU6NThaIiwgInRyYWNlYmFj
-        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBv
-        cnQiOiB7IjkiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
-        ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAi
-        aW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjVj
-        M2MzNWIwLWNkNDUtNDdmYy1hMTFhLWY3ODNiOTkyMTVlMiIsICJudW1fcHJv
-        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBl
-        IjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZDcyMWUzZC04
-        NDcyLTRmZTItYTk2MC0wZjdiODY0YzlmZjkiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
-        c2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVtc190b3Rh
-        bCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI2Zjg1NGQ5OS1jZDY3LTRhNjEtOWYwZC1lOWZjZTFhZjkxNTIiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUi
-        OiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNzg1MzVlZi1lOWExLTQ3NWMt
-        YmNjOS03YWE4ZjNmYjEyYmEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
-        bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJy
-        YXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        NTU3YzYwYzktOTAzOS00MWJkLWIzM2EtZjc2OTMyOTFiNGExIiwgIm51bV9w
-        cm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlv
-        biI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNv
-        bXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjMxNGRjOGEwLWMzM2YtNDE5NC05ZDk5
-        LWI2Y2M0ZmM5NDE0MyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1
-        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0
-        YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjog
-        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjBhMTFkZjlhLTA4MmQtNDc4Ny04N2Q2LTg1ZjQzNGIxNWYwYyIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRp
-        b24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJj
-        bG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE4YmE1ZDJm
-        LTY1ZTYtNGU4OS1iODMzLWRkNjg0MzBmNjEzMyIsICJudW1fcHJvY2Vzc2Vk
-        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2Vu
-        ZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRl
-        IHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjIyZmE5ODJiLTM5MGUtNDMzNC1h
-        ODM3LWQwOWY4M2ZlNzlhYiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxl
-        cyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5Iiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImE3OWZlMDk0LTQwN2ItNDYwYS1hNjExLThlZjBm
-        MmM4MDIyOSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiZDdjNGQyZTItYjZkMi00NDljLTk0MjUtZGQyNGE3MmFl
-        OGRjIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAicXVldWUiOiAicmVzZXJ2
-        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUu
-        Y29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVycml0by5l
-        eGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwg
-        ImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIjkiLCAic3RhcnRlZCI6
-        ICIyMDE2LTAyLTEyVDE5OjA1OjU4WiIsICJfbnMiOiAicmVwb19wdWJsaXNo
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTJUMTk6MDU6NTha
-        IiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjog
-        Inl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxp
-        dGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAi
-        RklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21l
-        dGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29t
-        cHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwg
-        InB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJG
-        SU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVz
-        c2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICI5IiwgImlkIjogIjU2
-        YmUyZDE2Njc3Yzc0NGE0ZTlhNzNlOSIsICJkZXRhaWxzIjogW3sibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8g
-        bWV0YWRhdGEiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRh
-        ZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1YzNjMzViMC1jZDQ1LTQ3ZmMtYTEx
-        YS1mNzgzYjk5MjE1ZTIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9z
-        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJp
-        YnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAi
-        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiYWQ3MjFlM2QtODQ3Mi00ZmUyLWE5NjAtMGY3Yjg2
-        NGM5ZmY5IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6
-        IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90
-        eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklO
-        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNmY4NTRkOTktY2Q2Ny00
-        YTYxLTlmMGQtZTlmY2UxYWY5MTUyIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwg
-        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
-        IERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3Rv
-        dGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYTc4NTM1ZWYtZTlhMS00NzVjLWJjYzktN2FhOGYzZmIxMmJhIiwg
-        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAi
-        ZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjU1N2M2MGM5LTkwMzktNDFiZC1i
-        MzNhLWY3NjkzMjkxYjRhMSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVt
-        X3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21w
-        cyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICIzMTRkYzhhMC1jMzNmLTQxOTQtOWQ5OS1iNmNjNGZjOTQxNDMiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJt
-        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYTExZGY5YS0wODJkLTQ3ODct
-        ODdkNi04NWY0MzRiMTVmMGMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
-        bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBt
-        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIxOGJhNWQyZi02NWU2LTRlODktYjgzMy1kZDY4
-        NDMwZjYxMzMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVz
-        IiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICIyMmZhOTgyYi0zOTBlLTQzMzQtYTgzNy1kMDlmODNmZTc5YWIiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlw
-        ZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNzlm
-        ZTA5NC00MDdiLTQ2MGEtYTYxMS04ZWYwZjJjODAyMjkiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
-        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ3YzRkMmUy
-        LWI2ZDItNDQ5Yy05NDI1LWRkMjRhNzJhZThkYyIsICJudW1fcHJvY2Vzc2Vk
-        IjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJl
-        MmQxNjM0NDcxZTQwMDcwYjBjN2UifSwgImlkIjogIjU2YmUyZDE2MzQ0NzFl
-        NDAwNzBiMGM3ZSJ9
-    http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:05:58 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:08 GMT
 - request:
     method: delete
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/9/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4323,7 +460,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Fri, 12 Feb 2016 19:05:59 GMT
+      - Tue, 23 Feb 2016 16:47:08 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -4336,14 +473,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2M3MGY5MDBjLWUxMzItNDQ4NC1hM2I4LWRkYWJiNjFmZmFhZi8iLCAi
-        dGFza19pZCI6ICJjNzBmOTAwYy1lMTMyLTQ0ODQtYTNiOC1kZGFiYjYxZmZh
-        YWYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzJlMGYwNmU3LWU5MmQtNDc0Yy05MDFmLWM0Zjk3NGFiOGVmZS8iLCAi
+        dGFza19pZCI6ICIyZTBmMDZlNy1lOTJkLTQ3NGMtOTAxZi1jNGY5NzRhYjhl
+        ZmUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:05:59 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:08 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/c70f900c-e132-4484-a3b8-ddabb61ffaaf/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/2e0f06e7-e92d-474c-901f-c4f974ab8efe/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4362,13 +499,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 12 Feb 2016 19:05:59 GMT
+      - Tue, 23 Feb 2016 16:47:08 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '541'
+      - '655'
       Connection:
       - close
       Content-Type:
@@ -4378,22 +515,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jNzBmOTAwYy1lMTMyLTQ0ODQtYTNiOC1kZGFiYjYxZmZh
-        YWYvIiwgInRhc2tfaWQiOiAiYzcwZjkwMGMtZTEzMi00NDg0LWEzYjgtZGRh
-        YmI2MWZmYWFmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
+        aS92Mi90YXNrcy8yZTBmMDZlNy1lOTJkLTQ3NGMtOTAxZi1jNGY5NzRhYjhl
+        ZmUvIiwgInRhc2tfaWQiOiAiMmUwZjA2ZTctZTkyZC00NzRjLTkwMWYtYzRm
+        OTc0YWI4ZWZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
         bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiBudWxsLCAiX25z
-        IjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3Jl
-        cG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6ICJ3YWl0
-        aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51bGwsICJl
-        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiZTJkMTczNDQ3MWU0
-        MDA3MGIwYzdmIn0sICJpZCI6ICI1NmJlMmQxNzM0NDcxZTQwMDcwYjBjN2Yi
-        fQ==
+        IjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1Qx
+        Njo0NzowOFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3Mi
+        OiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVz
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNTZjYzhkMGM5ODkwNTRmYzQ4YmEyZTQ4In0sICJpZCI6ICI1
+        NmNjOGQwYzk4OTA1NGZjNDhiYTJlNDgifQ==
     http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:05:59 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:08 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/c70f900c-e132-4484-a3b8-ddabb61ffaaf/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/2e0f06e7-e92d-474c-901f-c4f974ab8efe/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4412,13 +551,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 12 Feb 2016 19:05:59 GMT
+      - Tue, 23 Feb 2016 16:47:09 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '680'
+      - '674'
       Connection:
       - close
       Content-Type:
@@ -4428,20 +567,19 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jNzBmOTAwYy1lMTMyLTQ0ODQtYTNiOC1kZGFiYjYxZmZh
-        YWYvIiwgInRhc2tfaWQiOiAiYzcwZjkwMGMtZTEzMi00NDg0LWEzYjgtZGRh
-        YmI2MWZmYWFmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
-        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0x
-        MlQxOTowNTo1OVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3Rp
-        bWUiOiAiMjAxNi0wMi0xMlQxOTowNTo1OVoiLCAidHJhY2ViYWNrIjogbnVs
+        aS92Mi90YXNrcy8yZTBmMDZlNy1lOTJkLTQ3NGMtOTAxZi1jNGY5NzRhYjhl
+        ZmUvIiwgInRhc2tfaWQiOiAiMmUwZjA2ZTctZTkyZC00NzRjLTkwMWYtYzRm
+        OTc0YWI4ZWZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo5IiwgInB1
+        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0y
+        M1QxNjo0NzowOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3Rp
+        bWUiOiAiMjAxNi0wMi0yM1QxNjo0NzowOFoiLCAidHJhY2ViYWNrIjogbnVs
         bCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9
-        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAa2F0ZWxs
-        by1idXJyaXRvLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVk
-        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0w
-        QGthdGVsbG8tYnVycml0by5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmUyZDE3MzQ0
-        NzFlNDAwNzBiMGM3ZiJ9LCAiaWQiOiAiNTZiZTJkMTczNDQ3MWU0MDA3MGIw
-        YzdmIn0=
+        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
+        by15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDBjOTg5MDU0ZmM0
+        OGJhMmU0OCJ9LCAiaWQiOiAiNTZjYzhkMGM5ODkwNTRmYzQ4YmEyZTQ4In0=
     http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:05:59 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:09 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/actions/pulp/repository/remove_schedule/remove_schedule.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp/repository/remove_schedule/remove_schedule.yml
@@ -10,7 +10,8 @@ http_interactions:
         ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
         b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
         ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
+        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
+        IjpudWxsLCJyZW1vdmVfbWlzc2luZyI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
         LXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1
         dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9j
         b25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIiwiaHR0cCI6ZmFs
@@ -20,12 +21,10 @@ http_interactions:
         dHJpYnV0b3JfY29uZmlnIjp7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lk
         IjoiRmVkb3JhXzE3In0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1
         dG9yX2lkIjoiRmVkb3JhXzE3X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBl
-        X2lkIjoibm9kZXNfaHR0cF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2Nv
-        bmZpZyI6e30sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3JfaWQi
-        OiJGZWRvcmFfMTdfbm9kZXMifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJl
-        eHBvcnRfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0
-        cCI6ZmFsc2UsImh0dHBzIjpmYWxzZX0sImF1dG9fcHVibGlzaCI6ZmFsc2Us
-        ImRpc3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
+        X2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmln
+        Ijp7Imh0dHAiOmZhbHNlLCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6
+        InRlc3RfcGF0aCJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRv
+        cl9pZCI6ImV4cG9ydF9kaXN0cmlidXRvciJ9XX0=
     headers:
       Accept:
       - application/json
@@ -33,14 +32,8 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4",
-        oauth_nonce="eUt8PVft5LplYEXgoNiYiYWjojvlxNKOb6cXmDaU2GU", oauth_signature="UMriKPbmsV3SRKXngJE8NRNvBX8%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454291938", oauth_version="1.0"
-      Pulp-User:
-      - admin
       Content-Length:
-      - '895'
+      - '839'
       User-Agent:
       - Ruby
   response:
@@ -49,7 +42,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Mon, 01 Feb 2016 01:58:58 GMT
+      - Tue, 23 Feb 2016 16:47:02 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -68,568 +61,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZhZWJiZTJkZTA0MDMzNDZjZjY0OTU2In0sICJpZCI6ICJGZWRvcmFfMTci
+        NTZjYzhkMDZkZTA0MDMzZjQzNTE0ZjM2In0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:58:58 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:03 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/48dfe354-5c0c-437b-8ec3-31c746eddc2d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="wyuwWNZl382N9076QPsH3RcMvmXa1590Ek7ffMeH8g",
-        oauth_signature="imnhoLhh227Cpv%2FnBJtTdPRx2XE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291939", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:58:59 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '645'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80OGRmZTM1NC01YzBjLTQzN2ItOGVjMy0zMWM3NDZlZGRj
-        MmQvIiwgInRhc2tfaWQiOiAiNDhkZmUzNTQtNWMwYy00MzdiLThlYzMtMzFj
-        NzQ2ZWRkYzJkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3Rh
-        dGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmJlM2U1NDk3NWY3MWE2YTY0MmQifSwgImlkIjogIjU2YWViYmUzZTU0
-        OTc1ZjcxYTZhNjQyZCJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:58:59 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/48dfe354-5c0c-437b-8ec3-31c746eddc2d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="nclFAsd6atpKSCv3VNJLeODcXw2NVBpTJef6Q3434Q",
-        oauth_signature="TRLFd0bLGBLFySvlx7Zd%2BqiAhxE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291939", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:58:59 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '682'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80OGRmZTM1NC01YzBjLTQzN2ItOGVjMy0zMWM3NDZlZGRj
-        MmQvIiwgInRhc2tfaWQiOiAiNDhkZmUzNTQtNWMwYy00MzdiLThlYzMtMzFj
-        NzQ2ZWRkYzJkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTAxVDAxOjU4OjU5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTAxVDAxOjU4OjU5WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
-        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJiZTNl
-        NTQ5NzVmNzFhNmE2NDJkIn0sICJpZCI6ICI1NmFlYmJlM2U1NDk3NWY3MWE2
-        YTY0MmQifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:58:59 GMT
-- request:
-    method: post
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
-        IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRp
-        c3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwi
-        OiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3Rl
-        Y3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJleHBvcnRfZGlzdHJpYnV0
-        b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBz
-        IjpmYWxzZSwicmVsYXRpdmVfdXJsIjpudWxsfSwiYXV0b19wdWJsaXNoIjpm
-        YWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJleHBvcnRfZGlzdHJpYnV0b3IifV19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
-        oauth_nonce="CrZo9hUKFzJkBSxWuTQaUCZNoxciJsEpA665clALBJQ", oauth_signature="pnslY8Rk%2FB9NtDjgzxLvYEewB8s%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454693650", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '810'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:10 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '320'
-      Location:
-      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiNGRkMTJjNzgyMWIzMzAzNGJhZjJjIn0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:10 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/559db75e-f889-4d1c-bfe1-9efab3064b63/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="saMMQTmnJYkPMjBKxVRLxqSssgy3c7kK9wy4FiXk",
-        oauth_signature="x%2FeSfzMVJL2w6fTnG1jt2dISZwI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693651", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:11 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81NTlkYjc1ZS1mODg5LTRkMWMtYmZlMS05ZWZhYjMwNjRi
-        NjMvIiwgInRhc2tfaWQiOiAiNTU5ZGI3NWUtZjg4OS00ZDFjLWJmZTEtOWVm
-        YWIzMDY0YjYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0ZGQx
-        MzhhZGE0MGRiMDRlZTBmM2QifSwgImlkIjogIjU2YjRkZDEzOGFkYTQwZGIw
-        NGVlMGYzZCJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:11 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/559db75e-f889-4d1c-bfe1-9efab3064b63/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="iO5RBO9dAvTQYtqYVwFV2SSqGADANvdDssZhz7AbTU",
-        oauth_signature="77A0leN1GV%2Fr9k4cIQME9z3isFo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693652", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:12 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81NTlkYjc1ZS1mODg5LTRkMWMtYmZlMS05ZWZhYjMwNjRi
-        NjMvIiwgInRhc2tfaWQiOiAiNTU5ZGI3NWUtZjg4OS00ZDFjLWJmZTEtOWVm
-        YWIzMDY0YjYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA1VDE3OjM0OjEyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE3OjM0OjEyWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        NGRkMTM4YWRhNDBkYjA0ZWUwZjNkIn0sICJpZCI6ICI1NmI0ZGQxMzhhZGE0
-        MGRiMDRlZTBmM2QifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:12 GMT
-- request:
-    method: post
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
-        IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRp
-        c3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwi
-        OiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3Rl
-        Y3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJleHBvcnRfZGlzdHJpYnV0
-        b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBz
-        IjpmYWxzZSwicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIn0sImF1dG9fcHVi
-        bGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1
-        dG9yIn1dfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb",
-        oauth_nonce="r8y44ekqtIojrzDO3LWrz7NU9gwiuZ3P5RK1CsNaKV0", oauth_signature="MkKYj3c3uyZ%2BzTSnr0nCQgRxPps%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454949474", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '817'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:37:54 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '320'
-      Location:
-      - https://katello-centos7-devel.example.com/pulp/api/v2/repositories/Fedora_17/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: US-ASCII
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiOGM0NjIxN2YyNWUwZGE0OGI4NDBkIn0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:37:54 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/59e4e94d-3913-4944-975a-fddc239fd7b1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="eEfMcjDOLnU0w9xmeFy84rgpd1DsMLynqePv0KUHUk",
-        oauth_signature="%2BvgHkRg%2BEFlsNAoHASKC5gU45WU%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949475", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:37:55 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '663'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81OWU0ZTk0ZC0zOTEzLTQ5NDQtOTc1YS1mZGRjMjM5ZmQ3
-        YjEvIiwgInRhc2tfaWQiOiAiNTllNGU5NGQtMzkxMy00OTQ0LTk3NWEtZmRk
-        YzIzOWZkN2IxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20u
-        ZHEiLCAic3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwu
-        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
-        Il9pZCI6IHsiJG9pZCI6ICI1NmI4YzQ2M2MxOWZmNTA3OTgyM2YyMzYifSwg
-        ImlkIjogIjU2YjhjNDYzYzE5ZmY1MDc5ODIzZjIzNiJ9
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:37:55 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/59e4e94d-3913-4944-975a-fddc239fd7b1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="mPhMWTCsYBb2rcPtqlqXcTMju9djBY2eREqJbuItXY",
-        oauth_signature="ij9O77X1wGat35N5Fp%2BdP96j1vA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949475", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:37:56 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '700'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81OWU0ZTk0ZC0zOTEzLTQ5NDQtOTc1YS1mZGRjMjM5ZmQ3
-        YjEvIiwgInRhc2tfaWQiOiAiNTllNGU5NGQtMzkxMy00OTQ0LTk3NWEtZmRk
-        YzIzOWZkN2IxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA4VDE2OjM3OjU1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA4VDE2OjM3OjU1WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20uZHEiLCAic3Rh
-        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUu
-        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNTZiOGM0NjNjMTlmZjUwNzk4MjNmMjM2In0sICJpZCI6ICI1
-        NmI4YzQ2M2MxOWZmNTA3OTgyM2YyMzYifQ==
-    http_version:
-  recorded_at: Mon, 08 Feb 2016 16:37:56 GMT
-- request:
-    method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
-        IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRp
-        c3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwi
-        OiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3Rl
-        Y3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifV19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '636'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:56:48 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '320'
-      Location:
-      - https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiZDAzYTA2NzdjNzQyZDA0OWIwMGEyIn0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:56:48 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -648,7 +87,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:56:49 GMT
+      - Tue, 23 Feb 2016 16:47:03 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -662,10 +101,10 @@ http_interactions:
       base64_string: |
         W10=
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:56:49 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:03 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -684,43 +123,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:56:49 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '2'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W10=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:56:49 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:56:49 GMT
+      - Tue, 23 Feb 2016 16:47:03 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -734,10 +137,46 @@ http_interactions:
       base64_string: |
         W10=
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:56:49 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:03 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:47:03 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '2'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        W10=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:03 GMT
 - request:
     method: delete
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -756,7 +195,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:56:50 GMT
+      - Tue, 23 Feb 2016 16:47:03 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -769,14 +208,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzBmYWVkNTIwLTlhZWYtNDE4Zi1iYTM3LWYxMzJlNDM1MjcxMy8iLCAi
-        dGFza19pZCI6ICIwZmFlZDUyMC05YWVmLTQxOGYtYmEzNy1mMTMyZTQzNTI3
-        MTMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzlhMGEwMWZlLTFkYWUtNDYwNi1iNDkwLTI1YzMzYTNhMDU5MS8iLCAi
+        dGFza19pZCI6ICI5YTBhMDFmZS0xZGFlLTQ2MDYtYjQ5MC0yNWMzM2EzYTA1
+        OTEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:56:50 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:03 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/0faed520-9aef-418f-ba37-f132e4352713/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/9a0a01fe-1dae-4606-b490-25c33a3a0591/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -795,13 +234,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:56:50 GMT
+      - Tue, 23 Feb 2016 16:47:03 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '645'
       Connection:
       - close
       Content-Type:
@@ -811,22 +250,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wZmFlZDUyMC05YWVmLTQxOGYtYmEzNy1mMTMyZTQzNTI3
-        MTMvIiwgInRhc2tfaWQiOiAiMGZhZWQ1MjAtOWFlZi00MThmLWJhMzctZjEz
-        MmU0MzUyNzEzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy85YTBhMDFmZS0xZGFlLTQ2MDYtYjQ5MC0yNWMzM2EzYTA1
+        OTEvIiwgInRhc2tfaWQiOiAiOWEwYTAxZmUtMWRhZS00NjA2LWI0OTAtMjVj
+        MzNhM2EwNTkxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
         bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
         ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJkMDNh
-        MjM0NDcxZTQwMDcwYjA5NjcifSwgImlkIjogIjU2YmQwM2EyMzQ0NzFlNDAw
-        NzBiMDk2NyJ9
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3Rh
+        dGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        NmNjOGQwNzk4OTA1NGZjNDhiYTJlMjQifSwgImlkIjogIjU2Y2M4ZDA3OTg5
+        MDU0ZmM0OGJhMmUyNCJ9
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:56:50 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:03 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/0faed520-9aef-418f-ba37-f132e4352713/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/9a0a01fe-1dae-4606-b490-25c33a3a0591/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -845,13 +286,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:56:50 GMT
+      - Tue, 23 Feb 2016 16:47:04 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '688'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -861,20 +302,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wZmFlZDUyMC05YWVmLTQxOGYtYmEzNy1mMTMyZTQzNTI3
-        MTMvIiwgInRhc2tfaWQiOiAiMGZhZWQ1MjAtOWFlZi00MThmLWJhMzctZjEz
-        MmU0MzUyNzEzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy85YTBhMDFmZS0xZGFlLTQ2MDYtYjQ5MC0yNWMzM2EzYTA1
+        OTEvIiwgInRhc2tfaWQiOiAiOWEwYTAxZmUtMWRhZS00NjA2LWI0OTAtMjVj
+        MzNhM2EwNTkxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTExVDIxOjU2OjUwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTExVDIxOjU2OjUwWiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ3OjAzWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ3OjAzWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZDAzYTIzNDQ3MWU0MDA3MGIwOTY3In0sICJpZCI6ICI1NmJkMDNhMjM0NDcx
-        ZTQwMDcwYjA5NjcifQ==
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMDc5
+        ODkwNTRmYzQ4YmEyZTI0In0sICJpZCI6ICI1NmNjOGQwNzk4OTA1NGZjNDhi
+        YTJlMjQifQ==
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:56:50 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:04 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/actions/pulp/repository/sync/sync.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp/repository/sync/sync.yml
@@ -10,7 +10,8 @@ http_interactions:
         ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
         b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
         ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
+        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
+        IjpudWxsLCJyZW1vdmVfbWlzc2luZyI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
         LXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1
         dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9j
         b25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIiwiaHR0cCI6ZmFs
@@ -20,12 +21,10 @@ http_interactions:
         dHJpYnV0b3JfY29uZmlnIjp7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lk
         IjoiRmVkb3JhXzE3In0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1
         dG9yX2lkIjoiRmVkb3JhXzE3X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBl
-        X2lkIjoibm9kZXNfaHR0cF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2Nv
-        bmZpZyI6e30sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3JfaWQi
-        OiJGZWRvcmFfMTdfbm9kZXMifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJl
-        eHBvcnRfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0
-        cCI6ZmFsc2UsImh0dHBzIjpmYWxzZX0sImF1dG9fcHVibGlzaCI6ZmFsc2Us
-        ImRpc3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
+        X2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmln
+        Ijp7Imh0dHAiOmZhbHNlLCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6
+        InRlc3RfcGF0aCJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRv
+        cl9pZCI6ImV4cG9ydF9kaXN0cmlidXRvciJ9XX0=
     headers:
       Accept:
       - application/json
@@ -33,14 +32,8 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4",
-        oauth_nonce="362x6qewuiku2FlLYR31KCZjyXipim58uqBPrMUF8", oauth_signature="M4HUjYZvgh686jdQ5eVxFkZ2uAo%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454291940", oauth_version="1.0"
-      Pulp-User:
-      - admin
       Content-Length:
-      - '895'
+      - '839'
       User-Agent:
       - Ruby
   response:
@@ -49,7 +42,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Mon, 01 Feb 2016 01:59:00 GMT
+      - Tue, 23 Feb 2016 16:47:04 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -68,3082 +61,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZhZWJiZTRkZTA0MDMzNDZkMTg4ZmMwIn0sICJpZCI6ICJGZWRvcmFfMTci
+        NTZjYzhkMDhkZTA0MDMzZjQzNTE0ZjNlIn0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:00 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/6eefccea-6aba-487c-b01b-7c485278f725/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="0KTFb9lIjUZogdZpJrsOoDPgED9jkBt546a5iVJvs",
-        oauth_signature="dR3LJZnfaZZNuoGGq5RDwppjzuc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291940", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:00 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82ZWVmY2NlYS02YWJhLTQ4N2MtYjAxYi03YzQ4NTI3OGY3
-        MjUvIiwgInRhc2tfaWQiOiAiNmVlZmNjZWEtNmFiYS00ODdjLWIwMWItN2M0
-        ODUyNzhmNzI1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJiZTRl
-        NTQ5NzVmNzFhNmE2NDJlIn0sICJpZCI6ICI1NmFlYmJlNGU1NDk3NWY3MWE2
-        YTY0MmUifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:00 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/6eefccea-6aba-487c-b01b-7c485278f725/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="nfQ091l8oy264U75iUjOXrznQLWHwjLYT7EGePTtOY",
-        oauth_signature="YnUi3Tkf6VZadKW1mZCaJJoHxXQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291941", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:01 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2310'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82ZWVmY2NlYS02YWJhLTQ4N2MtYjAxYi03YzQ4NTI3OGY3
-        MjUvIiwgInRhc2tfaWQiOiAiNmVlZmNjZWEtNmFiYS00ODdjLWIwMWItN2M0
-        ODUyNzhmNzI1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMTo1OTowMVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OTowMFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZmFhYzlkNDItZGZiNy00NzU2LWEzZDItMGUwYTU4Mjg5
-        MGE2LyIsICJ0YXNrX2lkIjogImZhYWM5ZDQyLWRmYjctNDc1Ni1hM2QyLTBl
-        MGE1ODI4OTBhNiJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82
-        ODdhNGM4NC1lMGMxLTRjMjYtODAxYi03Y2I4YTM4ZWYxZDAvIiwgInRhc2tf
-        aWQiOiAiNjg3YTRjODQtZTBjMS00YzI2LTgwMWItN2NiOGEzOGVmMWQwIn1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJiZTRkZTA0MDMzNDZkMTg4ZmMx
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MTo1OTowMFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAxOjU5OjAwWiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmJlNGRlMDQwMzRjZDky
-        ZGM1MDYiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmJlNGU1NDk3NWY3MWE2YTY0MmUifSwgImlkIjogIjU2YWViYmU0ZTU0
-        OTc1ZjcxYTZhNjQyZSJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:01 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/faac9d42-dfb7-4756-a3d2-0e0a582890a6/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="LuAUZVSPw9T9geaR7xKk0fgyGtL3BEnl8SR8H4lLukA",
-        oauth_signature="xk3Lh9Ui8KEH75zQ8EbTN2rb7KE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291941", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:01 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9mYWFjOWQ0Mi1kZmI3LTQ3NTYtYTNkMi0wZTBh
-        NTgyODkwYTYvIiwgInRhc2tfaWQiOiAiZmFhYzlkNDItZGZiNy00NzU2LWEz
-        ZDItMGUwYTU4Mjg5MGE2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMTo1OTowMVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OTowMVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDE6NTk6MDFaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMTo1OTowMVoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmJlNWRlMDQwMzRjZDkyZGM1MDciLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJiZTRlNTQ5NzVmNzFhNmE2NDNlIn0s
-        ICJpZCI6ICI1NmFlYmJlNGU1NDk3NWY3MWE2YTY0M2UifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:01 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/687a4c84-e0c1-4c26-801b-7cb8a38ef1d0/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="kdzmt2eSFjKrNUDYBvDm5tWoYG1GyHEux88IvdFas",
-        oauth_signature="KUDhMes4WX5c079Z2POqirXtwLM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291941", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:01 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3523'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82ODdhNGM4NC1lMGMxLTRjMjYtODAxYi03Y2I4
-        YTM4ZWYxZDAvIiwgInRhc2tfaWQiOiAiNjg3YTRjODQtZTBjMS00YzI2LTgw
-        MWItN2NiOGEzOGVmMWQwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wMVQwMTo1OTowMVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIx
-        ZGMwYjRjNi1iYjliLTRjZmItOWM2Ny03Yjk5YjQ1MWJiMzciLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlw
-        ZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzNmOTdl
-        YzYtYmM4Zi00MDJmLTk2NGYtOTQ1MzY0YTJmZjk0IiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNf
-        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiNDc1ZDk5YWItNzcxNi00YzZiLWJlZDUtNGEwMjdlNGI3
-        Nzg5IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3Rl
-        cF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE4MzMwZWEy
-        LTQ5YTgtNDg1ZS04YTJmLTU5ZmFjODVkZWMzYiIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVt
-        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJlYTZmZWY3ZS1kYzRiLTQyZDctOTE4My1lZTE0ZmI0
-        MzExOGUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJz
-        dGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNmZhY2Ni
-        MGEtYmRmZC00MzA4LTgyZDYtNmYxMzNlYWNiNWExIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEi
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZDMwMWQwNzctNGM5YS00MTQ1LTlhOTct
-        MmU2ZjQ5NWEzMTZkIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRh
-        dGEiLCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiZjNhYmU2YWEtOTQ1Yi00ZWY4LWExNjItNDg3MGJk
-        MjgwNGJlIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
-        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIs
-        ICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjIwOGY5MDkwLWU2NGYtNDc0OS1iZmNkLTllZjVhOGU2NWU5NSIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
-        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90
-        eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjA1ODAxNWEzLWMzMzgtNDc1My05NTI5LWQyZjNjY2Q3NDc4NyIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJp
-        bml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        YmVkZTI5YWEtNDY5YS00YWVmLTk0ZGItMDRjNWY1NWM3MzRhIiwgIm51bV9w
-        cm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
-        Y2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZh
-        ZWJiZTRlNTQ5NzVmNzFhNmE2NDNmIn0sICJpZCI6ICI1NmFlYmJlNGU1NDk3
-        NWY3MWE2YTY0M2YifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:01 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/6eefccea-6aba-487c-b01b-7c485278f725/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="1QXS6EPM8MjSqJqsg6zE8b73dRbgMb8fJb9sShLo",
-        oauth_signature="f1Ko6vNkJpOtUS6xLd7%2Bp6XXeHc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291941", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:01 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2310'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82ZWVmY2NlYS02YWJhLTQ4N2MtYjAxYi03YzQ4NTI3OGY3
-        MjUvIiwgInRhc2tfaWQiOiAiNmVlZmNjZWEtNmFiYS00ODdjLWIwMWItN2M0
-        ODUyNzhmNzI1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMTo1OTowMVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OTowMFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZmFhYzlkNDItZGZiNy00NzU2LWEzZDItMGUwYTU4Mjg5
-        MGE2LyIsICJ0YXNrX2lkIjogImZhYWM5ZDQyLWRmYjctNDc1Ni1hM2QyLTBl
-        MGE1ODI4OTBhNiJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82
-        ODdhNGM4NC1lMGMxLTRjMjYtODAxYi03Y2I4YTM4ZWYxZDAvIiwgInRhc2tf
-        aWQiOiAiNjg3YTRjODQtZTBjMS00YzI2LTgwMWItN2NiOGEzOGVmMWQwIn1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJiZTRkZTA0MDMzNDZkMTg4ZmMx
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MTo1OTowMFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAxOjU5OjAwWiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmJlNGRlMDQwMzRjZDky
-        ZGM1MDYiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmJlNGU1NDk3NWY3MWE2YTY0MmUifSwgImlkIjogIjU2YWViYmU0ZTU0
-        OTc1ZjcxYTZhNjQyZSJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:01 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/faac9d42-dfb7-4756-a3d2-0e0a582890a6/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="QoDQlZZ1loTx1RMFwnQfVmOSrNmzVffu2oBEjQvlI",
-        oauth_signature="X85BTDcBezw%2B8gOwlYFNrkc8C5U%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291941", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:01 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9mYWFjOWQ0Mi1kZmI3LTQ3NTYtYTNkMi0wZTBh
-        NTgyODkwYTYvIiwgInRhc2tfaWQiOiAiZmFhYzlkNDItZGZiNy00NzU2LWEz
-        ZDItMGUwYTU4Mjg5MGE2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMTo1OTowMVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OTowMVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDE6NTk6MDFaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMTo1OTowMVoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmJlNWRlMDQwMzRjZDkyZGM1MDciLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJiZTRlNTQ5NzVmNzFhNmE2NDNlIn0s
-        ICJpZCI6ICI1NmFlYmJlNGU1NDk3NWY3MWE2YTY0M2UifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:01 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/687a4c84-e0c1-4c26-801b-7cb8a38ef1d0/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="Tkk2FyMSIIjwaUQk6fNzKgPiEZ8ZhxYFwYTKA8R8",
-        oauth_signature="g8%2FYtbRmFv0jB7wJvJ4ZfycD%2FL8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291941", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:01 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6923'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82ODdhNGM4NC1lMGMxLTRjMjYtODAxYi03Y2I4
-        YTM4ZWYxZDAvIiwgInRhc2tfaWQiOiAiNjg3YTRjODQtZTBjMS00YzI2LTgw
-        MWItN2NiOGEzOGVmMWQwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMTo1OTowMVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OTowMVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIxZGMwYjRjNi1iYjliLTRjZmItOWM2Ny03Yjk5YjQ1
-        MWJiMzciLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYzNmOTdlYzYtYmM4Zi00MDJmLTk2NGYtOTQ1MzY0YTJmZjk0Iiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNDc1ZDk5YWItNzcxNi00YzZiLWJlZDUt
-        NGEwMjdlNGI3Nzg5IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTgz
-        MzBlYTItNDlhOC00ODVlLThhMmYtNTlmYWM4NWRlYzNiIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImVhNmZlZjdlLWRjNGItNDJkNy05MTgzLWVlMTRm
-        YjQzMTE4ZSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2ZmFjY2Iw
-        YS1iZGZkLTQzMDgtODJkNi02ZjEzM2VhY2I1YTEiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJkMzAxZDA3Ny00YzlhLTQxNDUtOWE5Ny0yZTZm
-        NDk1YTMxNmQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJmM2FiZTZhYS05NDViLTRlZjgtYTE2Mi00ODcwYmQyODA0YmUi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyMDhm
-        OTA5MC1lNjRmLTQ3NDktYmZjZC05ZWY1YThlNjVlOTUiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNTgwMTVhMy1jMzM4
-        LTQ3NTMtOTUyOS1kMmYzY2NkNzQ3ODciLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJlZGUyOWFhLTQ2OWEtNGFl
-        Zi05NGRiLTA0YzVmNTVjNzM0YSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
-        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
-        c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTAxVDAxOjU5OjAxWiIsICJf
-        bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
-        MTYtMDItMDFUMDE6NTk6MDFaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
-        cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
-        IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
-        X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
-        RCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1z
-        IjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0
-        aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
-        SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
-        U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
-        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZhZWJiZTVkZTA0MDM0Y2Q5MmRj
-        NTA4IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjFkYzBiNGM2LWJiOWItNGNmYi05YzY3LTdiOTliNDUxYmIzNyIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
-        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjM2Y5
-        N2VjNi1iYzhmLTQwMmYtOTY0Zi05NDUzNjRhMmZmOTQiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
-        c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICI0NzVkOTlhYi03NzE2LTRjNmItYmVkNS00YTAyN2U0Yjc3
-        ODkiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
-        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxODMzMGVhMi00OWE4
-        LTQ4NWUtOGEyZi01OWZhYzg1ZGVjM2IiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
-        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZWE2ZmVmN2UtZGM0Yi00MmQ3LTkxODMtZWUxNGZiNDMxMThlIiwg
-        Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
-        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjZmYWNjYjBhLWJkZmQtNDMw
-        OC04MmQ2LTZmMTMzZWFjYjVhMSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
-        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
-        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogImQzMDFkMDc3LTRjOWEtNDE0NS05YTk3LTJlNmY0OTVhMzE2ZCIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
-        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
-        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImYz
-        YWJlNmFhLTk0NWItNGVmOC1hMTYyLTQ4NzBiZDI4MDRiZSIsICJudW1fcHJv
-        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
-        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
-        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjIwOGY5MDkwLWU2NGYt
-        NDc0OS1iZmNkLTllZjVhOGU2NWU5NSIsICJudW1fcHJvY2Vzc2VkIjogMH0s
-        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
-        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
-        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjA1ODAxNWEzLWMzMzgtNDc1My05NTI5
-        LWQyZjNjY2Q3NDc4NyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
-        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiYmVkZTI5YWEtNDY5YS00YWVmLTk0ZGItMDRj
-        NWY1NWM3MzRhIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YWViYmU0ZTU0OTc1ZjcxYTZhNjQz
-        ZiJ9LCAiaWQiOiAiNTZhZWJiZTRlNTQ5NzVmNzFhNmE2NDNmIn0=
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:01 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/ec3dc988-9147-4ed8-8f5c-29ec171c6a1a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="jFubCPSEWGhDcsG3T7dkc6MUcaoOCoSbWd4nFCkAL50",
-        oauth_signature="pu0RBnM7FWgatijOXqpPlro0as0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291942", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:02 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lYzNkYzk4OC05MTQ3LTRlZDgtOGY1Yy0yOWVjMTcxYzZh
-        MWEvIiwgInRhc2tfaWQiOiAiZWMzZGM5ODgtOTE0Ny00ZWQ4LThmNWMtMjll
-        YzE3MWM2YTFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmFlYmJl
-        NmU1NDk3NWY3MWE2YTY0NDAifSwgImlkIjogIjU2YWViYmU2ZTU0OTc1Zjcx
-        YTZhNjQ0MCJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:02 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/ec3dc988-9147-4ed8-8f5c-29ec171c6a1a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="IRi1EbggRFbuGistynsBRnhiMy3vplk0OGSi5JNDHM",
-        oauth_signature="YrbwgNbc21ovvxal4EVSaamtEyY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291942", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:02 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '682'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lYzNkYzk4OC05MTQ3LTRlZDgtOGY1Yy0yOWVjMTcxYzZh
-        MWEvIiwgInRhc2tfaWQiOiAiZWMzZGM5ODgtOTE0Ny00ZWQ4LThmNWMtMjll
-        YzE3MWM2YTFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTAxVDAxOjU5OjAyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTAxVDAxOjU5OjAyWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
-        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJiZTZl
-        NTQ5NzVmNzFhNmE2NDQwIn0sICJpZCI6ICI1NmFlYmJlNmU1NDk3NWY3MWE2
-        YTY0NDAifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:02 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:04 GMT
 - request:
     method: post
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
-        IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRp
-        c3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwi
-        OiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3Rl
-        Y3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJleHBvcnRfZGlzdHJpYnV0
-        b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBz
-        IjpmYWxzZSwicmVsYXRpdmVfdXJsIjpudWxsfSwiYXV0b19wdWJsaXNoIjpm
-        YWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJleHBvcnRfZGlzdHJpYnV0b3IifV19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
-        oauth_nonce="JeVBpi4uos7bro7yoXpiy0t91ftACkfSzkeSF82ll5Q", oauth_signature="WNJz9zMM6MWOlOYGPLNGx9zm3wE%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454693655", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '810'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '320'
-      Location:
-      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiNGRkMTdjNzgyMWIzMzAzNGJhZjM0In0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:15 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/a33429e9-f001-4cd1-99c8-1ca0f1580da7/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="VKyLJU22LiXVBi29UlB9UmxSUsTGfyNxCskcZAqML4A",
-        oauth_signature="07iaNzl%2Fl%2Fc9%2FN96iNRLSIjzVpk%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693655", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hMzM0MjllOS1mMDAxLTRjZDEtOTljOC0xY2EwZjE1ODBk
-        YTcvIiwgInRhc2tfaWQiOiAiYTMzNDI5ZTktZjAwMS00Y2QxLTk5YzgtMWNh
-        MGYxNTgwZGE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkMTc4
-        YWRhNDBkYjA0ZWUwZjNlIn0sICJpZCI6ICI1NmI0ZGQxNzhhZGE0MGRiMDRl
-        ZTBmM2UifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:15 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/a33429e9-f001-4cd1-99c8-1ca0f1580da7/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="11P400CanOwgHyU1K75SAS6CmXrPfCdyQ0VNvyy0k",
-        oauth_signature="HYo43gDGOoG72DmlvtUgCb91Rog%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693656", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:16 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1081'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hMzM0MjllOS1mMDAxLTRjZDEtOTljOC0xY2EwZjE1ODBk
-        YTcvIiwgInRhc2tfaWQiOiAiYTMzNDI5ZTktZjAwMS00Y2QxLTk5YzgtMWNh
-        MGYxNTgwZGE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0wNVQxNzozNDoxNVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJJ
-        Tl9QUk9HUkVTUyJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAi
-        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0
-        ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJl
-        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkMTc4YWRhNDBk
-        YjA0ZWUwZjNlIn0sICJpZCI6ICI1NmI0ZGQxNzhhZGE0MGRiMDRlZTBmM2Ui
-        fQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:16 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/a33429e9-f001-4cd1-99c8-1ca0f1580da7/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="v0iC9lWEUjp07MnPttLbGD3xJchmYs6kazFOLd9iE94",
-        oauth_signature="toAvnLSjloSPyH8Gp9%2BzZs7t4e0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693656", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:16 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hMzM0MjllOS1mMDAxLTRjZDEtOTljOC0xY2EwZjE1ODBk
-        YTcvIiwgInRhc2tfaWQiOiAiYTMzNDI5ZTktZjAwMS00Y2QxLTk5YzgtMWNh
-        MGYxNTgwZGE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozNDoxNloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozNDoxNVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNTkyMmYzMmUtMzkxYy00MDFhLTg1YjItMjJiNWQwOGUz
-        MDM3LyIsICJ0YXNrX2lkIjogIjU5MjJmMzJlLTM5MWMtNDAxYS04NWIyLTIy
-        YjVkMDhlMzAzNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZDE3Yzc4MjFiMzMwMzRiYWYzNSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6MzQ6MTVaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozNDox
-        NloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRkMThjNzgyMWIzNDQ0ZmNjM2RlIiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkMTc4YWRhNDBkYjA0ZWUwZjNlIn0s
-        ICJpZCI6ICI1NmI0ZGQxNzhhZGE0MGRiMDRlZTBmM2UifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:16 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/5922f32e-391c-401a-85b2-22b5d08e3037/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="vd9CzbN3nbc9ofqOglBrmDtpVneZBAdtAmfya9AYo8",
-        oauth_signature="oEWHd6QHGo3thLdtwdnP8Xb7PwA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693656", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:16 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3494'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy81OTIyZjMyZS0zOTFjLTQwMWEtODViMi0yMmI1
-        ZDA4ZTMwMzcvIiwgInRhc2tfaWQiOiAiNTkyMmYzMmUtMzkxYy00MDFhLTg1
-        YjItMjJiNWQwOGUzMDM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wNVQxNzozNDoxNloiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkMzNl
-        MTZkMi1iOGEwLTQxNmYtYjVhZi0zYzVhN2QyNDcxNGMiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZWM5Y2UzOGYtNzRm
-        Yi00NTkyLThmNzgtYTU4NTY1Y2VjOGU1IiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiMTQ3Y2U3ZGQtYTBjZS00YjgzLWJkMjktZGE1MGVjMTJjMzc4IiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDQwNDIwNzEtM2Q2ZS00M2M2LWFj
-        YzEtM2UyMGM5ZjUzYTRiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA1
-        ZDcxZjI4LTI3MDQtNDY3ZS1hNWY1LTM1Mjk2YjdhODcyNSIsICJudW1fcHJv
-        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIyNjI2M2Q2Ni1hNjQyLTRmNzAtOTAyMS1i
-        ZjAxNGViOGFlZDYiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEu
-        IiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0
-        NTVlZWU5Ni1jNTU2LTQ5ODQtYTU5Mi1iMDQxZTc1MTJhZTQiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9u
-        IjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xv
-        c2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiNTQ3ZThiZC1h
-        NWM1LTQxNzAtYjE1MC02YTQ0MjA0MTQzZjYiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVy
-        YXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBz
-        cWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkYWM3OGZkNS00ZDA5LTRlODYtYTRl
-        YS0yMDk5NTVhNjBmMGIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMg
-        dG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIwNzQwYmJjOC02NmQxLTRkMWQtOTJmZS02MDRkYmEx
-        NGE5OGUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImI2ZDRlZjBmLWMwMWQtNDljMi04NzRiLWUxYmNlODM5ZGMy
-        NiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVlIjogInJlc2VydmVk
-        X3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNv
-        bS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJl
-        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5leGFt
-        cGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YjRkZDE4OGFkYTQwZGIwNGVlMGY0ZSJ9LCAiaWQi
-        OiAiNTZiNGRkMTg4YWRhNDBkYjA0ZWUwZjRlIn0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:16 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/a33429e9-f001-4cd1-99c8-1ca0f1580da7/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="f1lZdeGPD3QFCHK5cWPweM5P6GxZCPMKVyiFLZ0Mmk0",
-        oauth_signature="hmgIqM%2FznwH2Fs5Hd206g3Lsbsg%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693657", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:17 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hMzM0MjllOS1mMDAxLTRjZDEtOTljOC0xY2EwZjE1ODBk
-        YTcvIiwgInRhc2tfaWQiOiAiYTMzNDI5ZTktZjAwMS00Y2QxLTk5YzgtMWNh
-        MGYxNTgwZGE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozNDoxNloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozNDoxNVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNTkyMmYzMmUtMzkxYy00MDFhLTg1YjItMjJiNWQwOGUz
-        MDM3LyIsICJ0YXNrX2lkIjogIjU5MjJmMzJlLTM5MWMtNDAxYS04NWIyLTIy
-        YjVkMDhlMzAzNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZDE3Yzc4MjFiMzMwMzRiYWYzNSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6MzQ6MTVaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozNDox
-        NloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRkMThjNzgyMWIzNDQ0ZmNjM2RlIiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkMTc4YWRhNDBkYjA0ZWUwZjNlIn0s
-        ICJpZCI6ICI1NmI0ZGQxNzhhZGE0MGRiMDRlZTBmM2UifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:17 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/5922f32e-391c-401a-85b2-22b5d08e3037/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="jEymXyiDrSzSWTeAzCxJvMkc1FbppT4FNkoioLg1lEE",
-        oauth_signature="HSK9n4UXQwx8NBew7rOnxqWcCbM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693657", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:17 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy81OTIyZjMyZS0zOTFjLTQwMWEtODViMi0yMmI1
-        ZDA4ZTMwMzcvIiwgInRhc2tfaWQiOiAiNTkyMmYzMmUtMzkxYy00MDFhLTg1
-        YjItMjJiNWQwOGUzMDM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wNVQxNzozNDoxNloiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozNDoxNloiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJkMzNlMTZkMi1iOGEwLTQxNmYtYjVhZi0zYzVhN2Qy
-        NDcxNGMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZWM5Y2UzOGYtNzRmYi00NTkyLThmNzgtYTU4NTY1Y2VjOGU1Iiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMTQ3Y2U3ZGQtYTBjZS00YjgzLWJkMjkt
-        ZGE1MGVjMTJjMzc4IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDQw
-        NDIwNzEtM2Q2ZS00M2M2LWFjYzEtM2UyMGM5ZjUzYTRiIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjA1ZDcxZjI4LTI3MDQtNDY3ZS1hNWY1LTM1Mjk2
-        YjdhODcyNSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyNjI2M2Q2
-        Ni1hNjQyLTRmNzAtOTAyMS1iZjAxNGViOGFlZDYiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI0NTVlZWU5Ni1jNTU2LTQ5ODQtYTU5Mi1iMDQx
-        ZTc1MTJhZTQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJiNTQ3ZThiZC1hNWM1LTQxNzAtYjE1MC02YTQ0MjA0MTQzZjYi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkYWM3
-        OGZkNS00ZDA5LTRlODYtYTRlYS0yMDk5NTVhNjBmMGIiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNzQwYmJjOC02NmQx
-        LTRkMWQtOTJmZS02MDRkYmExNGE5OGUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI2ZDRlZjBmLWMwMWQtNDlj
-        Mi04NzRiLWUxYmNlODM5ZGMyNiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
-        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE3OjM0OjE2
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMDVUMTc6MzQ6MTZaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGRkMThjNzgyMWIz
-        NDQ0ZmNjM2RmIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImQzM2UxNmQyLWI4YTAtNDE2Zi1iNWFmLTNjNWE3ZDI0NzE0
-        YyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJlYzljZTM4Zi03NGZiLTQ1OTItOGY3OC1hNTg1NjVjZWM4ZTUiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIxNDdjZTdkZC1hMGNlLTRiODMtYmQyOS1kYTUw
-        ZWMxMmMzNzgiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0NDA0MjA3
-        MS0zZDZlLTQzYzYtYWNjMS0zZTIwYzlmNTNhNGIiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiMDVkNzFmMjgtMjcwNC00NjdlLWE1ZjUtMzUyOTZiN2E4
-        NzI1IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI2MjYzZDY2LWE2
-        NDItNGY3MC05MDIxLWJmMDE0ZWI4YWVkNiIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjQ1NWVlZTk2LWM1NTYtNDk4NC1hNTkyLWIwNDFlNzUx
-        MmFlNCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImI1NDdlOGJkLWE1YzUtNDE3MC1iMTUwLTZhNDQyMDQxNDNmNiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImRhYzc4ZmQ1
-        LTRkMDktNGU4Ni1hNGVhLTIwOTk1NWE2MGYwYiIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA3NDBiYmM4LTY2ZDEtNGQx
-        ZC05MmZlLTYwNGRiYTE0YTk4ZSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjZkNGVmMGYtYzAxZC00OWMyLTg3
-        NGItZTFiY2U4MzlkYzI2IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRkZDE4OGFkYTQwZGIw
-        NGVlMGY0ZSJ9LCAiaWQiOiAiNTZiNGRkMTg4YWRhNDBkYjA0ZWUwZjRlIn0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:17 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f7f65bcc-36ea-4d2a-9b60-1f98327c223c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="76SwVXereUFhqiz1uKR95bBRiTcS6g7PUqjHJN7gBQ",
-        oauth_signature="G9FoH8oAf3nJpzMj2bB3L4Dv1lE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693657", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:17 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mN2Y2NWJjYy0zNmVhLTRkMmEtOWI2MC0xZjk4MzI3YzIy
-        M2MvIiwgInRhc2tfaWQiOiAiZjdmNjViY2MtMzZlYS00ZDJhLTliNjAtMWY5
-        ODMyN2MyMjNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0ZGQx
-        OThhZGE0MGRiMDRlZTBmNGYifSwgImlkIjogIjU2YjRkZDE5OGFkYTQwZGIw
-        NGVlMGY0ZiJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:17 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f7f65bcc-36ea-4d2a-9b60-1f98327c223c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="BLy311K9YrrNj24bwFWib0XpUHC7Id7B0NiU3hudSqA",
-        oauth_signature="ll02xzSUZ4B44Ig%2BLUJxpJDRdK4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693658", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:18 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mN2Y2NWJjYy0zNmVhLTRkMmEtOWI2MC0xZjk4MzI3YzIy
-        M2MvIiwgInRhc2tfaWQiOiAiZjdmNjViY2MtMzZlYS00ZDJhLTliNjAtMWY5
-        ODMyN2MyMjNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA1VDE3OjM0OjE4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE3OjM0OjE4WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        NGRkMTk4YWRhNDBkYjA0ZWUwZjRmIn0sICJpZCI6ICI1NmI0ZGQxOThhZGE0
-        MGRiMDRlZTBmNGYifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:18 GMT
-- request:
-    method: post
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
-        IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRp
-        c3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwi
-        OiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3Rl
-        Y3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJleHBvcnRfZGlzdHJpYnV0
-        b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBz
-        IjpmYWxzZSwicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIn0sImF1dG9fcHVi
-        bGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1
-        dG9yIn1dfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb",
-        oauth_nonce="ZtL5GnFjFDJqXUMUbbMJr3tQH4hmCtvxIyzHwE0cQnc", oauth_signature="W9sXoCArt6itLEIBUH1Xsq4odJs%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454949549", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '817'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:39:09 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '320'
-      Location:
-      - https://katello-centos7-devel.example.com/pulp/api/v2/repositories/Fedora_17/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: US-ASCII
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiOGM0YWQxN2YyNWUwZGE0OGI4NDE0In0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:39:09 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/c3c9be82-a90b-414d-a422-8b6fb21d83b0/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="82hmBOml6HPGRGSgGaFZwVxvMyuEbTwKqAtChvnw",
-        oauth_signature="7nLliOKZN%2Ben9A0vAViBrG5%2BD%2BI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949550", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:39:10 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jM2M5YmU4Mi1hOTBiLTQxNGQtYTQyMi04YjZmYjIxZDgz
-        YjAvIiwgInRhc2tfaWQiOiAiYzNjOWJlODItYTkwYi00MTRkLWE0MjItOGI2
-        ZmIyMWQ4M2IwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiOGM0YWVj
-        MTlmZjUwNzk4MjNmMjM3In0sICJpZCI6ICI1NmI4YzRhZWMxOWZmNTA3OTgy
-        M2YyMzcifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:39:10 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/c3c9be82-a90b-414d-a422-8b6fb21d83b0/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="xdT2ZowhkmeAzn55YoJwsAQVxktGCD6tqe1FSXnw",
-        oauth_signature="1%2B3LCMDBXpK2fvfpGTF%2FSyXsk7I%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949550", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:39:10 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jM2M5YmU4Mi1hOTBiLTQxNGQtYTQyMi04YjZmYjIxZDgz
-        YjAvIiwgInRhc2tfaWQiOiAiYzNjOWJlODItYTkwYi00MTRkLWE0MjItOGI2
-        ZmIyMWQ4M2IwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjozOToxMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjozOToxMFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMDM2ODQ1MDctMTk3ZS00YzljLWI4Y2ItOGMwZjg4MjJk
-        YjBiLyIsICJ0YXNrX2lkIjogIjAzNjg0NTA3LTE5N2UtNGM5Yy1iOGNiLThj
-        MGY4ODIyZGIwYiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjNGFkMTdmMjVlMGRhNDhiODQxNSJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6Mzk6MTBaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjozOToxMFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjNGFlMTdmMjVlMTEyYWU4OGFkMyIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNGFlYzE5ZmY1
-        MDc5ODIzZjIzNyJ9LCAiaWQiOiAiNTZiOGM0YWVjMTlmZjUwNzk4MjNmMjM3
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:39:10 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/03684507-197e-4c9c-b8cb-8c0f8822db0b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="S919IztkLstMWaPFlVM5ug24cmwuyorb4y6Wx2KwjTs",
-        oauth_signature="6FA1B43NbT%2Fcpa3kup5z6tymb%2B8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949550", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:39:10 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3506'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8wMzY4NDUwNy0xOTdlLTRjOWMtYjhjYi04YzBm
-        ODgyMmRiMGIvIiwgInRhc2tfaWQiOiAiMDM2ODQ1MDctMTk3ZS00YzljLWI4
-        Y2ItOGMwZjg4MjJkYjBiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wOFQxNjozOToxMFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0ZDE2
-        MWU1ZC1kMDg4LTRiMWMtYjRhNS01MTY5MzE3YTYyM2QiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmVjMjE2OTEtNDM3
-        Yy00YWM3LWE2NDUtNDZiMDRjMDIzZmMyIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiM2E3MWVhNTYtZjZiZi00N2FlLTg3ZjItZmI0YWZjOTEwZjczIiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGIzM2MyNmMtYzQ2NC00NDVlLThi
-        M2MtNGVkZDY3ZmM3OTAzIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNi
-        NzEwMTMyLTY3NzYtNDk0Mi1iYjE3LWRjZjk2NTQ2Y2QwZiIsICJudW1fcHJv
-        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJlNmJkNmYzNC01YWE1LTQ5MDItYTRhMi1i
-        YjNkOGVhYTBiODEiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEu
-        IiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIy
-        Mjc5ZWFiZC01ZTc0LTQwYWYtODliMS1hMmVlZjA5MmNkM2EiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9u
-        IjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xv
-        c2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxZDFiNjNiYi0z
-        NTg0LTRiOTMtYWNhMC1mZTE1NGY1YjVhMDEiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVy
-        YXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBz
-        cWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjOTE2ZDgyYi1lNDdhLTQwYmMtYWFi
-        OS0yZTAxMTkzNTE2MjMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMg
-        dG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI5YzQ4NTQ3YS1iOTQ3LTQ5YWEtYjVmZC0yOGRmY2I0
-        MzQzOWYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjY1NTM1OWZkLTNiNWMtNDkzMi04ODY3LTQxM2Q3MzZiY2M3
-        NyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVlIjogInJlc2VydmVk
-        X3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFt
-        cGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9z
-        Ny1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3Ii
-        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNGFlYzE5ZmY1MDc5ODIz
-        ZjI0NyJ9LCAiaWQiOiAiNTZiOGM0YWVjMTlmZjUwNzk4MjNmMjQ3In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:39:10 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/c3c9be82-a90b-414d-a422-8b6fb21d83b0/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="bT3ecjUsaOvJddvDQUBoB7AjzzvcrCOHlOnU74OUr7M",
-        oauth_signature="cu28EPkcYdtn0l%2BWKzRM1GrpqW8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949551", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:39:11 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jM2M5YmU4Mi1hOTBiLTQxNGQtYTQyMi04YjZmYjIxZDgz
-        YjAvIiwgInRhc2tfaWQiOiAiYzNjOWJlODItYTkwYi00MTRkLWE0MjItOGI2
-        ZmIyMWQ4M2IwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjozOToxMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjozOToxMFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMDM2ODQ1MDctMTk3ZS00YzljLWI4Y2ItOGMwZjg4MjJk
-        YjBiLyIsICJ0YXNrX2lkIjogIjAzNjg0NTA3LTE5N2UtNGM5Yy1iOGNiLThj
-        MGY4ODIyZGIwYiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjNGFkMTdmMjVlMGRhNDhiODQxNSJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6Mzk6MTBaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjozOToxMFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjNGFlMTdmMjVlMTEyYWU4OGFkMyIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNGFlYzE5ZmY1
-        MDc5ODIzZjIzNyJ9LCAiaWQiOiAiNTZiOGM0YWVjMTlmZjUwNzk4MjNmMjM3
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:39:11 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/03684507-197e-4c9c-b8cb-8c0f8822db0b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="QtZebnB3VlSQRJM3khl45j6cX0o6QNAcPiQnjo1s",
-        oauth_signature="yRopSna1zI6uQTk75oHeFVDtDFc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949551", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:39:11 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6941'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8wMzY4NDUwNy0xOTdlLTRjOWMtYjhjYi04YzBm
-        ODgyMmRiMGIvIiwgInRhc2tfaWQiOiAiMDM2ODQ1MDctMTk3ZS00YzljLWI4
-        Y2ItOGMwZjg4MjJkYjBiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wOFQxNjozOToxMFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjozOToxMFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI0ZDE2MWU1ZC1kMDg4LTRiMWMtYjRhNS01MTY5MzE3
-        YTYyM2QiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMmVjMjE2OTEtNDM3Yy00YWM3LWE2NDUtNDZiMDRjMDIzZmMyIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiM2E3MWVhNTYtZjZiZi00N2FlLTg3ZjIt
-        ZmI0YWZjOTEwZjczIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGIz
-        M2MyNmMtYzQ2NC00NDVlLThiM2MtNGVkZDY3ZmM3OTAzIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjNiNzEwMTMyLTY3NzYtNDk0Mi1iYjE3LWRjZjk2
-        NTQ2Y2QwZiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlNmJkNmYz
-        NC01YWE1LTQ5MDItYTRhMi1iYjNkOGVhYTBiODEiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIyMjc5ZWFiZC01ZTc0LTQwYWYtODliMS1hMmVl
-        ZjA5MmNkM2EiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIxZDFiNjNiYi0zNTg0LTRiOTMtYWNhMC1mZTE1NGY1YjVhMDEi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjOTE2
-        ZDgyYi1lNDdhLTQwYmMtYWFiOS0yZTAxMTkzNTE2MjMiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5YzQ4NTQ3YS1iOTQ3
-        LTQ5YWEtYjVmZC0yOGRmY2I0MzQzOWYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjY1NTM1OWZkLTNiNWMtNDkz
-        Mi04ODY3LTQxM2Q3MzZiY2M3NyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Y2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAy
-        LTA4VDE2OjM5OjEwWiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMi
-        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMDhUMTY6Mzk6MTBaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0
-        cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJ
-        UFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQi
-        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjog
-        IkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklO
-        SVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hf
-        ZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIs
-        ICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51
-        bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZi
-        OGM0YWUxN2YyNWUxMTJhZTg4YWQ0IiwgImRldGFpbHMiOiBbeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
-        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
-        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjRkMTYxZTVkLWQwODgtNGIxYy1iNGE1
-        LTUxNjkzMTdhNjIzZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
-        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIyZWMyMTY5MS00MzdjLTRhYzctYTY0NS00NmIwNGMw
-        MjNmYzIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        OCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
-        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzYTcxZWE1Ni1mNmJmLTQ3
-        YWUtODdmMi1mYjRhZmM5MTBmNzMiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7
-        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI0YjMzYzI2Yy1jNDY0LTQ0NWUtOGIzYy00ZWRkNjdmYzc5MDMiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
-        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiM2I3MTAxMzItNjc3Ni00OTQyLWJi
-        MTctZGNmOTY1NDZjZDBmIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBz
-        IGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjog
-        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImU2YmQ2ZjM0LTVhYTUtNDkwMi1hNGEyLWJiM2Q4ZWFhMGI4MSIsICJudW1f
-        cHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjIyNzllYWJkLTVlNzQtNDBhZi04
-        OWIxLWEyZWVmMDkyY2QzYSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjFkMWI2M2JiLTM1ODQtNGI5My1hY2EwLWZlMTU0
-        ZjViNWEwMSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMi
-        LCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImM5MTZkODJiLWU0N2EtNDBiYy1hYWI5LTJlMDExOTM1MTYyMyIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBl
-        IjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjljNDg1
-        NDdhLWI5NDctNDlhYS1iNWZkLTI4ZGZjYjQzNDM5ZiIsICJudW1fcHJvY2Vz
-        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
-        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjU1MzU5ZmQt
-        M2I1Yy00OTMyLTg4NjctNDEzZDczNmJjYzc3IiwgIm51bV9wcm9jZXNzZWQi
-        OiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Yjhj
-        NGFlYzE5ZmY1MDc5ODIzZjI0NyJ9LCAiaWQiOiAiNTZiOGM0YWVjMTlmZjUw
-        Nzk4MjNmMjQ3In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:39:11 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/cf124608-977a-4be3-907f-ed9991b8eb60/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="b44YVinEhKpxUWnIAwstTXGoVgWgR1jPCV5tdt7g",
-        oauth_signature="w5447Ut%2FDoF65ya7tibom3SfSpA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949551", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:39:11 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '663'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jZjEyNDYwOC05NzdhLTRiZTMtOTA3Zi1lZDk5OTFiOGVi
-        NjAvIiwgInRhc2tfaWQiOiAiY2YxMjQ2MDgtOTc3YS00YmUzLTkwN2YtZWQ5
-        OTkxYjhlYjYwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20u
-        ZHEiLCAic3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwu
-        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
-        Il9pZCI6IHsiJG9pZCI6ICI1NmI4YzRhZmMxOWZmNTA3OTgyM2YyNDgifSwg
-        ImlkIjogIjU2YjhjNGFmYzE5ZmY1MDc5ODIzZjI0OCJ9
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:39:11 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/cf124608-977a-4be3-907f-ed9991b8eb60/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="jbC6HRqp8KJJbd03C7EFd22G0B4YE8uymjlzEcdCBdA",
-        oauth_signature="xc7gjL1cWGHmlmuBnPvAqTaTSfU%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949552", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:39:12 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '700'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jZjEyNDYwOC05NzdhLTRiZTMtOTA3Zi1lZDk5OTFiOGVi
-        NjAvIiwgInRhc2tfaWQiOiAiY2YxMjQ2MDgtOTc3YS00YmUzLTkwN2YtZWQ5
-        OTkxYjhlYjYwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA4VDE2OjM5OjExWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA4VDE2OjM5OjExWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20uZHEiLCAic3Rh
-        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUu
-        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNTZiOGM0YWZjMTlmZjUwNzk4MjNmMjQ4In0sICJpZCI6ICI1
-        NmI4YzRhZmMxOWZmNTA3OTgyM2YyNDgifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:39:12 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/9357101f-a116-4209-99e5-dc689fb98c50/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:57:25 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '649'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85MzU3MTAxZi1hMTE2LTQyMDktOTllNS1kYzY4OWZiOThj
-        NTAvIiwgInRhc2tfaWQiOiAiOTM1NzEwMWYtYTExNi00MjA5LTk5ZTUtZGM2
-        ODlmYjk4YzUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tLmRxIiwgInN0
-        YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwg
-        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNTZiZDAzYzUzNDQ3MWU0MDA3MGIwOTY4In0sICJpZCI6ICI1NmJkMDNj
-        NTM0NDcxZTQwMDcwYjA5NjgifQ==
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:57:25 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/9357101f-a116-4209-99e5-dc689fb98c50/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:57:25 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1127'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85MzU3MTAxZi1hMTE2LTQyMDktOTllNS1kYzY4OWZiOThj
-        NTAvIiwgInRhc2tfaWQiOiAiOTM1NzEwMWYtYTExNi00MjA5LTk5ZTUtZGM2
-        ODlmYjk4YzUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0xMVQyMTo1NzoyNVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJJ
-        Tl9QUk9HUkVTUyJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        Tk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwi
-        OiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8t
-        YnVycml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGth
-        dGVsbG8tYnVycml0by5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmQwM2M1MzQ0NzFl
-        NDAwNzBiMDk2OCJ9LCAiaWQiOiAiNTZiZDAzYzUzNDQ3MWU0MDA3MGIwOTY4
-        In0=
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:57:25 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/9357101f-a116-4209-99e5-dc689fb98c50/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:57:26 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2324'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85MzU3MTAxZi1hMTE2LTQyMDktOTllNS1kYzY4OWZiOThj
-        NTAvIiwgInRhc2tfaWQiOiAiOTM1NzEwMWYtYTExNi00MjA5LTk5ZTUtZGM2
-        ODlmYjk4YzUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMTo1NzoyNVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMTo1NzoyNVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNDBiMTEyOGUtY2RlNy00MzhmLWFjM2YtMjc3MDBlY2E1
-        YzZmLyIsICJ0YXNrX2lkIjogIjQwYjExMjhlLWNkZTctNDM4Zi1hYzNmLTI3
-        NzAwZWNhNWM2ZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDNj
-        NDY3N2M3NDJkMDZjY2NkZWMifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIxOjU3OjI1WiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjE6NTc6MjVa
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDAzYzU2NzdjNzQwODEyMzIyM2ViIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwM2M1MzQ0NzFlNDAwNzBiMDk2OCJ9LCAiaWQi
-        OiAiNTZiZDAzYzUzNDQ3MWU0MDA3MGIwOTY4In0=
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:57:26 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/40b1128e-cde7-438f-ac3f-27700eca5c6f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:57:26 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80MGIxMTI4ZS1jZGU3LTQzOGYtYWMzZi0yNzcw
-        MGVjYTVjNmYvIiwgInRhc2tfaWQiOiAiNDBiMTEyOGUtY2RlNy00MzhmLWFj
-        M2YtMjc3MDBlY2E1YzZmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0xMVQyMTo1NzoyNloiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMTo1NzoyNloiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJmNmM0NmQ3ZC1iNjljLTRmMjYtYThkNi1jNTczOGJj
-        Yjc3NTMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiN2I2OTQ3YzEtNzYwNC00ODU0LWIzZDktMjkxMDdjNjg0M2YwIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiYjNlY2FhYjktMjIxMC00NmUwLWIxNjct
-        MWRlZTk2YzM4YjdhIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiN2Ez
-        ZGIzY2UtZjU5MS00NmNlLTg3ZWUtNTE4OGNmMmFmZDM4IiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImVmNWRhMjg0LTE5MTItNGM1My1iMjk5LTVkNWIx
-        OTU4ZDVjMSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxMGNiODgz
-        Ny1mMWNiLTRiYjktOTljMC0xNGZkMWY1NGFjZDUiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJlOTJhNmY1Yy1jYWQ3LTRiODEtOTQzNC1lZGVk
-        Yzc3MTlhYjIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI3NTZkMGI0Yi02MjgwLTRjOTItYTgwMS1iZDI3YjU0YTkyMzYi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYjJi
-        MzZjNS1jZGQ5LTRmZjUtYWEzMi04ZGRhOTU2NmVlMzAiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZjEzMTM2MC04YTcy
-        LTQxMzItOGQ4Yi04MTY0MDVkZGUxYmQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc3MTJlMmRmLTk3MTQtNDBm
-        NS04OGYzLTA0M2QyY2Y4NjhkMiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8t
-        YnVycml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBr
-        YXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTExVDIxOjU3OjI2
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMTFUMjE6NTc6MjZaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiZDAzYzY2NzdjNzQw
-        ODEyMzIyM2VjIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImY2YzQ2ZDdkLWI2OWMtNGYyNi1hOGQ2LWM1NzM4YmNiNzc1
-        MyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI3YjY5NDdjMS03NjA0LTQ4NTQtYjNkOS0yOTEwN2M2ODQzZjAiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJiM2VjYWFiOS0yMjEwLTQ2ZTAtYjE2Ny0xZGVl
-        OTZjMzhiN2EiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3YTNkYjNj
-        ZS1mNTkxLTQ2Y2UtODdlZS01MTg4Y2YyYWZkMzgiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiZWY1ZGEyODQtMTkxMi00YzUzLWIyOTktNWQ1YjE5NThk
-        NWMxIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjEwY2I4ODM3LWYx
-        Y2ItNGJiOS05OWMwLTE0ZmQxZjU0YWNkNSIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImU5MmE2ZjVjLWNhZDctNGI4MS05NDM0LWVkZWRjNzcx
-        OWFiMiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjc1NmQwYjRiLTYyODAtNGM5Mi1hODAxLWJkMjdiNTRhOTIzNiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBiMmIzNmM1
-        LWNkZDktNGZmNS1hYTMyLThkZGE5NTY2ZWUzMCIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFmMTMxMzYwLThhNzItNDEz
-        Mi04ZDhiLTgxNjQwNWRkZTFiZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzcxMmUyZGYtOTcxNC00MGY1LTg4
-        ZjMtMDQzZDJjZjg2OGQyIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmQwM2M1MzQ0NzFlNDAw
-        NzBiMDk3OCJ9LCAiaWQiOiAiNTZiZDAzYzUzNDQ3MWU0MDA3MGIwOTc4In0=
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:57:26 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/2d77d34e-7fb7-4c52-bd36-c45a0453a3f5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:57:26 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yZDc3ZDM0ZS03ZmI3LTRjNTItYmQzNi1jNDVhMDQ1M2Ez
-        ZjUvIiwgInRhc2tfaWQiOiAiMmQ3N2QzNGUtN2ZiNy00YzUyLWJkMzYtYzQ1
-        YTA0NTNhM2Y1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJkMDNj
-        NjM0NDcxZTQwMDcwYjA5NzkifSwgImlkIjogIjU2YmQwM2M2MzQ0NzFlNDAw
-        NzBiMDk3OSJ9
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:57:26 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/2d77d34e-7fb7-4c52-bd36-c45a0453a3f5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:57:27 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yZDc3ZDM0ZS03ZmI3LTRjNTItYmQzNi1jNDVhMDQ1M2Ez
-        ZjUvIiwgInRhc2tfaWQiOiAiMmQ3N2QzNGUtN2ZiNy00YzUyLWJkMzYtYzQ1
-        YTA0NTNhM2Y1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTExVDIxOjU3OjI2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTExVDIxOjU3OjI2WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZDAzYzYzNDQ3MWU0MDA3MGIwOTc5In0sICJpZCI6ICI1NmJkMDNjNjM0NDcx
-        ZTQwMDcwYjA5NzkifQ==
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:57:27 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/e694cc36-fb5c-435a-97c8-158a0d99c630/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 12 Feb 2016 19:05:53 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lNjk0Y2MzNi1mYjVjLTQzNWEtOTdjOC0xNThhMGQ5OWM2
-        MzAvIiwgInRhc2tfaWQiOiAiZTY5NGNjMzYtZmI1Yy00MzVhLTk3YzgtMTU4
-        YTBkOTljNjMwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTEyVDE5OjA1OjM4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTEyVDE5OjA1OjM4WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZTJiZDczNDQ3MWU0MDA3MGIwYzRhIn0sICJpZCI6ICI1NmJlMmJkNzM0NDcx
-        ZTQwMDcwYjBjNGEifQ==
-    http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:05:53 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/8f30a91a-6e17-452d-b346-55a37d0f9041/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 12 Feb 2016 19:05:53 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1853'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84ZjMwYTkxYS02ZTE3LTQ1MmQtYjM0Ni01NWEzN2QwZjkw
-        NDEvIiwgInRhc2tfaWQiOiAiOGYzMGE5MWEtNmUxNy00NTJkLWIzNDYtNTVh
-        MzdkMGY5MDQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTEyVDE5OjA1OjM4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTEyVDE5OjA1OjM4WiIsICJ0cmFjZWJh
-        Y2siOiAiVHJhY2ViYWNrIChtb3N0IHJlY2VudCBjYWxsIGxhc3QpOlxuICBG
-        aWxlIFwiL3Vzci9saWIvcHl0aG9uMi43L3NpdGUtcGFja2FnZXMvY2VsZXJ5
-        L2FwcC90cmFjZS5weVwiLCBsaW5lIDI0MCwgaW4gdHJhY2VfdGFza1xuICAg
-        IFIgPSByZXR2YWwgPSBmdW4oKmFyZ3MsICoqa3dhcmdzKVxuICBGaWxlIFwi
-        L3Vzci9saWIvcHl0aG9uMi43L3NpdGUtcGFja2FnZXMvcHVscC9zZXJ2ZXIv
-        YXN5bmMvdGFza3MucHlcIiwgbGluZSA0NzMsIGluIF9fY2FsbF9fXG4gICAg
-        cmV0dXJuIHN1cGVyKFRhc2ssIHNlbGYpLl9fY2FsbF9fKCphcmdzLCAqKmt3
-        YXJncylcbiAgRmlsZSBcIi91c3IvbGliL3B5dGhvbjIuNy9zaXRlLXBhY2th
-        Z2VzL3B1bHAvc2VydmVyL2FzeW5jL3Rhc2tzLnB5XCIsIGxpbmUgMTAzLCBp
-        biBfX2NhbGxfX1xuICAgIHJldHVybiBzdXBlcihQdWxwVGFzaywgc2VsZiku
-        X19jYWxsX18oKmFyZ3MsICoqa3dhcmdzKVxuICBGaWxlIFwiL3Vzci9saWIv
-        cHl0aG9uMi43L3NpdGUtcGFja2FnZXMvY2VsZXJ5L2FwcC90cmFjZS5weVwi
-        LCBsaW5lIDQzNywgaW4gX19wcm90ZWN0ZWRfY2FsbF9fXG4gICAgcmV0dXJu
-        IHNlbGYucnVuKCphcmdzLCAqKmt3YXJncylcbiAgRmlsZSBcIi91c3IvbGli
-        L3B5dGhvbjIuNy9zaXRlLXBhY2thZ2VzL3B1bHAvc2VydmVyL2NvbnRyb2xs
-        ZXJzL3JlcG9zaXRvcnkucHlcIiwgbGluZSA1MjIsIGluIGRlbGV0ZVxuICAg
-        IHJlcG8gPSBtb2RlbC5SZXBvc2l0b3J5Lm9iamVjdHMuZ2V0X3JlcG9fb3Jf
-        bWlzc2luZ19yZXNvdXJjZShyZXBvX2lkKVxuICBGaWxlIFwiL3Vzci9saWIv
-        cHl0aG9uMi43L3NpdGUtcGFja2FnZXMvcHVscC9zZXJ2ZXIvZGIvcXVlcnlz
-        ZXRzLnB5XCIsIGxpbmUgMTM5LCBpbiBnZXRfcmVwb19vcl9taXNzaW5nX3Jl
-        c291cmNlXG4gICAgcmFpc2UgcHVscF9leGNlcHRpb25zLk1pc3NpbmdSZXNv
-        dXJjZShyZXBvc2l0b3J5PXJlcG9faWQpXG5NaXNzaW5nUmVzb3VyY2U6IE1p
-        c3NpbmcgcmVzb3VyY2Uocyk6IHJlcG9zaXRvcnk9RmVkb3JhXzE3XG4iLCAi
-        c3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJx
-        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRlbGxvLWJ1
-        cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZXJyb3IiLCAid29y
-        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAa2F0ZWxs
-        by1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJv
-        ciI6IHsiY29kZSI6ICJQTFAwMDA5IiwgImRhdGEiOiB7InJlc291cmNlcyI6
-        IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0sICJkZXNjcmlwdGlvbiI6
-        ICJNaXNzaW5nIHJlc291cmNlKHMpOiByZXBvc2l0b3J5PUZlZG9yYV8xNyIs
-        ICJzdWJfZXJyb3JzIjogW119LCAiX2lkIjogeyIkb2lkIjogIjU2YmUyYzll
-        MzQ0NzFlNDAwNzBiMGM0YiJ9LCAiaWQiOiAiNTZiZTJjOWUzNDQ3MWU0MDA3
-        MGIwYzRiIn0=
-    http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:05:53 GMT
-- request:
-    method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
-        IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRp
-        c3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwi
-        OiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3Rl
-        Y3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifV19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '636'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Fri, 12 Feb 2016 19:05:53 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '320'
-      Location:
-      - https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiZTJkMTE2NzdjNzQyZDA1YWYzODQ4In0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:05:53 GMT
-- request:
-    method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3166,7 +91,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Fri, 12 Feb 2016 19:05:53 GMT
+      - Tue, 23 Feb 2016 16:47:05 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -3179,14 +104,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzE4NmI2NjhjLThmNmEtNGRiMS04MWVmLWM4ZDdiMTk4NWEyOC8iLCAi
-        dGFza19pZCI6ICIxODZiNjY4Yy04ZjZhLTRkYjEtODFlZi1jOGQ3YjE5ODVh
-        MjgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzc2YmRhYzZlLWNjMzYtNDg4YS04N2Y5LTc4MmU5NGZlMTg1YS8iLCAi
+        dGFza19pZCI6ICI3NmJkYWM2ZS1jYzM2LTQ4OGEtODdmOS03ODJlOTRmZTE4
+        NWEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:05:53 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:05 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/186b668c-8f6a-4db1-81ef-c8d7b1985a28/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/76bdac6e-cc36-488a-87f9-782e94fe185a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3205,7 +130,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 12 Feb 2016 19:05:53 GMT
+      - Tue, 23 Feb 2016 16:47:05 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -3221,22 +146,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xODZiNjY4Yy04ZjZhLTRkYjEtODFlZi1jOGQ3YjE5ODVh
-        MjgvIiwgInRhc2tfaWQiOiAiMTg2YjY2OGMtOGY2YS00ZGIxLTgxZWYtYzhk
-        N2IxOTg1YTI4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy83NmJkYWM2ZS1jYzM2LTQ4OGEtODdmOS03ODJlOTRmZTE4
+        NWEvIiwgInRhc2tfaWQiOiAiNzZiZGFjNmUtY2MzNi00ODhhLTg3ZjktNzgy
+        ZTk0ZmUxODVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
         ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiZTJkMTEz
-        NDQ3MWU0MDA3MGIwYzVjIn0sICJpZCI6ICI1NmJlMmQxMTM0NDcxZTQwMDcw
-        YjBjNWMifQ==
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMDk5
+        ODkwNTRmYzQ4YmEyZTI1In0sICJpZCI6ICI1NmNjOGQwOTk4OTA1NGZjNDhi
+        YTJlMjUifQ==
     http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:05:53 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:05 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/186b668c-8f6a-4db1-81ef-c8d7b1985a28/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/76bdac6e-cc36-488a-87f9-782e94fe185a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3255,13 +180,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 12 Feb 2016 19:05:54 GMT
+      - Tue, 23 Feb 2016 16:47:05 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2324'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -3271,16 +196,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xODZiNjY4Yy04ZjZhLTRkYjEtODFlZi1jOGQ3YjE5ODVh
-        MjgvIiwgInRhc2tfaWQiOiAiMTg2YjY2OGMtOGY2YS00ZGIxLTgxZWYtYzhk
-        N2IxOTg1YTI4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy83NmJkYWM2ZS1jYzM2LTQ4OGEtODdmOS03ODJlOTRmZTE4
+        NWEvIiwgInRhc2tfaWQiOiAiNzZiZGFjNmUtY2MzNi00ODhhLTg3ZjktNzgy
+        ZTk0ZmUxODVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMlQxOTowNTo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMlQxOTowNTo1M1oiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0NzowNVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0NzowNVoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNmYyM2UwMzAtODNhYy00NzM2LWJlYTktZDExNDI0M2Rj
-        YWYxLyIsICJ0YXNrX2lkIjogIjZmMjNlMDMwLTgzYWMtNDczNi1iZWE5LWQx
-        MTQyNDNkY2FmMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvYWY2ZTQyNjgtZDcxMC00Y2FiLTkyNmUtMmE1Zjc1NjU3
+        OTUxLyIsICJ0YXNrX2lkIjogImFmNmU0MjY4LWQ3MTAtNGNhYi05MjZlLTJh
+        NWY3NTY1Nzk1MSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -3291,41 +216,41 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJlMmQx
-        MTY3N2M3NDJkMDVhZjM4NDkifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTEyVDE5OjA1OjUzWiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTJUMTk6MDU6NTRa
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZTJkMTI2NzdjNzQ0YTRlOWE3M2UzIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmUyZDExMzQ0NzFlNDAwNzBiMGM1YyJ9LCAiaWQi
-        OiAiNTZiZTJkMTEzNDQ3MWU0MDA3MGIwYzVjIn0=
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQwOGRlMDQw
+        MzNmNDM1MTRmM2YifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ3OjA1WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDc6MDVaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkMDlk
+        ZTA0MDMwODk3NThhODQ3IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDA5OTg5MDU0ZmM0OGJhMmUyNSJ9LCAiaWQiOiAiNTZj
+        YzhkMDk5ODkwNTRmYzQ4YmEyZTI1In0=
     http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:05:54 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:05 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/6f23e030-83ac-4736-bea9-d114243dcaf1/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/af6e4268-d710-4cab-926e-2a5f75657951/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3344,13 +269,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 12 Feb 2016 19:05:54 GMT
+      - Tue, 23 Feb 2016 16:47:05 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '3516'
+      - '6923'
       Connection:
       - close
       Content-Type:
@@ -3360,368 +285,163 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82ZjIzZTAzMC04M2FjLTQ3MzYtYmVhOS1kMTE0
-        MjQzZGNhZjEvIiwgInRhc2tfaWQiOiAiNmYyM2UwMzAtODNhYy00NzM2LWJl
-        YTktZDExNDI0M2RjYWYxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy9hZjZlNDI2OC1kNzEwLTRjYWItOTI2ZS0yYTVm
+        NzU2NTc5NTEvIiwgInRhc2tfaWQiOiAiYWY2ZTQyNjgtZDcxMC00Y2FiLTky
+        NmUtMmE1Zjc1NjU3OTUxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0xMlQxOTowNTo1NFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4MDIw
-        ZTc1ZC0yYzExLTQxYTEtOGI2ZS01NGY4MDA4Y2RjYTEiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTJjNWY0MzEtNzcw
-        MS00NmMwLWE1NmUtNThhNzUxYzczY2VhIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiNmNmZGMyYjctMTQ5ZS00OGQzLTliZGEtNTQ4NmE3MjlkY2I4IiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTZiM2IzZjctOGFjNi00MjNhLThj
-        M2ItNDY2NmI2ZTZmNDUxIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjRjOThlYjI4LTczYjEtNDlhMi05ZDJiLTZjYzkwMGVhYjEyYyIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJj
-        b21wcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiY2U1NTJiMS05ZTU4LTQ5MzAt
-        OTUzNi04NDEwZTVkZDEyYmUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
-        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0
-        YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI2NzczNDVhMy05NTgxLTQ0NDQtOTEwYi00ODVmYTQ2NTA2MWYi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI2MWFhNGIwNC1iODNlLTRlZjItYjc5YS03MDIwNmE4NDIyZGYiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
-        aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjYxOTFh
-        NjktYmI5My00MWU3LWI0ZjctZDdkYzQ2NDJhOGNiIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
-        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
-        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTlkYTFkNmMtMzQw
-        MC00YTM4LWEwOTYtYmExZDAxNzEzNGM4IiwgIm51bV9wcm9jZXNzZWQiOiAw
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5n
-        IExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVw
-        b19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
-        U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1NTdlMDQ4Mi0zNmIz
-        LTRiOTYtYjI1OS0yZTdiNDJmMjFiZjEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmlu
-        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVs
-        bCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJlMmQxMjM0
-        NDcxZTQwMDcwYjBjNmMifSwgImlkIjogIjU2YmUyZDEyMzQ0NzFlNDAwNzBi
-        MGM2YyJ9
-    http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:05:54 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/186b668c-8f6a-4db1-81ef-c8d7b1985a28/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 12 Feb 2016 19:05:55 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2324'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xODZiNjY4Yy04ZjZhLTRkYjEtODFlZi1jOGQ3YjE5ODVh
-        MjgvIiwgInRhc2tfaWQiOiAiMTg2YjY2OGMtOGY2YS00ZGIxLTgxZWYtYzhk
-        N2IxOTg1YTI4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMlQxOTowNTo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMlQxOTowNTo1M1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNmYyM2UwMzAtODNhYy00NzM2LWJlYTktZDExNDI0M2Rj
-        YWYxLyIsICJ0YXNrX2lkIjogIjZmMjNlMDMwLTgzYWMtNDczNi1iZWE5LWQx
-        MTQyNDNkY2FmMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJlMmQx
-        MTY3N2M3NDJkMDVhZjM4NDkifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTEyVDE5OjA1OjUzWiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTJUMTk6MDU6NTRa
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZTJkMTI2NzdjNzQ0YTRlOWE3M2UzIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmUyZDExMzQ0NzFlNDAwNzBiMGM1YyJ9LCAiaWQi
-        OiAiNTZiZTJkMTEzNDQ3MWU0MDA3MGIwYzVjIn0=
-    http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:05:55 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/6f23e030-83ac-4736-bea9-d114243dcaf1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 12 Feb 2016 19:05:55 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82ZjIzZTAzMC04M2FjLTQ3MzYtYmVhOS1kMTE0
-        MjQzZGNhZjEvIiwgInRhc2tfaWQiOiAiNmYyM2UwMzAtODNhYy00NzM2LWJl
-        YTktZDExNDI0M2RjYWYxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0xMlQxOTowNTo1NFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMlQxOTowNTo1NFoiLCAi
+        bWUiOiAiMjAxNi0wMi0yM1QxNjo0NzowNVoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0NzowNVoiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI4MDIwZTc1ZC0yYzExLTQxYTEtOGI2ZS01NGY4MDA4
-        Y2RjYTEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICIwNzg2ZjQxMy04MTQxLTRiOTItOTFiMC03OTExZTk3
+        MjY0NzciLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZTJjNWY0MzEtNzcwMS00NmMwLWE1NmUtNThhNzUxYzczY2VhIiwg
+        aWQiOiAiMDM0MTgxMjgtNDY4YS00YzA5LTk0MzYtNGExZDA5Yzk3NzliIiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
         bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNmNmZGMyYjctMTQ5ZS00OGQzLTliZGEt
-        NTQ4NmE3MjlkY2I4IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNTZlOWM5MjctYzE3MC00N2M2LWIyOTYt
+        MTkzMDc0YWU0YTE2IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
         TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTZi
-        M2IzZjctOGFjNi00MjNhLThjM2ItNDY2NmI2ZTZmNDUxIiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjg5
+        ZWZiMzktNmNiNy00YmRjLThiM2UtMWE3OGI1MjYyZTY3IiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjRjOThlYjI4LTczYjEtNDlhMi05ZDJiLTZjYzkw
-        MGVhYjEyYyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        IDAsICJzdGVwX2lkIjogIjljMGI3MDBlLTczMjYtNDFkMC04YzUwLWJiNWNk
+        Mjk3NWU2OCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
         OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
         InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiY2U1NTJi
-        MS05ZTU4LTQ5MzAtOTUzNi04NDEwZTVkZDEyYmUiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2YjE2YmQx
+        Yy0xYjY2LTRlOGMtYmQyYi1jZjk3ZjNiNDhlMTMiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
         Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI2NzczNDVhMy05NTgxLTQ0NDQtOTEwYi00ODVm
-        YTQ2NTA2MWYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICIyN2U1ZDQzZC1lYjgxLTQ4OTAtYTk4My04MzBh
+        OTM1MThjOGIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
         ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI2MWFhNGIwNC1iODNlLTRlZjItYjc5YS03MDIwNmE4NDIyZGYi
+        cF9pZCI6ICIyNmNmYTRmZC02MzYyLTRmMWItYmM1My1jZTEyMjc1MzQ3OTQi
         LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
         dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
         c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyNjE5
-        MWE2OS1iYjkzLTQxZTctYjRmNy1kN2RjNDY0MmE4Y2IiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiY2Rj
+        OTE0Ny04YjA0LTQzYzAtOTkyMC00Njk2YWY4MDI5YjQiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
         aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxOWRhMWQ2Yy0zNDAw
-        LTRhMzgtYTA5Ni1iYTFkMDE3MTM0YzgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYzNiMjNiYS00Y2Vm
+        LTRkMTMtOWM3NC03NzI0YWM0MjYzMDkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
         TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
         X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjU1N2UwNDgyLTM2YjMtNGI5
-        Ni1iMjU5LTJlN2I0MmYyMWJmMSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8t
-        YnVycml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBr
-        YXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTEyVDE5OjA1OjU0
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMTJUMTk6MDU6NTRaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiZTJkMTI2NzdjNzQ0
-        YTRlOWE3M2U0IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjgwMjBlNzVkLTJjMTEtNDFhMS04YjZlLTU0ZjgwMDhjZGNh
-        MSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJlMmM1ZjQzMS03NzAxLTQ2YzAtYTU2ZS01OGE3NTFjNzNjZWEiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI2Y2ZkYzJiNy0xNDllLTQ4ZDMtOWJkYS01NDg2
-        YTcyOWRjYjgiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNmIzYjNm
-        Ny04YWM2LTQyM2EtOGMzYi00NjY2YjZlNmY0NTEiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiNGM5OGViMjgtNzNiMS00OWEyLTlkMmItNmNjOTAwZWFi
-        MTJjIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJjZTU1MmIxLTll
-        NTgtNDkzMC05NTM2LTg0MTBlNWRkMTJiZSIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjY3NzM0NWEzLTk1ODEtNDQ0NC05MTBiLTQ4NWZhNDY1
-        MDYxZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE2ZWY1N2FjLWMyNGItNDEx
+        ZS1iOWNhLTQxZGRlNDkzMDk5YiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
+        c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
+        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ3OjA1WiIsICJf
+        bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
+        MTYtMDItMjNUMTY6NDc6MDVaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
+        cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
+        IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
+        X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
+        RCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1z
+        IjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0
+        aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
+        SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
+        U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
+        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZjYzhkMDlkZTA0MDMwODk3NThh
+        ODQ4IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
         IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjYxYWE0YjA0LWI4M2UtNGVmMi1iNzlhLTcwMjA2YTg0MjJkZiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI2MTkxYTY5
-        LWJiOTMtNDFlNy1iNGY3LWQ3ZGM0NjQyYThjYiIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        IjogIjA3ODZmNDEzLTgxNDEtNGI5Mi05MWIwLTc5MTFlOTcyNjQ3NyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwMzQx
+        ODEyOC00NjhhLTRjMDktOTQzNi00YTFkMDljOTc3OWIiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI1NmU5YzkyNy1jMTcwLTQ3YzYtYjI5Ni0xOTMwNzRhZTRh
+        MTYiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyODllZmIzOS02Y2I3
+        LTRiZGMtOGIzZS0xYTc4YjUyNjJlNjciLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiOWMwYjcwMGUtNzMyNi00MWQwLThjNTAtYmI1Y2QyOTc1ZTY4Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
+        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE5ZGExZDZjLTM0MDAtNGEz
-        OC1hMDk2LWJhMWQwMTcxMzRjOCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTU3ZTA0ODItMzZiMy00Yjk2LWIy
-        NTktMmU3YjQyZjIxYmYxIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmUyZDEyMzQ0NzFlNDAw
-        NzBiMGM2YyJ9LCAiaWQiOiAiNTZiZTJkMTIzNDQ3MWU0MDA3MGIwYzZjIn0=
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjZiMTZiZDFjLTFiNjYtNGU4
+        Yy1iZDJiLWNmOTdmM2I0OGUxMyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
+        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjI3ZTVkNDNkLWViODEtNDg5MC1hOTgzLTgzMGE5MzUxOGM4YiIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI2
+        Y2ZhNGZkLTYzNjItNGYxYi1iYzUzLWNlMTIyNzUzNDc5NCIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
+        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
+        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJjZGM5MTQ3LThiMDQt
+        NDNjMC05OTIwLTQ2OTZhZjgwMjliNCIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
+        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjBjM2IyM2JhLTRjZWYtNGQxMy05Yzc0
+        LTc3MjRhYzQyNjMwOSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
+        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiMTZlZjU3YWMtYzI0Yi00MTFlLWI5Y2EtNDFk
+        ZGU0OTMwOTliIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDA5OTg5MDU0ZmM0OGJhMmUz
+        NSJ9LCAiaWQiOiAiNTZjYzhkMDk5ODkwNTRmYzQ4YmEyZTM1In0=
     http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:05:55 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:05 GMT
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3744,7 +464,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 12 Feb 2016 19:05:55 GMT
+      - Tue, 23 Feb 2016 16:47:06 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -3758,49 +478,49 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIwMTVhOGQyZC0zZDQzLTRmODMtODk3
-        YS0yODMyZWJjN2EyZWQiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
-        Il9pZCI6IHsiJG9pZCI6ICI1NmJlMmQxMjM0NDcxZTQwMDcwYjBjNjIifSwg
-        InVuaXRfaWQiOiAiMDE1YThkMmQtM2Q0My00ZjgzLTg5N2EtMjgzMmViYzdh
-        MmVkIiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogIjJmMmIzY2FlLTBmODktNDNjOC1hYzIxLWUzNTIyZjA2Mzk0OCIs
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIzMzYzODQ1NC01OGE4LTQxYjAtYjA2
+        Ni05YzkxMDVkYmYzOTUiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQwOTk4OTA1NGZjNDhiYTJlMmQifSwg
+        InVuaXRfaWQiOiAiMzM2Mzg0NTQtNThhOC00MWIwLWIwNjYtOWM5MTA1ZGJm
+        Mzk1IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
+        X2lkIjogIjU3NGRiNGM0LTQ5ZDEtNDk2OS1iZTZmLTYzYjExZDQ4NWVkZSIs
         ICJfY29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjog
-        IjU2YmUyZDEyMzQ0NzFlNDAwNzBiMGM1ZiJ9LCAidW5pdF9pZCI6ICIyZjJi
-        M2NhZS0wZjg5LTQzYzgtYWMyMS1lMzUyMmYwNjM5NDgiLCAidW5pdF90eXBl
-        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNGI5NjgzNTUt
-        YjQ0Zi00ZmZjLThiMzktZjY1YTViZDBiOTc4IiwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiZTJkMTIzNDQ3MWU0
-        MDA3MGIwYzVlIn0sICJ1bml0X2lkIjogIjRiOTY4MzU1LWI0NGYtNGZmYy04
-        YjM5LWY2NWE1YmQwYjk3OCIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
-        bWV0YWRhdGEiOiB7Il9pZCI6ICJiNjRmNThkMy0xNGZiLTQ3OTAtYTVmNC04
-        YjVmN2JmMjkzYTciLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1NmJlMmQxMjM0NDcxZTQwMDcwYjBjNWQifSwgInVu
-        aXRfaWQiOiAiYjY0ZjU4ZDMtMTRmYi00NzkwLWE1ZjQtOGI1ZjdiZjI5M2E3
+        IjU2Y2M4ZDA5OTg5MDU0ZmM0OGJhMmUyOSJ9LCAidW5pdF9pZCI6ICI1NzRk
+        YjRjNC00OWQxLTQ5NjktYmU2Zi02M2IxMWQ0ODVlZGUiLCAidW5pdF90eXBl
+        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNmI0NTE5Yzgt
+        MjgxNi00YzU1LTkzNzctMmRhYWVmZTY0ZjgxIiwgIl9jb250ZW50X3R5cGVf
+        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMDk5ODkwNTRm
+        YzQ4YmEyZTJjIn0sICJ1bml0X2lkIjogIjZiNDUxOWM4LTI4MTYtNGM1NS05
+        Mzc3LTJkYWFlZmU2NGY4MSIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
+        bWV0YWRhdGEiOiB7Il9pZCI6ICI4ODEyZjZjOC05ODU4LTRiZDYtOTM4Yi00
+        ZDk4MjM0MDBkYTQiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1NmNjOGQwOTk4OTA1NGZjNDhiYTJlMjcifSwgInVu
+        aXRfaWQiOiAiODgxMmY2YzgtOTg1OC00YmQ2LTkzOGItNGQ5ODIzNDAwZGE0
         IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lk
-        IjogImI4MzVlZDNhLWEzNjgtNGIwNS1hODg4LWQ3NmIzNDY3MTdiZSIsICJf
+        IjogImM2OGUxNzE2LTM0YWItNDdlMS1iNThlLWRiZWU3NzlhZGZkZCIsICJf
         Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2
-        YmUyZDEyMzQ0NzFlNDAwNzBiMGM2MCJ9LCAidW5pdF9pZCI6ICJiODM1ZWQz
-        YS1hMzY4LTRiMDUtYTg4OC1kNzZiMzQ2NzE3YmUiLCAidW5pdF90eXBlX2lk
-        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiZTJmY2UwYzYtN2Nl
-        Ny00OTU2LTk2M2ItZmYwMDQ0NGI0ODc4IiwgIl9jb250ZW50X3R5cGVfaWQi
-        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiZTJkMTIzNDQ3MWU0MDA3
-        MGIwYzYzIn0sICJ1bml0X2lkIjogImUyZmNlMGM2LTdjZTctNDk1Ni05NjNi
-        LWZmMDA0NDRiNDg3OCIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
-        YWRhdGEiOiB7Il9pZCI6ICJmZDIwZjA2NC03MDU2LTQ4M2YtOWEwYS00MmRj
-        YmVkYzIwNjkiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NmJlMmQxMjM0NDcxZTQwMDcwYjBjNjQifSwgInVuaXRf
-        aWQiOiAiZmQyMGYwNjQtNzA1Ni00ODNmLTlhMGEtNDJkY2JlZGMyMDY5Iiwg
+        Y2M4ZDA5OTg5MDU0ZmM0OGJhMmUyNiJ9LCAidW5pdF9pZCI6ICJjNjhlMTcx
+        Ni0zNGFiLTQ3ZTEtYjU4ZS1kYmVlNzc5YWRmZGQiLCAidW5pdF90eXBlX2lk
+        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiZDc3ZGVjOGQtM2Y0
+        NC00MzZmLThhYjQtMmI0N2QyOTI4Zjg2IiwgIl9jb250ZW50X3R5cGVfaWQi
+        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMDk5ODkwNTRmYzQ4
+        YmEyZTJiIn0sICJ1bml0X2lkIjogImQ3N2RlYzhkLTNmNDQtNDM2Zi04YWI0
+        LTJiNDdkMjkyOGY4NiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
+        YWRhdGEiOiB7Il9pZCI6ICJlYTA4MTJhNC1iN2E1LTRlODMtOTYyOS01N2M3
+        MGJiOThkZTgiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
+        IHsiJG9pZCI6ICI1NmNjOGQwOTk4OTA1NGZjNDhiYTJlMjgifSwgInVuaXRf
+        aWQiOiAiZWEwODEyYTQtYjdhNS00ZTgzLTk2MjktNTdjNzBiYjk4ZGU4Iiwg
         InVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjog
-        ImZkY2YzM2YyLTgwYWYtNDMxYS1hYWRhLWU0NDMxMDcxNzE5MiIsICJfY29u
-        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2YmUy
-        ZDEyMzQ0NzFlNDAwNzBiMGM2MSJ9LCAidW5pdF9pZCI6ICJmZGNmMzNmMi04
-        MGFmLTQzMWEtYWFkYS1lNDQzMTA3MTcxOTIiLCAidW5pdF90eXBlX2lkIjog
+        ImVlODExMTk3LWVmYTAtNDc1ZC1hNjM3LWQzYzZjODQzNWViMCIsICJfY29u
+        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4
+        ZDA5OTg5MDU0ZmM0OGJhMmUyYSJ9LCAidW5pdF9pZCI6ICJlZTgxMTE5Ny1l
+        ZmEwLTQ3NWQtYTYzNy1kM2M2Yzg0MzVlYjAiLCAidW5pdF90eXBlX2lkIjog
         InJwbSJ9XQ==
     http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:05:55 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:06 GMT
 - request:
     method: delete
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3819,7 +539,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Fri, 12 Feb 2016 19:05:55 GMT
+      - Tue, 23 Feb 2016 16:47:06 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -3832,14 +552,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2IyM2ViZTE1LWEzOGMtNDc5YS1iYWUxLTU2ODJlNWY0Njk0Mi8iLCAi
-        dGFza19pZCI6ICJiMjNlYmUxNS1hMzhjLTQ3OWEtYmFlMS01NjgyZTVmNDY5
-        NDIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzgwZmFlYzFjLTY0OTQtNDQwZC04ZGFlLWRjMzgzNmJlNGIyMC8iLCAi
+        dGFza19pZCI6ICI4MGZhZWMxYy02NDk0LTQ0MGQtOGRhZS1kYzM4MzZiZTRi
+        MjAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:05:55 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:06 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/b23ebe15-a38c-479a-bae1-5682e5f46942/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/80faec1c-6494-440d-8dae-dc3836be4b20/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3858,13 +578,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 12 Feb 2016 19:05:55 GMT
+      - Tue, 23 Feb 2016 16:47:06 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '645'
       Connection:
       - close
       Content-Type:
@@ -3874,22 +594,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iMjNlYmUxNS1hMzhjLTQ3OWEtYmFlMS01NjgyZTVmNDY5
-        NDIvIiwgInRhc2tfaWQiOiAiYjIzZWJlMTUtYTM4Yy00NzlhLWJhZTEtNTY4
-        MmU1ZjQ2OTQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy84MGZhZWMxYy02NDk0LTQ0MGQtOGRhZS1kYzM4MzZiZTRi
+        MjAvIiwgInRhc2tfaWQiOiAiODBmYWVjMWMtNjQ5NC00NDBkLThkYWUtZGMz
+        ODM2YmU0YjIwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
         bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
         ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJlMmQx
-        MzM0NDcxZTQwMDcwYjBjNmQifSwgImlkIjogIjU2YmUyZDEzMzQ0NzFlNDAw
-        NzBiMGM2ZCJ9
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3Rh
+        dGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        NmNjOGQwYTk4OTA1NGZjNDhiYTJlMzYifSwgImlkIjogIjU2Y2M4ZDBhOTg5
+        MDU0ZmM0OGJhMmUzNiJ9
     http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:05:55 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:06 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/b23ebe15-a38c-479a-bae1-5682e5f46942/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/80faec1c-6494-440d-8dae-dc3836be4b20/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3908,13 +630,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 12 Feb 2016 19:05:56 GMT
+      - Tue, 23 Feb 2016 16:47:06 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '688'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -3924,20 +646,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iMjNlYmUxNS1hMzhjLTQ3OWEtYmFlMS01NjgyZTVmNDY5
-        NDIvIiwgInRhc2tfaWQiOiAiYjIzZWJlMTUtYTM4Yy00NzlhLWJhZTEtNTY4
-        MmU1ZjQ2OTQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy84MGZhZWMxYy02NDk0LTQ0MGQtOGRhZS1kYzM4MzZiZTRi
+        MjAvIiwgInRhc2tfaWQiOiAiODBmYWVjMWMtNjQ5NC00NDBkLThkYWUtZGMz
+        ODM2YmU0YjIwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTEyVDE5OjA1OjU1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTEyVDE5OjA1OjU1WiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ3OjA2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ3OjA2WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZTJkMTMzNDQ3MWU0MDA3MGIwYzZkIn0sICJpZCI6ICI1NmJlMmQxMzM0NDcx
-        ZTQwMDcwYjBjNmQifQ==
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMGE5
+        ODkwNTRmYzQ4YmEyZTM2In0sICJpZCI6ICI1NmNjOGQwYTk4OTA1NGZjNDhi
+        YTJlMzYifQ==
     http_version: 
-  recorded_at: Fri, 12 Feb 2016 19:05:56 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:06 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/actions/pulp/repository/update_schedule/disable_schedule.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp/repository/update_schedule/disable_schedule.yml
@@ -10,7 +10,8 @@ http_interactions:
         ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
         b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
         ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
+        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
+        IjpudWxsLCJyZW1vdmVfbWlzc2luZyI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
         LXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1
         dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9j
         b25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIiwiaHR0cCI6ZmFs
@@ -20,12 +21,10 @@ http_interactions:
         dHJpYnV0b3JfY29uZmlnIjp7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lk
         IjoiRmVkb3JhXzE3In0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1
         dG9yX2lkIjoiRmVkb3JhXzE3X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBl
-        X2lkIjoibm9kZXNfaHR0cF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2Nv
-        bmZpZyI6e30sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3JfaWQi
-        OiJGZWRvcmFfMTdfbm9kZXMifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJl
-        eHBvcnRfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0
-        cCI6ZmFsc2UsImh0dHBzIjpmYWxzZX0sImF1dG9fcHVibGlzaCI6ZmFsc2Us
-        ImRpc3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
+        X2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmln
+        Ijp7Imh0dHAiOmZhbHNlLCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6
+        InRlc3RfcGF0aCJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRv
+        cl9pZCI6ImV4cG9ydF9kaXN0cmlidXRvciJ9XX0=
     headers:
       Accept:
       - application/json
@@ -33,14 +32,8 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4",
-        oauth_nonce="vKzdvJh1Mt7y3hs9cPIAGaVwKmqVv8DB6YfNtcMNk", oauth_signature="Ad%2BxWQWMl9rNr3fDRQ%2FwD9pObsQ%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454291943", oauth_version="1.0"
-      Pulp-User:
-      - admin
       Content-Length:
-      - '895'
+      - '839'
       User-Agent:
       - Ruby
   response:
@@ -49,7 +42,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Mon, 01 Feb 2016 01:59:03 GMT
+      - Tue, 23 Feb 2016 16:47:09 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -68,749 +61,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZhZWJiZTdkZTA0MDMzNDZjZjY0OTVmIn0sICJpZCI6ICJGZWRvcmFfMTci
+        NTZjYzhkMGRkZTA0MDMzZjQxZDJhM2I3In0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:03 GMT
-- request:
-    method: put
-    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56aebbe7de0403346bfdad10/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJlbmFibGVkIjpmYWxzZX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4",
-        oauth_nonce="1ZNil4cqN6I3mcKOCixcj1jzyd4pPZzFRFUYH6Po", oauth_signature="qjgkmWnMzWFO6s8CpoNagEoJq8I%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454291943", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '17'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:03 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '660'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJuZXh0X3J1biI6ICIyMDE2LTAyLTAxVDAxOjU5OjAzWiIsICJyZW1haW5p
-        bmdfcnVucyI6IDEsICJsYXN0X3VwZGF0ZWQiOiAxNDU0MjkxOTQzLjkyNzE3
-        LCAiZmlyc3RfcnVuIjogIjAzMDEtMDEtMDFUMDU6MDA6MDBaIiwgInRvdGFs
-        X3J1bl9jb3VudCI6IDAsICJzY2hlZHVsZSI6ICJSMS8wMzAtMDEtMDFUMDU6
-        MDA6MDBaL1AxRCIsICJrd2FyZ3MiOiB7Im92ZXJyaWRlcyI6IHt9LCAic2No
-        ZWR1bGVkX2NhbGxfaWQiOiAiNTZhZWJiZTdkZTA0MDMzNDZiZmRhZDEwIn0s
-        ICJhcmdzIjogWyJGZWRvcmFfMTciXSwgImVuYWJsZWQiOiBmYWxzZSwgImxh
-        c3RfcnVuX2F0IjogbnVsbCwgInRhc2siOiAicHVscC5zZXJ2ZXIuY29udHJv
-        bGxlcnMucmVwb3NpdG9yeS5xdWV1ZV9zeW5jX3dpdGhfYXV0b19wdWJsaXNo
-        IiwgImZhaWx1cmVfdGhyZXNob2xkIjogbnVsbCwgInJlc291cmNlIjogInB1
-        bHA6aW1wb3J0ZXI6RmVkb3JhXzE3Onl1bV9pbXBvcnRlciIsICJfaWQiOiAi
-        NTZhZWJiZTdkZTA0MDMzNDZiZmRhZDEwIiwgImNvbnNlY3V0aXZlX2ZhaWx1
-        cmVzIjogMCwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
-        RmVkb3JhXzE3L2ltcG9ydGVycy95dW1faW1wb3J0ZXIvc2NoZWR1bGVzL3N5
-        bmMvNTZhZWJiZTdkZTA0MDMzNDZiZmRhZDEwLyJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:03 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:09 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/5cdbf3c8-1b5c-44f6-a078-4b6dce1ae185/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="DyUBTjsLO8mX8r1mASSbS3av9AcbntQq84ws1rSTw",
-        oauth_signature="ipnVCce1H%2B4eonwL%2BAgKCpRaQIg%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291944", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:04 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81Y2RiZjNjOC0xYjVjLTQ0ZjYtYTA3OC00YjZkY2UxYWUx
-        ODUvIiwgInRhc2tfaWQiOiAiNWNkYmYzYzgtMWI1Yy00NGY2LWEwNzgtNGI2
-        ZGNlMWFlMTg1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmFlYmJl
-        OGU1NDk3NWY3MWE2YTY0NDEifSwgImlkIjogIjU2YWViYmU4ZTU0OTc1Zjcx
-        YTZhNjQ0MSJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:04 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/5cdbf3c8-1b5c-44f6-a078-4b6dce1ae185/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="iv4sLBECPQXiVqLdgkD63O9PsGVsBgBCJKYtaP084s",
-        oauth_signature="iv4rQT0RcmAdI4cryhCzYq6tZs4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291944", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:04 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '682'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81Y2RiZjNjOC0xYjVjLTQ0ZjYtYTA3OC00YjZkY2UxYWUx
-        ODUvIiwgInRhc2tfaWQiOiAiNWNkYmYzYzgtMWI1Yy00NGY2LWEwNzgtNGI2
-        ZGNlMWFlMTg1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTAxVDAxOjU5OjA0WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTAxVDAxOjU5OjA0WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
-        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJiZThl
-        NTQ5NzVmNzFhNmE2NDQxIn0sICJpZCI6ICI1NmFlYmJlOGU1NDk3NWY3MWE2
-        YTY0NDEifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:04 GMT
-- request:
-    method: post
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
-        IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRp
-        c3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwi
-        OiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3Rl
-        Y3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJleHBvcnRfZGlzdHJpYnV0
-        b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBz
-        IjpmYWxzZSwicmVsYXRpdmVfdXJsIjpudWxsfSwiYXV0b19wdWJsaXNoIjpm
-        YWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJleHBvcnRfZGlzdHJpYnV0b3IifV19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
-        oauth_nonce="q8Lqs7unG5YtsTBR1kDFpNoMb21jhTrdBEEiQghfGEU", oauth_signature="gQ4GKgPZvIKjaUI2kryL2vgp76w%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454693659", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '810'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:19 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '320'
-      Location:
-      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiNGRkMWJjNzgyMWIzMzA1Y2U1MjIwIn0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:19 GMT
-- request:
-    method: put
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56b4dd1bc7821b3305ce5226/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJlbmFibGVkIjpmYWxzZX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
-        oauth_nonce="v5csEo45IK2i92xFXOD2127etsOCaWuBsM18lhNRA", oauth_signature="3qH6amgiV54hi4gDDWq%2FTOqssPE%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454693660", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '17'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:20 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '661'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJuZXh0X3J1biI6ICIyMDE2LTAyLTA1VDE3OjM0OjIwWiIsICJyZW1haW5p
-        bmdfcnVucyI6IDEsICJsYXN0X3VwZGF0ZWQiOiAxNDU0NjkzNjYwLjIxODQw
-        OSwgImZpcnN0X3J1biI6ICIwMzAxLTAxLTAxVDA1OjAwOjAwWiIsICJ0b3Rh
-        bF9ydW5fY291bnQiOiAwLCAic2NoZWR1bGUiOiAiUjEvMDMwLTAxLTAxVDA1
-        OjAwOjAwWi9QMUQiLCAia3dhcmdzIjogeyJvdmVycmlkZXMiOiB7fSwgInNj
-        aGVkdWxlZF9jYWxsX2lkIjogIjU2YjRkZDFiYzc4MjFiMzMwNWNlNTIyNiJ9
-        LCAiYXJncyI6IFsiRmVkb3JhXzE3Il0sICJlbmFibGVkIjogZmFsc2UsICJs
-        YXN0X3J1bl9hdCI6IG51bGwsICJ0YXNrIjogInB1bHAuc2VydmVyLmNvbnRy
-        b2xsZXJzLnJlcG9zaXRvcnkucXVldWVfc3luY193aXRoX2F1dG9fcHVibGlz
-        aCIsICJmYWlsdXJlX3RocmVzaG9sZCI6IG51bGwsICJyZXNvdXJjZSI6ICJw
-        dWxwOmltcG9ydGVyOkZlZG9yYV8xNzp5dW1faW1wb3J0ZXIiLCAiX2lkIjog
-        IjU2YjRkZDFiYzc4MjFiMzMwNWNlNTIyNiIsICJjb25zZWN1dGl2ZV9mYWls
-        dXJlcyI6IDAsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVz
-        L0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyL3NjaGVkdWxlcy9z
-        eW5jLzU2YjRkZDFiYzc4MjFiMzMwNWNlNTIyNi8ifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:20 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f5b9c89e-3627-41a8-893c-f25fc571a79a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="IDfthFqTkxnuRFX8pmFY0ypw3dJjFnihrBoL4Vjc",
-        oauth_signature="4sFk0DqfTbzn0SzA5wX%2BKTnLw8U%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693660", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:20 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mNWI5Yzg5ZS0zNjI3LTQxYTgtODkzYy1mMjVmYzU3MWE3
-        OWEvIiwgInRhc2tfaWQiOiAiZjViOWM4OWUtMzYyNy00MWE4LTg5M2MtZjI1
-        ZmM1NzFhNzlhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0ZGQx
-        YzhhZGE0MGRiMDRlZTBmNTAifSwgImlkIjogIjU2YjRkZDFjOGFkYTQwZGIw
-        NGVlMGY1MCJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:20 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f5b9c89e-3627-41a8-893c-f25fc571a79a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="iE9zNsvp57v7oC3VHDe6HxEJmaYelcnJI9hiLGVNc0",
-        oauth_signature="qLsTniJoH0Nyxd8ZK2cA9chzPF8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693661", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:21 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mNWI5Yzg5ZS0zNjI3LTQxYTgtODkzYy1mMjVmYzU3MWE3
-        OWEvIiwgInRhc2tfaWQiOiAiZjViOWM4OWUtMzYyNy00MWE4LTg5M2MtZjI1
-        ZmM1NzFhNzlhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA1VDE3OjM0OjIwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE3OjM0OjIwWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        NGRkMWM4YWRhNDBkYjA0ZWUwZjUwIn0sICJpZCI6ICI1NmI0ZGQxYzhhZGE0
-        MGRiMDRlZTBmNTAifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:21 GMT
-- request:
-    method: post
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
-        IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRp
-        c3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwi
-        OiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3Rl
-        Y3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJleHBvcnRfZGlzdHJpYnV0
-        b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBz
-        IjpmYWxzZSwicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIn0sImF1dG9fcHVi
-        bGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1
-        dG9yIn1dfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb",
-        oauth_nonce="kCnCwx7KAHuUas0KIqIeEvMAlsmOXrYuIa1p5utrRM", oauth_signature="yv8IGrmPj%2BolpTPdOPnxfY2c45A%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454949628", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '817'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:40:28 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '320'
-      Location:
-      - https://katello-centos7-devel.example.com/pulp/api/v2/repositories/Fedora_17/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: US-ASCII
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiOGM0ZmMxN2YyNWUwZGE0OGI4NDE5In0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:40:28 GMT
-- request:
-    method: put
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56b8c4fc17f25e0da48b841f/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJlbmFibGVkIjpmYWxzZX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb",
-        oauth_nonce="VYAbabcphBQoYbJJ7qlicrNDszptOSgvWD1Dzo18M", oauth_signature="oEQSPbWFvUToLNIomwIo9s%2Fqkik%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454949629", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '17'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:40:29 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '661'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJuZXh0X3J1biI6ICIyMDE2LTAyLTA4VDE2OjQwOjI5WiIsICJyZW1haW5p
-        bmdfcnVucyI6IDEsICJsYXN0X3VwZGF0ZWQiOiAxNDU0OTQ5NjI5LjA5NTk2
-        NSwgImZpcnN0X3J1biI6ICIwMzAxLTAxLTAxVDA1OjAwOjAwWiIsICJ0b3Rh
-        bF9ydW5fY291bnQiOiAwLCAic2NoZWR1bGUiOiAiUjEvMDMwLTAxLTAxVDA1
-        OjAwOjAwWi9QMUQiLCAia3dhcmdzIjogeyJvdmVycmlkZXMiOiB7fSwgInNj
-        aGVkdWxlZF9jYWxsX2lkIjogIjU2YjhjNGZjMTdmMjVlMGRhNDhiODQxZiJ9
-        LCAiYXJncyI6IFsiRmVkb3JhXzE3Il0sICJlbmFibGVkIjogZmFsc2UsICJs
-        YXN0X3J1bl9hdCI6IG51bGwsICJ0YXNrIjogInB1bHAuc2VydmVyLmNvbnRy
-        b2xsZXJzLnJlcG9zaXRvcnkucXVldWVfc3luY193aXRoX2F1dG9fcHVibGlz
-        aCIsICJmYWlsdXJlX3RocmVzaG9sZCI6IG51bGwsICJyZXNvdXJjZSI6ICJw
-        dWxwOmltcG9ydGVyOkZlZG9yYV8xNzp5dW1faW1wb3J0ZXIiLCAiX2lkIjog
-        IjU2YjhjNGZjMTdmMjVlMGRhNDhiODQxZiIsICJjb25zZWN1dGl2ZV9mYWls
-        dXJlcyI6IDAsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVz
-        L0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyL3NjaGVkdWxlcy9z
-        eW5jLzU2YjhjNGZjMTdmMjVlMGRhNDhiODQxZi8ifQ==
-    http_version:
-  recorded_at: Mon, 08 Feb 2016 16:40:29 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/ca098115-fb94-4912-9d78-6bd5271d3b9a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="NQtEJY86N683uC7PPKWt471XuwRWt3CSEDoRQOYzhs",
-        oauth_signature="0wf1%2BEEOuAQh59y5nF6tjP%2FiEd4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949629", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:40:29 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '663'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jYTA5ODExNS1mYjk0LTQ5MTItOWQ3OC02YmQ1MjcxZDNi
-        OWEvIiwgInRhc2tfaWQiOiAiY2EwOTgxMTUtZmI5NC00OTEyLTlkNzgtNmJk
-        NTI3MWQzYjlhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20u
-        ZHEiLCAic3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwu
-        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
-        Il9pZCI6IHsiJG9pZCI6ICI1NmI4YzRmZGMxOWZmNTA3OTgyM2YyNDkifSwg
-        ImlkIjogIjU2YjhjNGZkYzE5ZmY1MDc5ODIzZjI0OSJ9
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:40:29 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/ca098115-fb94-4912-9d78-6bd5271d3b9a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="CUcP9stTbDpLGSIvo2FtSvNTUhrU7s0uO2w8onc",
-        oauth_signature="uej%2FsFtVdLtTqDXSfUlNleJ3cR4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949629", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:40:29 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '700'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jYTA5ODExNS1mYjk0LTQ5MTItOWQ3OC02YmQ1MjcxZDNi
-        OWEvIiwgInRhc2tfaWQiOiAiY2EwOTgxMTUtZmI5NC00OTEyLTlkNzgtNmJk
-        NTI3MWQzYjlhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA4VDE2OjQwOjI5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA4VDE2OjQwOjI5WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20uZHEiLCAic3Rh
-        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUu
-        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNTZiOGM0ZmRjMTlmZjUwNzk4MjNmMjQ5In0sICJpZCI6ICI1
-        NmI4YzRmZGMxOWZmNTA3OTgyM2YyNDkifQ==
-    http_version:
-  recorded_at: Mon, 08 Feb 2016 16:40:29 GMT
-- request:
-    method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
-        IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRp
-        c3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwi
-        OiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3Rl
-        Y3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifV19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '636'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:58:23 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '320'
-      Location:
-      - https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiZDAzZmY2NzdjNzQyZDA0OWIwMGE3In0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:58:23 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -829,7 +87,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:58:24 GMT
+      - Tue, 23 Feb 2016 16:47:09 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -842,11 +100,11 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         W10=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:58:24 GMT
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:09 GMT
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -868,13 +126,13 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:58:24 GMT
+      - Tue, 23 Feb 2016 16:47:09 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
-      - '660'
+      - '659'
       Location:
-      - https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56bd0400677c742d06cccdf0/
+      - https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56cc8d0dde04033f41d2a3bd/
       Connection:
       - close
       Content-Type:
@@ -882,26 +140,26 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJuZXh0X3J1biI6ICIyMDE2LTAyLTExVDIxOjU4OjI0WiIsICJyZW1haW5p
-        bmdfcnVucyI6IDEsICJsYXN0X3VwZGF0ZWQiOiAxNDU1MjI3OTA0LjUwOTg4
-        NiwgImZpcnN0X3J1biI6ICIwMzAxLTAxLTAxVDA1OjAwOjAwWiIsICJ0b3Rh
-        bF9ydW5fY291bnQiOiAwLCAic2NoZWR1bGUiOiAiUjEvMDMwLTAxLTAxVDA1
-        OjAwOjAwWi9QMUQiLCAia3dhcmdzIjogeyJvdmVycmlkZXMiOiB7fSwgInNj
-        aGVkdWxlZF9jYWxsX2lkIjogIjU2YmQwNDAwNjc3Yzc0MmQwNmNjY2RmMCJ9
-        LCAiYXJncyI6IFsiRmVkb3JhXzE3Il0sICJlbmFibGVkIjogdHJ1ZSwgImxh
-        c3RfcnVuX2F0IjogbnVsbCwgInRhc2siOiAicHVscC5zZXJ2ZXIuY29udHJv
-        bGxlcnMucmVwb3NpdG9yeS5xdWV1ZV9zeW5jX3dpdGhfYXV0b19wdWJsaXNo
-        IiwgImZhaWx1cmVfdGhyZXNob2xkIjogbnVsbCwgInJlc291cmNlIjogInB1
-        bHA6aW1wb3J0ZXI6RmVkb3JhXzE3Onl1bV9pbXBvcnRlciIsICJfaWQiOiAi
-        NTZiZDA0MDA2NzdjNzQyZDA2Y2NjZGYwIiwgImNvbnNlY3V0aXZlX2ZhaWx1
-        cmVzIjogMCwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
-        RmVkb3JhXzE3L2ltcG9ydGVycy95dW1faW1wb3J0ZXIvc2NoZWR1bGVzL3N5
-        bmMvNTZiZDA0MDA2NzdjNzQyZDA2Y2NjZGYwLyJ9
+        eyJuZXh0X3J1biI6ICIyMDE2LTAyLTIzVDE2OjQ3OjA5WiIsICJyZW1haW5p
+        bmdfcnVucyI6IDEsICJsYXN0X3VwZGF0ZWQiOiAxNDU2MjQ2MDI5Ljk3ODQ2
+        LCAiZmlyc3RfcnVuIjogIjAzMDEtMDEtMDFUMDU6MDA6MDBaIiwgInRvdGFs
+        X3J1bl9jb3VudCI6IDAsICJzY2hlZHVsZSI6ICJSMS8wMzAtMDEtMDFUMDU6
+        MDA6MDBaL1AxRCIsICJrd2FyZ3MiOiB7Im92ZXJyaWRlcyI6IHt9LCAic2No
+        ZWR1bGVkX2NhbGxfaWQiOiAiNTZjYzhkMGRkZTA0MDMzZjQxZDJhM2JkIn0s
+        ICJhcmdzIjogWyJGZWRvcmFfMTciXSwgImVuYWJsZWQiOiB0cnVlLCAibGFz
+        dF9ydW5fYXQiOiBudWxsLCAidGFzayI6ICJwdWxwLnNlcnZlci5jb250cm9s
+        bGVycy5yZXBvc2l0b3J5LnF1ZXVlX3N5bmNfd2l0aF9hdXRvX3B1Ymxpc2gi
+        LCAiZmFpbHVyZV90aHJlc2hvbGQiOiBudWxsLCAicmVzb3VyY2UiOiAicHVs
+        cDppbXBvcnRlcjpGZWRvcmFfMTc6eXVtX2ltcG9ydGVyIiwgIl9pZCI6ICI1
+        NmNjOGQwZGRlMDQwMzNmNDFkMmEzYmQiLCAiY29uc2VjdXRpdmVfZmFpbHVy
+        ZXMiOiAwLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9G
+        ZWRvcmFfMTcvaW1wb3J0ZXJzL3l1bV9pbXBvcnRlci9zY2hlZHVsZXMvc3lu
+        Yy81NmNjOGQwZGRlMDQwMzNmNDFkMmEzYmQvIn0=
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:58:24 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:09 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -920,13 +178,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:58:24 GMT
+      - Tue, 23 Feb 2016 16:47:10 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '662'
+      - '661'
       Connection:
       - close
       Content-Type:
@@ -934,26 +192,26 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibmV4dF9ydW4iOiAiMjAxNi0wMi0xMVQyMTo1ODoyNFoiLCAicmVtYWlu
-        aW5nX3J1bnMiOiAxLCAibGFzdF91cGRhdGVkIjogMTQ1NTIyNzkwNC41MDk4
-        ODYsICJmaXJzdF9ydW4iOiAiMDMwMS0wMS0wMVQwNTowMDowMFoiLCAidG90
-        YWxfcnVuX2NvdW50IjogMCwgInNjaGVkdWxlIjogIlIxLzAzMC0wMS0wMVQw
-        NTowMDowMFovUDFEIiwgImt3YXJncyI6IHsib3ZlcnJpZGVzIjoge30sICJz
-        Y2hlZHVsZWRfY2FsbF9pZCI6ICI1NmJkMDQwMDY3N2M3NDJkMDZjY2NkZjAi
-        fSwgImFyZ3MiOiBbIkZlZG9yYV8xNyJdLCAiZW5hYmxlZCI6IHRydWUsICJs
-        YXN0X3J1bl9hdCI6IG51bGwsICJ0YXNrIjogInB1bHAuc2VydmVyLmNvbnRy
-        b2xsZXJzLnJlcG9zaXRvcnkucXVldWVfc3luY193aXRoX2F1dG9fcHVibGlz
-        aCIsICJmYWlsdXJlX3RocmVzaG9sZCI6IG51bGwsICJyZXNvdXJjZSI6ICJw
-        dWxwOmltcG9ydGVyOkZlZG9yYV8xNzp5dW1faW1wb3J0ZXIiLCAiX2lkIjog
-        IjU2YmQwNDAwNjc3Yzc0MmQwNmNjY2RmMCIsICJjb25zZWN1dGl2ZV9mYWls
-        dXJlcyI6IDAsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVz
-        L0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyL3NjaGVkdWxlcy9z
-        eW5jLzU2YmQwNDAwNjc3Yzc0MmQwNmNjY2RmMC8ifV0=
+        W3sibmV4dF9ydW4iOiAiMjAxNi0wMi0yM1QxNjo0NzoxMFoiLCAicmVtYWlu
+        aW5nX3J1bnMiOiAxLCAibGFzdF91cGRhdGVkIjogMTQ1NjI0NjAyOS45Nzg0
+        NiwgImZpcnN0X3J1biI6ICIwMzAxLTAxLTAxVDA1OjAwOjAwWiIsICJ0b3Rh
+        bF9ydW5fY291bnQiOiAwLCAic2NoZWR1bGUiOiAiUjEvMDMwLTAxLTAxVDA1
+        OjAwOjAwWi9QMUQiLCAia3dhcmdzIjogeyJvdmVycmlkZXMiOiB7fSwgInNj
+        aGVkdWxlZF9jYWxsX2lkIjogIjU2Y2M4ZDBkZGUwNDAzM2Y0MWQyYTNiZCJ9
+        LCAiYXJncyI6IFsiRmVkb3JhXzE3Il0sICJlbmFibGVkIjogdHJ1ZSwgImxh
+        c3RfcnVuX2F0IjogbnVsbCwgInRhc2siOiAicHVscC5zZXJ2ZXIuY29udHJv
+        bGxlcnMucmVwb3NpdG9yeS5xdWV1ZV9zeW5jX3dpdGhfYXV0b19wdWJsaXNo
+        IiwgImZhaWx1cmVfdGhyZXNob2xkIjogbnVsbCwgInJlc291cmNlIjogInB1
+        bHA6aW1wb3J0ZXI6RmVkb3JhXzE3Onl1bV9pbXBvcnRlciIsICJfaWQiOiAi
+        NTZjYzhkMGRkZTA0MDMzZjQxZDJhM2JkIiwgImNvbnNlY3V0aXZlX2ZhaWx1
+        cmVzIjogMCwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
+        RmVkb3JhXzE3L2ltcG9ydGVycy95dW1faW1wb3J0ZXIvc2NoZWR1bGVzL3N5
+        bmMvNTZjYzhkMGRkZTA0MDMzZjQxZDJhM2JkLyJ9XQ==
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:58:24 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:10 GMT
 - request:
     method: put
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56bd0400677c742d06cccdf0/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56cc8d0dde04033f41d2a3bd/
     body:
       encoding: UTF-8
       base64_string: |
@@ -975,7 +233,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:58:24 GMT
+      - Tue, 23 Feb 2016 16:47:10 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -989,26 +247,26 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJuZXh0X3J1biI6ICIyMDE2LTAyLTExVDIxOjU4OjI1WiIsICJyZW1haW5p
-        bmdfcnVucyI6IDEsICJsYXN0X3VwZGF0ZWQiOiAxNDU1MjI3OTA0Ljk3MDcx
+        eyJuZXh0X3J1biI6ICIyMDE2LTAyLTIzVDE2OjQ3OjEwWiIsICJyZW1haW5p
+        bmdfcnVucyI6IDEsICJsYXN0X3VwZGF0ZWQiOiAxNDU2MjQ2MDMwLjMzMjIy
         NSwgImZpcnN0X3J1biI6ICIwMzAxLTAxLTAxVDA1OjAwOjAwWiIsICJ0b3Rh
         bF9ydW5fY291bnQiOiAwLCAic2NoZWR1bGUiOiAiUjEvMDMwLTAxLTAxVDA1
         OjAwOjAwWi9QMUQiLCAia3dhcmdzIjogeyJvdmVycmlkZXMiOiB7fSwgInNj
-        aGVkdWxlZF9jYWxsX2lkIjogIjU2YmQwNDAwNjc3Yzc0MmQwNmNjY2RmMCJ9
+        aGVkdWxlZF9jYWxsX2lkIjogIjU2Y2M4ZDBkZGUwNDAzM2Y0MWQyYTNiZCJ9
         LCAiYXJncyI6IFsiRmVkb3JhXzE3Il0sICJlbmFibGVkIjogZmFsc2UsICJs
         YXN0X3J1bl9hdCI6IG51bGwsICJ0YXNrIjogInB1bHAuc2VydmVyLmNvbnRy
         b2xsZXJzLnJlcG9zaXRvcnkucXVldWVfc3luY193aXRoX2F1dG9fcHVibGlz
         aCIsICJmYWlsdXJlX3RocmVzaG9sZCI6IG51bGwsICJyZXNvdXJjZSI6ICJw
         dWxwOmltcG9ydGVyOkZlZG9yYV8xNzp5dW1faW1wb3J0ZXIiLCAiX2lkIjog
-        IjU2YmQwNDAwNjc3Yzc0MmQwNmNjY2RmMCIsICJjb25zZWN1dGl2ZV9mYWls
+        IjU2Y2M4ZDBkZGUwNDAzM2Y0MWQyYTNiZCIsICJjb25zZWN1dGl2ZV9mYWls
         dXJlcyI6IDAsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVz
         L0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyL3NjaGVkdWxlcy9z
-        eW5jLzU2YmQwNDAwNjc3Yzc0MmQwNmNjY2RmMC8ifQ==
+        eW5jLzU2Y2M4ZDBkZGUwNDAzM2Y0MWQyYTNiZC8ifQ==
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:58:25 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:10 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1027,7 +285,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:58:25 GMT
+      - Tue, 23 Feb 2016 16:47:10 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -1041,26 +299,26 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibmV4dF9ydW4iOiAiMjAxNi0wMi0xMVQyMTo1ODoyNVoiLCAicmVtYWlu
-        aW5nX3J1bnMiOiAxLCAibGFzdF91cGRhdGVkIjogMTQ1NTIyNzkwNC45NzA3
-        MTUsICJmaXJzdF9ydW4iOiAiMDMwMS0wMS0wMVQwNTowMDowMFoiLCAidG90
+        W3sibmV4dF9ydW4iOiAiMjAxNi0wMi0yM1QxNjo0NzoxMFoiLCAicmVtYWlu
+        aW5nX3J1bnMiOiAxLCAibGFzdF91cGRhdGVkIjogMTQ1NjI0NjAzMC4zMzIy
+        MjUsICJmaXJzdF9ydW4iOiAiMDMwMS0wMS0wMVQwNTowMDowMFoiLCAidG90
         YWxfcnVuX2NvdW50IjogMCwgInNjaGVkdWxlIjogIlIxLzAzMC0wMS0wMVQw
         NTowMDowMFovUDFEIiwgImt3YXJncyI6IHsib3ZlcnJpZGVzIjoge30sICJz
-        Y2hlZHVsZWRfY2FsbF9pZCI6ICI1NmJkMDQwMDY3N2M3NDJkMDZjY2NkZjAi
+        Y2hlZHVsZWRfY2FsbF9pZCI6ICI1NmNjOGQwZGRlMDQwMzNmNDFkMmEzYmQi
         fSwgImFyZ3MiOiBbIkZlZG9yYV8xNyJdLCAiZW5hYmxlZCI6IGZhbHNlLCAi
         bGFzdF9ydW5fYXQiOiBudWxsLCAidGFzayI6ICJwdWxwLnNlcnZlci5jb250
         cm9sbGVycy5yZXBvc2l0b3J5LnF1ZXVlX3N5bmNfd2l0aF9hdXRvX3B1Ymxp
         c2giLCAiZmFpbHVyZV90aHJlc2hvbGQiOiBudWxsLCAicmVzb3VyY2UiOiAi
         cHVscDppbXBvcnRlcjpGZWRvcmFfMTc6eXVtX2ltcG9ydGVyIiwgIl9pZCI6
-        ICI1NmJkMDQwMDY3N2M3NDJkMDZjY2NkZjAiLCAiY29uc2VjdXRpdmVfZmFp
+        ICI1NmNjOGQwZGRlMDQwMzNmNDFkMmEzYmQiLCAiY29uc2VjdXRpdmVfZmFp
         bHVyZXMiOiAwLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
         cy9GZWRvcmFfMTcvaW1wb3J0ZXJzL3l1bV9pbXBvcnRlci9zY2hlZHVsZXMv
-        c3luYy81NmJkMDQwMDY3N2M3NDJkMDZjY2NkZjAvIn1d
+        c3luYy81NmNjOGQwZGRlMDQwMzNmNDFkMmEzYmQvIn1d
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:58:25 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:10 GMT
 - request:
     method: delete
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1079,7 +337,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:58:25 GMT
+      - Tue, 23 Feb 2016 16:47:10 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -1092,14 +350,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzYxMTcwMWIzLWM4OGYtNGI3OS05MWJjLWZhYzk5MWZlODdlOC8iLCAi
-        dGFza19pZCI6ICI2MTE3MDFiMy1jODhmLTRiNzktOTFiYy1mYWM5OTFmZTg3
-        ZTgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzEyNDA0ODZmLWQzYjctNDVjYi04YTlhLWQ3YTU5NDZhOWI3YS8iLCAi
+        dGFza19pZCI6ICIxMjQwNDg2Zi1kM2I3LTQ1Y2ItOGE5YS1kN2E1OTQ2YTli
+        N2EifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:58:25 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:10 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/611701b3-c88f-4b79-91bc-fac991fe87e8/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/1240486f-d3b7-45cb-8a9a-d7a5946a9b7a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1118,13 +376,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:58:25 GMT
+      - Tue, 23 Feb 2016 16:47:10 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '663'
       Connection:
       - close
       Content-Type:
@@ -1134,22 +392,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82MTE3MDFiMy1jODhmLTRiNzktOTFiYy1mYWM5OTFmZTg3
-        ZTgvIiwgInRhc2tfaWQiOiAiNjExNzAxYjMtYzg4Zi00Yjc5LTkxYmMtZmFj
-        OTkxZmU4N2U4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xMjQwNDg2Zi1kM2I3LTQ1Y2ItOGE5YS1kN2E1OTQ2YTli
+        N2EvIiwgInRhc2tfaWQiOiAiMTI0MDQ4NmYtZDNiNy00NWNiLThhOWEtZDdh
+        NTk0NmE5YjdhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJkMDQw
-        MTM0NDcxZTQwMDcwYjA5N2EifSwgImlkIjogIjU2YmQwNDAxMzQ0NzFlNDAw
-        NzBiMDk3YSJ9
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ3OjEwWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQwZTk4OTA1NGZjNDhiYTJlNDkifSwg
+        ImlkIjogIjU2Y2M4ZDBlOTg5MDU0ZmM0OGJhMmU0OSJ9
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:58:25 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:10 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/611701b3-c88f-4b79-91bc-fac991fe87e8/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/1240486f-d3b7-45cb-8a9a-d7a5946a9b7a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1168,13 +428,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:58:26 GMT
+      - Tue, 23 Feb 2016 16:47:11 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '688'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -1184,20 +444,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82MTE3MDFiMy1jODhmLTRiNzktOTFiYy1mYWM5OTFmZTg3
-        ZTgvIiwgInRhc2tfaWQiOiAiNjExNzAxYjMtYzg4Zi00Yjc5LTkxYmMtZmFj
-        OTkxZmU4N2U4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xMjQwNDg2Zi1kM2I3LTQ1Y2ItOGE5YS1kN2E1OTQ2YTli
+        N2EvIiwgInRhc2tfaWQiOiAiMTI0MDQ4NmYtZDNiNy00NWNiLThhOWEtZDdh
+        NTk0NmE5YjdhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTExVDIxOjU4OjI1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTExVDIxOjU4OjI1WiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ3OjEwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ3OjEwWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZDA0MDEzNDQ3MWU0MDA3MGIwOTdhIn0sICJpZCI6ICI1NmJkMDQwMTM0NDcx
-        ZTQwMDcwYjA5N2EifQ==
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMGU5
+        ODkwNTRmYzQ4YmEyZTQ5In0sICJpZCI6ICI1NmNjOGQwZTk4OTA1NGZjNDhi
+        YTJlNDkifQ==
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:58:26 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:11 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/actions/pulp/repository/update_schedule/update_schedule.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp/repository/update_schedule/update_schedule.yml
@@ -10,7 +10,8 @@ http_interactions:
         ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
         b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
         ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
+        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
+        IjpudWxsLCJyZW1vdmVfbWlzc2luZyI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
         LXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1
         dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9j
         b25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIiwiaHR0cCI6ZmFs
@@ -20,12 +21,10 @@ http_interactions:
         dHJpYnV0b3JfY29uZmlnIjp7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lk
         IjoiRmVkb3JhXzE3In0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1
         dG9yX2lkIjoiRmVkb3JhXzE3X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBl
-        X2lkIjoibm9kZXNfaHR0cF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2Nv
-        bmZpZyI6e30sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3JfaWQi
-        OiJGZWRvcmFfMTdfbm9kZXMifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJl
-        eHBvcnRfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0
-        cCI6ZmFsc2UsImh0dHBzIjpmYWxzZX0sImF1dG9fcHVibGlzaCI6ZmFsc2Us
-        ImRpc3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
+        X2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmln
+        Ijp7Imh0dHAiOmZhbHNlLCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6
+        InRlc3RfcGF0aCJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRv
+        cl9pZCI6ImV4cG9ydF9kaXN0cmlidXRvciJ9XX0=
     headers:
       Accept:
       - application/json
@@ -33,14 +32,8 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4",
-        oauth_nonce="kHIs2diRsYdP7h5sRsxEgpVIO3p3F6yJeMHFGZSNFw", oauth_signature="MiLmUcvFBeHcwOTKaxrNNiIXETY%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454291945", oauth_version="1.0"
-      Pulp-User:
-      - admin
       Content-Length:
-      - '895'
+      - '839'
       User-Agent:
       - Ruby
   response:
@@ -49,7 +42,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Mon, 01 Feb 2016 01:59:05 GMT
+      - Tue, 23 Feb 2016 16:47:11 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -68,14 +61,50 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZhZWJiZTlkZTA0MDMzNDZkMTg4ZmM3In0sICJpZCI6ICJGZWRvcmFfMTci
+        NTZjYzhkMGZkZTA0MDMzZjQzNTE0ZjQ0In0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:05 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:11 GMT
 - request:
-    method: put
-    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56aebbe9de0403346d188fce/
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:47:11 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '2'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        W10=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:11 GMT
+- request:
+    method: post
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -87,56 +116,50 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4",
-        oauth_nonce="RSqjSCMg0uAGbKJOEGItDK8ROOsrhhLUOEMQD20BuA", oauth_signature="vi%2BIy7Ylz1HWBi8R3DSlu2DFV0U%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454291945", oauth_version="1.0"
-      Pulp-User:
-      - admin
       Content-Length:
       - '41'
       User-Agent:
       - Ruby
   response:
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: CREATED
     headers:
       Date:
-      - Mon, 01 Feb 2016 01:59:05 GMT
+      - Tue, 23 Feb 2016 16:47:11 GMT
       Server:
       - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
       Content-Length:
       - '660'
+      Location:
+      - https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56cc8d0fde04033f43514f4a/
       Connection:
       - close
       Content-Type:
       - application/json; charset=utf-8
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       base64_string: |
-        eyJuZXh0X3J1biI6ICIyMDE2LTAyLTAxVDAxOjU5OjA1WiIsICJyZW1haW5p
-        bmdfcnVucyI6IDEsICJsYXN0X3VwZGF0ZWQiOiAxNDU0MjkxOTQ1LjkzNjIy
+        eyJuZXh0X3J1biI6ICIyMDE2LTAyLTIzVDE2OjQ3OjExWiIsICJyZW1haW5p
+        bmdfcnVucyI6IDEsICJsYXN0X3VwZGF0ZWQiOiAxNDU2MjQ2MDMxLjk5NTI0
         MywgImZpcnN0X3J1biI6ICIwMzAxLTAxLTAxVDA1OjAwOjAwWiIsICJ0b3Rh
         bF9ydW5fY291bnQiOiAwLCAic2NoZWR1bGUiOiAiUjEvMDMwLTAxLTAxVDA1
         OjAwOjAwWi9QMUQiLCAia3dhcmdzIjogeyJvdmVycmlkZXMiOiB7fSwgInNj
-        aGVkdWxlZF9jYWxsX2lkIjogIjU2YWViYmU5ZGUwNDAzMzQ2ZDE4OGZjZSJ9
+        aGVkdWxlZF9jYWxsX2lkIjogIjU2Y2M4ZDBmZGUwNDAzM2Y0MzUxNGY0YSJ9
         LCAiYXJncyI6IFsiRmVkb3JhXzE3Il0sICJlbmFibGVkIjogdHJ1ZSwgImxh
         c3RfcnVuX2F0IjogbnVsbCwgInRhc2siOiAicHVscC5zZXJ2ZXIuY29udHJv
         bGxlcnMucmVwb3NpdG9yeS5xdWV1ZV9zeW5jX3dpdGhfYXV0b19wdWJsaXNo
         IiwgImZhaWx1cmVfdGhyZXNob2xkIjogbnVsbCwgInJlc291cmNlIjogInB1
         bHA6aW1wb3J0ZXI6RmVkb3JhXzE3Onl1bV9pbXBvcnRlciIsICJfaWQiOiAi
-        NTZhZWJiZTlkZTA0MDMzNDZkMTg4ZmNlIiwgImNvbnNlY3V0aXZlX2ZhaWx1
+        NTZjYzhkMGZkZTA0MDMzZjQzNTE0ZjRhIiwgImNvbnNlY3V0aXZlX2ZhaWx1
         cmVzIjogMCwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
         RmVkb3JhXzE3L2ltcG9ydGVycy95dW1faW1wb3J0ZXIvc2NoZWR1bGVzL3N5
-        bmMvNTZhZWJiZTlkZTA0MDMzNDZkMTg4ZmNlLyJ9
+        bmMvNTZjYzhkMGZkZTA0MDMzZjQzNTE0ZjRhLyJ9
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:05 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:12 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/f8ae098b-520b-4c52-8f84-7bf3683eebcb/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -147,12 +170,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="rENtAhQRTYSKLfZLRRylwMRg1BzDKclNcFGaUCTHphs",
-        oauth_signature="bER0MRgtTv65Mr4wBCeRMCDlUkA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291946", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -161,13 +178,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 01:59:06 GMT
+      - Tue, 23 Feb 2016 16:47:12 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '662'
       Connection:
       - close
       Content-Type:
@@ -175,154 +192,26 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mOGFlMDk4Yi01MjBiLTRjNTItOGY4NC03YmYzNjgzZWVi
-        Y2IvIiwgInRhc2tfaWQiOiAiZjhhZTA5OGItNTIwYi00YzUyLThmODQtN2Jm
-        MzY4M2VlYmNiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmFlYmJl
-        YWU1NDk3NWY3MWE2YTY0NDIifSwgImlkIjogIjU2YWViYmVhZTU0OTc1Zjcx
-        YTZhNjQ0MiJ9
+        W3sibmV4dF9ydW4iOiAiMjAxNi0wMi0yM1QxNjo0NzoxMloiLCAicmVtYWlu
+        aW5nX3J1bnMiOiAxLCAibGFzdF91cGRhdGVkIjogMTQ1NjI0NjAzMS45OTUy
+        NDMsICJmaXJzdF9ydW4iOiAiMDMwMS0wMS0wMVQwNTowMDowMFoiLCAidG90
+        YWxfcnVuX2NvdW50IjogMCwgInNjaGVkdWxlIjogIlIxLzAzMC0wMS0wMVQw
+        NTowMDowMFovUDFEIiwgImt3YXJncyI6IHsib3ZlcnJpZGVzIjoge30sICJz
+        Y2hlZHVsZWRfY2FsbF9pZCI6ICI1NmNjOGQwZmRlMDQwMzNmNDM1MTRmNGEi
+        fSwgImFyZ3MiOiBbIkZlZG9yYV8xNyJdLCAiZW5hYmxlZCI6IHRydWUsICJs
+        YXN0X3J1bl9hdCI6IG51bGwsICJ0YXNrIjogInB1bHAuc2VydmVyLmNvbnRy
+        b2xsZXJzLnJlcG9zaXRvcnkucXVldWVfc3luY193aXRoX2F1dG9fcHVibGlz
+        aCIsICJmYWlsdXJlX3RocmVzaG9sZCI6IG51bGwsICJyZXNvdXJjZSI6ICJw
+        dWxwOmltcG9ydGVyOkZlZG9yYV8xNzp5dW1faW1wb3J0ZXIiLCAiX2lkIjog
+        IjU2Y2M4ZDBmZGUwNDAzM2Y0MzUxNGY0YSIsICJjb25zZWN1dGl2ZV9mYWls
+        dXJlcyI6IDAsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVz
+        L0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyL3NjaGVkdWxlcy9z
+        eW5jLzU2Y2M4ZDBmZGUwNDAzM2Y0MzUxNGY0YS8ifV0=
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:06 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/f8ae098b-520b-4c52-8f84-7bf3683eebcb/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="jOjxn3um3oBdq58gc7XVLIuXQaG3TBzLu2wBawvlo5U",
-        oauth_signature="7DJbSw%2BRSVg8%2Ficx3asKPhlQjSA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291946", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:06 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '682'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mOGFlMDk4Yi01MjBiLTRjNTItOGY4NC03YmYzNjgzZWVi
-        Y2IvIiwgInRhc2tfaWQiOiAiZjhhZTA5OGItNTIwYi00YzUyLThmODQtN2Jm
-        MzY4M2VlYmNiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTAxVDAxOjU5OjA2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTAxVDAxOjU5OjA2WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
-        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJiZWFl
-        NTQ5NzVmNzFhNmE2NDQyIn0sICJpZCI6ICI1NmFlYmJlYWU1NDk3NWY3MWE2
-        YTY0NDIifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:06 GMT
-- request:
-    method: post
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
-        IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRp
-        c3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwi
-        OiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3Rl
-        Y3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJleHBvcnRfZGlzdHJpYnV0
-        b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBz
-        IjpmYWxzZSwicmVsYXRpdmVfdXJsIjpudWxsfSwiYXV0b19wdWJsaXNoIjpm
-        YWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJleHBvcnRfZGlzdHJpYnV0b3IifV19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
-        oauth_nonce="4X9zwYH6ba1DPBFEt3DwoA8aMjPz4z6RDThY2Vs", oauth_signature="X6V5ymjSA5aMdHj95H4k0GC%2B1xM%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454693662", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '810'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:22 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '320'
-      Location:
-      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiNGRkMWVjNzgyMWIzMzAzNGJhZjM5In0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:22 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:12 GMT
 - request:
     method: put
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56b4dd1ec7821b3305ce5229/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56cc8d0fde04033f43514f4a/
     body:
       encoding: UTF-8
       base64_string: |
@@ -334,12 +223,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
-        oauth_nonce="gzDrJzvFnBGuxTFaCTwAZwHK5ODq3i1AnBaOkTZX0Y", oauth_signature="LojLtAo0nPZzgEngiWunt0lykGY%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454693662", oauth_version="1.0"
-      Pulp-User:
-      - admin
       Content-Length:
       - '41'
       User-Agent:
@@ -350,257 +233,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 05 Feb 2016 17:34:22 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '660'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJuZXh0X3J1biI6ICIyMDE2LTAyLTA1VDE3OjM0OjIyWiIsICJyZW1haW5p
-        bmdfcnVucyI6IDEsICJsYXN0X3VwZGF0ZWQiOiAxNDU0NjkzNjYyLjc3Njc3
-        MSwgImZpcnN0X3J1biI6ICIwMzAxLTAxLTAxVDA1OjAwOjAwWiIsICJ0b3Rh
-        bF9ydW5fY291bnQiOiAwLCAic2NoZWR1bGUiOiAiUjEvMDMwLTAxLTAxVDA1
-        OjAwOjAwWi9QMUQiLCAia3dhcmdzIjogeyJvdmVycmlkZXMiOiB7fSwgInNj
-        aGVkdWxlZF9jYWxsX2lkIjogIjU2YjRkZDFlYzc4MjFiMzMwNWNlNTIyOSJ9
-        LCAiYXJncyI6IFsiRmVkb3JhXzE3Il0sICJlbmFibGVkIjogdHJ1ZSwgImxh
-        c3RfcnVuX2F0IjogbnVsbCwgInRhc2siOiAicHVscC5zZXJ2ZXIuY29udHJv
-        bGxlcnMucmVwb3NpdG9yeS5xdWV1ZV9zeW5jX3dpdGhfYXV0b19wdWJsaXNo
-        IiwgImZhaWx1cmVfdGhyZXNob2xkIjogbnVsbCwgInJlc291cmNlIjogInB1
-        bHA6aW1wb3J0ZXI6RmVkb3JhXzE3Onl1bV9pbXBvcnRlciIsICJfaWQiOiAi
-        NTZiNGRkMWVjNzgyMWIzMzA1Y2U1MjI5IiwgImNvbnNlY3V0aXZlX2ZhaWx1
-        cmVzIjogMCwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
-        RmVkb3JhXzE3L2ltcG9ydGVycy95dW1faW1wb3J0ZXIvc2NoZWR1bGVzL3N5
-        bmMvNTZiNGRkMWVjNzgyMWIzMzA1Y2U1MjI5LyJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:22 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/20ec4a05-4a3e-4611-936e-71fbcd1939a4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="JrMwwHDV6PvbjtsPSSbcuHk2zpSzMtoZLwFAmR2Djs",
-        oauth_signature="FJ3CuAba4SgDc3XAt%2B7epZDQWK4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693663", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:23 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '651'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yMGVjNGEwNS00YTNlLTQ2MTEtOTM2ZS03MWZiY2QxOTM5
-        YTQvIiwgInRhc2tfaWQiOiAiMjBlYzRhMDUtNGEzZS00NjExLTkzNmUtNzFm
-        YmNkMTkzOWE0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAi
-        c3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
-        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20i
-        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmI0ZGQxZjhhZGE0MGRiMDRlZTBmNTEifSwgImlkIjogIjU2YjRk
-        ZDFmOGFkYTQwZGIwNGVlMGY1MSJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:23 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/20ec4a05-4a3e-4611-936e-71fbcd1939a4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="lgzaGV3unchoBoVWTPFXrVtvGmcKhxgjATefYIDI",
-        oauth_signature="c1lc4di4ldatrbxYQzdBbVEP0XQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693663", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:23 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yMGVjNGEwNS00YTNlLTQ2MTEtOTM2ZS03MWZiY2QxOTM5
-        YTQvIiwgInRhc2tfaWQiOiAiMjBlYzRhMDUtNGEzZS00NjExLTkzNmUtNzFm
-        YmNkMTkzOWE0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA1VDE3OjM0OjIzWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE3OjM0OjIzWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        NGRkMWY4YWRhNDBkYjA0ZWUwZjUxIn0sICJpZCI6ICI1NmI0ZGQxZjhhZGE0
-        MGRiMDRlZTBmNTEifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:23 GMT
-- request:
-    method: post
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
-        IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRp
-        c3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwi
-        OiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3Rl
-        Y3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJleHBvcnRfZGlzdHJpYnV0
-        b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBz
-        IjpmYWxzZSwicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIn0sImF1dG9fcHVi
-        bGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1
-        dG9yIn1dfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb",
-        oauth_nonce="BcL9GvebRkiupROrsIgqwGD1aRghrqKAyzMSl2TlC4", oauth_signature="6v0NDjGML4s8aqnBb0IccvF2HO0%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454949630", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '817'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:40:30 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '320'
-      Location:
-      - https://katello-centos7-devel.example.com/pulp/api/v2/repositories/Fedora_17/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: US-ASCII
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiOGM0ZmUxN2YyNWUwZGE0OGI4NDIyIn0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:40:30 GMT
-- request:
-    method: put
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56b8c4fe17f25e0da48b8428/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY2hlZHVsZSI6IlIxLzAzMC0wMS0wMVQwNTowMDowMFovUDFEIn0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb",
-        oauth_nonce="mhWPhALS82m9BqK3RfWiRpXxiD0CWC1Spol2khTQhQg", oauth_signature="EavraXvii7E096YPLogM6ud4ajc%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454949631", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '41'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:40:31 GMT
+      - Tue, 23 Feb 2016 16:47:12 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -614,26 +247,26 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJuZXh0X3J1biI6ICIyMDE2LTAyLTA4VDE2OjQwOjMxWiIsICJyZW1haW5p
-        bmdfcnVucyI6IDEsICJsYXN0X3VwZGF0ZWQiOiAxNDU0OTQ5NjMxLjI3MDE3
+        eyJuZXh0X3J1biI6ICIyMDE2LTAyLTIzVDE2OjQ3OjEyWiIsICJyZW1haW5p
+        bmdfcnVucyI6IDEsICJsYXN0X3VwZGF0ZWQiOiAxNDU2MjQ2MDMyLjMwNjM0
         LCAiZmlyc3RfcnVuIjogIjAzMDEtMDEtMDFUMDU6MDA6MDBaIiwgInRvdGFs
         X3J1bl9jb3VudCI6IDAsICJzY2hlZHVsZSI6ICJSMS8wMzAtMDEtMDFUMDU6
         MDA6MDBaL1AxRCIsICJrd2FyZ3MiOiB7Im92ZXJyaWRlcyI6IHt9LCAic2No
-        ZWR1bGVkX2NhbGxfaWQiOiAiNTZiOGM0ZmUxN2YyNWUwZGE0OGI4NDI4In0s
+        ZWR1bGVkX2NhbGxfaWQiOiAiNTZjYzhkMGZkZTA0MDMzZjQzNTE0ZjRhIn0s
         ICJhcmdzIjogWyJGZWRvcmFfMTciXSwgImVuYWJsZWQiOiB0cnVlLCAibGFz
         dF9ydW5fYXQiOiBudWxsLCAidGFzayI6ICJwdWxwLnNlcnZlci5jb250cm9s
         bGVycy5yZXBvc2l0b3J5LnF1ZXVlX3N5bmNfd2l0aF9hdXRvX3B1Ymxpc2gi
         LCAiZmFpbHVyZV90aHJlc2hvbGQiOiBudWxsLCAicmVzb3VyY2UiOiAicHVs
         cDppbXBvcnRlcjpGZWRvcmFfMTc6eXVtX2ltcG9ydGVyIiwgIl9pZCI6ICI1
-        NmI4YzRmZTE3ZjI1ZTBkYTQ4Yjg0MjgiLCAiY29uc2VjdXRpdmVfZmFpbHVy
+        NmNjOGQwZmRlMDQwMzNmNDM1MTRmNGEiLCAiY29uc2VjdXRpdmVfZmFpbHVy
         ZXMiOiAwLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9G
         ZWRvcmFfMTcvaW1wb3J0ZXJzL3l1bV9pbXBvcnRlci9zY2hlZHVsZXMvc3lu
-        Yy81NmI4YzRmZTE3ZjI1ZTBkYTQ4Yjg0MjgvIn0=
-    http_version:
-  recorded_at: Mon, 08 Feb 2016 16:40:31 GMT
+        Yy81NmNjOGQwZmRlMDQwMzNmNDM1MTRmNGEvIn0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:12 GMT
 - request:
     method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/592c4784-7d87-412d-b78f-2f8ecb9e2398/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -644,12 +277,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="GXvlnoZITPl2I0LFOe1EBvCFGFhTSpYU5vAo0x8O04",
-        oauth_signature="d9gOpM4Lq9tnMRXv6Qj76gSJ86k%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949631", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -658,13 +285,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 08 Feb 2016 16:40:31 GMT
+      - Tue, 23 Feb 2016 16:47:12 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '661'
       Connection:
       - close
       Content-Type:
@@ -672,395 +299,26 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81OTJjNDc4NC03ZDg3LTQxMmQtYjc4Zi0yZjhlY2I5ZTIz
-        OTgvIiwgInRhc2tfaWQiOiAiNTkyYzQ3ODQtN2Q4Ny00MTJkLWI3OGYtMmY4
-        ZWNiOWUyMzk4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI4YzRm
-        ZmMxOWZmNTA3OTgyM2YyNGEifSwgImlkIjogIjU2YjhjNGZmYzE5ZmY1MDc5
-        ODIzZjI0YSJ9
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:40:31 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/592c4784-7d87-412d-b78f-2f8ecb9e2398/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="tknETJUhKeFRd079JhAtPAiKrlB2aRdaOPMAezLzBs",
-        oauth_signature="YJo3aZUJSZvlS1lVCSNjQxIf5L0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949632", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:40:32 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '700'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81OTJjNDc4NC03ZDg3LTQxMmQtYjc4Zi0yZjhlY2I5ZTIz
-        OTgvIiwgInRhc2tfaWQiOiAiNTkyYzQ3ODQtN2Q4Ny00MTJkLWI3OGYtMmY4
-        ZWNiOWUyMzk4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA4VDE2OjQwOjMxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA4VDE2OjQwOjMxWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20uZHEiLCAic3Rh
-        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUu
-        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNTZiOGM0ZmZjMTlmZjUwNzk4MjNmMjRhIn0sICJpZCI6ICI1
-        NmI4YzRmZmMxOWZmNTA3OTgyM2YyNGEifQ==
-    http_version:
-  recorded_at: Mon, 08 Feb 2016 16:40:32 GMT
-- request:
-    method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
-        IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRp
-        c3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwi
-        OiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3Rl
-        Y3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifV19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '636'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:58:27 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '320'
-      Location:
-      - https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiZDA0MDM2NzdjNzQyZDA2Y2NjZGYyIn0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:58:27 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:58:27 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '2'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W10=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:58:27 GMT
-- request:
-    method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY2hlZHVsZSI6IlIxLzAzMC0wMS0wMVQwNTowMDowMFovUDFEIn0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '41'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:58:27 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '660'
-      Location:
-      - https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56bd0403677c742d049b00ac/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJuZXh0X3J1biI6ICIyMDE2LTAyLTExVDIxOjU4OjI3WiIsICJyZW1haW5p
-        bmdfcnVucyI6IDEsICJsYXN0X3VwZGF0ZWQiOiAxNDU1MjI3OTA3LjcwMDcy
-        MywgImZpcnN0X3J1biI6ICIwMzAxLTAxLTAxVDA1OjAwOjAwWiIsICJ0b3Rh
+        W3sibmV4dF9ydW4iOiAiMjAxNi0wMi0yM1QxNjo0NzoxMloiLCAicmVtYWlu
+        aW5nX3J1bnMiOiAxLCAibGFzdF91cGRhdGVkIjogMTQ1NjI0NjAzMi4zMDYz
+        NCwgImZpcnN0X3J1biI6ICIwMzAxLTAxLTAxVDA1OjAwOjAwWiIsICJ0b3Rh
         bF9ydW5fY291bnQiOiAwLCAic2NoZWR1bGUiOiAiUjEvMDMwLTAxLTAxVDA1
         OjAwOjAwWi9QMUQiLCAia3dhcmdzIjogeyJvdmVycmlkZXMiOiB7fSwgInNj
-        aGVkdWxlZF9jYWxsX2lkIjogIjU2YmQwNDAzNjc3Yzc0MmQwNDliMDBhYyJ9
+        aGVkdWxlZF9jYWxsX2lkIjogIjU2Y2M4ZDBmZGUwNDAzM2Y0MzUxNGY0YSJ9
         LCAiYXJncyI6IFsiRmVkb3JhXzE3Il0sICJlbmFibGVkIjogdHJ1ZSwgImxh
         c3RfcnVuX2F0IjogbnVsbCwgInRhc2siOiAicHVscC5zZXJ2ZXIuY29udHJv
         bGxlcnMucmVwb3NpdG9yeS5xdWV1ZV9zeW5jX3dpdGhfYXV0b19wdWJsaXNo
         IiwgImZhaWx1cmVfdGhyZXNob2xkIjogbnVsbCwgInJlc291cmNlIjogInB1
         bHA6aW1wb3J0ZXI6RmVkb3JhXzE3Onl1bV9pbXBvcnRlciIsICJfaWQiOiAi
-        NTZiZDA0MDM2NzdjNzQyZDA0OWIwMGFjIiwgImNvbnNlY3V0aXZlX2ZhaWx1
+        NTZjYzhkMGZkZTA0MDMzZjQzNTE0ZjRhIiwgImNvbnNlY3V0aXZlX2ZhaWx1
         cmVzIjogMCwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
         RmVkb3JhXzE3L2ltcG9ydGVycy95dW1faW1wb3J0ZXIvc2NoZWR1bGVzL3N5
-        bmMvNTZiZDA0MDM2NzdjNzQyZDA0OWIwMGFjLyJ9
+        bmMvNTZjYzhkMGZkZTA0MDMzZjQzNTE0ZjRhLyJ9XQ==
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:58:27 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:58:28 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '662'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sibmV4dF9ydW4iOiAiMjAxNi0wMi0xMVQyMTo1ODoyOFoiLCAicmVtYWlu
-        aW5nX3J1bnMiOiAxLCAibGFzdF91cGRhdGVkIjogMTQ1NTIyNzkwNy43MDA3
-        MjMsICJmaXJzdF9ydW4iOiAiMDMwMS0wMS0wMVQwNTowMDowMFoiLCAidG90
-        YWxfcnVuX2NvdW50IjogMCwgInNjaGVkdWxlIjogIlIxLzAzMC0wMS0wMVQw
-        NTowMDowMFovUDFEIiwgImt3YXJncyI6IHsib3ZlcnJpZGVzIjoge30sICJz
-        Y2hlZHVsZWRfY2FsbF9pZCI6ICI1NmJkMDQwMzY3N2M3NDJkMDQ5YjAwYWMi
-        fSwgImFyZ3MiOiBbIkZlZG9yYV8xNyJdLCAiZW5hYmxlZCI6IHRydWUsICJs
-        YXN0X3J1bl9hdCI6IG51bGwsICJ0YXNrIjogInB1bHAuc2VydmVyLmNvbnRy
-        b2xsZXJzLnJlcG9zaXRvcnkucXVldWVfc3luY193aXRoX2F1dG9fcHVibGlz
-        aCIsICJmYWlsdXJlX3RocmVzaG9sZCI6IG51bGwsICJyZXNvdXJjZSI6ICJw
-        dWxwOmltcG9ydGVyOkZlZG9yYV8xNzp5dW1faW1wb3J0ZXIiLCAiX2lkIjog
-        IjU2YmQwNDAzNjc3Yzc0MmQwNDliMDBhYyIsICJjb25zZWN1dGl2ZV9mYWls
-        dXJlcyI6IDAsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVz
-        L0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyL3NjaGVkdWxlcy9z
-        eW5jLzU2YmQwNDAzNjc3Yzc0MmQwNDliMDBhYy8ifV0=
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:58:28 GMT
-- request:
-    method: put
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56bd0403677c742d049b00ac/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY2hlZHVsZSI6IlIxLzAzMC0wMS0wMVQwNTowMDowMFovUDFEIn0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '41'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:58:28 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '660'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJuZXh0X3J1biI6ICIyMDE2LTAyLTExVDIxOjU4OjI4WiIsICJyZW1haW5p
-        bmdfcnVucyI6IDEsICJsYXN0X3VwZGF0ZWQiOiAxNDU1MjI3OTA4LjExODIz
-        NiwgImZpcnN0X3J1biI6ICIwMzAxLTAxLTAxVDA1OjAwOjAwWiIsICJ0b3Rh
-        bF9ydW5fY291bnQiOiAwLCAic2NoZWR1bGUiOiAiUjEvMDMwLTAxLTAxVDA1
-        OjAwOjAwWi9QMUQiLCAia3dhcmdzIjogeyJvdmVycmlkZXMiOiB7fSwgInNj
-        aGVkdWxlZF9jYWxsX2lkIjogIjU2YmQwNDAzNjc3Yzc0MmQwNDliMDBhYyJ9
-        LCAiYXJncyI6IFsiRmVkb3JhXzE3Il0sICJlbmFibGVkIjogdHJ1ZSwgImxh
-        c3RfcnVuX2F0IjogbnVsbCwgInRhc2siOiAicHVscC5zZXJ2ZXIuY29udHJv
-        bGxlcnMucmVwb3NpdG9yeS5xdWV1ZV9zeW5jX3dpdGhfYXV0b19wdWJsaXNo
-        IiwgImZhaWx1cmVfdGhyZXNob2xkIjogbnVsbCwgInJlc291cmNlIjogInB1
-        bHA6aW1wb3J0ZXI6RmVkb3JhXzE3Onl1bV9pbXBvcnRlciIsICJfaWQiOiAi
-        NTZiZDA0MDM2NzdjNzQyZDA0OWIwMGFjIiwgImNvbnNlY3V0aXZlX2ZhaWx1
-        cmVzIjogMCwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
-        RmVkb3JhXzE3L2ltcG9ydGVycy95dW1faW1wb3J0ZXIvc2NoZWR1bGVzL3N5
-        bmMvNTZiZDA0MDM2NzdjNzQyZDA0OWIwMGFjLyJ9
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:58:28 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:58:28 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '662'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sibmV4dF9ydW4iOiAiMjAxNi0wMi0xMVQyMTo1ODoyOFoiLCAicmVtYWlu
-        aW5nX3J1bnMiOiAxLCAibGFzdF91cGRhdGVkIjogMTQ1NTIyNzkwOC4xMTgy
-        MzYsICJmaXJzdF9ydW4iOiAiMDMwMS0wMS0wMVQwNTowMDowMFoiLCAidG90
-        YWxfcnVuX2NvdW50IjogMCwgInNjaGVkdWxlIjogIlIxLzAzMC0wMS0wMVQw
-        NTowMDowMFovUDFEIiwgImt3YXJncyI6IHsib3ZlcnJpZGVzIjoge30sICJz
-        Y2hlZHVsZWRfY2FsbF9pZCI6ICI1NmJkMDQwMzY3N2M3NDJkMDQ5YjAwYWMi
-        fSwgImFyZ3MiOiBbIkZlZG9yYV8xNyJdLCAiZW5hYmxlZCI6IHRydWUsICJs
-        YXN0X3J1bl9hdCI6IG51bGwsICJ0YXNrIjogInB1bHAuc2VydmVyLmNvbnRy
-        b2xsZXJzLnJlcG9zaXRvcnkucXVldWVfc3luY193aXRoX2F1dG9fcHVibGlz
-        aCIsICJmYWlsdXJlX3RocmVzaG9sZCI6IG51bGwsICJyZXNvdXJjZSI6ICJw
-        dWxwOmltcG9ydGVyOkZlZG9yYV8xNzp5dW1faW1wb3J0ZXIiLCAiX2lkIjog
-        IjU2YmQwNDAzNjc3Yzc0MmQwNDliMDBhYyIsICJjb25zZWN1dGl2ZV9mYWls
-        dXJlcyI6IDAsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVz
-        L0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyL3NjaGVkdWxlcy9z
-        eW5jLzU2YmQwNDAzNjc3Yzc0MmQwNDliMDBhYy8ifV0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:58:28 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:12 GMT
 - request:
     method: delete
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1079,7 +337,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:58:28 GMT
+      - Tue, 23 Feb 2016 16:47:12 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -1092,14 +350,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2UyZGVhN2VlLWEyZWMtNDk1NC1iZjNkLWQxYzc4MWRjN2E1YS8iLCAi
-        dGFza19pZCI6ICJlMmRlYTdlZS1hMmVjLTQ5NTQtYmYzZC1kMWM3ODFkYzdh
-        NWEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2FiYTJhZjBlLWY4NTMtNDI4Zi05YTZmLTA5ZTc4MzJlZmI0YS8iLCAi
+        dGFza19pZCI6ICJhYmEyYWYwZS1mODUzLTQyOGYtOWE2Zi0wOWU3ODMyZWZi
+        NGEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:58:28 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:12 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/e2dea7ee-a2ec-4954-bf3d-d1c781dc7a5a/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/aba2af0e-f853-428f-9a6f-09e7832efb4a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1118,13 +376,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:58:28 GMT
+      - Tue, 23 Feb 2016 16:47:12 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '567'
       Connection:
       - close
       Content-Type:
@@ -1134,22 +392,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lMmRlYTdlZS1hMmVjLTQ5NTQtYmYzZC1kMWM3ODFkYzdh
-        NWEvIiwgInRhc2tfaWQiOiAiZTJkZWE3ZWUtYTJlYy00OTU0LWJmM2QtZDFj
-        NzgxZGM3YTVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hYmEyYWYwZS1mODUzLTQyOGYtOWE2Zi0wOWU3ODMyZWZi
+        NGEvIiwgInRhc2tfaWQiOiAiYWJhMmFmMGUtZjg1My00MjhmLTlhNmYtMDll
+        NzgzMmVmYjRhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJkMDQw
-        NDM0NDcxZTQwMDcwYjA5N2IifSwgImlkIjogIjU2YmQwNDA0MzQ0NzFlNDAw
-        NzBiMDk3YiJ9
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ3OjEyWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJOb25lLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiBudWxsLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6
+        IHsiJG9pZCI6ICI1NmNjOGQxMDk4OTA1NGZjNDhiYTJlNGEifSwgImlkIjog
+        IjU2Y2M4ZDEwOTg5MDU0ZmM0OGJhMmU0YSJ9
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:58:28 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:12 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/e2dea7ee-a2ec-4954-bf3d-d1c781dc7a5a/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/aba2af0e-f853-428f-9a6f-09e7832efb4a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1168,13 +426,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:58:29 GMT
+      - Tue, 23 Feb 2016 16:47:13 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '688'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -1184,20 +442,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lMmRlYTdlZS1hMmVjLTQ5NTQtYmYzZC1kMWM3ODFkYzdh
-        NWEvIiwgInRhc2tfaWQiOiAiZTJkZWE3ZWUtYTJlYy00OTU0LWJmM2QtZDFj
-        NzgxZGM3YTVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hYmEyYWYwZS1mODUzLTQyOGYtOWE2Zi0wOWU3ODMyZWZi
+        NGEvIiwgInRhc2tfaWQiOiAiYWJhMmFmMGUtZjg1My00MjhmLTlhNmYtMDll
+        NzgzMmVmYjRhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTExVDIxOjU4OjI4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTExVDIxOjU4OjI4WiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ3OjEyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ3OjEyWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZDA0MDQzNDQ3MWU0MDA3MGIwOTdiIn0sICJpZCI6ICI1NmJkMDQwNDM0NDcx
-        ZTQwMDcwYjA5N2IifQ==
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMTA5
+        ODkwNTRmYzQ4YmEyZTRhIn0sICJpZCI6ICI1NmNjOGQxMDk4OTA1NGZjNDhi
+        YTJlNGEifQ==
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:58:29 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:13 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/pulp/consumer/consumer.yml
+++ b/test/fixtures/vcr_cassettes/pulp/consumer/consumer.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/consumers/
+    uri: https://katello-yoda.example.com/pulp/api/v2/consumers/
     body:
       encoding: UTF-8
       base64_string: |
@@ -26,13 +26,13 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:00 GMT
+      - Tue, 23 Feb 2016 16:47:15 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
       - '2184'
       Location:
-      - https://katello-burrito.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
+      - https://katello-yoda.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
       Connection:
       - close
       Content-Type:
@@ -44,56 +44,56 @@ http_interactions:
         MTFFMi04MUMxLTA4MDAyMDBDOUE2NiIsICJkZXNjcmlwdGlvbiI6IG51bGws
         ICJfbnMiOiAiY29uc3VtZXJzIiwgIm5vdGVzIjoge30sICJyc2FfcHViIjog
         bnVsbCwgImNhcGFiaWxpdGllcyI6IHt9LCAiX2lkIjogeyIkb2lkIjogIjU2
-        YmQwNDI0Njc3Yzc0MmQwNDliMDBiNCJ9LCAiaWQiOiAiMDEwRTk5QzAtMzI3
+        Y2M4ZDEzZGUwNDAzM2Y0MWQyYTNjYyJ9LCAiaWQiOiAiMDEwRTk5QzAtMzI3
         Ni0xMUUyLTgxQzEtMDgwMDIwMEM5QTY2IiwgIl9ocmVmIjogIi9wdWxwL2Fw
         aS92Mi9jb25zdW1lcnMvMDEwRTk5QzAtMzI3Ni0xMUUyLTgxQzEtMDgwMDIw
         MEM5QTY2LyJ9LCAiY2VydGlmaWNhdGUiOiAiLS0tLS1CRUdJTiBSU0EgUFJJ
-        VkFURSBLRVktLS0tLVxuTUlJQ1hRSUJBQUtCZ1FER2FibnRHaTUyYTJGd0VL
-        bjlGamxTMkFTbEVzelpQWmk0OFFzOUFqdW52Z2VMV1JRbVxuRkhzeEhpbWVy
-        bElBRkk3ekJvNjNLTGZJV3YyRFpKbk8zRkNaTlp0NWc1R2R4NmRZL2l2L20r
-        enNkM0M5b1lya1xuMFQ0RHVxbEJqdWlwVHVvR2tXUks3eldLUDdNbXh6ZlBv
-        ekxYRHdVSlNwNlBRbklGRlVlUzVKWWhvUUlEQVFBQlxuQW9HQUVTZ2xScVpq
-        N0NOKzZuVFdiaWNVeitBVURyNGdib3lQL3pZQXRjYlNwNytiNFdYVGd6TjBM
-        NXdmRnpTVlxucktJYWRsTlQxZXkwYjZQR2xpMEZ5OGhyUTUwY1VtekIwMFZJ
-        eUljVUR3Rnc4ZXFVYmlvYktCRnZqaDhYcGxobVxuN24wdnRtM1FzNGlMQlhq
-        cVVPN1JUVG9jN0krTUZyeW5rem02a0E1ald4OW5saEVDUVFENWdFT3Q5UFNN
-        ZFBPdlxuNFNwRmJSTDgvSEdOMUZ5TEFPNFZldFhOS3RmUEpoT0VBR1JVeGhl
-        Qkp5eEsvSFFQcWttQ09qWEF6TFp4UXN3UFxuNlh4aXkrbmxBa0VBeTVUTFJB
-        ejJQMlZGR21nREIvMVRnNmR5QzBCQ2FLMldYSUhLd1ViNGtiQzVCbmtHd1lm
-        aVxuOVh6YUlvR09TYXJheHFGdkxIbjlRamdLbGFKU2pjWXREUUpCQUlLR0hH
-        SHI3T2R4NDI0V1lGUFRuUVJtV0UxM1xuVkRhUDlQMmR0aTNRQlBoa2xmOFBh
-        VzJEK0JYajFXTWhNT0psRm5HZlhER1JwcndYMHNOY1JXczEvQlVDUUVsOFxu
-        cjVjaitxdk51WkVicEtSNHJISGt1c1VXOENIckwxQzdSVjVaYVJibUxSUUtF
-        Z2RBTHd3Z2dubGNQT21ZdEJwcFxuWWNFelU5bFljM0dxUTVTTHllMENRUUMv
-        dHBKUGtYM2s0UHlJL1d0MW80bGxxVFkxWU93cEpocUEvNjRBY2IxUlxuSG9r
-        MDZYZEdSdlh1ZDhBTzBFUzFDVUE2dFcwcVZuUkJOdG1mVitHUmFLeUdcbi0t
+        VkFURSBLRVktLS0tLVxuTUlJQ1d3SUJBQUtCZ1FDcWZMWlJBaGRWSytNQjRl
+        c245T1VFSU5QN004WlFqUnpYcURxMXpKMFowcDJvbUpNaFxuUUJNaC8wUk9C
+        ZmtFVjkyekdMMml2YndUd1NQRGlRWmFjeFRnaVQ3OTE5UGJrZ2pUSmoyMTlG
+        elZHdUJHM21ZOVxuVXBTVXpsck9YTEszOWNWZVNGcWZmemxZTnJkcndjbVEv
+        NlZoTXB6QWxtRzVZbGFNU2NEUHZ5UFpNUUlEQVFBQlxuQW9HQVkwUXdKNlRQ
+        RHlGNWtPd0pMdit4cFNDMExPeXRpTk5ST3VSU0l1NmJmcUNhZWNNMHo4UnVI
+        M3B4Ty9qUVxuVUU0VTRTWURyTkZLeERuTjZCbE5vTGFuTFU1NC9KMjNJN3h2
+        dWt1V1lZbEhyR215QWREbmNJcDAzT2ZwSUFlM1xuSzJRMWpvN1Q3Zy9ySWY0
+        OG5seUJiQWtTOWNmcG52SEhaSTBjczFsaDltYnJEQjBDUVFEWEloR0NyVE5X
+        WUtLalxuZ3YxQW1ONXRQYStOSmh2SmV3YU80NFZrUGVJRU81SUNmWTI1WXlt
+        cUZ5ZklJQ3hKWTZTUW4raS9Nd1cvdGZ0ZFxueEw1NUFpUkhBa0VBeXQrQ3Ix
+        VDZheGR6RmgzV0IwMDcyMHlGVk82UnlaTTY3dVp0L1pnT1dTdEVKand4bnM5
+        M1xuaWN3cm9OYkp2R3BjQTQ2dDZpM3RqK2ErVTRNbWFFb3F4d0pBS0l6YVlo
+        aEZnZldMRW1rQlZXaTdIRG94V2RpaVxuQ2pNdlJFV3NnZjJNR2FJazNtVk9E
+        bkNiak56NmVhVmUwNko5aFdrdTFNTklSUitITnVCN3lwRlZ4d0pBUGZSUVxu
+        QnBkZStrRnBCZ0lLa0tSSGVVcy9GSmJlc3I1aHF2OTM2NC82SWNVU3hOSnhI
+        TnlpMXRRaEpyY3hXSGJxcnJOdFxuN1N3bGRtS3pFUEhtVXNjRGxRSkFRc0Fx
+        SUtXOEYwdTM5bGZLNXFiSWdvWXRjVld6Ulp4aWFCYytXakZFUmRvMFxubG9q
+        WklTVjh0dWdJVWVreUd6U2ZwWlVOY0pzSjNmYy8yOUR1Ui8vQnhnPT1cbi0t
         LS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tXG4tLS0tLUJFR0lOIENFUlRJ
-        RklDQVRFLS0tLS1cbk1JSUNmakNDQVdZQ0FTc3dEUVlKS29aSWh2Y05BUUVG
-        QlFBd05URWtNQ0lHQTFVRUF3d2JhMkYwWld4c2J5MWlcbmRYSnlhWFJ2TG1W
-        NFlXMXdiR1V1WTI5dE1RMHdDd1lEVlFRS0RBUlFWVXhRTUI0WERURTJNREl4
-        TVRJeE5Ua3dcbk1Gb1hEVEkyTURJd09ESXhOVGt3TUZvd1dURXRNQ3NHQTFV
-        RUF4TWtNREV3UlRrNVF6QXRNekkzTmkweE1VVXlcbkxUZ3hRekV0TURnd01E
-        SXdNRU01UVRZMk1TZ3dKZ1lLQ1pJbWlaUHlMR1FCQVJNWU5UWmlaREEwTWpR
-        Mk56ZGpcbk56UXlaREEwT1dJd01HSTBNSUdmTUEwR0NTcUdTSWIzRFFFQkFR
-        VUFBNEdOQURDQmlRS0JnUURHYWJudEdpNTJcbmEyRndFS245RmpsUzJBU2xF
-        c3paUFppNDhRczlBanVudmdlTFdSUW1GSHN4SGltZXJsSUFGSTd6Qm82M0tM
-        Zklcbld2MkRaSm5PM0ZDWk5adDVnNUdkeDZkWS9pdi9tK3pzZDNDOW9Zcmsw
-        VDREdXFsQmp1aXBUdW9Ha1dSSzd6V0tcblA3TW14emZQb3pMWER3VUpTcDZQ
-        UW5JRkZVZVM1Sllob1FJREFRQUJNQTBHQ1NxR1NJYjNEUUVCQlFVQUE0SUJc
-        bkFRQS9ZVGlSV1BGRmo2ZUI5cVZHZFpOVWpBMDMyakdsQ1RvTno5SkJiL0xl
-        RG42ejgrNGpYSzZQbnFBUk1NRStcblJ0cTYxYVRDNWlJNHRSVDRNa2dNdWNH
-        RHZjOElhK0UyQ1l3UHowcmNybEtmSlozbXB5dnBkVkd6anBFdlVkYmVcbkpq
-        djBLSDVLSHhPazA4cmYwVERkdncxeDdrWTVEdWJmRHo0WmNvVTliLzFyZHRx
-        bForYTJDd1daRHRPMEdNM1RcbndlVUVoMXhYQkxGakx6YldsSU5UK0F1N3ZJ
-        bTBkSHJaNDk1akk4Wk5CYW5VRUp2ZlcyOXdzN3FTMVI0NnVlRjJcbnFaU2lO
-        T3FlY3A4SVJ5SHJtODBkNFlCVHp6MHhJWjZLVWFIUUZVWWJRYUxCMVV5L2Fl
-        SDFXSEFtTTFBRXMyTHhcbkxCOHBBWDg5SGZCYlgrTEZDOVBDMk9BMlxuLS0t
+        RklDQVRFLS0tLS1cbk1JSUNmRENDQVdRQ0FnRXBNQTBHQ1NxR1NJYjNEUUVC
+        QlFVQU1ESXhJVEFmQmdOVkJBTU1HR3RoZEdWc2JHOHRcbmVXOWtZUzVsZUdG
+        dGNHeGxMbU52YlRFTk1Bc0dBMVVFQ2d3RVVGVk1VREFlRncweE5qQXlNak14
+        TmpRM01UVmFcbkZ3MHlOakF5TWpBeE5qUTNNVFZhTUZreExUQXJCZ05WQkFN
+        VEpEQXhNRVU1T1VNd0xUTXlOell0TVRGRk1pMDRcbk1VTXhMVEE0TURBeU1E
+        QkRPVUUyTmpFb01DWUdDZ21TSm9tVDhpeGtBUUVUR0RVMlkyTTRaREV6WkdV
+        d05EQXpcbk0yWTBNV1F5WVROall6Q0JuekFOQmdrcWhraUc5dzBCQVFFRkFB
+        T0JqUUF3Z1lrQ2dZRUFxbnkyVVFJWFZTdmpcbkFlSHJKL1RsQkNEVCt6UEdV
+        STBjMTZnNnRjeWRHZEtkcUppVElVQVRJZjlFVGdYNUJGZmRzeGk5b3IyOEU4
+        RWpcbnc0a0dXbk1VNElrKy9kZlQyNUlJMHlZOXRmUmMxUnJnUnQ1bVBWS1Vs
+        TTVhemx5eXQvWEZYa2hhbjM4NVdEYTNcbmE4SEprUCtsWVRLY3dKWmh1V0pX
+        akVuQXo3OGoyVEVDQXdFQUFUQU5CZ2txaGtpRzl3MEJBUVVGQUFPQ0FRRUFc
+        bmlQUTdVcFdleFNjNmhqWEhzYXByeFZla24vY0dXeGFabzljRnBOTmJuMUFl
+        QmFTQWVBS3BTTlJzV1U0NTZ3VUdcbnowMC9TKzBUSTlsSTkzYjh2Q2x2dkFE
+        NUtLamVuajg3Y2VEVDdpc0JjdXFqY2dzZjdYZHQ5akVKV3EyOUtYNzJcbjB5
+        MzdFRUlLeFVqMlpJcStxeU0vd085azN3Y0hPRGk0QkVHQkpnKzgrRXVIQmVz
+        RXlNVVAvSG9KMnNhQkJ1K0RcbnZIVnFnUWgxNTI0cVVBeGlQYUVUL0k5bmhj
+        VFMzMlNoZXNTeWJjMEJwaTRCaE9yRTFuRUd6ZG5HQ3I0MnZ2OUhcblppMjR1
+        ZkRZVHk1dzJXMHhZc0hDdWtmQ25yNUVqSUgxSDlFcXhCVE9yU3ZLdnovZVpI
+        OHVmZW5xVHhvOUUxNmZcbmdqOFBUYld1TmZtRDk3M0JHUDg2WkE9PVxuLS0t
         LS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:59:00 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:15 GMT
 - request:
     method: put
-    uri: https://katello-burrito.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
+    uri: https://katello-yoda.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
     body:
       encoding: UTF-8
       base64_string: |
@@ -116,7 +116,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:00 GMT
+      - Tue, 23 Feb 2016 16:47:15 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -133,15 +133,15 @@ http_interactions:
         eyJkaXNwbGF5X25hbWUiOiAiTm90IFNvIFNpbXBsZSBTZXJ2ZXIiLCAiZGVz
         Y3JpcHRpb24iOiBudWxsLCAiX25zIjogImNvbnN1bWVycyIsICJub3RlcyI6
         IHt9LCAicnNhX3B1YiI6IG51bGwsICJjYXBhYmlsaXRpZXMiOiB7fSwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1NmJkMDQyNDY3N2M3NDJkMDQ5YjAwYjQifSwgImlk
+        ZCI6IHsiJG9pZCI6ICI1NmNjOGQxM2RlMDQwMzNmNDFkMmEzY2MifSwgImlk
         IjogIjAxMEU5OUMwLTMyNzYtMTFFMi04MUMxLTA4MDAyMDBDOUE2NiIsICJf
         aHJlZiI6ICIvcHVscC9hcGkvdjIvY29uc3VtZXJzLzAxMEU5OUMwLTMyNzYt
         MTFFMi04MUMxLTA4MDAyMDBDOUE2Ni8ifQ==
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:59:00 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:15 GMT
 - request:
     method: delete
-    uri: https://katello-burrito.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
+    uri: https://katello-yoda.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -160,7 +160,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:00 GMT
+      - Tue, 23 Feb 2016 16:47:15 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -174,5 +174,5 @@ http_interactions:
       base64_string: |
         bnVsbA==
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:59:00 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:15 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/pulp/consumer/content.yml
+++ b/test/fixtures/vcr_cassettes/pulp/consumer/content.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/e7d16301-7924-48f0-9c5b-d208b6aa0031/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/30c75750-1f1f-41d8-8228-08a7519e40e7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -13,12 +13,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="6BU5CGUO1Y62Awj18mVgrMZmPRQhGqKOpsRLRSATY",
-        oauth_signature="2Tkd4OrbRikg9sU01L6ahqS2fTE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291958", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -27,13 +21,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 01:59:18 GMT
+      - Tue, 23 Feb 2016 16:47:16 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '643'
+      - '547'
       Connection:
       - close
       Content-Type:
@@ -43,24 +37,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lN2QxNjMwMS03OTI0LTQ4ZjAtOWM1Yi1kMjA4YjZhYTAw
-        MzEvIiwgInRhc2tfaWQiOiAiZTdkMTYzMDEtNzkyNC00OGYwLTljNWItZDIw
-        OGI2YWEwMDMxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8zMGM3NTc1MC0xZjFmLTQxZDgtODIyOC0wOGE3NTE5ZTQw
+        ZTcvIiwgInRhc2tfaWQiOiAiMzBjNzU3NTAtMWYxZi00MWQ4LTgyMjgtMDhh
+        NzUxOWU0MGU3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
-        Y2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZh
-        ZWJiZjZlNTQ5NzVmNzFhNmE2NDRiIn0sICJpZCI6ICI1NmFlYmJmNmU1NDk3
-        NWY3MWE2YTY0NGIifQ==
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMTQ5
+        ODkwNTRmYzQ4YmEyZTRmIn0sICJpZCI6ICI1NmNjOGQxNDk4OTA1NGZjNDhi
+        YTJlNGYifQ==
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:18 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:16 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/e7d16301-7924-48f0-9c5b-d208b6aa0031/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/30c75750-1f1f-41d8-8228-08a7519e40e7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -71,12 +63,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="KJc5nnufW6qXa3syaQ3TL5cUq2BzRWk3aRDgffa4",
-        oauth_signature="lrOk3fAjm%2FfNTumCu6KG7NBLv7k%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291959", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -85,13 +71,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 01:59:19 GMT
+      - Tue, 23 Feb 2016 16:47:16 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2310'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -101,61 +87,61 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lN2QxNjMwMS03OTI0LTQ4ZjAtOWM1Yi1kMjA4YjZhYTAw
-        MzEvIiwgInRhc2tfaWQiOiAiZTdkMTYzMDEtNzkyNC00OGYwLTljNWItZDIw
-        OGI2YWEwMDMxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8zMGM3NTc1MC0xZjFmLTQxZDgtODIyOC0wOGE3NTE5ZTQw
+        ZTcvIiwgInRhc2tfaWQiOiAiMzBjNzU3NTAtMWYxZi00MWQ4LTgyMjgtMDhh
+        NzUxOWU0MGU3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMTo1OToxOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OToxOFoiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0NzoxNloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0NzoxNloiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvOTY4ZDFhYmYtMWUxNC00YzJjLWJiZjUtMjdjNTM1NWM2
-        MDA4LyIsICJ0YXNrX2lkIjogIjk2OGQxYWJmLTFlMTQtNGMyYy1iYmY1LTI3
-        YzUzNTVjNjAwOCJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81
-        OThjYjJmNC0yMTlkLTRiZTItOGU1YS03M2M2NTJjY2JhYWQvIiwgInRhc2tf
-        aWQiOiAiNTk4Y2IyZjQtMjE5ZC00YmUyLThlNWEtNzNjNjUyY2NiYWFkIn1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJiZjZkZTA0MDMzNDZiZmRhZDFm
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MTo1OToxOFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAxOjU5OjE5WiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmJmN2RlMDQwMzRjZDky
-        ZGM1MGQiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmJmNmU1NDk3NWY3MWE2YTY0NGIifSwgImlkIjogIjU2YWViYmY2ZTU0
-        OTc1ZjcxYTZhNjQ0YiJ9
+        cGkvdjIvdGFza3MvNzA0OWE5YjUtMzgyOC00OGVjLWJjYzAtNWU0OTFkZjNk
+        YTIwLyIsICJ0YXNrX2lkIjogIjcwNDlhOWI1LTM4MjgtNDhlYy1iY2MwLTVl
+        NDkxZGYzZGEyMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQxM2RlMDQw
+        MzNmNDFkMmEzY2YifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ3OjE2WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDc6MTZaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkMTRk
+        ZTA0MDMwODk3NThhODUxIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDE0OTg5MDU0ZmM0OGJhMmU0ZiJ9LCAiaWQiOiAiNTZj
+        YzhkMTQ5ODkwNTRmYzQ4YmEyZTRmIn0=
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:19 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:16 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/968d1abf-1e14-4c2c-bbf5-27c5355c6008/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/7049a9b5-3828-48ec-bcc0-5e491df3da20/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -166,12 +152,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="hkWRab8Ku4XneKviEhjbt1lniOYzf4fUjgRBas7KE8",
-        oauth_signature="soFd6fS4gT6byOMzHiELzLN1qZ8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291959", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -180,74 +160,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 01:59:19 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy85NjhkMWFiZi0xZTE0LTRjMmMtYmJmNS0yN2M1
-        MzU1YzYwMDgvIiwgInRhc2tfaWQiOiAiOTY4ZDFhYmYtMWUxNC00YzJjLWJi
-        ZjUtMjdjNTM1NWM2MDA4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMTo1OToxOVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OToxOVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDE6NTk6MTlaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMTo1OToxOVoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmJmN2RlMDQwMzRjZDkyZGM1MGUiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJiZjdlNTQ5NzVmNzFhNmE2NDViIn0s
-        ICJpZCI6ICI1NmFlYmJmN2U1NDk3NWY3MWE2YTY0NWIifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:19 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/598cb2f4-219d-4be2-8e5a-73c652ccbaad/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="peHOTwo8K2SE6g9hFeH0PSlKigfkFKku2oE8Mhi2o",
-        oauth_signature="22qHHUzS3jlKE77WeZzR7JtC2WI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291959", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:19 GMT
+      - Tue, 23 Feb 2016 16:47:16 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -263,84 +176,84 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy81OThjYjJmNC0yMTlkLTRiZTItOGU1YS03M2M2
-        NTJjY2JhYWQvIiwgInRhc2tfaWQiOiAiNTk4Y2IyZjQtMjE5ZC00YmUyLThl
-        NWEtNzNjNjUyY2NiYWFkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy83MDQ5YTliNS0zODI4LTQ4ZWMtYmNjMC01ZTQ5
+        MWRmM2RhMjAvIiwgInRhc2tfaWQiOiAiNzA0OWE5YjUtMzgyOC00OGVjLWJj
+        YzAtNWU0OTFkZjNkYTIwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMTo1OToxOVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OToxOVoiLCAi
+        bWUiOiAiMjAxNi0wMi0yM1QxNjo0NzoxNloiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0NzoxNloiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI4MjMxYmJhZi1kNzY5LTRkYjktYjA1My0yNzlkMjNj
-        NWI3ZWUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICJmYTdkZjQ2Yi0wMzIzLTRhMzUtOGIxOC1kMGJiZDg1
+        NWI5NjgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiY2Y3MDU4NWMtN2JmNC00NmRlLTkxYTItZTQ1NjY4YWZmYTEyIiwg
+        aWQiOiAiYjU1MmI3YzAtZmJkMy00MWRjLTgxNDQtNTk2MzI5NzRlNGYzIiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
         bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMmMzN2UxOTEtY2MwMS00MmIyLTlhYzIt
-        NzAyZjlmN2M5MjBmIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZjFmMTQxZWItZWE4Ni00YzYxLWI0MGYt
+        MGNjYWJlYTc3MWNlIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
         TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTI0
-        NzVjMjItNGI3Yi00MTljLTk2NjYtYTZjN2Q2NDVkZTA4IiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTJk
+        MTZhMGMtMmRiYi00ZjNjLWE2YzEtNzBlOGFiNjYxZGQyIiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjlhZGMzYWUyLTQwZjctNDc5NC1hMjU2LWYzYmQ4
-        ZWYzNGQwZSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        IDAsICJzdGVwX2lkIjogIjg4OWFhMmJlLTYzYTAtNGZkMC1iZDZjLTQ0NjFi
+        NTVjMzM3MiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
         OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
         InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNzBlOWJl
-        NS01NjUxLTQ5MTUtYmUyNy1mMTc1Yzg2OGFiMjgiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3Yjc0YzEx
+        OC1kYThjLTQwZTItOTFlNS05OGM3OTM5ODQ1NzkiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
         Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJmYTgzZTU2Ni1kYzFlLTQxODEtOWEyNy0yYjUz
-        MTE2ODNhZmUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICI3N2M0YmEzOS1jMjc4LTQ0NjgtOTQ0ZS1hY2Rm
+        ZTE5N2U0ZTciLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
         ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIzNzFjZmJiOC1kNTAyLTRmZDctOTMxYi1hMDZlMTU3ZjFkZTki
+        cF9pZCI6ICI2MWRiMDZjYy0xNjRhLTQ0Y2QtYmQ2YS05YmU1NzYxOTA5MWUi
         LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
         dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
         c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkMjYw
-        Y2NjMi1iYjg5LTRkZWUtOGU3Yi1kYjc0ZTU1MGEyODIiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzYWMw
+        ZmFhYS1kZmFjLTRiZjMtOWMwMS01OTQ2NTc2OGVlOGMiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
         aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2NWZiZGNhOC1jZDM1
-        LTQ2MzYtODM4ZC04NTkyOGIxYjdhYzEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNzljYTY0MC1iYWRi
+        LTQ1ZDItODZmZi1kNDVhNjdjYjQ4MDMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
         TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
         X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImY3Mjc1N2FlLTM3NGYtNDA5
-        NC04ZmNlLWI5YzU2YzQxZmZiMyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc4MDIwYzFjLTA3MzMtNDNj
+        Yi05NmZmLWMxOTUxZDFjZjNjYSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
         InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
         eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
         b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
         bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
         c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTAxVDAxOjU5OjE5WiIsICJf
+        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ3OjE2WiIsICJf
         bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
-        MTYtMDItMDFUMDE6NTk6MTlaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
+        MTYtMDItMjNUMTY6NDc6MTZaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
         cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
         IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
         X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
@@ -349,77 +262,77 @@ http_interactions:
         aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
         SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
         U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
-        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZhZWJiZjdkZTA0MDM0Y2Q5MmRj
-        NTBmIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZjYzhkMTRkZTA0MDMwODk3NThh
+        ODUyIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
         dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
         cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
         IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjgyMzFiYmFmLWQ3NjktNGRiOS1iMDUzLTI3OWQyM2M1YjdlZSIsICJu
+        IjogImZhN2RmNDZiLTAzMjMtNGEzNS04YjE4LWQwYmJkODU1Yjk2OCIsICJu
         dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
         cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
         cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjZjcw
-        NTg1Yy03YmY0LTQ2ZGUtOTFhMi1lNDU2NjhhZmZhMTIiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiNTUy
+        YjdjMC1mYmQzLTQxZGMtODE0NC01OTYzMjk3NGU0ZjMiLCAibnVtX3Byb2Nl
         c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
         c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICIyYzM3ZTE5MS1jYzAxLTQyYjItOWFjMi03MDJmOWY3Yzky
-        MGYiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICJmMWYxNDFlYi1lYTg2LTRjNjEtYjQwZi0wY2NhYmVhNzcx
+        Y2UiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
         X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
         U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1MjQ3NWMyMi00Yjdi
-        LTQxOWMtOTY2Ni1hNmM3ZDY0NWRlMDgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5MmQxNmEwYy0yZGJi
+        LTRmM2MtYTZjMS03MGU4YWI2NjFkZDIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
         LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
         bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
         YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiOWFkYzNhZTItNDBmNy00Nzk0LWEyNTYtZjNiZDhlZjM0ZDBlIiwg
+        aWQiOiAiODg5YWEyYmUtNjNhMC00ZmQwLWJkNmMtNDQ2MWI1NWMzMzcyIiwg
         Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
         IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA3MGU5YmU1LTU2NTEtNDkx
-        NS1iZTI3LWYxNzVjODY4YWIyOCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdiNzRjMTE4LWRhOGMtNDBl
+        Mi05MWU1LTk4Yzc5Mzk4NDU3OSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
         bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
         ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
         dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
         OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogImZhODNlNTY2LWRjMWUtNDE4MS05YTI3LTJiNTMxMTY4M2FmZSIs
+        X2lkIjogIjc3YzRiYTM5LWMyNzgtNDQ2OC05NDRlLWFjZGZlMTk3ZTRlNyIs
         ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
         Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
         ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM3
-        MWNmYmI4LWQ1MDItNGZkNy05MzFiLWEwNmUxNTdmMWRlOSIsICJudW1fcHJv
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjYx
+        ZGIwNmNjLTE2NGEtNDRjZC1iZDZhLTliZTU3NjE5MDkxZSIsICJudW1fcHJv
         Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
         OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
         bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
         S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQyNjBjY2MyLWJiODkt
-        NGRlZS04ZTdiLWRiNzRlNTUwYTI4MiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNhYzBmYWFhLWRmYWMt
+        NGJmMy05YzAxLTU5NDY1NzY4ZWU4YyIsICJudW1fcHJvY2Vzc2VkIjogMH0s
         IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
         ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
         b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjY1ZmJkY2E4LWNkMzUtNDYzNi04Mzhk
-        LTg1OTI4YjFiN2FjMSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjE3OWNhNjQwLWJhZGItNDVkMi04NmZm
+        LWQ0NWE2N2NiNDgwMyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
         Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
         aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
         LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
         b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiZjcyNzU3YWUtMzc0Zi00MDk0LThmY2UtYjlj
-        NTZjNDFmZmIzIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YWViYmY3ZTU0OTc1ZjcxYTZhNjQ1
-        YyJ9LCAiaWQiOiAiNTZhZWJiZjdlNTQ5NzVmNzFhNmE2NDVjIn0=
+        IjogMCwgInN0ZXBfaWQiOiAiNzgwMjBjMWMtMDczMy00M2NiLTk2ZmYtYzE5
+        NTFkMWNmM2NhIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDE0OTg5MDU0ZmM0OGJhMmU1
+        ZiJ9LCAiaWQiOiAiNTZjYzhkMTQ5ODkwNTRmYzQ4YmEyZTVmIn0=
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:19 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:16 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/476b4ee1-8d02-4797-bc1e-33a485eb0cf4/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/f784181d-c923-4a6f-b13a-980e82ad4e12/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -430,12 +343,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="vI34lzOVcdQ0lAEfdNMgLWzQcVvcW3oX8CwdlmqC3s",
-        oauth_signature="Z1PPGQDMpTBT6MSmgVht5eu3ds0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291960", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -444,12679 +351,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 01:59:20 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NzZiNGVlMS04ZDAyLTQ3OTctYmMxZS0zM2E0ODVlYjBj
-        ZjQvIiwgInRhc2tfaWQiOiAiNDc2YjRlZTEtOGQwMi00Nzk3LWJjMWUtMzNh
-        NDg1ZWIwY2Y0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmFlYmJm
-        OGU1NDk3NWY3MWE2YTY0NWQifSwgImlkIjogIjU2YWViYmY4ZTU0OTc1Zjcx
-        YTZhNjQ1ZCJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:20 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/476b4ee1-8d02-4797-bc1e-33a485eb0cf4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="GL2zd0LixXev7kQchqp9XJwcxsPVcQbi3LssjuQVXXg",
-        oauth_signature="cDODFP%2Fvo0bdDxx2HnKpkJIa4Pg%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291960", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:20 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '682'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NzZiNGVlMS04ZDAyLTQ3OTctYmMxZS0zM2E0ODVlYjBj
-        ZjQvIiwgInRhc2tfaWQiOiAiNDc2YjRlZTEtOGQwMi00Nzk3LWJjMWUtMzNh
-        NDg1ZWIwY2Y0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTAxVDAxOjU5OjIwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTAxVDAxOjU5OjIwWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
-        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJiZjhl
-        NTQ5NzVmNzFhNmE2NDVkIn0sICJpZCI6ICI1NmFlYmJmOGU1NDk3NWY3MWE2
-        YTY0NWQifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:20 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/8aea5922-7cf4-480a-8ef0-797cc2d51036/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="2GtaB4oSiplL2UguEg8KGwzHcX0VuMcv4nHl04Ees",
-        oauth_signature="qgu6Z9crF7GA32OkRXtYVzvklRo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291961", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:21 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84YWVhNTkyMi03Y2Y0LTQ4MGEtOGVmMC03OTdjYzJkNTEw
-        MzYvIiwgInRhc2tfaWQiOiAiOGFlYTU5MjItN2NmNC00ODBhLThlZjAtNzk3
-        Y2MyZDUxMDM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJiZjll
-        NTQ5NzVmNzFhNmE2NDVmIn0sICJpZCI6ICI1NmFlYmJmOWU1NDk3NWY3MWE2
-        YTY0NWYifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:21 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/8aea5922-7cf4-480a-8ef0-797cc2d51036/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="JiHoQD9VJFlBl1ACneQhtS6a8kr4BYqAnp29XgBjciY",
-        oauth_signature="4da0uQaPGda9wtGMKZbBW%2FmalSY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291962", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:22 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2310'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84YWVhNTkyMi03Y2Y0LTQ4MGEtOGVmMC03OTdjYzJkNTEw
-        MzYvIiwgInRhc2tfaWQiOiAiOGFlYTU5MjItN2NmNC00ODBhLThlZjAtNzk3
-        Y2MyZDUxMDM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMTo1OToyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OToyMVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMjMwYTg2NjEtZjE1Ni00N2Y1LTkwMGQtZmViYWU3NTg4
-        ZjJkLyIsICJ0YXNrX2lkIjogIjIzMGE4NjYxLWYxNTYtNDdmNS05MDBkLWZl
-        YmFlNzU4OGYyZCJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9h
-        MjI0YTA4Ny1hZTc3LTQ2NjktYmU3Yy00MTZiZDMyZTlhYjEvIiwgInRhc2tf
-        aWQiOiAiYTIyNGEwODctYWU3Ny00NjY5LWJlN2MtNDE2YmQzMmU5YWIxIn1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJiZjlkZTA0MDMzNDZiZmRhZDI1
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MTo1OToyMVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAxOjU5OjIyWiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmJmYWRlMDQwMzRjZDky
-        ZGM1MTMiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmJmOWU1NDk3NWY3MWE2YTY0NWYifSwgImlkIjogIjU2YWViYmY5ZTU0
-        OTc1ZjcxYTZhNjQ1ZiJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:22 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/230a8661-f156-47f5-900d-febae7588f2d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="xqyI0BMJ3CIB6HxrRsiBPZw9sWA94NeFcGG31QER20",
-        oauth_signature="Rc8oLcxon7NjQP3LEMPCwWcWD30%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291962", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:22 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8yMzBhODY2MS1mMTU2LTQ3ZjUtOTAwZC1mZWJh
-        ZTc1ODhmMmQvIiwgInRhc2tfaWQiOiAiMjMwYTg2NjEtZjE1Ni00N2Y1LTkw
-        MGQtZmViYWU3NTg4ZjJkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMTo1OToyMloiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OToyMloiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDE6NTk6MjJaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMTo1OToyMloiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmJmYWRlMDQwMzRjZDkyZGM1MTQiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJiZmFlNTQ5NzVmNzFhNmE2NDZmIn0s
-        ICJpZCI6ICI1NmFlYmJmYWU1NDk3NWY3MWE2YTY0NmYifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:22 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/a224a087-ae77-4669-be7c-416bd32e9ab1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="vPx9tojQGqCBCEjqydkGHJ0vIufyvci9cEbWkywdGoM",
-        oauth_signature="HOdlgfv5c9wQz%2BQrxvvTUwKb9XA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291962", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:22 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6923'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9hMjI0YTA4Ny1hZTc3LTQ2NjktYmU3Yy00MTZi
-        ZDMyZTlhYjEvIiwgInRhc2tfaWQiOiAiYTIyNGEwODctYWU3Ny00NjY5LWJl
-        N2MtNDE2YmQzMmU5YWIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMTo1OToyMloiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OToyMloiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI4ZTMyY2M5NS0xMDk1LTQ4NDAtOWMwNS1mZWJiMTY3
-        NjU1ZGIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZjc1Y2FmMWMtOWRhYy00YzhkLThmMmQtNTMzZTIwNTUwOGY5Iiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiN2RhZTRmZGYtNmE5Zi00M2I4LTlmMmIt
-        OTUwNjkyNTBkOWU3IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZGJl
-        ZGE2ZDctZmY4ZC00ZDc4LThjNDUtMjI3YzY1NDQwYTYxIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjcwZjQzYWIwLTY0MjItNGEwYy04ZWI4LWJhYzFl
-        NGFjOGFmNSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmNzJjMzRm
-        OS00MzYwLTQ3NmYtYWMxYi1hMTY3NGVhYmU5NzgiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJhODAxMDE5NC1hYzkyLTRkYWYtOGMwNi1hNWY3
-        MDg2MWY5NjciLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJiYjAxYWI0NC03MmFiLTQ3YzMtYTEyYi1hZWJkY2FjMzY1Zjgi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxN2I1
-        MWJmYS02MzgxLTQzMjctOGQ4MS0yZjNmMjhjOWU4OGYiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4ZThiZjRlMC04MzZm
-        LTRkOWYtYjMzYS05YjIwNGY0NWZlNmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM2NzM5NTA3LWI2ZWMtNGJi
-        ZC1hOTlmLWQyZjRiMmQ0N2YzYSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
-        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
-        c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTAxVDAxOjU5OjIyWiIsICJf
-        bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
-        MTYtMDItMDFUMDE6NTk6MjJaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
-        cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
-        IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
-        X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
-        RCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1z
-        IjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0
-        aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
-        SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
-        U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
-        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZhZWJiZmFkZTA0MDM0Y2Q5MmRj
-        NTE1IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjhlMzJjYzk1LTEwOTUtNDg0MC05YzA1LWZlYmIxNjc2NTVkYiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
-        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmNzVj
-        YWYxYy05ZGFjLTRjOGQtOGYyZC01MzNlMjA1NTA4ZjkiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
-        c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICI3ZGFlNGZkZi02YTlmLTQzYjgtOWYyYi05NTA2OTI1MGQ5
-        ZTciLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
-        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkYmVkYTZkNy1mZjhk
-        LTRkNzgtOGM0NS0yMjdjNjU0NDBhNjEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
-        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNzBmNDNhYjAtNjQyMi00YTBjLThlYjgtYmFjMWU0YWM4YWY1Iiwg
-        Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
-        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImY3MmMzNGY5LTQzNjAtNDc2
-        Zi1hYzFiLWExNjc0ZWFiZTk3OCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
-        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
-        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogImE4MDEwMTk0LWFjOTItNGRhZi04YzA2LWE1ZjcwODYxZjk2NyIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
-        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
-        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJi
-        MDFhYjQ0LTcyYWItNDdjMy1hMTJiLWFlYmRjYWMzNjVmOCIsICJudW1fcHJv
-        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
-        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
-        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE3YjUxYmZhLTYzODEt
-        NDMyNy04ZDgxLTJmM2YyOGM5ZTg4ZiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
-        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
-        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
-        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjhlOGJmNGUwLTgzNmYtNGQ5Zi1iMzNh
-        LTliMjA0ZjQ1ZmU2ZSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
-        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiMzY3Mzk1MDctYjZlYy00YmJkLWE5OWYtZDJm
-        NGIyZDQ3ZjNhIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YWViYmZhZTU0OTc1ZjcxYTZhNjQ3
-        MCJ9LCAiaWQiOiAiNTZhZWJiZmFlNTQ5NzVmNzFhNmE2NDcwIn0=
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:22 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/ebb89bac-b9e7-453c-a375-4c38428d54c1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="6Iyewcdt8K08sAVtG8f9GjfMyX5D4hgiauAN0WMEVE",
-        oauth_signature="N1xdlh1GIjD%2BZV7IQheqVxisoMY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291963", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:23 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lYmI4OWJhYy1iOWU3LTQ1M2MtYTM3NS00YzM4NDI4ZDU0
-        YzEvIiwgInRhc2tfaWQiOiAiZWJiODliYWMtYjllNy00NTNjLWEzNzUtNGMz
-        ODQyOGQ1NGMxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmFlYmJm
-        YmU1NDk3NWY3MWE2YTY0NzEifSwgImlkIjogIjU2YWViYmZiZTU0OTc1Zjcx
-        YTZhNjQ3MSJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:23 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/ebb89bac-b9e7-453c-a375-4c38428d54c1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="k7IoJpUhEZUDWFrNdALkAVSqohc9cqlk2Cs10Qo",
-        oauth_signature="eVKCFBFrArMrV%2FbZ1WWzX19ufM4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291963", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:23 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '682'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lYmI4OWJhYy1iOWU3LTQ1M2MtYTM3NS00YzM4NDI4ZDU0
-        YzEvIiwgInRhc2tfaWQiOiAiZWJiODliYWMtYjllNy00NTNjLWEzNzUtNGMz
-        ODQyOGQ1NGMxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTAxVDAxOjU5OjIzWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTAxVDAxOjU5OjIzWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
-        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJiZmJl
-        NTQ5NzVmNzFhNmE2NDcxIn0sICJpZCI6ICI1NmFlYmJmYmU1NDk3NWY3MWE2
-        YTY0NzEifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:23 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/bc7331dd-231a-4ae3-b299-3f44d89582cf/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="7bAM2tDF5wKGf7HdwaUjP94Ro1pxEdyY4SZawkq6E2M",
-        oauth_signature="cWClWQqr5PE1J4d2%2Fkx0HsvExSA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291964", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:24 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '643'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iYzczMzFkZC0yMzFhLTRhZTMtYjI5OS0zZjQ0ZDg5NTgy
-        Y2YvIiwgInRhc2tfaWQiOiAiYmM3MzMxZGQtMjMxYS00YWUzLWIyOTktM2Y0
-        NGQ4OTU4MmNmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
-        Y2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZh
-        ZWJiZmNlNTQ5NzVmNzFhNmE2NDczIn0sICJpZCI6ICI1NmFlYmJmY2U1NDk3
-        NWY3MWE2YTY0NzMifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:24 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/bc7331dd-231a-4ae3-b299-3f44d89582cf/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="EPKNW8ujdfLqr4LSQs3YVR7af3TuyoyLgd4C2zybQDc",
-        oauth_signature="DgioR5kJf8DgK9v0HRRfHfru55k%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291965", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:25 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2310'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iYzczMzFkZC0yMzFhLTRhZTMtYjI5OS0zZjQ0ZDg5NTgy
-        Y2YvIiwgInRhc2tfaWQiOiAiYmM3MzMxZGQtMjMxYS00YWUzLWIyOTktM2Y0
-        NGQ4OTU4MmNmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMTo1OToyNVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OToyNFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZDMwMGMwZTQtYTY5ZS00ODE3LTkzM2QtZDgxMzg1NjJi
-        ZjM3LyIsICJ0YXNrX2lkIjogImQzMDBjMGU0LWE2OWUtNDgxNy05MzNkLWQ4
-        MTM4NTYyYmYzNyJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84
-        ZjBmN2E4YS02NTRhLTRmZDMtODA4OS1jMWI2NDVjZmE0NmQvIiwgInRhc2tf
-        aWQiOiAiOGYwZjdhOGEtNjU0YS00ZmQzLTgwODktYzFiNjQ1Y2ZhNDZkIn1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJiZmNkZTA0MDMzNDZkMTg4ZmUz
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MTo1OToyNFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAxOjU5OjI1WiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmJmZGRlMDQwMzRjZDky
-        ZGM1MTkiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmJmY2U1NDk3NWY3MWE2YTY0NzMifSwgImlkIjogIjU2YWViYmZjZTU0
-        OTc1ZjcxYTZhNjQ3MyJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:25 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/d300c0e4-a69e-4817-933d-d8138562bf37/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="xUC17ZAi2FguuSzk6Rl4stxu0HD2oOMkkCCizjaHRdY",
-        oauth_signature="hW8mMvXc%2FPAsU3oT1zzXV%2F5CtJA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291965", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:25 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9kMzAwYzBlNC1hNjllLTQ4MTctOTMzZC1kODEz
-        ODU2MmJmMzcvIiwgInRhc2tfaWQiOiAiZDMwMGMwZTQtYTY5ZS00ODE3LTkz
-        M2QtZDgxMzg1NjJiZjM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMTo1OToyNVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OToyNVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDE6NTk6MjVaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMTo1OToyNVoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmJmZGRlMDQwMzRjZDkyZGM1MWEiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJiZmRlNTQ5NzVmNzFhNmE2NDgzIn0s
-        ICJpZCI6ICI1NmFlYmJmZGU1NDk3NWY3MWE2YTY0ODMifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:25 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/8f0f7a8a-654a-4fd3-8089-c1b645cfa46d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="nBiE2on9v9EQ4iR1jxP8kEgyq7tPi7ZqsOem5b0yY",
-        oauth_signature="zcvQwEwCCvIS02j6cHQBHZ1O1AE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291965", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:25 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '652'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84ZjBmN2E4YS02NTRhLTRmZDMtODA4OS1jMWI2
-        NDVjZmE0NmQvIiwgInRhc2tfaWQiOiAiOGYwZjdhOGEtNjU0YS00ZmQzLTgw
-        ODktYzFiNjQ1Y2ZhNDZkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiBudWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBb
-        XSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRf
-        cmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRx
-        IiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
-        ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRv
-        aWQiOiAiNTZhZWJiZmRlNTQ5NzVmNzFhNmE2NDg0In0sICJpZCI6ICI1NmFl
-        YmJmZGU1NDk3NWY3MWE2YTY0ODQifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:25 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/bc7331dd-231a-4ae3-b299-3f44d89582cf/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="2GHuCRFC0va5uQg5d3y57NK8ipFYwMPnXtnE5DiDDzY",
-        oauth_signature="PzPoisonTZbe7gLgMtDD%2FAPa1aw%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291966", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:26 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2310'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iYzczMzFkZC0yMzFhLTRhZTMtYjI5OS0zZjQ0ZDg5NTgy
-        Y2YvIiwgInRhc2tfaWQiOiAiYmM3MzMxZGQtMjMxYS00YWUzLWIyOTktM2Y0
-        NGQ4OTU4MmNmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMTo1OToyNVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OToyNFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZDMwMGMwZTQtYTY5ZS00ODE3LTkzM2QtZDgxMzg1NjJi
-        ZjM3LyIsICJ0YXNrX2lkIjogImQzMDBjMGU0LWE2OWUtNDgxNy05MzNkLWQ4
-        MTM4NTYyYmYzNyJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84
-        ZjBmN2E4YS02NTRhLTRmZDMtODA4OS1jMWI2NDVjZmE0NmQvIiwgInRhc2tf
-        aWQiOiAiOGYwZjdhOGEtNjU0YS00ZmQzLTgwODktYzFiNjQ1Y2ZhNDZkIn1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJiZmNkZTA0MDMzNDZkMTg4ZmUz
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MTo1OToyNFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAxOjU5OjI1WiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmJmZGRlMDQwMzRjZDky
-        ZGM1MTkiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmJmY2U1NDk3NWY3MWE2YTY0NzMifSwgImlkIjogIjU2YWViYmZjZTU0
-        OTc1ZjcxYTZhNjQ3MyJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:26 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/d300c0e4-a69e-4817-933d-d8138562bf37/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="0P3tmdweXkG4xHYXeOqVXJPzf1pUFacv7GOi6kTRkg",
-        oauth_signature="MFYDV0oehGWmbRzkanY%2FFsHW29s%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291966", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:26 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9kMzAwYzBlNC1hNjllLTQ4MTctOTMzZC1kODEz
-        ODU2MmJmMzcvIiwgInRhc2tfaWQiOiAiZDMwMGMwZTQtYTY5ZS00ODE3LTkz
-        M2QtZDgxMzg1NjJiZjM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMTo1OToyNVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OToyNVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDE6NTk6MjVaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMTo1OToyNVoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmJmZGRlMDQwMzRjZDkyZGM1MWEiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJiZmRlNTQ5NzVmNzFhNmE2NDgzIn0s
-        ICJpZCI6ICI1NmFlYmJmZGU1NDk3NWY3MWE2YTY0ODMifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:26 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/8f0f7a8a-654a-4fd3-8089-c1b645cfa46d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="9zRUtDDgdu6nbtGTICdtFJarXCNjDzm2niaINGbtEsI",
-        oauth_signature="P%2Ft1MJw1h70xv7e9bs%2FckoAwJQc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291966", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:26 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6923'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84ZjBmN2E4YS02NTRhLTRmZDMtODA4OS1jMWI2
-        NDVjZmE0NmQvIiwgInRhc2tfaWQiOiAiOGYwZjdhOGEtNjU0YS00ZmQzLTgw
-        ODktYzFiNjQ1Y2ZhNDZkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMTo1OToyNVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OToyNVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI5ZDE1NzZmZC0zZmE5LTQxNmUtOTVlMi0xNDU4YzNi
-        OThhMGMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMjVhNzdkY2EtOGZlYi00YjY2LTk2YWUtNmJiNGQxNzMzZWJmIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMWQ0ZjYxMmQtNTAwYS00NTZlLWJjZmEt
-        YjFlY2U1YThjZTc4IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNWRm
-        YTNlMGItMjEyOS00ZjI4LWE4N2UtMTk2NmFiMjZhNzYwIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjI1NTcxYmNiLThmYjYtNDIyOS05MDA5LTJhNjBi
-        NWMwNWUwMCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyNzM2Mjdj
-        NC0zNjQyLTRhNTktYmZkMi01OTZmMmQ5NDQyMWEiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI5ZGQ1ODNmMi01ZDI4LTRhY2YtYWU2OC04NDgw
-        NDY2NjY2YzEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJkMzYxMzRmNy1kOTFjLTQ2MTYtYTNiYS01ZWIwNGIzYjFiMGYi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMTg4
-        YTczZS1lOWVlLTQ0Y2UtOGE4Ny0xOGJkOTcxNTRiMTQiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNTc0YjJhYy1lOWVl
-        LTQxYTEtYTc0My1hM2VlYmZmMThlYjQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFhYTM3N2E5LWFlZjEtNDY1
-        Yy04MTIxLTM3MTJjMDE2NTNhZSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
-        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
-        c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTAxVDAxOjU5OjI1WiIsICJf
-        bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
-        MTYtMDItMDFUMDE6NTk6MjVaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
-        cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
-        IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
-        X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
-        RCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1z
-        IjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0
-        aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
-        SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
-        U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
-        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZhZWJiZmRkZTA0MDM0Y2Q5MmRj
-        NTFiIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjlkMTU3NmZkLTNmYTktNDE2ZS05NWUyLTE0NThjM2I5OGEwYyIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
-        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyNWE3
-        N2RjYS04ZmViLTRiNjYtOTZhZS02YmI0ZDE3MzNlYmYiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
-        c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICIxZDRmNjEyZC01MDBhLTQ1NmUtYmNmYS1iMWVjZTVhOGNl
-        NzgiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
-        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1ZGZhM2UwYi0yMTI5
-        LTRmMjgtYTg3ZS0xOTY2YWIyNmE3NjAiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
-        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMjU1NzFiY2ItOGZiNi00MjI5LTkwMDktMmE2MGI1YzA1ZTAwIiwg
-        Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
-        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI3MzYyN2M0LTM2NDItNGE1
-        OS1iZmQyLTU5NmYyZDk0NDIxYSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
-        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
-        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjlkZDU4M2YyLTVkMjgtNGFjZi1hZTY4LTg0ODA0NjY2NjZjMSIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
-        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
-        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQz
-        NjEzNGY3LWQ5MWMtNDYxNi1hM2JhLTVlYjA0YjNiMWIwZiIsICJudW1fcHJv
-        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
-        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
-        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImIxODhhNzNlLWU5ZWUt
-        NDRjZS04YTg3LTE4YmQ5NzE1NGIxNCIsICJudW1fcHJvY2Vzc2VkIjogMH0s
-        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
-        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
-        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjE1NzRiMmFjLWU5ZWUtNDFhMS1hNzQz
-        LWEzZWViZmYxOGViNCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
-        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiYWFhMzc3YTktYWVmMS00NjVjLTgxMjEtMzcx
-        MmMwMTY1M2FlIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YWViYmZkZTU0OTc1ZjcxYTZhNjQ4
-        NCJ9LCAiaWQiOiAiNTZhZWJiZmRlNTQ5NzVmNzFhNmE2NDg0In0=
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:26 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/b3f75e89-d248-4e4d-bece-e5a32d508f65/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="1b1YqvELjMhr77AI3JB1qLXjfJTzixhAapD0kJivAU",
-        oauth_signature="inKrnhEnFuWKllymb541X0jtgDo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291966", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:26 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iM2Y3NWU4OS1kMjQ4LTRlNGQtYmVjZS1lNWEzMmQ1MDhm
-        NjUvIiwgInRhc2tfaWQiOiAiYjNmNzVlODktZDI0OC00ZTRkLWJlY2UtZTVh
-        MzJkNTA4ZjY1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmFlYmJm
-        ZWU1NDk3NWY3MWE2YTY0ODUifSwgImlkIjogIjU2YWViYmZlZTU0OTc1Zjcx
-        YTZhNjQ4NSJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:26 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/b3f75e89-d248-4e4d-bece-e5a32d508f65/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="5nHBhDNl2LQ62RKrHGG642Fpy79cYbGL1lDpuJFg",
-        oauth_signature="zo08Bnvir2KWF0LCaiDExTynlK8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291967", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:27 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '682'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iM2Y3NWU4OS1kMjQ4LTRlNGQtYmVjZS1lNWEzMmQ1MDhm
-        NjUvIiwgInRhc2tfaWQiOiAiYjNmNzVlODktZDI0OC00ZTRkLWJlY2UtZTVh
-        MzJkNTA4ZjY1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTAxVDAxOjU5OjI2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTAxVDAxOjU5OjI2WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
-        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJiZmVl
-        NTQ5NzVmNzFhNmE2NDg1In0sICJpZCI6ICI1NmFlYmJmZWU1NDk3NWY3MWE2
-        YTY0ODUifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:27 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/ef8d66a8-3dea-48ce-9ff4-02ca7a1340f0/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="tDSibGPTmkCOHUItWIKKMvXxmEGdkvu0u9If917as",
-        oauth_signature="pnuwmzOj%2BP%2FfoVbtPklGUkJ9Bns%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291968", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:28 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lZjhkNjZhOC0zZGVhLTQ4Y2UtOWZmNC0wMmNhN2ExMzQw
-        ZjAvIiwgInRhc2tfaWQiOiAiZWY4ZDY2YTgtM2RlYS00OGNlLTlmZjQtMDJj
-        YTdhMTM0MGYwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjMDBl
-        NTQ5NzVmNzFhNmE2NDg3In0sICJpZCI6ICI1NmFlYmMwMGU1NDk3NWY3MWE2
-        YTY0ODcifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:28 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/ef8d66a8-3dea-48ce-9ff4-02ca7a1340f0/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="J6gl3cCSz04Bcb4Kk7Dqke17Esc9x4enVJW2Dk6i0Tc",
-        oauth_signature="b%2F%2FkjN9N4qUTOZDsRp68NJroqOo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291968", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:28 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2310'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lZjhkNjZhOC0zZGVhLTQ4Y2UtOWZmNC0wMmNhN2ExMzQw
-        ZjAvIiwgInRhc2tfaWQiOiAiZWY4ZDY2YTgtM2RlYS00OGNlLTlmZjQtMDJj
-        YTdhMTM0MGYwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMTo1OToyOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OToyOFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvM2MxZmVmYWUtNzUzNC00NTI0LTgyMzItOThkMjhlYTJl
-        ZDgyLyIsICJ0YXNrX2lkIjogIjNjMWZlZmFlLTc1MzQtNDUyNC04MjMyLTk4
-        ZDI4ZWEyZWQ4MiJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8y
-        ZTMwNTc2NC0zNDA5LTRlMjYtOTQ3ZS0wYjVmNDJiNzRlNGMvIiwgInRhc2tf
-        aWQiOiAiMmUzMDU3NjQtMzQwOS00ZTI2LTk0N2UtMGI1ZjQyYjc0ZTRjIn1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjMDBkZTA0MDMzNDZjZjY0OTcy
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MTo1OToyOFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAxOjU5OjI4WiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmMwMGRlMDQwMzRjZDky
-        ZGM1MWYiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmMwMGU1NDk3NWY3MWE2YTY0ODcifSwgImlkIjogIjU2YWViYzAwZTU0
-        OTc1ZjcxYTZhNjQ4NyJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:28 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/3c1fefae-7534-4524-8232-98d28ea2ed82/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="rZsNtXGp9eJ1uZqmodgpoF38q0wPVNCDReoTuggFw9Q",
-        oauth_signature="pZ3M7Sg88%2BDA%2F9koXoFvL8QHyxU%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291968", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:29 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8zYzFmZWZhZS03NTM0LTQ1MjQtODIzMi05OGQy
-        OGVhMmVkODIvIiwgInRhc2tfaWQiOiAiM2MxZmVmYWUtNzUzNC00NTI0LTgy
-        MzItOThkMjhlYTJlZDgyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMTo1OToyOFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OToyOFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDE6NTk6MjhaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMTo1OToyOFoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmMwMGRlMDQwMzRjZDkyZGM1MjAiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjMDBlNTQ5NzVmNzFhNmE2NDk3In0s
-        ICJpZCI6ICI1NmFlYmMwMGU1NDk3NWY3MWE2YTY0OTcifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:29 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/2e305764-3409-4e26-947e-0b5f42b74e4c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="7Ku0m9QFM38LzUwrZ7OHX9aU3CsUySGfdlEcEKfpg",
-        oauth_signature="reRs1mPbf%2FcYAWBObrlGEAs%2FNO8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291969", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:29 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3510'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8yZTMwNTc2NC0zNDA5LTRlMjYtOTQ3ZS0wYjVm
-        NDJiNzRlNGMvIiwgInRhc2tfaWQiOiAiMmUzMDU3NjQtMzQwOS00ZTI2LTk0
-        N2UtMGI1ZjQyYjc0ZTRjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wMVQwMTo1OToyOFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyNjJj
-        YzllMy1kNDhiLTQ0OTUtOTY0MS1mMGJiNDQyZDIzNTciLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiY2RjNjVhYTEtM2Zk
-        Yi00OTQ2LTgzYjYtYTg2MmIzZmYyMDk4IiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiMjBkOWU5OGUtNTg1NS00NTFhLTk5MmEtODkxYzEyMmRmZDkxIiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjNiZjFhNWItYjc2My00MzU3LWFm
-        ZWYtYjA4M2MxZDFiMjBhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImZiZGJlN2QyLTU0NmMtNDE4NC1hN2U1LWI2MzU1NjdkMWYyYiIsICJudW1f
-        cHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJj
-        b21wcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyZTQ4ODZmMS1kODZhLTQ3ZmUt
-        YWRiYi1lNzFkYThhNjBiNGYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
-        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0
-        YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI2YjM0NjNiNS0yMTgwLTQyMzktYmU3OS0yOWM3YjBmOTVkZWQi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJhNTBiNjE0YS0yZjhjLTQ0ZDQtYWEwOC1jMzBmZTEyODlmN2YiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
-        aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTQ4ZjEx
-        ZDYtYTk2Yy00YTIyLWJhNmUtNzc3MGVkZjJhMjNhIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
-        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
-        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmRmZDRkZTMtMzgz
-        Zi00ODdhLTg5YzQtYTE0MjA1ZDY4NWUyIiwgIm51bV9wcm9jZXNzZWQiOiAw
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5n
-        IExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVw
-        b19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
-        U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiNTFhZTcwYi1jZTNk
-        LTQ2YjAtOTMxNS00MmM1ZmRkNGEzYzYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
-        bGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
-        YXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
-        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmFlYmMwMGU1NDk3NWY3
-        MWE2YTY0OTgifSwgImlkIjogIjU2YWViYzAwZTU0OTc1ZjcxYTZhNjQ5OCJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:29 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/ef8d66a8-3dea-48ce-9ff4-02ca7a1340f0/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="DOIbdYqtwDFh6Qxwby7VE3ewx7mmPzLmTTVAWYsxrLM",
-        oauth_signature="LannpBxBDEArd3ZrBArYF7sMMvg%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291969", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:29 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2310'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lZjhkNjZhOC0zZGVhLTQ4Y2UtOWZmNC0wMmNhN2ExMzQw
-        ZjAvIiwgInRhc2tfaWQiOiAiZWY4ZDY2YTgtM2RlYS00OGNlLTlmZjQtMDJj
-        YTdhMTM0MGYwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMTo1OToyOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OToyOFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvM2MxZmVmYWUtNzUzNC00NTI0LTgyMzItOThkMjhlYTJl
-        ZDgyLyIsICJ0YXNrX2lkIjogIjNjMWZlZmFlLTc1MzQtNDUyNC04MjMyLTk4
-        ZDI4ZWEyZWQ4MiJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8y
-        ZTMwNTc2NC0zNDA5LTRlMjYtOTQ3ZS0wYjVmNDJiNzRlNGMvIiwgInRhc2tf
-        aWQiOiAiMmUzMDU3NjQtMzQwOS00ZTI2LTk0N2UtMGI1ZjQyYjc0ZTRjIn1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjMDBkZTA0MDMzNDZjZjY0OTcy
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MTo1OToyOFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAxOjU5OjI4WiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmMwMGRlMDQwMzRjZDky
-        ZGM1MWYiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmMwMGU1NDk3NWY3MWE2YTY0ODcifSwgImlkIjogIjU2YWViYzAwZTU0
-        OTc1ZjcxYTZhNjQ4NyJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:29 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/3c1fefae-7534-4524-8232-98d28ea2ed82/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="RuG6K6Wkk6uXDagEioLvneLzXtbOcSWwvTqarxBpn8",
-        oauth_signature="QflzAyV84y0XNZ6yAhTT4fVZd4U%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291969", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:29 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8zYzFmZWZhZS03NTM0LTQ1MjQtODIzMi05OGQy
-        OGVhMmVkODIvIiwgInRhc2tfaWQiOiAiM2MxZmVmYWUtNzUzNC00NTI0LTgy
-        MzItOThkMjhlYTJlZDgyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMTo1OToyOFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OToyOFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDE6NTk6MjhaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMTo1OToyOFoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmMwMGRlMDQwMzRjZDkyZGM1MjAiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjMDBlNTQ5NzVmNzFhNmE2NDk3In0s
-        ICJpZCI6ICI1NmFlYmMwMGU1NDk3NWY3MWE2YTY0OTcifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:29 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/2e305764-3409-4e26-947e-0b5f42b74e4c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="ZmSNL9fTAj8mtfSZs2JzGSlULpG969rlrruqEKY",
-        oauth_signature="50hcc3hScfCiDheCuenBMrqnj3c%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291969", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:29 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6923'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8yZTMwNTc2NC0zNDA5LTRlMjYtOTQ3ZS0wYjVm
-        NDJiNzRlNGMvIiwgInRhc2tfaWQiOiAiMmUzMDU3NjQtMzQwOS00ZTI2LTk0
-        N2UtMGI1ZjQyYjc0ZTRjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMTo1OToyOVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OToyOFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIyNjJjYzllMy1kNDhiLTQ0OTUtOTY0MS1mMGJiNDQy
-        ZDIzNTciLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiY2RjNjVhYTEtM2ZkYi00OTQ2LTgzYjYtYTg2MmIzZmYyMDk4Iiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMjBkOWU5OGUtNTg1NS00NTFhLTk5MmEt
-        ODkxYzEyMmRmZDkxIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjNi
-        ZjFhNWItYjc2My00MzU3LWFmZWYtYjA4M2MxZDFiMjBhIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImZiZGJlN2QyLTU0NmMtNDE4NC1hN2U1LWI2MzU1
-        NjdkMWYyYiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyZTQ4ODZm
-        MS1kODZhLTQ3ZmUtYWRiYi1lNzFkYThhNjBiNGYiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI2YjM0NjNiNS0yMTgwLTQyMzktYmU3OS0yOWM3
-        YjBmOTVkZWQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJhNTBiNjE0YS0yZjhjLTQ0ZDQtYWEwOC1jMzBmZTEyODlmN2Yi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNDhm
-        MTFkNi1hOTZjLTRhMjItYmE2ZS03NzcwZWRmMmEyM2EiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmZGZkNGRlMy0zODNm
-        LTQ4N2EtODljNC1hMTQyMDVkNjg1ZTIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI1MWFlNzBiLWNlM2QtNDZi
-        MC05MzE1LTQyYzVmZGQ0YTNjNiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
-        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
-        c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTAxVDAxOjU5OjI4WiIsICJf
-        bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
-        MTYtMDItMDFUMDE6NTk6MjlaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
-        cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
-        IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
-        X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
-        RCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1z
-        IjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0
-        aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
-        SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
-        U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
-        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZhZWJjMDFkZTA0MDM0Y2Q5MmRj
-        NTIxIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjI2MmNjOWUzLWQ0OGItNDQ5NS05NjQxLWYwYmI0NDJkMjM1NyIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
-        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjZGM2
-        NWFhMS0zZmRiLTQ5NDYtODNiNi1hODYyYjNmZjIwOTgiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
-        c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICIyMGQ5ZTk4ZS01ODU1LTQ1MWEtOTkyYS04OTFjMTIyZGZk
-        OTEiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
-        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2M2JmMWE1Yi1iNzYz
-        LTQzNTctYWZlZi1iMDgzYzFkMWIyMGEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
-        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZmJkYmU3ZDItNTQ2Yy00MTg0LWE3ZTUtYjYzNTU2N2QxZjJiIiwg
-        Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
-        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjJlNDg4NmYxLWQ4NmEtNDdm
-        ZS1hZGJiLWU3MWRhOGE2MGI0ZiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
-        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
-        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjZiMzQ2M2I1LTIxODAtNDIzOS1iZTc5LTI5YzdiMGY5NWRlZCIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
-        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
-        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE1
-        MGI2MTRhLTJmOGMtNDRkNC1hYTA4LWMzMGZlMTI4OWY3ZiIsICJudW1fcHJv
-        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
-        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
-        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE0OGYxMWQ2LWE5NmMt
-        NGEyMi1iYTZlLTc3NzBlZGYyYTIzYSIsICJudW1fcHJvY2Vzc2VkIjogMH0s
-        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
-        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
-        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImZkZmQ0ZGUzLTM4M2YtNDg3YS04OWM0
-        LWExNDIwNWQ2ODVlMiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
-        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiYjUxYWU3MGItY2UzZC00NmIwLTkzMTUtNDJj
-        NWZkZDRhM2M2IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YWViYzAwZTU0OTc1ZjcxYTZhNjQ5
-        OCJ9LCAiaWQiOiAiNTZhZWJjMDBlNTQ5NzVmNzFhNmE2NDk4In0=
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:29 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/d29b3d42-0065-4db5-aea6-99281e5df5e4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="HXJamWnrFsueI8xhY3ZffLmwSkGwe7vND3G1cfMAE",
-        oauth_signature="6GZoNdEwkLomO4bAQ1bQzfgtMOI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291970", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:30 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kMjliM2Q0Mi0wMDY1LTRkYjUtYWVhNi05OTI4MWU1ZGY1
-        ZTQvIiwgInRhc2tfaWQiOiAiZDI5YjNkNDItMDA2NS00ZGI1LWFlYTYtOTky
-        ODFlNWRmNWU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmFlYmMw
-        MmU1NDk3NWY3MWE2YTY0OTkifSwgImlkIjogIjU2YWViYzAyZTU0OTc1Zjcx
-        YTZhNjQ5OSJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:30 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/d29b3d42-0065-4db5-aea6-99281e5df5e4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="0CYkQ75psCRJ7fA5mAWNeZ5EwnwhJc5k3eax2WDGU",
-        oauth_signature="mzLs9c4%2F8MCc2oCXR75B4kTuqjs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291971", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:31 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '682'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kMjliM2Q0Mi0wMDY1LTRkYjUtYWVhNi05OTI4MWU1ZGY1
-        ZTQvIiwgInRhc2tfaWQiOiAiZDI5YjNkNDItMDA2NS00ZGI1LWFlYTYtOTky
-        ODFlNWRmNWU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTAxVDAxOjU5OjMwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTAxVDAxOjU5OjMwWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
-        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjMDJl
-        NTQ5NzVmNzFhNmE2NDk5In0sICJpZCI6ICI1NmFlYmMwMmU1NDk3NWY3MWE2
-        YTY0OTkifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:31 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/3825693c-a76f-4129-9eb8-8ad8fc6c9c6f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="cYtLYqVmjpbLupy8XlPHLN7a0i1ct9RSiwt1y2Ck",
-        oauth_signature="AbV2lhZ6Qf6LFhxr6qt6oaXDs5U%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291972", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:32 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zODI1NjkzYy1hNzZmLTQxMjktOWViOC04YWQ4ZmM2Yzlj
-        NmYvIiwgInRhc2tfaWQiOiAiMzgyNTY5M2MtYTc2Zi00MTI5LTllYjgtOGFk
-        OGZjNmM5YzZmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjMDRl
-        NTQ5NzVmNzFhNmE2NDliIn0sICJpZCI6ICI1NmFlYmMwNGU1NDk3NWY3MWE2
-        YTY0OWIifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:32 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/3825693c-a76f-4129-9eb8-8ad8fc6c9c6f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="MlUDhycfRZa7g2VA5CgaMLHH1agfhwcxEe9rCjsYI",
-        oauth_signature="ZP6E2FyEodO3j9Kja%2FfVcgtDD8c%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291972", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:33 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2310'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zODI1NjkzYy1hNzZmLTQxMjktOWViOC04YWQ4ZmM2Yzlj
-        NmYvIiwgInRhc2tfaWQiOiAiMzgyNTY5M2MtYTc2Zi00MTI5LTllYjgtOGFk
-        OGZjNmM5YzZmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMTo1OTozMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OTozMloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMDQwOWNhYTItMjA3OC00YTk5LThkY2YtMTkwMzVkMzYx
-        YmQ3LyIsICJ0YXNrX2lkIjogIjA0MDljYWEyLTIwNzgtNGE5OS04ZGNmLTE5
-        MDM1ZDM2MWJkNyJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82
-        NDhhOGU2My0zODJiLTRlZTItOWM2MC1iYTllNDc0M2E5ODkvIiwgInRhc2tf
-        aWQiOiAiNjQ4YThlNjMtMzgyYi00ZWUyLTljNjAtYmE5ZTQ3NDNhOTg5In1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjMDRkZTA0MDMzNDZjZjY0OTdj
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MTo1OTozMloiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAxOjU5OjMyWiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmMwNGRlMDQwMzRjZDky
-        ZGM1MjUiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmMwNGU1NDk3NWY3MWE2YTY0OWIifSwgImlkIjogIjU2YWViYzA0ZTU0
-        OTc1ZjcxYTZhNjQ5YiJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:33 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/0409caa2-2078-4a99-8dcf-19035d361bd7/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="994dIh5BSkh8ck8plpFZvScm8Zl38BOm7fwGd7gI",
-        oauth_signature="YqCvOJHKqyTEyTAf5A2uMuUpSbk%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291973", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:33 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '652'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8wNDA5Y2FhMi0yMDc4LTRhOTktOGRjZi0xOTAz
-        NWQzNjFiZDcvIiwgInRhc2tfaWQiOiAiMDQwOWNhYTItMjA3OC00YTk5LThk
-        Y2YtMTkwMzVkMzYxYmQ3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiBudWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBb
-        XSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRf
-        cmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRx
-        IiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
-        ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRv
-        aWQiOiAiNTZhZWJjMDRlNTQ5NzVmNzFhNmE2NGFiIn0sICJpZCI6ICI1NmFl
-        YmMwNGU1NDk3NWY3MWE2YTY0YWIifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:33 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/648a8e63-382b-4ee2-9c60-ba9e4743a989/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="dWayUEdmtgjadIw8MxlLiSaO1ThsetKH1v31Nq0iqI",
-        oauth_signature="2J4gspa47KEXapmDTZq2Hefg7Sc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291973", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:33 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '652'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82NDhhOGU2My0zODJiLTRlZTItOWM2MC1iYTll
-        NDc0M2E5ODkvIiwgInRhc2tfaWQiOiAiNjQ4YThlNjMtMzgyYi00ZWUyLTlj
-        NjAtYmE5ZTQ3NDNhOTg5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiBudWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBb
-        XSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRf
-        cmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRx
-        IiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
-        ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRv
-        aWQiOiAiNTZhZWJjMDRlNTQ5NzVmNzFhNmE2NGFjIn0sICJpZCI6ICI1NmFl
-        YmMwNGU1NDk3NWY3MWE2YTY0YWMifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:33 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/3825693c-a76f-4129-9eb8-8ad8fc6c9c6f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="XniRpJA9cnm0FKVGu062hlQO67diNoW1aiWOuT0as",
-        oauth_signature="5NJZ7Sk449pDD%2Fh9zOvnaEYPFpY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291973", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:33 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2310'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zODI1NjkzYy1hNzZmLTQxMjktOWViOC04YWQ4ZmM2Yzlj
-        NmYvIiwgInRhc2tfaWQiOiAiMzgyNTY5M2MtYTc2Zi00MTI5LTllYjgtOGFk
-        OGZjNmM5YzZmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMTo1OTozMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OTozMloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMDQwOWNhYTItMjA3OC00YTk5LThkY2YtMTkwMzVkMzYx
-        YmQ3LyIsICJ0YXNrX2lkIjogIjA0MDljYWEyLTIwNzgtNGE5OS04ZGNmLTE5
-        MDM1ZDM2MWJkNyJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82
-        NDhhOGU2My0zODJiLTRlZTItOWM2MC1iYTllNDc0M2E5ODkvIiwgInRhc2tf
-        aWQiOiAiNjQ4YThlNjMtMzgyYi00ZWUyLTljNjAtYmE5ZTQ3NDNhOTg5In1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjMDRkZTA0MDMzNDZjZjY0OTdj
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MTo1OTozMloiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAxOjU5OjMyWiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmMwNGRlMDQwMzRjZDky
-        ZGM1MjUiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmMwNGU1NDk3NWY3MWE2YTY0OWIifSwgImlkIjogIjU2YWViYzA0ZTU0
-        OTc1ZjcxYTZhNjQ5YiJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:33 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/0409caa2-2078-4a99-8dcf-19035d361bd7/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="DdUjsVDe4PuAFXzee5KGacJgWdqkUBuUgov44hWT38U",
-        oauth_signature="FUewHBJCfFCi%2FJBLNqJ1GVcMFfY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291973", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:33 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8wNDA5Y2FhMi0yMDc4LTRhOTktOGRjZi0xOTAz
-        NWQzNjFiZDcvIiwgInRhc2tfaWQiOiAiMDQwOWNhYTItMjA3OC00YTk5LThk
-        Y2YtMTkwMzVkMzYxYmQ3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMTo1OTozM1oiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OTozM1oiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDE6NTk6MzNaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMTo1OTozM1oiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmMwNWRlMDQwMzRjZDkyZGM1MjYiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjMDRlNTQ5NzVmNzFhNmE2NGFiIn0s
-        ICJpZCI6ICI1NmFlYmMwNGU1NDk3NWY3MWE2YTY0YWIifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:33 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/648a8e63-382b-4ee2-9c60-ba9e4743a989/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="2YkU3HLsY4nS1WrS0JJdISWk94Y7XTprN5MjO1FzlcQ",
-        oauth_signature="dsaeqigH%2FB3c4CIgcBc9Qk5AzzY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291973", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:33 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6923'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82NDhhOGU2My0zODJiLTRlZTItOWM2MC1iYTll
-        NDc0M2E5ODkvIiwgInRhc2tfaWQiOiAiNjQ4YThlNjMtMzgyYi00ZWUyLTlj
-        NjAtYmE5ZTQ3NDNhOTg5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMTo1OTozM1oiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OTozM1oiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIwMWM2OWYxZC04Mzc1LTQ5NmQtYjc2My1hNzQ0OTdl
-        YWMwMGYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYzdhMThmOTgtNmZhMC00Yjc5LWI2NTYtYTJlZmNiNWJjZTdjIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiOWQ3NjU2MTctMDY5Yy00NDU0LThjNGEt
-        ZWYwNWYxMWM5YjRhIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWM2
-        NTg4ZmEtZjUxYS00NjBiLThhOTUtMzZhMWVmZDQxOTkwIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjZjMmQ5MDE0LWVmZDUtNGNkYS1iYzBkLTZjMmVk
-        ODYxNGEzYyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmYTUyOTEy
-        NS1jNDY3LTQ1NjMtYWIwMC1jZDVhZWZkNTkxYTIiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJkNjU2YjExYS02NGNkLTQ0ZmEtYWQ3ZC0yY2Rj
-        ZjlhNTRlOGEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJhYjVlM2FlYS0wMzlkLTQ5NWYtYWZiNy0wYmE3MTA2YWZiY2Ei
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkNDIw
-        MGY0Yy0zMGYyLTRkZDktYjllMC1mMGIyYzI4MThmMzUiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYTQ0YzM5Ni1jMDA2
-        LTQ5OGItYWMzZS1hOGUyY2M2NDE4MWYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBhZWRjMjU2LTY5YmUtNDQ1
-        Ni1hOGU4LTEyNWRkOTMyNzYxZCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
-        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
-        c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTAxVDAxOjU5OjMzWiIsICJf
-        bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
-        MTYtMDItMDFUMDE6NTk6MzNaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
-        cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
-        IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
-        X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
-        RCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1z
-        IjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0
-        aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
-        SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
-        U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
-        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZhZWJjMDVkZTA0MDM0Y2Q5MmRj
-        NTI3IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjAxYzY5ZjFkLTgzNzUtNDk2ZC1iNzYzLWE3NDQ5N2VhYzAwZiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
-        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjN2Ex
-        OGY5OC02ZmEwLTRiNzktYjY1Ni1hMmVmY2I1YmNlN2MiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
-        c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICI5ZDc2NTYxNy0wNjljLTQ0NTQtOGM0YS1lZjA1ZjExYzli
-        NGEiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
-        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhYzY1ODhmYS1mNTFh
-        LTQ2MGItOGE5NS0zNmExZWZkNDE5OTAiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
-        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNmMyZDkwMTQtZWZkNS00Y2RhLWJjMGQtNmMyZWQ4NjE0YTNjIiwg
-        Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
-        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZhNTI5MTI1LWM0NjctNDU2
-        My1hYjAwLWNkNWFlZmQ1OTFhMiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
-        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
-        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogImQ2NTZiMTFhLTY0Y2QtNDRmYS1hZDdkLTJjZGNmOWE1NGU4YSIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
-        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
-        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFi
-        NWUzYWVhLTAzOWQtNDk1Zi1hZmI3LTBiYTcxMDZhZmJjYSIsICJudW1fcHJv
-        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
-        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
-        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ0MjAwZjRjLTMwZjIt
-        NGRkOS1iOWUwLWYwYjJjMjgxOGYzNSIsICJudW1fcHJvY2Vzc2VkIjogMH0s
-        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
-        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
-        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjBhNDRjMzk2LWMwMDYtNDk4Yi1hYzNl
-        LWE4ZTJjYzY0MTgxZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
-        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiMGFlZGMyNTYtNjliZS00NDU2LWE4ZTgtMTI1
-        ZGQ5MzI3NjFkIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YWViYzA0ZTU0OTc1ZjcxYTZhNjRh
-        YyJ9LCAiaWQiOiAiNTZhZWJjMDRlNTQ5NzVmNzFhNmE2NGFjIn0=
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:33 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/a15a3de7-f2c1-4b47-8c84-eb772a6792bf/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="I6MnZlygKwGRNcarIBcokBPweC7jLTQ0nYU4CovW0",
-        oauth_signature="1po5tO8jCjGLmjdnSVa8THThYwE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291974", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:34 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hMTVhM2RlNy1mMmMxLTRiNDctOGM4NC1lYjc3MmE2Nzky
-        YmYvIiwgInRhc2tfaWQiOiAiYTE1YTNkZTctZjJjMS00YjQ3LThjODQtZWI3
-        NzJhNjc5MmJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmFlYmMw
-        NmU1NDk3NWY3MWE2YTY0YWQifSwgImlkIjogIjU2YWViYzA2ZTU0OTc1Zjcx
-        YTZhNjRhZCJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:34 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/a15a3de7-f2c1-4b47-8c84-eb772a6792bf/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="dzhkTpimEIEsS4EXdtSioqKgONatWybFascjVc",
-        oauth_signature="hEZCPLsPLzinln7OMWn1vNJ4rmA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291974", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:34 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '682'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hMTVhM2RlNy1mMmMxLTRiNDctOGM4NC1lYjc3MmE2Nzky
-        YmYvIiwgInRhc2tfaWQiOiAiYTE1YTNkZTctZjJjMS00YjQ3LThjODQtZWI3
-        NzJhNjc5MmJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTAxVDAxOjU5OjM0WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTAxVDAxOjU5OjM0WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
-        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjMDZl
-        NTQ5NzVmNzFhNmE2NGFkIn0sICJpZCI6ICI1NmFlYmMwNmU1NDk3NWY3MWE2
-        YTY0YWQifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:34 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/5dc981c4-9cc5-4649-80fd-365d87e51cab/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="7TXsEj9NKfhd5VJLKEjiLun7UNE9rx16dpfmLIwErI",
-        oauth_signature="xn5BWU%2BKyn1lwoWsPH2Ew1buVg4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291975", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:35 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81ZGM5ODFjNC05Y2M1LTQ2NDktODBmZC0zNjVkODdlNTFj
-        YWIvIiwgInRhc2tfaWQiOiAiNWRjOTgxYzQtOWNjNS00NjQ5LTgwZmQtMzY1
-        ZDg3ZTUxY2FiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjMDdl
-        NTQ5NzVmNzFhNmE2NGFmIn0sICJpZCI6ICI1NmFlYmMwN2U1NDk3NWY3MWE2
-        YTY0YWYifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:35 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/5dc981c4-9cc5-4649-80fd-365d87e51cab/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="cJJjJeSFcKeyRPq4sXQCfyGocA7NYRMTcu9aKYsIFw4",
-        oauth_signature="xeTp%2F4HKdK4edk34GV%2FiIVFkI9Q%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291976", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:36 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2310'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81ZGM5ODFjNC05Y2M1LTQ2NDktODBmZC0zNjVkODdlNTFj
-        YWIvIiwgInRhc2tfaWQiOiAiNWRjOTgxYzQtOWNjNS00NjQ5LTgwZmQtMzY1
-        ZDg3ZTUxY2FiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMTo1OTozNloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OTozNloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMDM5YjViY2MtNTg0Ni00YTAyLTk0OWItZDMzMDlhNTA4
-        ZmNhLyIsICJ0YXNrX2lkIjogIjAzOWI1YmNjLTU4NDYtNGEwMi05NDliLWQz
-        MzA5YTUwOGZjYSJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82
-        YTJhMzY4Yy04OTY3LTQwM2YtYjE2MS0xM2I0MzI3ODE4OTQvIiwgInRhc2tf
-        aWQiOiAiNmEyYTM2OGMtODk2Ny00MDNmLWIxNjEtMTNiNDMyNzgxODk0In1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjMDdkZTA0MDMzNDZjZjY0OTg2
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MTo1OTozNloiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAxOjU5OjM2WiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmMwOGRlMDQwMzRjZDky
-        ZGM1MmIiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmMwN2U1NDk3NWY3MWE2YTY0YWYifSwgImlkIjogIjU2YWViYzA3ZTU0
-        OTc1ZjcxYTZhNjRhZiJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:36 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/039b5bcc-5846-4a02-949b-d3309a508fca/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="pHsnsLfNFunPmUMb3ui0GCoL3e5QAg8mr3cLL0lSG7Q",
-        oauth_signature="WBK8Hv3uS2oyG12hWBXuDmsTZmU%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291976", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:36 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8wMzliNWJjYy01ODQ2LTRhMDItOTQ5Yi1kMzMw
-        OWE1MDhmY2EvIiwgInRhc2tfaWQiOiAiMDM5YjViY2MtNTg0Ni00YTAyLTk0
-        OWItZDMzMDlhNTA4ZmNhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMTo1OTozNloiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OTozNloiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDE6NTk6MzZaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMTo1OTozNloiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmMwOGRlMDQwMzRjZDkyZGM1MmMiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjMDhlNTQ5NzVmNzFhNmE2NGJmIn0s
-        ICJpZCI6ICI1NmFlYmMwOGU1NDk3NWY3MWE2YTY0YmYifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:36 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/6a2a368c-8967-403f-b161-13b432781894/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="dbgeH4cnxupNZY9HaB74g0Bh6cVfYZieAjpUN3j5vgs",
-        oauth_signature="5x7d%2Fu%2FBxW3elQNTPKrWrkH0yVg%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291976", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:36 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3523'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82YTJhMzY4Yy04OTY3LTQwM2YtYjE2MS0xM2I0
-        MzI3ODE4OTQvIiwgInRhc2tfaWQiOiAiNmEyYTM2OGMtODk2Ny00MDNmLWIx
-        NjEtMTNiNDMyNzgxODk0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wMVQwMTo1OTozNloiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJh
-        NjU2YmFhMS1kMWVjLTQ2MTctODczMC05N2QxNzIyMDkzMzMiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlw
-        ZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiY2FiMTlk
-        OWYtNGRjNS00ZTc3LTg5NTItZDkzMzg4MmVkMjY3IiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNf
-        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiODlmNTY1ZTMtNzYyYy00OGEwLTgzYzItMmE5ODFhYTk4
-        NGNkIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3Rl
-        cF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQwYjM1ZWM1
-        LTAyNGMtNDQ1Yy05YTNmLWExOGM2ZGJhZGFlMyIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVt
-        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI2MTU3OWFmNy02ZmFlLTQyZGQtODEyYy04YjYyMGZl
-        ZTI2Y2QiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJz
-        dGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjkwMGI4
-        MTgtZjA5Zi00Yjg4LTg0MTgtNDJkMjg0NDQ5NGQ4IiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEi
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZWRmNWYxOWQtZTlkOS00MTRjLTg2YzUt
-        M2RhNmVmZDEyN2ZiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRh
-        dGEiLCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiOGUxMGYzZjEtM2RhYy00ZDRhLTlkYmUtMDE3MzEw
-        YTJmNWY1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
-        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIs
-        ICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjc5MzMyZjMyLWI4NTktNGMxZC04NWIyLWFjYWE1NGNlNGQ2MSIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
-        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90
-        eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjMwZjI4ZDA1LTM0NWEtNDU0OC05M2RmLTE5OTg1NWY1ODliZiIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJp
-        bml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        NTdkMWM2MTMtZTAwMi00MGQ1LTk1M2MtYmRlYThjNDgwMjIxIiwgIm51bV9w
-        cm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
-        Y2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZh
-        ZWJjMDhlNTQ5NzVmNzFhNmE2NGMwIn0sICJpZCI6ICI1NmFlYmMwOGU1NDk3
-        NWY3MWE2YTY0YzAifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:36 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/5dc981c4-9cc5-4649-80fd-365d87e51cab/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="i0josb4GUP8xKQfKxsrYDFcOktLefrzBWq5rYp5bFU",
-        oauth_signature="FO%2FYyHMoVNaC%2FvQs0063Vid63Jk%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291977", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2310'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81ZGM5ODFjNC05Y2M1LTQ2NDktODBmZC0zNjVkODdlNTFj
-        YWIvIiwgInRhc2tfaWQiOiAiNWRjOTgxYzQtOWNjNS00NjQ5LTgwZmQtMzY1
-        ZDg3ZTUxY2FiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMTo1OTozNloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OTozNloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMDM5YjViY2MtNTg0Ni00YTAyLTk0OWItZDMzMDlhNTA4
-        ZmNhLyIsICJ0YXNrX2lkIjogIjAzOWI1YmNjLTU4NDYtNGEwMi05NDliLWQz
-        MzA5YTUwOGZjYSJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82
-        YTJhMzY4Yy04OTY3LTQwM2YtYjE2MS0xM2I0MzI3ODE4OTQvIiwgInRhc2tf
-        aWQiOiAiNmEyYTM2OGMtODk2Ny00MDNmLWIxNjEtMTNiNDMyNzgxODk0In1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjMDdkZTA0MDMzNDZjZjY0OTg2
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MTo1OTozNloiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAxOjU5OjM2WiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmMwOGRlMDQwMzRjZDky
-        ZGM1MmIiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmMwN2U1NDk3NWY3MWE2YTY0YWYifSwgImlkIjogIjU2YWViYzA3ZTU0
-        OTc1ZjcxYTZhNjRhZiJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:37 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/039b5bcc-5846-4a02-949b-d3309a508fca/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="sYNAB2BBmkFZj0ChQUiUQxIN5OqeB6SylRdfXTfDVA",
-        oauth_signature="ihi3k%2BPvLfNVLXL2IyB7ktcPHMU%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291977", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8wMzliNWJjYy01ODQ2LTRhMDItOTQ5Yi1kMzMw
-        OWE1MDhmY2EvIiwgInRhc2tfaWQiOiAiMDM5YjViY2MtNTg0Ni00YTAyLTk0
-        OWItZDMzMDlhNTA4ZmNhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMTo1OTozNloiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OTozNloiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDE6NTk6MzZaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMTo1OTozNloiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmMwOGRlMDQwMzRjZDkyZGM1MmMiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjMDhlNTQ5NzVmNzFhNmE2NGJmIn0s
-        ICJpZCI6ICI1NmFlYmMwOGU1NDk3NWY3MWE2YTY0YmYifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:37 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/6a2a368c-8967-403f-b161-13b432781894/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="41p5WoBGWT7arbnVMPi7LG2zNnXnxBz0v5wiUoHxyI",
-        oauth_signature="Gk%2FzV2AFkjNYsGE7N70VfRVaHHw%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291977", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6923'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82YTJhMzY4Yy04OTY3LTQwM2YtYjE2MS0xM2I0
-        MzI3ODE4OTQvIiwgInRhc2tfaWQiOiAiNmEyYTM2OGMtODk2Ny00MDNmLWIx
-        NjEtMTNiNDMyNzgxODk0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMTo1OTozNloiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OTozNloiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJhNjU2YmFhMS1kMWVjLTQ2MTctODczMC05N2QxNzIy
-        MDkzMzMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiY2FiMTlkOWYtNGRjNS00ZTc3LTg5NTItZDkzMzg4MmVkMjY3Iiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiODlmNTY1ZTMtNzYyYy00OGEwLTgzYzIt
-        MmE5ODFhYTk4NGNkIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDBi
-        MzVlYzUtMDI0Yy00NDVjLTlhM2YtYTE4YzZkYmFkYWUzIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjYxNTc5YWY3LTZmYWUtNDJkZC04MTJjLThiNjIw
-        ZmVlMjZjZCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmOTAwYjgx
-        OC1mMDlmLTRiODgtODQxOC00MmQyODQ0NDk0ZDgiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJlZGY1ZjE5ZC1lOWQ5LTQxNGMtODZjNS0zZGE2
-        ZWZkMTI3ZmIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI4ZTEwZjNmMS0zZGFjLTRkNGEtOWRiZS0wMTczMTBhMmY1ZjUi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3OTMz
-        MmYzMi1iODU5LTRjMWQtODViMi1hY2FhNTRjZTRkNjEiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzMGYyOGQwNS0zNDVh
-        LTQ1NDgtOTNkZi0xOTk4NTVmNTg5YmYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjU3ZDFjNjEzLWUwMDItNDBk
-        NS05NTNjLWJkZWE4YzQ4MDIyMSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
-        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
-        c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTAxVDAxOjU5OjM2WiIsICJf
-        bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
-        MTYtMDItMDFUMDE6NTk6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
-        cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
-        IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
-        X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
-        RCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1z
-        IjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0
-        aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
-        SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
-        U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
-        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZhZWJjMDhkZTA0MDM0Y2Q5MmRj
-        NTJkIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImE2NTZiYWExLWQxZWMtNDYxNy04NzMwLTk3ZDE3MjIwOTMzMyIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
-        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjYWIx
-        OWQ5Zi00ZGM1LTRlNzctODk1Mi1kOTMzODgyZWQyNjciLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
-        c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICI4OWY1NjVlMy03NjJjLTQ4YTAtODNjMi0yYTk4MWFhOTg0
-        Y2QiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
-        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0MGIzNWVjNS0wMjRj
-        LTQ0NWMtOWEzZi1hMThjNmRiYWRhZTMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
-        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNjE1NzlhZjctNmZhZS00MmRkLTgxMmMtOGI2MjBmZWUyNmNkIiwg
-        Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
-        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImY5MDBiODE4LWYwOWYtNGI4
-        OC04NDE4LTQyZDI4NDQ0OTRkOCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
-        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
-        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogImVkZjVmMTlkLWU5ZDktNDE0Yy04NmM1LTNkYTZlZmQxMjdmYiIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
-        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
-        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjhl
-        MTBmM2YxLTNkYWMtNGQ0YS05ZGJlLTAxNzMxMGEyZjVmNSIsICJudW1fcHJv
-        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
-        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
-        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc5MzMyZjMyLWI4NTkt
-        NGMxZC04NWIyLWFjYWE1NGNlNGQ2MSIsICJudW1fcHJvY2Vzc2VkIjogMH0s
-        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
-        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
-        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjMwZjI4ZDA1LTM0NWEtNDU0OC05M2Rm
-        LTE5OTg1NWY1ODliZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
-        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiNTdkMWM2MTMtZTAwMi00MGQ1LTk1M2MtYmRl
-        YThjNDgwMjIxIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YWViYzA4ZTU0OTc1ZjcxYTZhNjRj
-        MCJ9LCAiaWQiOiAiNTZhZWJjMDhlNTQ5NzVmNzFhNmE2NGMwIn0=
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:37 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/2f8e2a4a-4c15-4cb6-989b-dbebcb87add7/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="pwRxRJ0QMMVfpdp1vK3RWI6POtO8zYQEeUWRNelANO4",
-        oauth_signature="cQzqMKDVI5FScvAxOkOdNFioBHI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291977", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yZjhlMmE0YS00YzE1LTRjYjYtOTg5Yi1kYmViY2I4N2Fk
-        ZDcvIiwgInRhc2tfaWQiOiAiMmY4ZTJhNGEtNGMxNS00Y2I2LTk4OWItZGJl
-        YmNiODdhZGQ3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmFlYmMw
-        OWU1NDk3NWY3MWE2YTY0YzEifSwgImlkIjogIjU2YWViYzA5ZTU0OTc1Zjcx
-        YTZhNjRjMSJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:38 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/2f8e2a4a-4c15-4cb6-989b-dbebcb87add7/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="tnnDh8Xq6lTMl9pAP48DVJ4bJRm7qNgf9yq5xWAE3kA",
-        oauth_signature="myxxliB6XRGl7dW3O%2FamZ4LXucs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291978", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '682'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yZjhlMmE0YS00YzE1LTRjYjYtOTg5Yi1kYmViY2I4N2Fk
-        ZDcvIiwgInRhc2tfaWQiOiAiMmY4ZTJhNGEtNGMxNS00Y2I2LTk4OWItZGJl
-        YmNiODdhZGQ3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTAxVDAxOjU5OjM4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTAxVDAxOjU5OjM4WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
-        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjMDll
-        NTQ5NzVmNzFhNmE2NGMxIn0sICJpZCI6ICI1NmFlYmMwOWU1NDk3NWY3MWE2
-        YTY0YzEifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:38 GMT
-- request:
-    method: post
-    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
-        LXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1
-        dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9j
-        b25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIiwiaHR0cCI6ZmFs
-        c2UsImh0dHBzIjp0cnVlLCJwcm90ZWN0ZWQiOnRydWV9LCJhdXRvX3B1Ymxp
-        c2giOnRydWUsImRpc3RyaWJ1dG9yX2lkIjoiRmVkb3JhXzE3In0seyJkaXN0
-        cmlidXRvcl90eXBlX2lkIjoieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwiZGlz
-        dHJpYnV0b3JfY29uZmlnIjp7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lk
-        IjoiRmVkb3JhXzE3In0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1
-        dG9yX2lkIjoiRmVkb3JhXzE3X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBl
-        X2lkIjoibm9kZXNfaHR0cF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2Nv
-        bmZpZyI6e30sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3JfaWQi
-        OiJGZWRvcmFfMTdfbm9kZXMifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJl
-        eHBvcnRfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0
-        cCI6ZmFsc2UsImh0dHBzIjpmYWxzZX0sImF1dG9fcHVibGlzaCI6ZmFsc2Us
-        ImRpc3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4",
-        oauth_nonce="dCPWL9oqGUs6lFH99Ls1IKikTonnwPKTFrxsaN4VVM", oauth_signature="bIprBd%2BVza5cFPmTsg1SOD7wjU8%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454291979", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '895'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:39 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '320'
-      Location:
-      - https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZhZWJjMGJkZTA0MDMzNDZjZjY0OThkIn0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:39 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/df2fb67a-049e-48ed-9615-4d9ae4db6d97/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="huzuGQxpwLWxshfBdqzBXuboyPrFxGVT87HkDt0NRQ",
-        oauth_signature="VKsiPs8zbWmZG6DVqua4dVRN1lw%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291979", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:39 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kZjJmYjY3YS0wNDllLTQ4ZWQtOTYxNS00ZDlhZTRkYjZk
-        OTcvIiwgInRhc2tfaWQiOiAiZGYyZmI2N2EtMDQ5ZS00OGVkLTk2MTUtNGQ5
-        YWU0ZGI2ZDk3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjMGJl
-        NTQ5NzVmNzFhNmE2NGMzIn0sICJpZCI6ICI1NmFlYmMwYmU1NDk3NWY3MWE2
-        YTY0YzMifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:39 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/df2fb67a-049e-48ed-9615-4d9ae4db6d97/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="8xFtNBAOmOHCVu4Fj1I1WTlZAfBaah7tAF1HLUIVM",
-        oauth_signature="7YXVJ0XHZb9KDw8YbesuObafWSc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291980", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:40 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2310'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kZjJmYjY3YS0wNDllLTQ4ZWQtOTYxNS00ZDlhZTRkYjZk
-        OTcvIiwgInRhc2tfaWQiOiAiZGYyZmI2N2EtMDQ5ZS00OGVkLTk2MTUtNGQ5
-        YWU0ZGI2ZDk3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMTo1OTo0MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OTozOVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNDA3NWQ3NGMtYjZlNC00MTNjLWEzYmMtYTk1ODhmOWUz
-        NTNkLyIsICJ0YXNrX2lkIjogIjQwNzVkNzRjLWI2ZTQtNDEzYy1hM2JjLWE5
-        NTg4ZjllMzUzZCJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8x
-        Y2VhMDczYS05MmI1LTRhNTQtODhkMC1hYjkzYTE2ZWFjYzcvIiwgInRhc2tf
-        aWQiOiAiMWNlYTA3M2EtOTJiNS00YTU0LTg4ZDAtYWI5M2ExNmVhY2M3In1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjMGJkZTA0MDMzNDZjZjY0OThl
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MTo1OTozOVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAxOjU5OjM5WiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmMwYmRlMDQwMzRjZDky
-        ZGM1MzEiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmMwYmU1NDk3NWY3MWE2YTY0YzMifSwgImlkIjogIjU2YWViYzBiZTU0
-        OTc1ZjcxYTZhNjRjMyJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:40 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/4075d74c-b6e4-413c-a3bc-a9588f9e353d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="IgTlSPiNyY7gakOJplhvCJ0EN4Bl8xBZVxOIh5X6qw",
-        oauth_signature="WPjbicPdht8dmhszJSJb8uvB1RE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291980", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:40 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80MDc1ZDc0Yy1iNmU0LTQxM2MtYTNiYy1hOTU4
-        OGY5ZTM1M2QvIiwgInRhc2tfaWQiOiAiNDA3NWQ3NGMtYjZlNC00MTNjLWEz
-        YmMtYTk1ODhmOWUzNTNkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMTo1OTo0MFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OTo0MFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDE6NTk6NDBaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMTo1OTo0MFoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmMwY2RlMDQwMzRjZDkyZGM1MzIiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjMGNlNTQ5NzVmNzFhNmE2NGQzIn0s
-        ICJpZCI6ICI1NmFlYmMwY2U1NDk3NWY3MWE2YTY0ZDMifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:40 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/1cea073a-92b5-4a54-88d0-ab93a16eacc7/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="g0hZjy08dz6cRe8KemJOpdNymNIK2KMIBL3d99Tatng",
-        oauth_signature="AmoSgq2IDDLdRroB2NUCuXesmQo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291980", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:40 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3507'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8xY2VhMDczYS05MmI1LTRhNTQtODhkMC1hYjkz
-        YTE2ZWFjYzcvIiwgInRhc2tfaWQiOiAiMWNlYTA3M2EtOTJiNS00YTU0LTg4
-        ZDAtYWI5M2ExNmVhY2M3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wMVQwMTo1OTo0MFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3NmY3
-        OGY4MS03NDI0LTQ5ZTMtOWVhMC1kYjlhNDY3OTEzYzciLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjFkMDFkYzAtZDhl
-        NS00N2VmLTkyNzctNmJkZjVmMjc0ZGRkIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiN2JiNWM0NWMtYmE0YS00NmZmLTk1NDktOTcyYjUwYjJjMzkxIiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTQ2YTBiOWQtNTU4Mi00M2Y5LWFh
-        OGYtMmNiYmFhYmQ0NjUyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjMw
-        MmQ3NWJmLTlkMjAtNDg0Mi1iOTY1LWEyZmQxMWU5YzRhMiIsICJudW1fcHJv
-        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjZTllNzkzZC05ZWYyLTRjMzUtYTEz
-        Mi1hZThhNjgyNGY3M2YiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRh
-        dGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICJiYmYyY2E3Zi05MzViLTQyMzMtOWNiZS1jN2IzNDViYjA1ZGEiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUi
-        OiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJk
-        NmEzMzZjOC1lMzA4LTRlNTctOTFkYy0xYmU2ODEwMzc1NGIiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJn
-        ZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGIxZWUxNGMt
-        NzdmZS00ZDM3LTgzN2QtYWI5NTY3NjA5NzFjIiwgIm51bV9wcm9jZXNzZWQi
-        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJs
-        aXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9k
-        aXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
-        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjdmMDk0MjAtYTRmMy00
-        NDA0LTk4MzctNGY0MjliMGJiZjdkIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
-        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExp
-        c3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19t
-        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RB
-        UlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkM2ZmODJhYy1lNzMwLTRh
-        NmEtODg5Yy1kOTE1YzI3OTMwYjUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0s
-        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
-        LXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
-        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9y
-        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmFlYmMwY2U1NDk3NWY3MWE2
-        YTY0ZDQifSwgImlkIjogIjU2YWViYzBjZTU0OTc1ZjcxYTZhNjRkNCJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:40 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/df2fb67a-049e-48ed-9615-4d9ae4db6d97/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="xszfrTwk37FhFspPdfFRmIaxeAxht9zINBE09HvSsGE",
-        oauth_signature="g2G8INrhThoVoxa98KkezWLewAM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291980", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:40 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2310'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kZjJmYjY3YS0wNDllLTQ4ZWQtOTYxNS00ZDlhZTRkYjZk
-        OTcvIiwgInRhc2tfaWQiOiAiZGYyZmI2N2EtMDQ5ZS00OGVkLTk2MTUtNGQ5
-        YWU0ZGI2ZDk3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMTo1OTo0MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OTozOVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNDA3NWQ3NGMtYjZlNC00MTNjLWEzYmMtYTk1ODhmOWUz
-        NTNkLyIsICJ0YXNrX2lkIjogIjQwNzVkNzRjLWI2ZTQtNDEzYy1hM2JjLWE5
-        NTg4ZjllMzUzZCJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8x
-        Y2VhMDczYS05MmI1LTRhNTQtODhkMC1hYjkzYTE2ZWFjYzcvIiwgInRhc2tf
-        aWQiOiAiMWNlYTA3M2EtOTJiNS00YTU0LTg4ZDAtYWI5M2ExNmVhY2M3In1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjMGJkZTA0MDMzNDZjZjY0OThl
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MTo1OTozOVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAxOjU5OjM5WiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmMwYmRlMDQwMzRjZDky
-        ZGM1MzEiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmMwYmU1NDk3NWY3MWE2YTY0YzMifSwgImlkIjogIjU2YWViYzBiZTU0
-        OTc1ZjcxYTZhNjRjMyJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:40 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/4075d74c-b6e4-413c-a3bc-a9588f9e353d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="xLhDa7WgipfKCXLtVm9f9gArEi3cymIHOukmAB2L0",
-        oauth_signature="HKxI8PdHKviX%2FUM5FEN%2Fxqn%2FTjI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291980", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:40 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80MDc1ZDc0Yy1iNmU0LTQxM2MtYTNiYy1hOTU4
-        OGY5ZTM1M2QvIiwgInRhc2tfaWQiOiAiNDA3NWQ3NGMtYjZlNC00MTNjLWEz
-        YmMtYTk1ODhmOWUzNTNkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMTo1OTo0MFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OTo0MFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDE6NTk6NDBaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMTo1OTo0MFoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmMwY2RlMDQwMzRjZDkyZGM1MzIiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjMGNlNTQ5NzVmNzFhNmE2NGQzIn0s
-        ICJpZCI6ICI1NmFlYmMwY2U1NDk3NWY3MWE2YTY0ZDMifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:40 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/1cea073a-92b5-4a54-88d0-ab93a16eacc7/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="PJFMAxr6y6Ag0KXSRIiwXnPydAFsct1zRkpHaJKQ",
-        oauth_signature="tqq2d%2FM3j2dBlLs%2B30KZwlueVsc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291980", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:41 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6923'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8xY2VhMDczYS05MmI1LTRhNTQtODhkMC1hYjkz
-        YTE2ZWFjYzcvIiwgInRhc2tfaWQiOiAiMWNlYTA3M2EtOTJiNS00YTU0LTg4
-        ZDAtYWI5M2ExNmVhY2M3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMTo1OTo0MFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMTo1OTo0MFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI3NmY3OGY4MS03NDI0LTQ5ZTMtOWVhMC1kYjlhNDY3
-        OTEzYzciLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZjFkMDFkYzAtZDhlNS00N2VmLTkyNzctNmJkZjVmMjc0ZGRkIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiN2JiNWM0NWMtYmE0YS00NmZmLTk1NDkt
-        OTcyYjUwYjJjMzkxIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTQ2
-        YTBiOWQtNTU4Mi00M2Y5LWFhOGYtMmNiYmFhYmQ0NjUyIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjMwMmQ3NWJmLTlkMjAtNDg0Mi1iOTY1LWEyZmQx
-        MWU5YzRhMiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjZTllNzkz
-        ZC05ZWYyLTRjMzUtYTEzMi1hZThhNjgyNGY3M2YiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJiYmYyY2E3Zi05MzViLTQyMzMtOWNiZS1jN2Iz
-        NDViYjA1ZGEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJkNmEzMzZjOC1lMzA4LTRlNTctOTFkYy0xYmU2ODEwMzc1NGIi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYjFl
-        ZTE0Yy03N2ZlLTRkMzctODM3ZC1hYjk1Njc2MDk3MWMiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiN2YwOTQyMC1hNGYz
-        LTQ0MDQtOTgzNy00ZjQyOWIwYmJmN2QiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQzZmY4MmFjLWU3MzAtNGE2
-        YS04ODljLWQ5MTVjMjc5MzBiNSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
-        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
-        c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTAxVDAxOjU5OjQwWiIsICJf
-        bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
-        MTYtMDItMDFUMDE6NTk6NDBaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
-        cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
-        IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
-        X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
-        RCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1z
-        IjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0
-        aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
-        SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
-        U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
-        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZhZWJjMGNkZTA0MDM0Y2Q5MmRj
-        NTMzIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjc2Zjc4ZjgxLTc0MjQtNDllMy05ZWEwLWRiOWE0Njc5MTNjNyIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
-        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmMWQw
-        MWRjMC1kOGU1LTQ3ZWYtOTI3Ny02YmRmNWYyNzRkZGQiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
-        c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICI3YmI1YzQ1Yy1iYTRhLTQ2ZmYtOTU0OS05NzJiNTBiMmMz
-        OTEiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
-        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNDZhMGI5ZC01NTgy
-        LTQzZjktYWE4Zi0yY2JiYWFiZDQ2NTIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
-        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMzAyZDc1YmYtOWQyMC00ODQyLWI5NjUtYTJmZDExZTljNGEyIiwg
-        Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
-        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNlOWU3OTNkLTllZjItNGMz
-        NS1hMTMyLWFlOGE2ODI0ZjczZiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
-        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
-        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogImJiZjJjYTdmLTkzNWItNDIzMy05Y2JlLWM3YjM0NWJiMDVkYSIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
-        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
-        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ2
-        YTMzNmM4LWUzMDgtNGU1Ny05MWRjLTFiZTY4MTAzNzU0YiIsICJudW1fcHJv
-        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
-        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
-        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBiMWVlMTRjLTc3ZmUt
-        NGQzNy04MzdkLWFiOTU2NzYwOTcxYyIsICJudW1fcHJvY2Vzc2VkIjogMH0s
-        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
-        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
-        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImI3ZjA5NDIwLWE0ZjMtNDQwNC05ODM3
-        LTRmNDI5YjBiYmY3ZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
-        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiZDNmZjgyYWMtZTczMC00YTZhLTg4OWMtZDkx
-        NWMyNzkzMGI1IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YWViYzBjZTU0OTc1ZjcxYTZhNjRk
-        NCJ9LCAiaWQiOiAiNTZhZWJjMGNlNTQ5NzVmNzFhNmE2NGQ0In0=
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:41 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/c7c72e2e-05e0-4b6e-b14e-c70ac3a76f04/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="JpUg3MYf7lPMFNFC9iy0Z4ftUpAhgNdvWl50rdmvKE",
-        oauth_signature="JOwjJAexg8fIRO%2BtVsIS%2FVLnys8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291981", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:41 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '645'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jN2M3MmUyZS0wNWUwLTRiNmUtYjE0ZS1jNzBhYzNhNzZm
-        MDQvIiwgInRhc2tfaWQiOiAiYzdjNzJlMmUtMDVlMC00YjZlLWIxNGUtYzcw
-        YWMzYTc2ZjA0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3Rh
-        dGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmMwZGU1NDk3NWY3MWE2YTY0ZDUifSwgImlkIjogIjU2YWViYzBkZTU0
-        OTc1ZjcxYTZhNjRkNSJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:41 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/c7c72e2e-05e0-4b6e-b14e-c70ac3a76f04/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="anBdbmEVPQbZfLATJRn2qQRSrWVA6vSnFFc37q0vels",
-        oauth_signature="21MBLBbjMtprcaKYC0cqyNrrMo0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454291982", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 01:59:42 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '682'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jN2M3MmUyZS0wNWUwLTRiNmUtYjE0ZS1jNzBhYzNhNzZm
-        MDQvIiwgInRhc2tfaWQiOiAiYzdjNzJlMmUtMDVlMC00YjZlLWIxNGUtYzcw
-        YWMzYTc2ZjA0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTAxVDAxOjU5OjQxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTAxVDAxOjU5OjQxWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
-        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjMGRl
-        NTQ5NzVmNzFhNmE2NGQ1In0sICJpZCI6ICI1NmFlYmMwZGU1NDk3NWY3MWE2
-        YTY0ZDUifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 01:59:42 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/5414c37f-e2a8-4441-8b67-f86cd7bedbe2/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Iqt0LCcmw5y65MXNIpLgWtqVcAbmp6qJKeFzwLE9Ho",
-        oauth_signature="H0hcVdJ9j4v4GDBqFBLCBGkS640%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693683", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:43 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81NDE0YzM3Zi1lMmE4LTQ0NDEtOGI2Ny1mODZjZDdiZWRi
-        ZTIvIiwgInRhc2tfaWQiOiAiNTQxNGMzN2YtZTJhOC00NDQxLThiNjctZjg2
-        Y2Q3YmVkYmUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkMzM4
-        YWRhNDBkYjA0ZWUwZjVhIn0sICJpZCI6ICI1NmI0ZGQzMzhhZGE0MGRiMDRl
-        ZTBmNWEifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:43 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/5414c37f-e2a8-4441-8b67-f86cd7bedbe2/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="wutbeq87UMgiifodBWWNVKwhW2BGfMz36LSGWPUfVM",
-        oauth_signature="zWa1c3U6bHfCPY26%2F7xKfLmHWic%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693684", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:44 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1081'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81NDE0YzM3Zi1lMmE4LTQ0NDEtOGI2Ny1mODZjZDdiZWRi
-        ZTIvIiwgInRhc2tfaWQiOiAiNTQxNGMzN2YtZTJhOC00NDQxLThiNjctZjg2
-        Y2Q3YmVkYmUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0wNVQxNzozNDo0M1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJO
-        T1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAi
-        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0
-        ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJl
-        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkMzM4YWRhNDBk
-        YjA0ZWUwZjVhIn0sICJpZCI6ICI1NmI0ZGQzMzhhZGE0MGRiMDRlZTBmNWEi
-        fQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:44 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/5414c37f-e2a8-4441-8b67-f86cd7bedbe2/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="4CARJKkVJAIfSsLDPnpOc1jhSsdo7OXfsJ3OcjsKc",
-        oauth_signature="I6M8iLEPE6LMM%2BkSvuF78vWOAjw%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693684", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:44 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81NDE0YzM3Zi1lMmE4LTQ0NDEtOGI2Ny1mODZjZDdiZWRi
-        ZTIvIiwgInRhc2tfaWQiOiAiNTQxNGMzN2YtZTJhOC00NDQxLThiNjctZjg2
-        Y2Q3YmVkYmUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozNDo0NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozNDo0M1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNTI2MjU5MzEtOGM2MS00NjQ3LWJmYjUtZTQxYjZhZjBh
-        YTY0LyIsICJ0YXNrX2lkIjogIjUyNjI1OTMxLThjNjEtNDY0Ny1iZmI1LWU0
-        MWI2YWYwYWE2NCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZDMzYzc4MjFiMzMwMzRiYWY0OSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6MzQ6NDNaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozNDo0
-        NFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRkMzRjNzgyMWIzNDQ0ZmNjM2U0IiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkMzM4YWRhNDBkYjA0ZWUwZjVhIn0s
-        ICJpZCI6ICI1NmI0ZGQzMzhhZGE0MGRiMDRlZTBmNWEifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:44 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/52625931-8c61-4647-bfb5-e41b6af0aa64/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="FFwlhVfBq4MKlBgnGUWJevtmeZ2kzOf8emWpIXOs4Ag",
-        oauth_signature="e2h1poiX0%2BAIirAl%2F2e8OgDxROo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693684", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:44 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3513'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy81MjYyNTkzMS04YzYxLTQ2NDctYmZiNS1lNDFi
-        NmFmMGFhNjQvIiwgInRhc2tfaWQiOiAiNTI2MjU5MzEtOGM2MS00NjQ3LWJm
-        YjUtZTQxYjZhZjBhYTY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wNVQxNzozNDo0NFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjNjMx
-        YmI4ZC1iNjQ5LTRhY2MtYWJmZS0yZmNkYTQ4MDczY2YiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGM2NGU1NjAtYjE4
-        My00MDJkLTg4NDItNTMxMGI0MGVjOGJhIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiMzk5MjQxMTEtNWQ3MS00MDIzLWFlZDYtMzZiMjQ3OWYyMDZkIiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzhjYjNkM2EtYmI4MS00ZjBiLWFm
-        N2UtNzdlNGFjOTQ5MTBhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ4
-        ODBiNjg4LTY2YmQtNGYzMi1hMmZlLTA1N2QyMmNmYWY3YyIsICJudW1fcHJv
-        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAyLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiOTU2YTJjNC0yZjUzLTQ0MWQtYmU2
-        Yy01NDkwNmM4MjhkZDciLCAibnVtX3Byb2Nlc3NlZCI6IDJ9LCB7Im51bV9z
-        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRh
-        dGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICIyN2ZjMzY2Zi01ZTk4LTRkY2EtOTY2YS01ODZmY2U2NzU3ZjciLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUi
-        OiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1
-        NjcyNDE3ZS00OWMxLTRmMmEtOTNiMy1lMzFiZGIwMmE4YTciLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJn
-        ZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGQzNzkyOTgt
-        MTk2Zi00MDllLTgwYTctZWVmMThjN2ZiMGJkIiwgIm51bV9wcm9jZXNzZWQi
-        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJs
-        aXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9k
-        aXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
-        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGMyZjI2MDctNTEwOC00
-        MWRhLTg0M2QtMjdlN2FhMDJkNTRlIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
-        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExp
-        c3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19t
-        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RB
-        UlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0ZjBmMjhkMC00ZjY2LTRl
-        OGUtOWUxYS1jY2U0YWUwZDFkZjgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0s
-        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
-        LTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
-        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwg
-        ImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0ZGQzNDhhZGE0
-        MGRiMDRlZTBmNmEifSwgImlkIjogIjU2YjRkZDM0OGFkYTQwZGIwNGVlMGY2
-        YSJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:44 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/5414c37f-e2a8-4441-8b67-f86cd7bedbe2/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="SMF1NwFkR3ZouTHtplsvx3oAqLdrFwu5GuibnAPOu0",
-        oauth_signature="pLMaOGUqw%2FkcLG9tj7ZDT%2B8eri4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693685", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:45 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81NDE0YzM3Zi1lMmE4LTQ0NDEtOGI2Ny1mODZjZDdiZWRi
-        ZTIvIiwgInRhc2tfaWQiOiAiNTQxNGMzN2YtZTJhOC00NDQxLThiNjctZjg2
-        Y2Q3YmVkYmUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozNDo0NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozNDo0M1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNTI2MjU5MzEtOGM2MS00NjQ3LWJmYjUtZTQxYjZhZjBh
-        YTY0LyIsICJ0YXNrX2lkIjogIjUyNjI1OTMxLThjNjEtNDY0Ny1iZmI1LWU0
-        MWI2YWYwYWE2NCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZDMzYzc4MjFiMzMwMzRiYWY0OSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6MzQ6NDNaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozNDo0
-        NFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRkMzRjNzgyMWIzNDQ0ZmNjM2U0IiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkMzM4YWRhNDBkYjA0ZWUwZjVhIn0s
-        ICJpZCI6ICI1NmI0ZGQzMzhhZGE0MGRiMDRlZTBmNWEifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:45 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/52625931-8c61-4647-bfb5-e41b6af0aa64/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="5PBwZQDzDgYQkiLk8eeNxDj5BzxlYZDuY8m8fIlaM",
-        oauth_signature="v0yYFlJFracH5%2BknLCiNf%2BjuZPs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693685", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:45 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy81MjYyNTkzMS04YzYxLTQ2NDctYmZiNS1lNDFi
-        NmFmMGFhNjQvIiwgInRhc2tfaWQiOiAiNTI2MjU5MzEtOGM2MS00NjQ3LWJm
-        YjUtZTQxYjZhZjBhYTY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wNVQxNzozNDo0NVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozNDo0NFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJjNjMxYmI4ZC1iNjQ5LTRhY2MtYWJmZS0yZmNkYTQ4
-        MDczY2YiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNGM2NGU1NjAtYjE4My00MDJkLTg4NDItNTMxMGI0MGVjOGJhIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMzk5MjQxMTEtNWQ3MS00MDIzLWFlZDYt
-        MzZiMjQ3OWYyMDZkIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzhj
-        YjNkM2EtYmI4MS00ZjBiLWFmN2UtNzdlNGFjOTQ5MTBhIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImQ4ODBiNjg4LTY2YmQtNGYzMi1hMmZlLTA1N2Qy
-        MmNmYWY3YyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiOTU2YTJj
-        NC0yZjUzLTQ0MWQtYmU2Yy01NDkwNmM4MjhkZDciLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIyN2ZjMzY2Zi01ZTk4LTRkY2EtOTY2YS01ODZm
-        Y2U2NzU3ZjciLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI1NjcyNDE3ZS00OWMxLTRmMmEtOTNiMy1lMzFiZGIwMmE4YTci
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0ZDM3
-        OTI5OC0xOTZmLTQwOWUtODBhNy1lZWYxOGM3ZmIwYmQiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0YzJmMjYwNy01MTA4
-        LTQxZGEtODQzZC0yN2U3YWEwMmQ1NGUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRmMGYyOGQwLTRmNjYtNGU4
-        ZS05ZTFhLWNjZTRhZTBkMWRmOCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
-        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE3OjM0OjQ0
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMDVUMTc6MzQ6NDVaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGRkMzVjNzgyMWIz
-        NDQ0ZmNjM2U1IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImM2MzFiYjhkLWI2NDktNGFjYy1hYmZlLTJmY2RhNDgwNzNj
-        ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI0YzY0ZTU2MC1iMTgzLTQwMmQtODg0Mi01MzEwYjQwZWM4YmEiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIzOTkyNDExMS01ZDcxLTQwMjMtYWVkNi0zNmIy
-        NDc5ZjIwNmQiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzOGNiM2Qz
-        YS1iYjgxLTRmMGItYWY3ZS03N2U0YWM5NDkxMGEiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiZDg4MGI2ODgtNjZiZC00ZjMyLWEyZmUtMDU3ZDIyY2Zh
-        ZjdjIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI5NTZhMmM0LTJm
-        NTMtNDQxZC1iZTZjLTU0OTA2YzgyOGRkNyIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjI3ZmMzNjZmLTVlOTgtNGRjYS05NjZhLTU4NmZjZTY3
-        NTdmNyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjU2NzI0MTdlLTQ5YzEtNGYyYS05M2IzLWUzMWJkYjAyYThhNyIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRkMzc5Mjk4
-        LTE5NmYtNDA5ZS04MGE3LWVlZjE4YzdmYjBiZCIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRjMmYyNjA3LTUxMDgtNDFk
-        YS04NDNkLTI3ZTdhYTAyZDU0ZSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGYwZjI4ZDAtNGY2Ni00ZThlLTll
-        MWEtY2NlNGFlMGQxZGY4IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRkZDM0OGFkYTQwZGIw
-        NGVlMGY2YSJ9LCAiaWQiOiAiNTZiNGRkMzQ4YWRhNDBkYjA0ZWUwZjZhIn0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:45 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/4ffa4579-6297-4eb7-abb9-e9158160d660/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="3NbS76kedWpAnQ6kOXUtFPic5sqpe3O41OtKGLleis",
-        oauth_signature="YEvnVXRv%2FQmFgXoEpF6ybYRfItw%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693686", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:46 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80ZmZhNDU3OS02Mjk3LTRlYjctYWJiOS1lOTE1ODE2MGQ2
-        NjAvIiwgInRhc2tfaWQiOiAiNGZmYTQ1NzktNjI5Ny00ZWI3LWFiYjktZTkx
-        NTgxNjBkNjYwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0ZGQz
-        NjhhZGE0MGRiMDRlZTBmNmIifSwgImlkIjogIjU2YjRkZDM2OGFkYTQwZGIw
-        NGVlMGY2YiJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:46 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/4ffa4579-6297-4eb7-abb9-e9158160d660/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="vvXGZaxFZiSbtJMPngSPKNselesMykos9R3kMfMBs",
-        oauth_signature="eyv7qqvF9%2FqyJIyeTbjzNbmGqQI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693687", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:47 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80ZmZhNDU3OS02Mjk3LTRlYjctYWJiOS1lOTE1ODE2MGQ2
-        NjAvIiwgInRhc2tfaWQiOiAiNGZmYTQ1NzktNjI5Ny00ZWI3LWFiYjktZTkx
-        NTgxNjBkNjYwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA1VDE3OjM0OjQ2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE3OjM0OjQ2WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        NGRkMzY4YWRhNDBkYjA0ZWUwZjZiIn0sICJpZCI6ICI1NmI0ZGQzNjhhZGE0
-        MGRiMDRlZTBmNmIifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:47 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/9ac4039c-f578-4fcc-b4ba-5a1388a5591d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="ZdYz1AkYcx5oSs0qfhCGuk6FH8f8tsWR3rzeVtnyP7c",
-        oauth_signature="AFNjSQdaoTkn3VObBpcE75gssnk%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693688", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:48 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85YWM0MDM5Yy1mNTc4LTRmY2MtYjRiYS01YTEzODhhNTU5
-        MWQvIiwgInRhc2tfaWQiOiAiOWFjNDAzOWMtZjU3OC00ZmNjLWI0YmEtNWEx
-        Mzg4YTU1OTFkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkMzg4
-        YWRhNDBkYjA0ZWUwZjZkIn0sICJpZCI6ICI1NmI0ZGQzODhhZGE0MGRiMDRl
-        ZTBmNmQifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:48 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/9ac4039c-f578-4fcc-b4ba-5a1388a5591d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="u315QgijCxN5UftYOQHlrbsN9VKD2GkEuaMdtoVWs",
-        oauth_signature="RxSc0acjcR5oNGUrxiE83xTC1nM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693689", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:49 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1090'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85YWM0MDM5Yy1mNTc4LTRmY2MtYjRiYS01YTEzODhhNTU5
-        MWQvIiwgInRhc2tfaWQiOiAiOWFjNDAzOWMtZjU3OC00ZmNjLWI0YmEtNWEx
-        Mzg4YTU1OTFkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0wNVQxNzozNDo0OVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
-        Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJOT1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
-        bCI6IDAsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        a2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1
-        bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
-        IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRk
-        Mzg4YWRhNDBkYjA0ZWUwZjZkIn0sICJpZCI6ICI1NmI0ZGQzODhhZGE0MGRi
-        MDRlZTBmNmQifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:49 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/9ac4039c-f578-4fcc-b4ba-5a1388a5591d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="WVeIktKtmQ2Ip6BcZWn3U47KL6NnPQutWf74oXYIo",
-        oauth_signature="OKzcoEzH5dCqE6037jDThxRfFOM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693690", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:50 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85YWM0MDM5Yy1mNTc4LTRmY2MtYjRiYS01YTEzODhhNTU5
-        MWQvIiwgInRhc2tfaWQiOiAiOWFjNDAzOWMtZjU3OC00ZmNjLWI0YmEtNWEx
-        Mzg4YTU1OTFkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozNDo0OVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozNDo0OVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZmZhZmI3ODEtMWQ4MC00NGYzLWIyNjMtOWNlMGE0NzA3
-        OWE2LyIsICJ0YXNrX2lkIjogImZmYWZiNzgxLTFkODAtNDRmMy1iMjYzLTlj
-        ZTBhNDcwNzlhNiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZDM4Yzc4MjFiMzMwNWNlNTIzMSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6MzQ6NDlaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozNDo0
-        OVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRkMzljNzgyMWIzNDQ0ZmNjM2U5IiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkMzg4YWRhNDBkYjA0ZWUwZjZkIn0s
-        ICJpZCI6ICI1NmI0ZGQzODhhZGE0MGRiMDRlZTBmNmQifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:50 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ffafb781-1d80-44f3-b263-9ce0a47079a6/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Cishlac30ZRtxnRwlkvtBO9AmdGrEiFkPqG8PPvaYAA",
-        oauth_signature="%2FpVkx1XgYRmR2BjXge%2BjleAi94U%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693690", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:50 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3526'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9mZmFmYjc4MS0xZDgwLTQ0ZjMtYjI2My05Y2Uw
-        YTQ3MDc5YTYvIiwgInRhc2tfaWQiOiAiZmZhZmI3ODEtMWQ4MC00NGYzLWIy
-        NjMtOWNlMGE0NzA3OWE2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wNVQxNzozNDo1MFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlYTY1
-        MDYyOS1iYmExLTQ5MjgtYTBjNy1mNGZhYjY3NmVjY2QiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        SU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODg1NjU5NDAt
-        MWUyYi00Y2MzLThjMjMtNzBiZjhjNjc2ZGVhIiwgIm51bV9wcm9jZXNzZWQi
-        OiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJs
-        aXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
-        ZXBfaWQiOiAiMzZlOTU5ZjktM2IxZC00MmQ3LTg2OTItMjkzM2NlNjVhNGMy
-        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
-        ZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90
-        eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5P
-        VF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNhNWY5MDFjLWQ1
-        YWEtNGNhNi1hMzUxLTU3NTZhY2IzMTdiOSIsICJudW1fcHJvY2Vzc2VkIjog
-        MH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICJhNWU5MmI1Ny00ZjQ2LTQxOTItYTBlMC1iYzA0ZDdiZGMw
-        N2QiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVw
-        X3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzdiYWQ2YWUt
-        MTc5MS00NzEzLThlY2YtY2VhMjlkNmY3YjNlIiwgIm51bV9wcm9jZXNzZWQi
-        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJs
-        aXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAi
-        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiMDdhNjMzZGYtZTE2NS00YmQzLTllM2QtOWUx
-        MDgzZDg1MTMyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
-        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNf
-        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiMzc3YzVlMzQtODhkMy00MGFhLWJkNjItYTdmZmY5NDI5
-        NTRmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
-        ICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJz
-        dGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjog
-        MSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImY4NzgxYjA0LTE3YTctNDQzMC1iNmI2LTc5ZmRlYjA2Njg5MyIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBl
-        IjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM3
-        OGM2ODE4LWJmM2MtNGU3My1hOWM4LTc4MDZjNzk1NjY0ZCIsICJudW1fcHJv
-        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzMw
-        ODAwZWUtOTFkNS00M2E3LWIwZTgtNjcxYWE5YTRiZGZlIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
-        Y2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJl
-        c3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiNGRkMzk4YWRhNDBkYjA0ZWUwZjdkIn0sICJpZCI6ICI1NmI0ZGQzOThh
-        ZGE0MGRiMDRlZTBmN2QifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:50 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/9ac4039c-f578-4fcc-b4ba-5a1388a5591d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="MkzdQhUyEjIX8wQ1PKLvLGy5pzUYz3Xawm4cRl9po",
-        oauth_signature="FNfRNxvxi4uzUhJFLXCsFIoLOWE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693690", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:50 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85YWM0MDM5Yy1mNTc4LTRmY2MtYjRiYS01YTEzODhhNTU5
-        MWQvIiwgInRhc2tfaWQiOiAiOWFjNDAzOWMtZjU3OC00ZmNjLWI0YmEtNWEx
-        Mzg4YTU1OTFkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozNDo0OVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozNDo0OVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZmZhZmI3ODEtMWQ4MC00NGYzLWIyNjMtOWNlMGE0NzA3
-        OWE2LyIsICJ0YXNrX2lkIjogImZmYWZiNzgxLTFkODAtNDRmMy1iMjYzLTlj
-        ZTBhNDcwNzlhNiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZDM4Yzc4MjFiMzMwNWNlNTIzMSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6MzQ6NDlaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozNDo0
-        OVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRkMzljNzgyMWIzNDQ0ZmNjM2U5IiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkMzg4YWRhNDBkYjA0ZWUwZjZkIn0s
-        ICJpZCI6ICI1NmI0ZGQzODhhZGE0MGRiMDRlZTBmNmQifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:50 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ffafb781-1d80-44f3-b263-9ce0a47079a6/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="KUl1Figm1ShFtRqCk6N86cjvzeFCuuLIF01XBH5jL0",
-        oauth_signature="2E6IoU%2BGjNb4fWi3oZvkfCzC6ug%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693690", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:50 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9mZmFmYjc4MS0xZDgwLTQ0ZjMtYjI2My05Y2Uw
-        YTQ3MDc5YTYvIiwgInRhc2tfaWQiOiAiZmZhZmI3ODEtMWQ4MC00NGYzLWIy
-        NjMtOWNlMGE0NzA3OWE2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wNVQxNzozNDo1MFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozNDo1MFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJlYTY1MDYyOS1iYmExLTQ5MjgtYTBjNy1mNGZhYjY3
-        NmVjY2QiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiODg1NjU5NDAtMWUyYi00Y2MzLThjMjMtNzBiZjhjNjc2ZGVhIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMzZlOTU5ZjktM2IxZC00MmQ3LTg2OTIt
-        MjkzM2NlNjVhNGMyIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiY2E1
-        ZjkwMWMtZDVhYS00Y2E2LWEzNTEtNTc1NmFjYjMxN2I5IiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImE1ZTkyYjU3LTRmNDYtNDE5Mi1hMGUwLWJjMDRk
-        N2JkYzA3ZCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3N2JhZDZh
-        ZS0xNzkxLTQ3MTMtOGVjZi1jZWEyOWQ2ZjdiM2UiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIwN2E2MzNkZi1lMTY1LTRiZDMtOWUzZC05ZTEw
-        ODNkODUxMzIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIzNzdjNWUzNC04OGQzLTQwYWEtYmQ2Mi1hN2ZmZjk0Mjk1NGYi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmODc4
-        MWIwNC0xN2E3LTQ0MzAtYjZiNi03OWZkZWIwNjY4OTMiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjNzhjNjgxOC1iZjNj
-        LTRlNzMtYTljOC03ODA2Yzc5NTY2NGQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjMzMDgwMGVlLTkxZDUtNDNh
-        Ny1iMGU4LTY3MWFhOWE0YmRmZSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
-        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE3OjM0OjUw
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMDVUMTc6MzQ6NTBaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGRkM2FjNzgyMWIz
-        NDQ0ZmNjM2VhIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImVhNjUwNjI5LWJiYTEtNDkyOC1hMGM3LWY0ZmFiNjc2ZWNj
-        ZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI4ODU2NTk0MC0xZTJiLTRjYzMtOGMyMy03MGJmOGM2NzZkZWEiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIzNmU5NTlmOS0zYjFkLTQyZDctODY5Mi0yOTMz
-        Y2U2NWE0YzIiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjYTVmOTAx
-        Yy1kNWFhLTRjYTYtYTM1MS01NzU2YWNiMzE3YjkiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiYTVlOTJiNTctNGY0Ni00MTkyLWEwZTAtYmMwNGQ3YmRj
-        MDdkIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc3YmFkNmFlLTE3
-        OTEtNDcxMy04ZWNmLWNlYTI5ZDZmN2IzZSIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjA3YTYzM2RmLWUxNjUtNGJkMy05ZTNkLTllMTA4M2Q4
-        NTEzMiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjM3N2M1ZTM0LTg4ZDMtNDBhYS1iZDYyLWE3ZmZmOTQyOTU0ZiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImY4NzgxYjA0
-        LTE3YTctNDQzMC1iNmI2LTc5ZmRlYjA2Njg5MyIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM3OGM2ODE4LWJmM2MtNGU3
-        My1hOWM4LTc4MDZjNzk1NjY0ZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzMwODAwZWUtOTFkNS00M2E3LWIw
-        ZTgtNjcxYWE5YTRiZGZlIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRkZDM5OGFkYTQwZGIw
-        NGVlMGY3ZCJ9LCAiaWQiOiAiNTZiNGRkMzk4YWRhNDBkYjA0ZWUwZjdkIn0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:50 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/b4e807c2-a37f-4ea8-8fea-0d7581f02555/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="TQpuDK6Pv4ee70B5ZdlYvYlInv1OoBDjHEV6NBlhpw",
-        oauth_signature="0w3vE%2FaR5B%2ByETl7uhH7bqeOb38%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693691", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:51 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '651'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iNGU4MDdjMi1hMzdmLTRlYTgtOGZlYS0wZDc1ODFmMDI1
-        NTUvIiwgInRhc2tfaWQiOiAiYjRlODA3YzItYTM3Zi00ZWE4LThmZWEtMGQ3
-        NTgxZjAyNTU1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAi
-        c3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
-        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20i
-        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmI0ZGQzYjhhZGE0MGRiMDRlZTBmN2UifSwgImlkIjogIjU2YjRk
-        ZDNiOGFkYTQwZGIwNGVlMGY3ZSJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:52 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/b4e807c2-a37f-4ea8-8fea-0d7581f02555/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="TdZ6X8BtAFfR0z1S1sg8OmCCDVvgZwfHFjImSa4iFPY",
-        oauth_signature="w5EH0%2BzSeNhGUAYMfUosEOxmZ5A%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693692", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:52 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iNGU4MDdjMi1hMzdmLTRlYTgtOGZlYS0wZDc1ODFmMDI1
-        NTUvIiwgInRhc2tfaWQiOiAiYjRlODA3YzItYTM3Zi00ZWE4LThmZWEtMGQ3
-        NTgxZjAyNTU1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA1VDE3OjM0OjUyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE3OjM0OjUyWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        NGRkM2I4YWRhNDBkYjA0ZWUwZjdlIn0sICJpZCI6ICI1NmI0ZGQzYjhhZGE0
-        MGRiMDRlZTBmN2UifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:52 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/d83540d3-e4dc-4517-a9e7-e4f2f2defc6b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="XsMsmfHoFlosRwHH7mlDFYvkejW8NGELfOc9618IJA",
-        oauth_signature="Cew%2Bf4rhWsf%2BmoiU0j6dMabTqdM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693694", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:54 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kODM1NDBkMy1lNGRjLTQ1MTctYTllNy1lNGYyZjJkZWZj
-        NmIvIiwgInRhc2tfaWQiOiAiZDgzNTQwZDMtZTRkYy00NTE3LWE5ZTctZTRm
-        MmYyZGVmYzZiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkM2U4
-        YWRhNDBkYjA0ZWUwZjgwIn0sICJpZCI6ICI1NmI0ZGQzZThhZGE0MGRiMDRl
-        ZTBmODAifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:54 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/d83540d3-e4dc-4517-a9e7-e4f2f2defc6b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="C77UKcrG81e0RFQyu8cyDo9RMISAXqVWNjLsSaOoK8",
-        oauth_signature="Q13mMibK6Evn2j6YmKOG%2FwV%2B2MA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693694", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:54 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1081'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kODM1NDBkMy1lNGRjLTQ1MTctYTllNy1lNGYyZjJkZWZj
-        NmIvIiwgInRhc2tfaWQiOiAiZDgzNTQwZDMtZTRkYy00NTE3LWE5ZTctZTRm
-        MmYyZGVmYzZiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0wNVQxNzozNDo1NFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJJ
-        Tl9QUk9HUkVTUyJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAi
-        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0
-        ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJl
-        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkM2U4YWRhNDBk
-        YjA0ZWUwZjgwIn0sICJpZCI6ICI1NmI0ZGQzZThhZGE0MGRiMDRlZTBmODAi
-        fQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:54 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/d83540d3-e4dc-4517-a9e7-e4f2f2defc6b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="zznk1nzyKbDWSHGiqmb6NjEf4vHKEwVIb1tYD1HE",
-        oauth_signature="iDkSquK9nc%2FAyVn1M%2FmP5iorgCY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693695", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:55 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kODM1NDBkMy1lNGRjLTQ1MTctYTllNy1lNGYyZjJkZWZj
-        NmIvIiwgInRhc2tfaWQiOiAiZDgzNTQwZDMtZTRkYy00NTE3LWE5ZTctZTRm
-        MmYyZGVmYzZiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozNDo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozNDo1NFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYTE5MGI0M2QtZjczNC00MjY2LTk2NWQtZjVlODg3NGZm
-        ZWUzLyIsICJ0YXNrX2lkIjogImExOTBiNDNkLWY3MzQtNDI2Ni05NjVkLWY1
-        ZTg4NzRmZmVlMyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZDNkYzc4MjFiMzMwMzRiYWY1NCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6MzQ6NTRaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozNDo1
-        NFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRkM2VjNzgyMWIzNDQ0ZmNjM2VlIiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkM2U4YWRhNDBkYjA0ZWUwZjgwIn0s
-        ICJpZCI6ICI1NmI0ZGQzZThhZGE0MGRiMDRlZTBmODAifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:55 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/a190b43d-f734-4266-965d-f5e8874ffee3/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="JDAtlhC55wN11WaVopkEGkYch9MatWw4tuRuiTKak",
-        oauth_signature="blyEyLXAk7H%2Frvxk%2FSUO0XF%2B77g%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693695", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:55 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3500'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9hMTkwYjQzZC1mNzM0LTQyNjYtOTY1ZC1mNWU4
-        ODc0ZmZlZTMvIiwgInRhc2tfaWQiOiAiYTE5MGI0M2QtZjczNC00MjY2LTk2
-        NWQtZjVlODg3NGZmZWUzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wNVQxNzozNDo1NVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0NWNj
-        MWQ5YS1kNDc0LTRjNzItOTcyOS04N2RhOWM1M2FlNGYiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTE5ZTljMjAtZDlk
-        ZS00NGVmLWE1MmYtMTFlNWRkMmJlMDk1IiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiNzQ2Mzg4ZjEtMTI2ZS00N2YzLWFlNjktOTQ2YzUxOTA1N2RiIiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjRmYmM5MzUtYjdhZi00NGU1LWI2
-        YzUtYTJhM2U4ODdhMzljIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjhl
-        YThlMTdlLTFiYWUtNDA2ZC1iYjBiLTM2M2Y2ZjEwMTUyNyIsICJudW1fcHJv
-        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJlNTYzOTU1OS04NDczLTRlOGYtODRhYy00
-        MzIwMjAyOGNhNTUiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEu
-        IiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIx
-        OTc3NmFhMC01OWMzLTQ1NjctODdiNi02MzA1M2FhYTI0YTYiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9u
-        IjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xv
-        c2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlY2E0MzRkNS1h
-        MjFmLTQzNzAtOWVjYS1lNjVkZDI3OGNlODgiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVy
-        YXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBz
-        cWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjYTFmNmVlNy1mODlhLTQ3MGQtYjc4
-        Zi1hZWU1Y2MyNTYzMjQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMg
-        dG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJmMmJlMTJkYS00NTBlLTRkZDMtOGE4Zi1lMWNi
-        NDM4NTIyZTYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIs
-        ICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjQ5MTQxMmY2LTlkMzMtNGVlZi04YTk3LTc5YzAz
-        YzJiY2RiNyIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJl
-        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5leGFt
-        cGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRl
-        di5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
-        LCAiX2lkIjogeyIkb2lkIjogIjU2YjRkZDNlOGFkYTQwZGIwNGVlMGY5MCJ9
-        LCAiaWQiOiAiNTZiNGRkM2U4YWRhNDBkYjA0ZWUwZjkwIn0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:55 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/d83540d3-e4dc-4517-a9e7-e4f2f2defc6b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="m1id9uiWAGT0co67XuWKyEd4Tb0TcPhxTN7UpkJFbA",
-        oauth_signature="8kHvzHxuBgopEQmWccz2Gir%2B4Qg%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693696", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:56 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kODM1NDBkMy1lNGRjLTQ1MTctYTllNy1lNGYyZjJkZWZj
-        NmIvIiwgInRhc2tfaWQiOiAiZDgzNTQwZDMtZTRkYy00NTE3LWE5ZTctZTRm
-        MmYyZGVmYzZiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozNDo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozNDo1NFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYTE5MGI0M2QtZjczNC00MjY2LTk2NWQtZjVlODg3NGZm
-        ZWUzLyIsICJ0YXNrX2lkIjogImExOTBiNDNkLWY3MzQtNDI2Ni05NjVkLWY1
-        ZTg4NzRmZmVlMyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZDNkYzc4MjFiMzMwMzRiYWY1NCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6MzQ6NTRaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozNDo1
-        NFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRkM2VjNzgyMWIzNDQ0ZmNjM2VlIiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkM2U4YWRhNDBkYjA0ZWUwZjgwIn0s
-        ICJpZCI6ICI1NmI0ZGQzZThhZGE0MGRiMDRlZTBmODAifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:56 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/a190b43d-f734-4266-965d-f5e8874ffee3/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="CGXflVBd7d8AJJjHkz4g1ZIyyJRkuCuPsLEQvyDho4",
-        oauth_signature="%2FebRVu7u7Hf6QLHkvTbVcWnJvJc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693696", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:56 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9hMTkwYjQzZC1mNzM0LTQyNjYtOTY1ZC1mNWU4
-        ODc0ZmZlZTMvIiwgInRhc2tfaWQiOiAiYTE5MGI0M2QtZjczNC00MjY2LTk2
-        NWQtZjVlODg3NGZmZWUzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wNVQxNzozNDo1NVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozNDo1NVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI0NWNjMWQ5YS1kNDc0LTRjNzItOTcyOS04N2RhOWM1
-        M2FlNGYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNTE5ZTljMjAtZDlkZS00NGVmLWE1MmYtMTFlNWRkMmJlMDk1Iiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNzQ2Mzg4ZjEtMTI2ZS00N2YzLWFlNjkt
-        OTQ2YzUxOTA1N2RiIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjRm
-        YmM5MzUtYjdhZi00NGU1LWI2YzUtYTJhM2U4ODdhMzljIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjhlYThlMTdlLTFiYWUtNDA2ZC1iYjBiLTM2M2Y2
-        ZjEwMTUyNyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlNTYzOTU1
-        OS04NDczLTRlOGYtODRhYy00MzIwMjAyOGNhNTUiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIxOTc3NmFhMC01OWMzLTQ1NjctODdiNi02MzA1
-        M2FhYTI0YTYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJlY2E0MzRkNS1hMjFmLTQzNzAtOWVjYS1lNjVkZDI3OGNlODgi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjYTFm
-        NmVlNy1mODlhLTQ3MGQtYjc4Zi1hZWU1Y2MyNTYzMjQiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmMmJlMTJkYS00NTBl
-        LTRkZDMtOGE4Zi1lMWNiNDM4NTIyZTYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQ5MTQxMmY2LTlkMzMtNGVl
-        Zi04YTk3LTc5YzAzYzJiY2RiNyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
-        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE3OjM0OjU1
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMDVUMTc6MzQ6NTVaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGRkM2ZjNzgyMWIz
-        NDQ0ZmNjM2VmIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjQ1Y2MxZDlhLWQ0NzQtNGM3Mi05NzI5LTg3ZGE5YzUzYWU0
-        ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI1MTllOWMyMC1kOWRlLTQ0ZWYtYTUyZi0xMWU1ZGQyYmUwOTUiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI3NDYzODhmMS0xMjZlLTQ3ZjMtYWU2OS05NDZj
-        NTE5MDU3ZGIiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2NGZiYzkz
-        NS1iN2FmLTQ0ZTUtYjZjNS1hMmEzZTg4N2EzOWMiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiOGVhOGUxN2UtMWJhZS00MDZkLWJiMGItMzYzZjZmMTAx
-        NTI3IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImU1NjM5NTU5LTg0
-        NzMtNGU4Zi04NGFjLTQzMjAyMDI4Y2E1NSIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjE5Nzc2YWEwLTU5YzMtNDU2Ny04N2I2LTYzMDUzYWFh
-        MjRhNiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImVjYTQzNGQ1LWEyMWYtNDM3MC05ZWNhLWU2NWRkMjc4Y2U4OCIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNhMWY2ZWU3
-        LWY4OWEtNDcwZC1iNzhmLWFlZTVjYzI1NjMyNCIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImYyYmUxMmRhLTQ1MGUtNGRk
-        My04YThmLWUxY2I0Mzg1MjJlNiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDkxNDEyZjYtOWQzMy00ZWVmLThh
-        OTctNzljMDNjMmJjZGI3IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRkZDNlOGFkYTQwZGIw
-        NGVlMGY5MCJ9LCAiaWQiOiAiNTZiNGRkM2U4YWRhNDBkYjA0ZWUwZjkwIn0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:56 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/49b550c0-57c7-4909-8a8a-5b0d7794bfce/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="R8Pnqmq8hpXPIduqgWoDf7s8CimV1FNpTAndm8gMX8",
-        oauth_signature="3bdFpByCRQRZ%2FfXuSiqzg16LiuY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693697", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:57 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80OWI1NTBjMC01N2M3LTQ5MDktOGE4YS01YjBkNzc5NGJm
-        Y2UvIiwgInRhc2tfaWQiOiAiNDliNTUwYzAtNTdjNy00OTA5LThhOGEtNWIw
-        ZDc3OTRiZmNlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0ZGQ0
-        MThhZGE0MGRiMDRlZTBmOTEifSwgImlkIjogIjU2YjRkZDQxOGFkYTQwZGIw
-        NGVlMGY5MSJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:57 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/49b550c0-57c7-4909-8a8a-5b0d7794bfce/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="hpxUpGontQf93FZFf8pCJe7E490P3iIH6BlzHtHm7I",
-        oauth_signature="%2BdEdmaIP%2FVCOHPBRpZm3M%2BrC9tQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693697", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:34:57 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80OWI1NTBjMC01N2M3LTQ5MDktOGE4YS01YjBkNzc5NGJm
-        Y2UvIiwgInRhc2tfaWQiOiAiNDliNTUwYzAtNTdjNy00OTA5LThhOGEtNWIw
-        ZDc3OTRiZmNlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA1VDE3OjM0OjU3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE3OjM0OjU3WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        NGRkNDE4YWRhNDBkYjA0ZWUwZjkxIn0sICJpZCI6ICI1NmI0ZGQ0MThhZGE0
-        MGRiMDRlZTBmOTEifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:34:57 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/100095f3-3e0d-41fa-bc54-793b5e6bcb5d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="caiJVNg1UqO8hhQ1hzuoDrqKTg7QphO8XSmwXwEC3w",
-        oauth_signature="OMDfbw9vIz0c1yhDLHWYe2bdPyk%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693700", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:00 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xMDAwOTVmMy0zZTBkLTQxZmEtYmM1NC03OTNiNWU2YmNi
-        NWQvIiwgInRhc2tfaWQiOiAiMTAwMDk1ZjMtM2UwZC00MWZhLWJjNTQtNzkz
-        YjVlNmJjYjVkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkNDQ4
-        YWRhNDBkYjA0ZWUwZjkzIn0sICJpZCI6ICI1NmI0ZGQ0NDhhZGE0MGRiMDRl
-        ZTBmOTMifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:00 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/100095f3-3e0d-41fa-bc54-793b5e6bcb5d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="ETGLpAdShik8s7sOLzdslpYPzaVyWi2e0fTHdAI",
-        oauth_signature="RjsWCWTUbkNDZXOW0LIum4tRYtM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693700", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:00 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1081'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xMDAwOTVmMy0zZTBkLTQxZmEtYmM1NC03OTNiNWU2YmNi
-        NWQvIiwgInRhc2tfaWQiOiAiMTAwMDk1ZjMtM2UwZC00MWZhLWJjNTQtNzkz
-        YjVlNmJjYjVkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0wNVQxNzozNTowMFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJO
-        T1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAi
-        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0
-        ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJl
-        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkNDQ4YWRhNDBk
-        YjA0ZWUwZjkzIn0sICJpZCI6ICI1NmI0ZGQ0NDhhZGE0MGRiMDRlZTBmOTMi
-        fQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:00 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/100095f3-3e0d-41fa-bc54-793b5e6bcb5d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="1wTlHLO25e1qAFzrVd1KlATzloJECWH0V00e9Q5qjXI",
-        oauth_signature="d8pjUtmLPqWRhGvFP%2FMQATPbOb8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693701", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:01 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xMDAwOTVmMy0zZTBkLTQxZmEtYmM1NC03OTNiNWU2YmNi
-        NWQvIiwgInRhc2tfaWQiOiAiMTAwMDk1ZjMtM2UwZC00MWZhLWJjNTQtNzkz
-        YjVlNmJjYjVkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozNTowMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozNTowMFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMWQ1ZmQ2ODEtODRiMy00NzNlLWFlOGEtZjAyODdmZGJi
-        Nzg5LyIsICJ0YXNrX2lkIjogIjFkNWZkNjgxLTg0YjMtNDczZS1hZThhLWYw
-        Mjg3ZmRiYjc4OSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZDQzYzc4MjFiMzMwNWNlNTIzYSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6MzU6MDBaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozNTow
-        MFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRkNDRjNzgyMWIzNDQ0ZmNjM2YzIiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkNDQ4YWRhNDBkYjA0ZWUwZjkzIn0s
-        ICJpZCI6ICI1NmI0ZGQ0NDhhZGE0MGRiMDRlZTBmOTMifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:01 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/1d5fd681-84b3-473e-ae8a-f0287fdbb789/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="M6BHAnj1NNnbXDgdmgDgNTZA0ehA6dkO7zyR9afrHyY",
-        oauth_signature="7fee9zvCE3RMia4XFoHjFmCNhLE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693701", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:01 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3497'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8xZDVmZDY4MS04NGIzLTQ3M2UtYWU4YS1mMDI4
-        N2ZkYmI3ODkvIiwgInRhc2tfaWQiOiAiMWQ1ZmQ2ODEtODRiMy00NzNlLWFl
-        OGEtZjAyODdmZGJiNzg5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wNVQxNzozNTowMVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1MDM2
-        ZWQ0Ni03OWQyLTRkMzEtOTk5ZS0wNzhiY2FlNjFmNzgiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTg1NDI1YzAtYmM1
-        Zi00Y2Y5LThjZTgtY2JiZDA1MTZhMGM0IiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiOWFiOWI3MjEtY2ViMy00ZmM0LWE0ZTktNDY3Y2NkNTY3NjgyIiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNWI0ZjE2YmYtMGViYi00YWQwLWFi
-        NmYtOWY1MjZkNzc4MDBkIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZm
-        M2M1YjJhLTgwZmYtNGJhYS1iMTM5LTA0MWU4YTg2YjM5YyIsICJudW1fcHJv
-        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI1NGI3Y2YxMC00MGZkLTQ2ZTItODFjZS0w
-        ZmVhNDdlYTdmOWUiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEu
-        IiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1
-        ZjQ0Y2Q4Yi1iYmI3LTQ0YzMtYWE2ZS1hNzhhNTI0YjY4ZTkiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9u
-        IjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xv
-        c2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMWQ1MmYwMi1i
-        YzRjLTQ1MDktODVlZS00Mjg1MjIxOGI4YTkiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVy
-        YXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBz
-        cWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMzRhMTJiYi0wYzgyLTRiNGQtODgz
-        Yy0xNWE4YjA4ODE5MWEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMg
-        dG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI1M2Y0NWVlMS0zNWUzLTQyZjktYmEyMy1hNjQ0ZGY5
-        N2JkODkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImUxZWI1MTQzLWU4ZmItNDBiMy1iZDU5LTcxYTc3ODRl
-        OTE0NyIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5leGFtcGxl
-        LmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5l
-        eGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjU2YjRkZDQ0OGFkYTQwZGIwNGVlMGZhMyJ9LCAi
-        aWQiOiAiNTZiNGRkNDQ4YWRhNDBkYjA0ZWUwZmEzIn0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:01 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/100095f3-3e0d-41fa-bc54-793b5e6bcb5d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="6LTHVRXqYKueUdurKWduXDpH5SfmeDWdNuRxi64y8",
-        oauth_signature="0Tgvccpn3nqEFeeXBs3PZSqwdRs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693702", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:02 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xMDAwOTVmMy0zZTBkLTQxZmEtYmM1NC03OTNiNWU2YmNi
-        NWQvIiwgInRhc2tfaWQiOiAiMTAwMDk1ZjMtM2UwZC00MWZhLWJjNTQtNzkz
-        YjVlNmJjYjVkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozNTowMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozNTowMFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMWQ1ZmQ2ODEtODRiMy00NzNlLWFlOGEtZjAyODdmZGJi
-        Nzg5LyIsICJ0YXNrX2lkIjogIjFkNWZkNjgxLTg0YjMtNDczZS1hZThhLWYw
-        Mjg3ZmRiYjc4OSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZDQzYzc4MjFiMzMwNWNlNTIzYSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6MzU6MDBaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozNTow
-        MFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRkNDRjNzgyMWIzNDQ0ZmNjM2YzIiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkNDQ4YWRhNDBkYjA0ZWUwZjkzIn0s
-        ICJpZCI6ICI1NmI0ZGQ0NDhhZGE0MGRiMDRlZTBmOTMifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:02 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/1d5fd681-84b3-473e-ae8a-f0287fdbb789/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="TSwVE11X3Y4fQPzx1IqtqmnMyKwM5y5CQtKTQY1Qoag",
-        oauth_signature="tHgjki0XocNqDG7whN%2BSyw7a6fw%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693702", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:02 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8xZDVmZDY4MS04NGIzLTQ3M2UtYWU4YS1mMDI4
-        N2ZkYmI3ODkvIiwgInRhc2tfaWQiOiAiMWQ1ZmQ2ODEtODRiMy00NzNlLWFl
-        OGEtZjAyODdmZGJiNzg5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wNVQxNzozNTowMVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozNTowMVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI1MDM2ZWQ0Ni03OWQyLTRkMzEtOTk5ZS0wNzhiY2Fl
-        NjFmNzgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMTg1NDI1YzAtYmM1Zi00Y2Y5LThjZTgtY2JiZDA1MTZhMGM0Iiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiOWFiOWI3MjEtY2ViMy00ZmM0LWE0ZTkt
-        NDY3Y2NkNTY3NjgyIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNWI0
-        ZjE2YmYtMGViYi00YWQwLWFiNmYtOWY1MjZkNzc4MDBkIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImZmM2M1YjJhLTgwZmYtNGJhYS1iMTM5LTA0MWU4
-        YTg2YjM5YyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1NGI3Y2Yx
-        MC00MGZkLTQ2ZTItODFjZS0wZmVhNDdlYTdmOWUiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI1ZjQ0Y2Q4Yi1iYmI3LTQ0YzMtYWE2ZS1hNzhh
-        NTI0YjY4ZTkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJiMWQ1MmYwMi1iYzRjLTQ1MDktODVlZS00Mjg1MjIxOGI4YTki
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMzRh
-        MTJiYi0wYzgyLTRiNGQtODgzYy0xNWE4YjA4ODE5MWEiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1M2Y0NWVlMS0zNWUz
-        LTQyZjktYmEyMy1hNjQ0ZGY5N2JkODkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUxZWI1MTQzLWU4ZmItNDBi
-        My1iZDU5LTcxYTc3ODRlOTE0NyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
-        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE3OjM1OjAx
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMDVUMTc6MzU6MDFaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGRkNDVjNzgyMWIz
-        NDQ0ZmNjM2Y0IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjUwMzZlZDQ2LTc5ZDItNGQzMS05OTllLTA3OGJjYWU2MWY3
-        OCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICIxODU0MjVjMC1iYzVmLTRjZjktOGNlOC1jYmJkMDUxNmEwYzQiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI5YWI5YjcyMS1jZWIzLTRmYzQtYTRlOS00Njdj
-        Y2Q1Njc2ODIiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1YjRmMTZi
-        Zi0wZWJiLTRhZDAtYWI2Zi05ZjUyNmQ3NzgwMGQiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiZmYzYzViMmEtODBmZi00YmFhLWIxMzktMDQxZThhODZi
-        MzljIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjU0YjdjZjEwLTQw
-        ZmQtNDZlMi04MWNlLTBmZWE0N2VhN2Y5ZSIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjVmNDRjZDhiLWJiYjctNDRjMy1hYTZlLWE3OGE1MjRi
-        NjhlOSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImIxZDUyZjAyLWJjNGMtNDUwOS04NWVlLTQyODUyMjE4YjhhOSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImIzNGExMmJi
-        LTBjODItNGI0ZC04ODNjLTE1YThiMDg4MTkxYSIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjUzZjQ1ZWUxLTM1ZTMtNDJm
-        OS1iYTIzLWE2NDRkZjk3YmQ4OSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTFlYjUxNDMtZThmYi00MGIzLWJk
-        NTktNzFhNzc4NGU5MTQ3IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRkZDQ0OGFkYTQwZGIw
-        NGVlMGZhMyJ9LCAiaWQiOiAiNTZiNGRkNDQ4YWRhNDBkYjA0ZWUwZmEzIn0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:02 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/b05b4b28-cbc4-477a-bc29-ca9c482d7109/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="ATF948U1PLIz6JbAVwNqmhStJ35GhrnfFE6eH1ovTE",
-        oauth_signature="R5O1UJzPURjgxnYAabZi%2BbMkW1c%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693703", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:03 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iMDViNGIyOC1jYmM0LTQ3N2EtYmMyOS1jYTljNDgyZDcx
-        MDkvIiwgInRhc2tfaWQiOiAiYjA1YjRiMjgtY2JjNC00NzdhLWJjMjktY2E5
-        YzQ4MmQ3MTA5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0ZGQ0
-        NzhhZGE0MGRiMDRlZTBmYTQifSwgImlkIjogIjU2YjRkZDQ3OGFkYTQwZGIw
-        NGVlMGZhNCJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:03 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/b05b4b28-cbc4-477a-bc29-ca9c482d7109/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="CvHQM5Q0FIhAjnsgwcHBA7sSokVlJvKCXZ0huEBqu5U",
-        oauth_signature="V7FkDvPAfvuzbyPIP4yADxq0jJs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693703", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:03 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iMDViNGIyOC1jYmM0LTQ3N2EtYmMyOS1jYTljNDgyZDcx
-        MDkvIiwgInRhc2tfaWQiOiAiYjA1YjRiMjgtY2JjNC00NzdhLWJjMjktY2E5
-        YzQ4MmQ3MTA5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA1VDE3OjM1OjAzWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE3OjM1OjAzWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        NGRkNDc4YWRhNDBkYjA0ZWUwZmE0In0sICJpZCI6ICI1NmI0ZGQ0NzhhZGE0
-        MGRiMDRlZTBmYTQifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:03 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ff625d60-560e-4717-9c33-6056597af090/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="GeNdX8FakE7G5fuq28eZ3Tao4eO835IN9bW6R9sMKek",
-        oauth_signature="bDBuaKUyspftMz5s7ioyaTXdD4M%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693705", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:05 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mZjYyNWQ2MC01NjBlLTQ3MTctOWMzMy02MDU2NTk3YWYw
-        OTAvIiwgInRhc2tfaWQiOiAiZmY2MjVkNjAtNTYwZS00NzE3LTljMzMtNjA1
-        NjU5N2FmMDkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkNDk4
-        YWRhNDBkYjA0ZWUwZmE2In0sICJpZCI6ICI1NmI0ZGQ0OThhZGE0MGRiMDRl
-        ZTBmYTYifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:05 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ff625d60-560e-4717-9c33-6056597af090/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Lxrmvlpc0dVyqtofWV4ZCO4dtjvkRGGKAzFsQxS0",
-        oauth_signature="yS8QjEyokulz0kY5zlCNvzlslvI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693706", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:06 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1078'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mZjYyNWQ2MC01NjBlLTQ3MTctOWMzMy02MDU2NTk3YWYw
-        OTAvIiwgInRhc2tfaWQiOiAiZmY2MjVkNjAtNTYwZS00NzE3LTljMzMtNjA1
-        NjU5N2FmMDkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0wNVQxNzozNTowNVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
-        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVl
-        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgt
-        ZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29y
-        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
-        by0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJv
-        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkNDk4YWRhNDBkYjA0
-        ZWUwZmE2In0sICJpZCI6ICI1NmI0ZGQ0OThhZGE0MGRiMDRlZTBmYTYifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:06 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ff625d60-560e-4717-9c33-6056597af090/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="ilBkZnaMkwulOQcjSfFcYWVLrpUkFGZFsKTrlchbeW0",
-        oauth_signature="eO38GEjmmxxpHyWvEQ48zPmDndQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693706", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:06 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mZjYyNWQ2MC01NjBlLTQ3MTctOWMzMy02MDU2NTk3YWYw
-        OTAvIiwgInRhc2tfaWQiOiAiZmY2MjVkNjAtNTYwZS00NzE3LTljMzMtNjA1
-        NjU5N2FmMDkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozNTowNloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozNTowNVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNjQxOTc3NTMtYjNkMy00OTJkLTg0ZmYtM2FkMWJjNmI0
-        MmRiLyIsICJ0YXNrX2lkIjogIjY0MTk3NzUzLWIzZDMtNDkyZC04NGZmLTNh
-        ZDFiYzZiNDJkYiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZDQ5Yzc4MjFiMzMwNWNlNTI0NyJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6MzU6MDVaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozNTow
-        NloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRkNGFjNzgyMWIzNDQ0ZmNjM2Y4IiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkNDk4YWRhNDBkYjA0ZWUwZmE2In0s
-        ICJpZCI6ICI1NmI0ZGQ0OThhZGE0MGRiMDRlZTBmYTYifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:06 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/64197753-b3d3-492d-84ff-3ad1bc6b42db/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Au1xtsmIc5ZaM2KDMJcj9T19atDtO00L9RYzUU",
-        oauth_signature="x0mdbbcS1JYpmbxmcc6YqGVvAkQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693706", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:07 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3494'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82NDE5Nzc1My1iM2QzLTQ5MmQtODRmZi0zYWQx
-        YmM2YjQyZGIvIiwgInRhc2tfaWQiOiAiNjQxOTc3NTMtYjNkMy00OTJkLTg0
-        ZmYtM2FkMWJjNmI0MmRiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wNVQxNzozNTowNloiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwOWY1
-        NzQ0OS05NmFhLTRlYTgtYmJlNy1lNmM0YThkMWIxOGEiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGE3ZTM0ZDQtZmJm
-        MC00MGYzLWIwMTYtZTQyZWE3ZjgyZTQ4IiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiNDE1NjRjNTItNjliMS00NGQ1LTk4Y2ItZmRiNjg4YzEwM2RmIiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODk3OGE5MWUtMDA1NS00MGU1LTg3
-        MDktYjkyNGI5ZTJiYzhhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ3
-        YzgzMWIzLTQ0MzUtNGJmZC05ZTJhLTVmMDcwZWE1MDRlMyIsICJudW1fcHJv
-        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIxNDZkZmNkNS03MDZjLTRkNDUtOTc3Yi02
-        ZTEyZDI3OThjMTkiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEu
-        IiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIy
-        ZWIwN2E5ZC05ODc0LTRiODMtODliMi04Y2M2MmIyYTMxMTciLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9u
-        IjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xv
-        c2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhMWQ2OGE3OS1l
-        NzY5LTRhYWEtYTcxNi1lODljMGRiZWFlN2QiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVy
-        YXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBz
-        cWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlNzc5YzVmMS03YjExLTQ0NzgtYmY1
-        NC1hYzdjMDQ1NDgwNzUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMg
-        dG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIyMmM3YmY4NS0xMDMxLTRmZWYtYTQ0OS1kYzI2MDYw
-        ZGM2ZjQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImUwNTQzYjcxLTA5YmMtNDU1My05MWJlLWVmNDRkNjFjZTVl
-        MCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVlIjogInJlc2VydmVk
-        X3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNv
-        bS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJl
-        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5leGFt
-        cGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YjRkZDRhOGFkYTQwZGIwNGVlMGZiNiJ9LCAiaWQi
-        OiAiNTZiNGRkNGE4YWRhNDBkYjA0ZWUwZmI2In0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:07 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ff625d60-560e-4717-9c33-6056597af090/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="1oNOTF1VllxFyyqNFD7I7joYRiem8eF9nSIE6oGM",
-        oauth_signature="lFEF4%2FBiGj3xmclhnodmwi9ba0Y%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693707", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:07 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mZjYyNWQ2MC01NjBlLTQ3MTctOWMzMy02MDU2NTk3YWYw
-        OTAvIiwgInRhc2tfaWQiOiAiZmY2MjVkNjAtNTYwZS00NzE3LTljMzMtNjA1
-        NjU5N2FmMDkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozNTowNloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozNTowNVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNjQxOTc3NTMtYjNkMy00OTJkLTg0ZmYtM2FkMWJjNmI0
-        MmRiLyIsICJ0YXNrX2lkIjogIjY0MTk3NzUzLWIzZDMtNDkyZC04NGZmLTNh
-        ZDFiYzZiNDJkYiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZDQ5Yzc4MjFiMzMwNWNlNTI0NyJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6MzU6MDVaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozNTow
-        NloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRkNGFjNzgyMWIzNDQ0ZmNjM2Y4IiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkNDk4YWRhNDBkYjA0ZWUwZmE2In0s
-        ICJpZCI6ICI1NmI0ZGQ0OThhZGE0MGRiMDRlZTBmYTYifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:07 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/64197753-b3d3-492d-84ff-3ad1bc6b42db/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="eeTBCaSzxYbEWSTOdn8jCMOyyGI44tw6H463eD7Is",
-        oauth_signature="7Cq%2BLRheZw%2FZ%2Fe9lsYhQfI7Fs5M%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693707", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:07 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82NDE5Nzc1My1iM2QzLTQ5MmQtODRmZi0zYWQx
-        YmM2YjQyZGIvIiwgInRhc2tfaWQiOiAiNjQxOTc3NTMtYjNkMy00OTJkLTg0
-        ZmYtM2FkMWJjNmI0MmRiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wNVQxNzozNTowN1oiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozNTowNloiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIwOWY1NzQ0OS05NmFhLTRlYTgtYmJlNy1lNmM0YThk
-        MWIxOGEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNGE3ZTM0ZDQtZmJmMC00MGYzLWIwMTYtZTQyZWE3ZjgyZTQ4Iiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNDE1NjRjNTItNjliMS00NGQ1LTk4Y2It
-        ZmRiNjg4YzEwM2RmIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODk3
-        OGE5MWUtMDA1NS00MGU1LTg3MDktYjkyNGI5ZTJiYzhhIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImQ3YzgzMWIzLTQ0MzUtNGJmZC05ZTJhLTVmMDcw
-        ZWE1MDRlMyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNDZkZmNk
-        NS03MDZjLTRkNDUtOTc3Yi02ZTEyZDI3OThjMTkiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIyZWIwN2E5ZC05ODc0LTRiODMtODliMi04Y2M2
-        MmIyYTMxMTciLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJhMWQ2OGE3OS1lNzY5LTRhYWEtYTcxNi1lODljMGRiZWFlN2Qi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlNzc5
-        YzVmMS03YjExLTQ0NzgtYmY1NC1hYzdjMDQ1NDgwNzUiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyMmM3YmY4NS0xMDMx
-        LTRmZWYtYTQ0OS1kYzI2MDYwZGM2ZjQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUwNTQzYjcxLTA5YmMtNDU1
-        My05MWJlLWVmNDRkNjFjZTVlMCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
-        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE3OjM1OjA2
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMDVUMTc6MzU6MDdaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGRkNGJjNzgyMWIz
-        NDQ0ZmNjM2Y5IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjA5ZjU3NDQ5LTk2YWEtNGVhOC1iYmU3LWU2YzRhOGQxYjE4
-        YSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI0YTdlMzRkNC1mYmYwLTQwZjMtYjAxNi1lNDJlYTdmODJlNDgiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI0MTU2NGM1Mi02OWIxLTQ0ZDUtOThjYi1mZGI2
-        ODhjMTAzZGYiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4OTc4YTkx
-        ZS0wMDU1LTQwZTUtODcwOS1iOTI0YjllMmJjOGEiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiZDdjODMxYjMtNDQzNS00YmZkLTllMmEtNWYwNzBlYTUw
-        NGUzIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE0NmRmY2Q1LTcw
-        NmMtNGQ0NS05NzdiLTZlMTJkMjc5OGMxOSIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjJlYjA3YTlkLTk4NzQtNGI4My04OWIyLThjYzYyYjJh
-        MzExNyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImExZDY4YTc5LWU3NjktNGFhYS1hNzE2LWU4OWMwZGJlYWU3ZCIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImU3NzljNWYx
-        LTdiMTEtNDQ3OC1iZjU0LWFjN2MwNDU0ODA3NSIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjIyYzdiZjg1LTEwMzEtNGZl
-        Zi1hNDQ5LWRjMjYwNjBkYzZmNCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTA1NDNiNzEtMDliYy00NTUzLTkx
-        YmUtZWY0NGQ2MWNlNWUwIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRkZDRhOGFkYTQwZGIw
-        NGVlMGZiNiJ9LCAiaWQiOiAiNTZiNGRkNGE4YWRhNDBkYjA0ZWUwZmI2In0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:07 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/8a5d9d9a-216e-4750-84ee-68eee7f9816c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="PH3Kq8KKIZDaMayvec8amEqewnVxA9bAgGDiB3nGuU",
-        oauth_signature="VQqlo41QkVN0Y1mqx4er2N8kw94%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693708", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:08 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '651'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84YTVkOWQ5YS0yMTZlLTQ3NTAtODRlZS02OGVlZTdmOTgx
-        NmMvIiwgInRhc2tfaWQiOiAiOGE1ZDlkOWEtMjE2ZS00NzUwLTg0ZWUtNjhl
-        ZWU3Zjk4MTZjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAi
-        c3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
-        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20i
-        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmI0ZGQ0YzhhZGE0MGRiMDRlZTBmYjcifSwgImlkIjogIjU2YjRk
-        ZDRjOGFkYTQwZGIwNGVlMGZiNyJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:08 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/8a5d9d9a-216e-4750-84ee-68eee7f9816c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="mkmvMMmCkmlScKOEA6ifQGlEjRWxTfkELYF23DbY",
-        oauth_signature="UYN5JP%2F%2F4m8SZJxnWWOo30JKBfE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693709", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:09 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84YTVkOWQ5YS0yMTZlLTQ3NTAtODRlZS02OGVlZTdmOTgx
-        NmMvIiwgInRhc2tfaWQiOiAiOGE1ZDlkOWEtMjE2ZS00NzUwLTg0ZWUtNjhl
-        ZWU3Zjk4MTZjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA1VDE3OjM1OjA4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE3OjM1OjA4WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        NGRkNGM4YWRhNDBkYjA0ZWUwZmI3In0sICJpZCI6ICI1NmI0ZGQ0YzhhZGE0
-        MGRiMDRlZTBmYjcifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:09 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/17820868-423b-4d43-ad95-76b0b4ba8636/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="uldmGmSpN55OLvDwGz6CVGg6NNPOR4Kz6FpIMPo",
-        oauth_signature="aGtrN8UHMe3xGdepgGGLGVQAM8A%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693711", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:11 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '649'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xNzgyMDg2OC00MjNiLTRkNDMtYWQ5NS03NmIwYjRiYTg2
-        MzYvIiwgInRhc2tfaWQiOiAiMTc4MjA4NjgtNDIzYi00ZDQzLWFkOTUtNzZi
-        MGI0YmE4NjM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0
-        YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwg
-        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNTZiNGRkNGY4YWRhNDBkYjA0ZWUwZmI5In0sICJpZCI6ICI1NmI0ZGQ0
-        ZjhhZGE0MGRiMDRlZTBmYjkifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:11 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/17820868-423b-4d43-ad95-76b0b4ba8636/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="0zkJYvmANChQdKack7mNA85P74FfSASr9XMIcmw",
-        oauth_signature="Ef%2FpFSF92qugW1%2FyXd6Omez8cvQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693711", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:11 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1078'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xNzgyMDg2OC00MjNiLTRkNDMtYWQ5NS03NmIwYjRiYTg2
-        MzYvIiwgInRhc2tfaWQiOiAiMTc4MjA4NjgtNDIzYi00ZDQzLWFkOTUtNzZi
-        MGI0YmE4NjM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0wNVQxNzozNToxMVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
-        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVl
-        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgt
-        ZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29y
-        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
-        by0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJv
-        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkNGY4YWRhNDBkYjA0
-        ZWUwZmI5In0sICJpZCI6ICI1NmI0ZGQ0ZjhhZGE0MGRiMDRlZTBmYjkifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:11 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/17820868-423b-4d43-ad95-76b0b4ba8636/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="lJh4jGVmSBhbGPsvfgDKCOyeOtTxPjcYlqVMQU498U",
-        oauth_signature="WGdlWh1MgLiGiM1DWKOZtGnQork%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693712", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:12 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xNzgyMDg2OC00MjNiLTRkNDMtYWQ5NS03NmIwYjRiYTg2
-        MzYvIiwgInRhc2tfaWQiOiAiMTc4MjA4NjgtNDIzYi00ZDQzLWFkOTUtNzZi
-        MGI0YmE4NjM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozNToxMVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozNToxMVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYjMzZDBmNDEtMmM1NS00Njc2LTgyNWUtMDE0ODIxMWIy
-        MjNkLyIsICJ0YXNrX2lkIjogImIzM2QwZjQxLTJjNTUtNDY3Ni04MjVlLTAx
-        NDgyMTFiMjIzZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZDRlYzc4MjFiMzMwNDJkOWYxMCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6MzU6MTFaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozNTox
-        MVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRkNGZjNzgyMWIzNDQ0ZmNjM2ZkIiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkNGY4YWRhNDBkYjA0ZWUwZmI5In0s
-        ICJpZCI6ICI1NmI0ZGQ0ZjhhZGE0MGRiMDRlZTBmYjkifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:12 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/b33d0f41-2c55-4676-825e-0148211b223d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="qkr1KcvT8AI4DoDgPbSV8uONVeEVGQrph6LyC0nUc",
-        oauth_signature="hDjDS6rBLfTZsSm2KD9yKmpx9Mk%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693712", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:12 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9iMzNkMGY0MS0yYzU1LTQ2NzYtODI1ZS0wMTQ4
-        MjExYjIyM2QvIiwgInRhc2tfaWQiOiAiYjMzZDBmNDEtMmM1NS00Njc2LTgy
-        NWUtMDE0ODIxMWIyMjNkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wNVQxNzozNToxMloiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozNToxMloiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJiZDhmYTE2MC0xYTlhLTQ4OWUtYTg1My02YWM5Njg3
-        MWEwN2QiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNDE4MjY2NzgtODhhMy00MWE3LTlkOTMtNjczMjVmNGI1ZDAyIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiYjAwYWI0ZWYtZWE5ZC00YjI5LWIwYjIt
-        ZmRlNzRjNzk3MDE5IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYmRk
-        M2FlOTUtNGQ2Yy00NGMxLWE4MmMtMzYzMmEwNWY4YmE1IiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImQ5NmY2MzZhLWNjNmMtNDEzZi04Y2Q1LWFkMTc5
-        Y2JmZmY3ZCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyZTdhZmQw
-        MC0zMDA4LTRkN2QtYjRlMS02YjQyODE5YzA5YjgiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIxN2I3YmFkNS1jOTMzLTQ4ZmItODg0NC0zNjY5
-        MGJiNmVhZGEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIyY2JiOWZkNC0zMTA2LTQ1MmMtYjE0Yy0wZDJjYjkwZWFkMzQi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlMzYy
-        NWY3ZC1lOTI2LTQwZTMtYTQ0Mi03OWNkMDM0NWZkYTAiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzNTM4ODljOC03MzJj
-        LTRlODgtOGQ0Mi01MjQ5NjYxODk2MGIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdiZTEyOGQ5LTQ0MzEtNGVl
-        My1hMDlhLWZhYjYwN2UzM2M5MSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
-        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE3OjM1OjEy
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMDVUMTc6MzU6MTJaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGRkNTBjNzgyMWIz
-        NDQ0ZmNjM2ZlIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImJkOGZhMTYwLTFhOWEtNDg5ZS1hODUzLTZhYzk2ODcxYTA3
-        ZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI0MTgyNjY3OC04OGEzLTQxYTctOWQ5My02NzMyNWY0YjVkMDIiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJiMDBhYjRlZi1lYTlkLTRiMjktYjBiMi1mZGU3
-        NGM3OTcwMTkiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiZGQzYWU5
-        NS00ZDZjLTQ0YzEtYTgyYy0zNjMyYTA1ZjhiYTUiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiZDk2ZjYzNmEtY2M2Yy00MTNmLThjZDUtYWQxNzljYmZm
-        ZjdkIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjJlN2FmZDAwLTMw
-        MDgtNGQ3ZC1iNGUxLTZiNDI4MTljMDliOCIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjE3YjdiYWQ1LWM5MzMtNDhmYi04ODQ0LTM2NjkwYmI2
-        ZWFkYSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjJjYmI5ZmQ0LTMxMDYtNDUyYy1iMTRjLTBkMmNiOTBlYWQzNCIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUzNjI1Zjdk
-        LWU5MjYtNDBlMy1hNDQyLTc5Y2QwMzQ1ZmRhMCIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM1Mzg4OWM4LTczMmMtNGU4
-        OC04ZDQyLTUyNDk2NjE4OTYwYiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiN2JlMTI4ZDktNDQzMS00ZWUzLWEw
-        OWEtZmFiNjA3ZTMzYzkxIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRkZDRmOGFkYTQwZGIw
-        NGVlMGZjOSJ9LCAiaWQiOiAiNTZiNGRkNGY4YWRhNDBkYjA0ZWUwZmM5In0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:12 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f0245b41-09d8-421c-b733-1af20307c3aa/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="lbAjZklcC47A0Ocd3V3OqrtCKSA7ALDxpxpAyaqA",
-        oauth_signature="jwBnxhMP6T0nG1t0f9jhv%2FE51PE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693713", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:13 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '651'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mMDI0NWI0MS0wOWQ4LTQyMWMtYjczMy0xYWYyMDMwN2Mz
-        YWEvIiwgInRhc2tfaWQiOiAiZjAyNDViNDEtMDlkOC00MjFjLWI3MzMtMWFm
-        MjAzMDdjM2FhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAi
-        c3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
-        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20i
-        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmI0ZGQ1MThhZGE0MGRiMDRlZTBmY2EifSwgImlkIjogIjU2YjRk
-        ZDUxOGFkYTQwZGIwNGVlMGZjYSJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:13 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f0245b41-09d8-421c-b733-1af20307c3aa/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="6xHvVl8ujGdHT04Peo2muikw66maPHi4tXouDoLpo",
-        oauth_signature="suNFRVgTRBbVIbSYziZq1MOATxQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693714", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:14 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mMDI0NWI0MS0wOWQ4LTQyMWMtYjczMy0xYWYyMDMwN2Mz
-        YWEvIiwgInRhc2tfaWQiOiAiZjAyNDViNDEtMDlkOC00MjFjLWI3MzMtMWFm
-        MjAzMDdjM2FhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA1VDE3OjM1OjEzWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE3OjM1OjEzWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        NGRkNTE4YWRhNDBkYjA0ZWUwZmNhIn0sICJpZCI6ICI1NmI0ZGQ1MThhZGE0
-        MGRiMDRlZTBmY2EifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:14 GMT
-- request:
-    method: post
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
-        IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRp
-        c3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwi
-        OiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3Rl
-        Y3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJleHBvcnRfZGlzdHJpYnV0
-        b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBz
-        IjpmYWxzZSwicmVsYXRpdmVfdXJsIjpudWxsfSwiYXV0b19wdWJsaXNoIjpm
-        YWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJleHBvcnRfZGlzdHJpYnV0b3IifV19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
-        oauth_nonce="5vXni25PiOGoZ9mk6j0yR00b6aECXRwgKYayfkuUM", oauth_signature="V80j9qoDZgEA03aB8Tka83MS0Ao%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454693715", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '810'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '320'
-      Location:
-      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiNGRkNTNjNzgyMWIzMzAzNGJhZjZhIn0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:15 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/17381425-fe03-44fb-9cca-a6387b1f749c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="tXNuklO37LZpgopI0qZPRCFJMTNOUFwBlRCdzUwEM",
-        oauth_signature="hf0U%2FBNfEwEQdIum84XEt58NqiY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693716", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:16 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xNzM4MTQyNS1mZTAzLTQ0ZmItOWNjYS1hNjM4N2IxZjc0
-        OWMvIiwgInRhc2tfaWQiOiAiMTczODE0MjUtZmUwMy00NGZiLTljY2EtYTYz
-        ODdiMWY3NDljIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkNTQ4
-        YWRhNDBkYjA0ZWUwZmNjIn0sICJpZCI6ICI1NmI0ZGQ1NDhhZGE0MGRiMDRl
-        ZTBmY2MifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:16 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/17381425-fe03-44fb-9cca-a6387b1f749c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="jYRvvbplDbFInB4Q9rh6ZM89XsmiUdlRJgorpejTc",
-        oauth_signature="XbMq5h6nN5uRhTe67c7ThFmRprA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693716", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:16 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1078'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xNzM4MTQyNS1mZTAzLTQ0ZmItOWNjYS1hNjM4N2IxZjc0
-        OWMvIiwgInRhc2tfaWQiOiAiMTczODE0MjUtZmUwMy00NGZiLTljY2EtYTYz
-        ODdiMWY3NDljIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0wNVQxNzozNToxNloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
-        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVl
-        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgt
-        ZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29y
-        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
-        by0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJv
-        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkNTQ4YWRhNDBkYjA0
-        ZWUwZmNjIn0sICJpZCI6ICI1NmI0ZGQ1NDhhZGE0MGRiMDRlZTBmY2MifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:16 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/17381425-fe03-44fb-9cca-a6387b1f749c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="eB8lWrajopHRmlMmawsNeIXcLfgMUkwxRVRQwdcTEI",
-        oauth_signature="2RSrFHEhQqgNTeVUYEYZyLMeOW0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693717", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:17 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xNzM4MTQyNS1mZTAzLTQ0ZmItOWNjYS1hNjM4N2IxZjc0
-        OWMvIiwgInRhc2tfaWQiOiAiMTczODE0MjUtZmUwMy00NGZiLTljY2EtYTYz
-        ODdiMWY3NDljIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozNToxNloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozNToxNloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNGE0MWQyOTItNGVmYS00ZDE2LThkNGEtNmI5ZTlmNGI1
-        ZGJmLyIsICJ0YXNrX2lkIjogIjRhNDFkMjkyLTRlZmEtNGQxNi04ZDRhLTZi
-        OWU5ZjRiNWRiZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZDUzYzc4MjFiMzMwMzRiYWY2YiJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6MzU6MTZaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozNTox
-        NloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRkNTRjNzgyMWIzNDQ0ZmNjNDAyIiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkNTQ4YWRhNDBkYjA0ZWUwZmNjIn0s
-        ICJpZCI6ICI1NmI0ZGQ1NDhhZGE0MGRiMDRlZTBmY2MifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:17 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/4a41d292-4efa-4d16-8d4a-6b9e9f4b5dbf/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="O3KYcdIQKao6XgQ6xnjkYacJ1tQVnIpZxjHTzhxBA",
-        oauth_signature="D1ZSOqwr8Z4yYQTWjYsxrVrdspg%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693717", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:17 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80YTQxZDI5Mi00ZWZhLTRkMTYtOGQ0YS02Yjll
-        OWY0YjVkYmYvIiwgInRhc2tfaWQiOiAiNGE0MWQyOTItNGVmYS00ZDE2LThk
-        NGEtNmI5ZTlmNGI1ZGJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wNVQxNzozNToxN1oiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozNToxNloiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIxZjdmZTIwYy04NGQwLTQyZWEtYWU4Zi1hZDdlMWJk
-        YzBmNTIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNWIxNWEyMGMtNTU2ZS00NjkyLWI4MDItMWE2NDllYzJiYjY3Iiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNzgwNDI5MTEtNTA1NC00YWRkLWJiZTUt
-        NWU3ZmZlZjVhMGVkIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTVi
-        NTZiN2ItYmZmZC00NzMwLWJkZDgtNGUzMTg2Y2E0MTdjIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjgwOWI5YjI3LWZjZTgtNDVlMy1iYWIwLTU4OWQ5
-        MzlmNzAyMSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxZGViOTVm
-        MC1lZWMyLTQ3MGUtYWIwMy0zMzM5YzlkYTM0ZmQiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI2YTNiZDZmYS0yNjdjLTQyYTUtOWFiNi0wZWRh
-        NGM4ODFiZWQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJkNWQ4YjcyNC1lMGQ5LTQ5M2EtYjNiZC02NmE1NDg5ZDJiYmIi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiNDQw
-        YTUxNC00NmIzLTQwYmEtOWY5NS00Njk2YzdmMzAwNjciLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3ZGJlNGEzMS0wNjA0
-        LTRkNWUtYTgxZS01ZGUzMWRhODNkNGQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjk3ZTRlMjc0LTA2NzgtNGY5
-        OS04Yzg4LTc1NzEyMzE1YzQ0OSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
-        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE3OjM1OjE2
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMDVUMTc6MzU6MTdaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGRkNTVjNzgyMWIz
-        NDQ0ZmNjNDAzIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjFmN2ZlMjBjLTg0ZDAtNDJlYS1hZThmLWFkN2UxYmRjMGY1
-        MiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI1YjE1YTIwYy01NTZlLTQ2OTItYjgwMi0xYTY0OWVjMmJiNjciLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI3ODA0MjkxMS01MDU0LTRhZGQtYmJlNS01ZTdm
-        ZmVmNWEwZWQiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1NWI1NmI3
-        Yi1iZmZkLTQ3MzAtYmRkOC00ZTMxODZjYTQxN2MiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiODA5YjliMjctZmNlOC00NWUzLWJhYjAtNTg5ZDkzOWY3
-        MDIxIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjFkZWI5NWYwLWVl
-        YzItNDcwZS1hYjAzLTMzMzljOWRhMzRmZCIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjZhM2JkNmZhLTI2N2MtNDJhNS05YWI2LTBlZGE0Yzg4
-        MWJlZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImQ1ZDhiNzI0LWUwZDktNDkzYS1iM2JkLTY2YTU0ODlkMmJiYiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI0NDBhNTE0
-        LTQ2YjMtNDBiYS05Zjk1LTQ2OTZjN2YzMDA2NyIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdkYmU0YTMxLTA2MDQtNGQ1
-        ZS1hODFlLTVkZTMxZGE4M2Q0ZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTdlNGUyNzQtMDY3OC00Zjk5LThj
-        ODgtNzU3MTIzMTVjNDQ5IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRkZDU0OGFkYTQwZGIw
-        NGVlMGZkYyJ9LCAiaWQiOiAiNTZiNGRkNTQ4YWRhNDBkYjA0ZWUwZmRjIn0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:17 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/53e4a724-2656-4eae-a068-75dc89cace6d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="RIu5uWDJ97iYBzfKopU3Yt3cgSynxKJv1AVQkUSGypY",
-        oauth_signature="Hv8FUQhgmQchSwaX0RG%2BXorGcQ4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693718", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:18 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81M2U0YTcyNC0yNjU2LTRlYWUtYTA2OC03NWRjODljYWNl
-        NmQvIiwgInRhc2tfaWQiOiAiNTNlNGE3MjQtMjY1Ni00ZWFlLWEwNjgtNzVk
-        Yzg5Y2FjZTZkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0ZGQ1
-        NjhhZGE0MGRiMDRlZTBmZGQifSwgImlkIjogIjU2YjRkZDU2OGFkYTQwZGIw
-        NGVlMGZkZCJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:18 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/53e4a724-2656-4eae-a068-75dc89cace6d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="77HD44eaZm59PoxPk6yXtfjlk3oqO5GP9y4wzUSRpw",
-        oauth_signature="TnlwJQf5yaU%2B9bCBjtZB0tdOxTU%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693719", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:35:19 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81M2U0YTcyNC0yNjU2LTRlYWUtYTA2OC03NWRjODljYWNl
-        NmQvIiwgInRhc2tfaWQiOiAiNTNlNGE3MjQtMjY1Ni00ZWFlLWEwNjgtNzVk
-        Yzg5Y2FjZTZkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA1VDE3OjM1OjE4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE3OjM1OjE4WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        NGRkNTY4YWRhNDBkYjA0ZWUwZmRkIn0sICJpZCI6ICI1NmI0ZGQ1NjhhZGE0
-        MGRiMDRlZTBmZGQifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:35:19 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/7f354556-98c2-4631-a4e7-65f60c2792c1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="KsywVPLH3dUsly0v8WUS1AqmcQZyGyIzsUGWRpwow",
-        oauth_signature="J4ECb8NUQY0avO%2Bkp9o%2BW%2BeEqIQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949707", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:41:47 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '661'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83ZjM1NDU1Ni05OGMyLTQ2MzEtYTRlNy02NWY2MGMyNzky
-        YzEvIiwgInRhc2tfaWQiOiAiN2YzNTQ1NTYtOThjMi00NjMxLWE0ZTctNjVm
-        NjBjMjc5MmMxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRx
-        IiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
-        ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
-        aWQiOiB7IiRvaWQiOiAiNTZiOGM1NGJjMTlmZjUwNzk4MjNmMjRmIn0sICJp
-        ZCI6ICI1NmI4YzU0YmMxOWZmNTA3OTgyM2YyNGYifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:41:47 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/7f354556-98c2-4631-a4e7-65f60c2792c1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="TFcpU5sl8RRQsvbGCoDJnElhfOKHJLFVgSpF7okweLI",
-        oauth_signature="3qGuABVQwt%2BIKJkBbwOBwmoLCOs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949708", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:41:48 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83ZjM1NDU1Ni05OGMyLTQ2MzEtYTRlNy02NWY2MGMyNzky
-        YzEvIiwgInRhc2tfaWQiOiAiN2YzNTQ1NTYtOThjMi00NjMxLWE0ZTctNjVm
-        NjBjMjc5MmMxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo0MTo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo0MTo0N1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvOGYyYWQ1MmEtNjhlYS00ZjcwLWEyOWUtMzg4MDJlOTA5
-        NzZiLyIsICJ0YXNrX2lkIjogIjhmMmFkNTJhLTY4ZWEtNGY3MC1hMjllLTM4
-        ODAyZTkwOTc2YiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjNTRiMTdmMjVlMGRhNDhiODQyYSJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NDE6NDdaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo0MTo0N1oiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjNTRiMTdmMjVlMTEyYWU4OGFkOCIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNTRiYzE5ZmY1
-        MDc5ODIzZjI0ZiJ9LCAiaWQiOiAiNTZiOGM1NGJjMTlmZjUwNzk4MjNmMjRm
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:41:48 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/8f2ad52a-68ea-4f70-a29e-38802e90976b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="xdKqgzPIxc099M1XbgdnAwedMSo4brqzU6cCYodVw",
-        oauth_signature="cOiiVHWlfTqx9CK37jDqVwrzw2I%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949708", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:41:48 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6941'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84ZjJhZDUyYS02OGVhLTRmNzAtYTI5ZS0zODgw
-        MmU5MDk3NmIvIiwgInRhc2tfaWQiOiAiOGYyYWQ1MmEtNjhlYS00ZjcwLWEy
-        OWUtMzg4MDJlOTA5NzZiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wOFQxNjo0MTo0OFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo0MTo0N1oiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJlZmJlOGUxZS1hOWU2LTRiOWUtOWM5MC1iZjk0ZDk2
-        YWZkODMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiOGRmZDMxMzEtMTQ2ZC00MzNjLWI5NDktMjUyMjYxMzg4OGZkIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiYzQ5MzUzYmYtNDBhNC00ZWU5LTgyZmYt
-        MjQ5OGJhZmY0MTJlIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGEz
-        MDgxMDktMGQ2OC00ZmE2LTg0NWMtMjVjNTE5YzJlMTAxIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjNkNmE4MjIzLWY4MTYtNDNmYi04ZGMwLTU4N2M4
-        NzA5ODAwMCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzNjk0NzAy
-        MC00OTdhLTQ1YjgtYWFmZi0wYTEyYzE5NzRkNTYiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIwNmI3ZmVlMi0xNWZmLTRiMDgtOTM2Yy01MzQz
-        ODY4ZmFiZDQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJmOWJkNjkyNy02Y2Q5LTRkMTQtYjk3NS0yYzYzMTM4N2VjNjQi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmNzU0
-        Mjc2My1jOTllLTQxNmItYjNiOS1mMDBjMjE4OGVmMzciLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0NGExNTFkMy1lNWFm
-        LTQzMTEtOTJlZS01NjY5NDM2MGFlMTQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjMyMjNhM2IzLTc3YTYtNDMy
-        YS04YmQzLWVmZWFiZTE1M2NiNCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Y2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAy
-        LTA4VDE2OjQxOjQ3WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMi
-        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMDhUMTY6NDE6NDhaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0
-        cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJ
-        UFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQi
-        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjog
-        IkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklO
-        SVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hf
-        ZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIs
-        ICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51
-        bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZi
-        OGM1NGMxN2YyNWUxMTJhZTg4YWQ5IiwgImRldGFpbHMiOiBbeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
-        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
-        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImVmYmU4ZTFlLWE5ZTYtNGI5ZS05Yzkw
-        LWJmOTRkOTZhZmQ4MyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
-        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI4ZGZkMzEzMS0xNDZkLTQzM2MtYjk0OS0yNTIyNjEz
-        ODg4ZmQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        OCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
-        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjNDkzNTNiZi00MGE0LTRl
-        ZTktODJmZi0yNDk4YmFmZjQxMmUiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7
-        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICIwYTMwODEwOS0wZDY4LTRmYTYtODQ1Yy0yNWM1MTljMmUxMDEiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
-        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiM2Q2YTgyMjMtZjgxNi00M2ZiLThk
-        YzAtNTg3Yzg3MDk4MDAwIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBz
-        IGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjog
-        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjM2OTQ3MDIwLTQ5N2EtNDViOC1hYWZmLTBhMTJjMTk3NGQ1NiIsICJudW1f
-        cHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA2YjdmZWUyLTE1ZmYtNGIwOC05
-        MzZjLTUzNDM4NjhmYWJkNCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImY5YmQ2OTI3LTZjZDktNGQxNC1iOTc1LTJjNjMx
-        Mzg3ZWM2NCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMi
-        LCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImY3NTQyNzYzLWM5OWUtNDE2Yi1iM2I5LWYwMGMyMTg4ZWYzNyIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBl
-        IjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQ0YTE1
-        MWQzLWU1YWYtNDMxMS05MmVlLTU2Njk0MzYwYWUxNCIsICJudW1fcHJvY2Vz
-        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
-        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzIyM2EzYjMt
-        NzdhNi00MzJhLThiZDMtZWZlYWJlMTUzY2I0IiwgIm51bV9wcm9jZXNzZWQi
-        OiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Yjhj
-        NTRiYzE5ZmY1MDc5ODIzZjI1ZiJ9LCAiaWQiOiAiNTZiOGM1NGJjMTlmZjUw
-        Nzk4MjNmMjVmIn0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:41:48 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/ec31c7fa-74e8-4367-bf42-08ef7e9cd08e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="45osW00eEHF2xEiI4lYFR24kAGtuXDuED94y7BoqGU",
-        oauth_signature="5dg5ePcEAgV22VGgjIVhujL5qkA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949709", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:41:49 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lYzMxYzdmYS03NGU4LTQzNjctYmY0Mi0wOGVmN2U5Y2Qw
-        OGUvIiwgInRhc2tfaWQiOiAiZWMzMWM3ZmEtNzRlOC00MzY3LWJmNDItMDhl
-        ZjdlOWNkMDhlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI4YzU0
-        ZGMxOWZmNTA3OTgyM2YyNjAifSwgImlkIjogIjU2YjhjNTRkYzE5ZmY1MDc5
-        ODIzZjI2MCJ9
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:41:49 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/ec31c7fa-74e8-4367-bf42-08ef7e9cd08e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="0YCsHG8YIbXBUTR5bzM6JRxEk3b9EIiBMpcdN1PCc",
-        oauth_signature="%2Fi1kCStsWVCB7ppmHbqYwFg0UOo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949709", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:41:49 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '700'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lYzMxYzdmYS03NGU4LTQzNjctYmY0Mi0wOGVmN2U5Y2Qw
-        OGUvIiwgInRhc2tfaWQiOiAiZWMzMWM3ZmEtNzRlOC00MzY3LWJmNDItMDhl
-        ZjdlOWNkMDhlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA4VDE2OjQxOjQ5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA4VDE2OjQxOjQ5WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20uZHEiLCAic3Rh
-        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUu
-        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNTZiOGM1NGRjMTlmZjUwNzk4MjNmMjYwIn0sICJpZCI6ICI1
-        NmI4YzU0ZGMxOWZmNTA3OTgyM2YyNjAifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:41:49 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/a32126df-4730-430e-a222-6705c7723444/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="nAV4m1hfm4Z21z4uR5CL1LJDTmeCqQ4OnuIV110",
-        oauth_signature="4ICGyBj6kfNpaTaENkfdN3ylKPc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949711", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:41:51 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hMzIxMjZkZi00NzMwLTQzMGUtYTIyMi02NzA1Yzc3MjM0
-        NDQvIiwgInRhc2tfaWQiOiAiYTMyMTI2ZGYtNDczMC00MzBlLWEyMjItNjcw
-        NWM3NzIzNDQ0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiOGM1NGZj
-        MTlmZjUwNzk4MjNmMjYyIn0sICJpZCI6ICI1NmI4YzU0ZmMxOWZmNTA3OTgy
-        M2YyNjIifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:41:51 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/a32126df-4730-430e-a222-6705c7723444/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="6ZeoJ1eQxvXGqJkw8KzV7E1CQt82pBDhQFHAGcnvzI",
-        oauth_signature="j40f%2F3R6dsiItoSFwTE%2BV9JhqFE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949711", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:41:51 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hMzIxMjZkZi00NzMwLTQzMGUtYTIyMi02NzA1Yzc3MjM0
-        NDQvIiwgInRhc2tfaWQiOiAiYTMyMTI2ZGYtNDczMC00MzBlLWEyMjItNjcw
-        NWM3NzIzNDQ0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo0MTo1MVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo0MTo1MVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZTY2NDBiYzUtNjhiNC00NmNjLTkzNGQtZTZhYTA5NWJk
-        ODlkLyIsICJ0YXNrX2lkIjogImU2NjQwYmM1LTY4YjQtNDZjYy05MzRkLWU2
-        YWEwOTViZDg5ZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjNTRlMTdmMjVlMGRhNDhiODQzMyJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NDE6NTFaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo0MTo1MVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjNTRmMTdmMjVlMTEyYWU4OGFkZCIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNTRmYzE5ZmY1
-        MDc5ODIzZjI2MiJ9LCAiaWQiOiAiNTZiOGM1NGZjMTlmZjUwNzk4MjNmMjYy
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:41:51 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/e6640bc5-68b4-46cc-934d-e6aa095bd89d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="J6yxhTYmE8GRRe7R4083LgeudGTFl2Qqj9KpvaJEJuM",
-        oauth_signature="rH9NM2tkQ%2FGnLO3zb%2FNE%2BlV6M7Q%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949711", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:41:51 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '670'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9lNjY0MGJjNS02OGI0LTQ2Y2MtOTM0ZC1lNmFh
-        MDk1YmQ4OWQvIiwgInRhc2tfaWQiOiAiZTY2NDBiYzUtNjhiNC00NmNjLTkz
-        NGQtZTZhYTA5NWJkODlkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiBudWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBb
-        XSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRf
-        cmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1w
-        bGUuY29tLmRxIiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUi
-        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3
-        LWRldmVsLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiOGM1NGZjMTlmZjUwNzk4MjNm
-        MjcyIn0sICJpZCI6ICI1NmI4YzU0ZmMxOWZmNTA3OTgyM2YyNzIifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:41:51 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/a32126df-4730-430e-a222-6705c7723444/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="8lG0JVeARIQTPqIojuTAV4eu900TfgqRsz0nKxJdCoU",
-        oauth_signature="782yJemOZTrFn97VPVZRoqd3%2FwU%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949712", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:41:52 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hMzIxMjZkZi00NzMwLTQzMGUtYTIyMi02NzA1Yzc3MjM0
-        NDQvIiwgInRhc2tfaWQiOiAiYTMyMTI2ZGYtNDczMC00MzBlLWEyMjItNjcw
-        NWM3NzIzNDQ0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo0MTo1MVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo0MTo1MVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZTY2NDBiYzUtNjhiNC00NmNjLTkzNGQtZTZhYTA5NWJk
-        ODlkLyIsICJ0YXNrX2lkIjogImU2NjQwYmM1LTY4YjQtNDZjYy05MzRkLWU2
-        YWEwOTViZDg5ZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjNTRlMTdmMjVlMGRhNDhiODQzMyJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NDE6NTFaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo0MTo1MVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjNTRmMTdmMjVlMTEyYWU4OGFkZCIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNTRmYzE5ZmY1
-        MDc5ODIzZjI2MiJ9LCAiaWQiOiAiNTZiOGM1NGZjMTlmZjUwNzk4MjNmMjYy
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:41:52 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/e6640bc5-68b4-46cc-934d-e6aa095bd89d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="PvKLymOqEwxoXdPr5niPSpSu8KHLzaBB14cZhQ1uBAg",
-        oauth_signature="YIPMKRiGDGF2qLtZCWSPv6Vm0NQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949712", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:41:52 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6941'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9lNjY0MGJjNS02OGI0LTQ2Y2MtOTM0ZC1lNmFh
-        MDk1YmQ4OWQvIiwgInRhc2tfaWQiOiAiZTY2NDBiYzUtNjhiNC00NmNjLTkz
-        NGQtZTZhYTA5NWJkODlkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wOFQxNjo0MTo1MloiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo0MTo1MVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJhNWY4ZWQ2Yi0wMWUyLTQwMGQtYTA3NS1jYTA5ZWQz
-        ZWIxODkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiOGQ0ZjEyM2EtYzA2Ni00OTkzLTgyYTAtMTU5MTZjYWZkYWY2Iiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZmRiNTVhNWMtZDZjYS00NjUzLTgzY2Ut
-        MTkwNjk4OTc0OGZjIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOGNl
-        Njk0ZGUtYzI5OC00NWU4LTgwNjctZGM1NmIxMWUwNDg5IiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjBkZWUxM2ZiLWIyM2UtNDZlOS1iNDFiLTEzNjE2
-        ODhhNzMxYSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyMmJiNWRm
-        Zi0zYTUwLTQ2MzctYmRiYy0wNjUxMTQxM2MzNDMiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIxODMwYjE4NS03OTFkLTQ3ZDEtYmUwMi02NzQy
-        MjQ3Y2FhNzkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIyZjUzMjM3Yi01Y2E5LTQ4NmYtYTA3Mi01ZWJmMjg5YzBhNTAi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0OGU5
-        MjU0Yi0wOTY5LTQwYzAtOTk0Zi0xZDIwNGJjMmRlODMiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3OWNjYTUzOC1mZjUx
-        LTRkYWItOWYwNi03ZWJiMzVkNDZhYTAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjUyNTJjMmZjLTAzNjktNGIw
-        NC1hZmY1LWZlM2MzMTg2YzFlNSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Y2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAy
-        LTA4VDE2OjQxOjUxWiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMi
-        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMDhUMTY6NDE6NTJaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0
-        cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJ
-        UFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQi
-        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjog
-        IkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklO
-        SVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hf
-        ZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIs
-        ICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51
-        bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZi
-        OGM1NTAxN2YyNWUxMTJhZTg4YWRlIiwgImRldGFpbHMiOiBbeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
-        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
-        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImE1ZjhlZDZiLTAxZTItNDAwZC1hMDc1
-        LWNhMDllZDNlYjE4OSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
-        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI4ZDRmMTIzYS1jMDY2LTQ5OTMtODJhMC0xNTkxNmNh
-        ZmRhZjYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        OCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
-        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmZGI1NWE1Yy1kNmNhLTQ2
-        NTMtODNjZS0xOTA2OTg5NzQ4ZmMiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7
-        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI4Y2U2OTRkZS1jMjk4LTQ1ZTgtODA2Ny1kYzU2YjExZTA0ODkiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
-        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGRlZTEzZmItYjIzZS00NmU5LWI0
-        MWItMTM2MTY4OGE3MzFhIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBz
-        IGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjog
-        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjIyYmI1ZGZmLTNhNTAtNDYzNy1iZGJjLTA2NTExNDEzYzM0MyIsICJudW1f
-        cHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE4MzBiMTg1LTc5MWQtNDdkMS1i
-        ZTAyLTY3NDIyNDdjYWE3OSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjJmNTMyMzdiLTVjYTktNDg2Zi1hMDcyLTVlYmYy
-        ODljMGE1MCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMi
-        LCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjQ4ZTkyNTRiLTA5NjktNDBjMC05OTRmLTFkMjA0YmMyZGU4MyIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBl
-        IjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc5Y2Nh
-        NTM4LWZmNTEtNGRhYi05ZjA2LTdlYmIzNWQ0NmFhMCIsICJudW1fcHJvY2Vz
-        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
-        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTI1MmMyZmMt
-        MDM2OS00YjA0LWFmZjUtZmUzYzMxODZjMWU1IiwgIm51bV9wcm9jZXNzZWQi
-        OiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Yjhj
-        NTRmYzE5ZmY1MDc5ODIzZjI3MiJ9LCAiaWQiOiAiNTZiOGM1NGZjMTlmZjUw
-        Nzk4MjNmMjcyIn0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:41:52 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/e4b46259-b40b-448e-a8ad-a003b32a21f5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="GQDfX3p6GelzATa0IgFVGV08gdjmvPhSHPImMC5u4",
-        oauth_signature="fiNlbhNW7TZsl3J4%2FgxH4ZDP8IY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949713", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:41:53 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lNGI0NjI1OS1iNDBiLTQ0OGUtYThhZC1hMDAzYjMyYTIx
-        ZjUvIiwgInRhc2tfaWQiOiAiZTRiNDYyNTktYjQwYi00NDhlLWE4YWQtYTAw
-        M2IzMmEyMWY1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI4YzU1
-        MWMxOWZmNTA3OTgyM2YyNzMifSwgImlkIjogIjU2YjhjNTUxYzE5ZmY1MDc5
-        ODIzZjI3MyJ9
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:41:53 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/e4b46259-b40b-448e-a8ad-a003b32a21f5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="XLWrey4WamVuel48yTm56DADNPrrDfYqTJSbC4uTg",
-        oauth_signature="1%2BnkYPLmLjwCr4kpjfqexHAMH9U%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949713", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:41:53 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '700'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lNGI0NjI1OS1iNDBiLTQ0OGUtYThhZC1hMDAzYjMyYTIx
-        ZjUvIiwgInRhc2tfaWQiOiAiZTRiNDYyNTktYjQwYi00NDhlLWE4YWQtYTAw
-        M2IzMmEyMWY1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA4VDE2OjQxOjUzWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA4VDE2OjQxOjUzWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20uZHEiLCAic3Rh
-        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUu
-        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNTZiOGM1NTFjMTlmZjUwNzk4MjNmMjczIn0sICJpZCI6ICI1
-        NmI4YzU1MWMxOWZmNTA3OTgyM2YyNzMifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:41:53 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/d05d6ccc-1e8b-4509-b290-06c00bb60941/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="M2xOBavX1L4y6ioHaPgffziGxx3a3xMkfdJX30FBaw",
-        oauth_signature="fatapPnDiXU1KO6UK4wEJLWP7LY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949715", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:41:55 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kMDVkNmNjYy0xZThiLTQ1MDktYjI5MC0wNmMwMGJiNjA5
-        NDEvIiwgInRhc2tfaWQiOiAiZDA1ZDZjY2MtMWU4Yi00NTA5LWIyOTAtMDZj
-        MDBiYjYwOTQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiOGM1NTNj
-        MTlmZjUwNzk4MjNmMjc1In0sICJpZCI6ICI1NmI4YzU1M2MxOWZmNTA3OTgy
-        M2YyNzUifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:41:55 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/d05d6ccc-1e8b-4509-b290-06c00bb60941/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="i7n4J1aHdg7RxPQtjcLlEYQwOGVuPk3RZXq2SVrYw",
-        oauth_signature="nTxS8a2%2B0q12NhXILFr4Nd548cc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949716", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:41:56 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kMDVkNmNjYy0xZThiLTQ1MDktYjI5MC0wNmMwMGJiNjA5
-        NDEvIiwgInRhc2tfaWQiOiAiZDA1ZDZjY2MtMWU4Yi00NTA5LWIyOTAtMDZj
-        MDBiYjYwOTQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo0MTo1NloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo0MTo1NloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNTBjYmM0ZDQtODRjYi00ODM3LWJlMDItNWZjNzBjNmE4
-        N2NmLyIsICJ0YXNrX2lkIjogIjUwY2JjNGQ0LTg0Y2ItNDgzNy1iZTAyLTVm
-        YzcwYzZhODdjZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjNTUzMTdmMjVlMGRhNDhiODQzYSJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NDE6NTZaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo0MTo1NloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjNTU0MTdmMjVlMTEyYWU4OGFlMiIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNTUzYzE5ZmY1
-        MDc5ODIzZjI3NSJ9LCAiaWQiOiAiNTZiOGM1NTNjMTlmZjUwNzk4MjNmMjc1
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:41:56 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/50cbc4d4-84cb-4837-be02-5fc70c6a87cf/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="MgSNyLdYsbv1cu0DW0bm2W1KddkGW5rguek7WTrzA",
-        oauth_signature="YV7m8icltQo%2BVZIRLBf0dPFTwP8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949716", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:41:56 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '670'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy81MGNiYzRkNC04NGNiLTQ4MzctYmUwMi01ZmM3
-        MGM2YTg3Y2YvIiwgInRhc2tfaWQiOiAiNTBjYmM0ZDQtODRjYi00ODM3LWJl
-        MDItNWZjNzBjNmE4N2NmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiBudWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBb
-        XSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRf
-        cmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1w
-        bGUuY29tLmRxIiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUi
-        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3
-        LWRldmVsLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiOGM1NTRjMTlmZjUwNzk4MjNm
-        Mjg1In0sICJpZCI6ICI1NmI4YzU1NGMxOWZmNTA3OTgyM2YyODUifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:41:56 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/d05d6ccc-1e8b-4509-b290-06c00bb60941/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="8GOBS9A43MRK4IpcmCpCVqmu53FSGACQmGMiQ3EOE",
-        oauth_signature="vdjzGc12Fc5iCv5GTsCKRsBXpd4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949717", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:41:57 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kMDVkNmNjYy0xZThiLTQ1MDktYjI5MC0wNmMwMGJiNjA5
-        NDEvIiwgInRhc2tfaWQiOiAiZDA1ZDZjY2MtMWU4Yi00NTA5LWIyOTAtMDZj
-        MDBiYjYwOTQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo0MTo1NloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo0MTo1NloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNTBjYmM0ZDQtODRjYi00ODM3LWJlMDItNWZjNzBjNmE4
-        N2NmLyIsICJ0YXNrX2lkIjogIjUwY2JjNGQ0LTg0Y2ItNDgzNy1iZTAyLTVm
-        YzcwYzZhODdjZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjNTUzMTdmMjVlMGRhNDhiODQzYSJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NDE6NTZaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo0MTo1NloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjNTU0MTdmMjVlMTEyYWU4OGFlMiIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNTUzYzE5ZmY1
-        MDc5ODIzZjI3NSJ9LCAiaWQiOiAiNTZiOGM1NTNjMTlmZjUwNzk4MjNmMjc1
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:41:57 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/50cbc4d4-84cb-4837-be02-5fc70c6a87cf/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="RfJS0FoGERe2i5edDxDXe1fsGx59T4oEuTbYjZACQ",
-        oauth_signature="Mh042D0DMEjYMUPGPXLkMmKgKFE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949717", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:41:57 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6941'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy81MGNiYzRkNC04NGNiLTQ4MzctYmUwMi01ZmM3
-        MGM2YTg3Y2YvIiwgInRhc2tfaWQiOiAiNTBjYmM0ZDQtODRjYi00ODM3LWJl
-        MDItNWZjNzBjNmE4N2NmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wOFQxNjo0MTo1NloiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo0MTo1NloiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJiNWRjMTE1OC1mYWY2LTRmNzAtYTMxMC01MTI5ODc1
-        NDA2OGEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMDRjOTNiN2QtMzQ0ZS00MDU5LTg4OWEtNjQyNWZhYzBhOTRlIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNWIwYWYxOWYtYWRkNy00OTlkLTg3NTIt
-        OGU5MjE1M2M5M2Y4IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjJm
-        M2Q1YjMtYzdhNS00ZGFlLThmMWMtNTc1YzdlN2IwYmMyIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjM5MzNjNmRiLWI4YTQtNDg0NS05N2I0LTMyODNk
-        MDc3NGYzZSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzZjYyMWFj
-        ZC1mMjNjLTRiNjEtYTM2OS1jYWVkMmM5MWQxZjQiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJhZGM2M2EwYy05MWFlLTQ4ZjUtOTJlOC0wMDI3
-        NzU1YTZhYTEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJkZTdhZTcwYi1lNWRlLTQ5YTktOGM2NS1hYzExNjhjOTAzN2Yi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3NGEy
-        OTM0ZS1jNGQzLTQyZGItOGQ0Ni1hNmRlOTNmN2ExNWIiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3YWM3MGFlYi1lZmMw
-        LTQ0MWItYmQwZS00NTAzYzljY2FjZjkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjUyOTVhYWQwLTQ2OTAtNGM3
-        MC1iNzBmLTZkZGZjYmU4NjdjNyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Y2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAy
-        LTA4VDE2OjQxOjU2WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMi
-        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMDhUMTY6NDE6NTZaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0
-        cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJ
-        UFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQi
-        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjog
-        IkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklO
-        SVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hf
-        ZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIs
-        ICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51
-        bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZi
-        OGM1NTQxN2YyNWUxMTJhZTg4YWUzIiwgImRldGFpbHMiOiBbeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
-        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
-        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImI1ZGMxMTU4LWZhZjYtNGY3MC1hMzEw
-        LTUxMjk4NzU0MDY4YSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
-        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIwNGM5M2I3ZC0zNDRlLTQwNTktODg5YS02NDI1ZmFj
-        MGE5NGUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        OCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
-        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1YjBhZjE5Zi1hZGQ3LTQ5
-        OWQtODc1Mi04ZTkyMTUzYzkzZjgiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7
-        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICJmMmYzZDViMy1jN2E1LTRkYWUtOGYxYy01NzVjN2U3YjBiYzIiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
-        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzkzM2M2ZGItYjhhNC00ODQ1LTk3
-        YjQtMzI4M2QwNzc0ZjNlIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBz
-        IGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjog
-        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjNmNjIxYWNkLWYyM2MtNGI2MS1hMzY5LWNhZWQyYzkxZDFmNCIsICJudW1f
-        cHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFkYzYzYTBjLTkxYWUtNDhmNS05
-        MmU4LTAwMjc3NTVhNmFhMSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImRlN2FlNzBiLWU1ZGUtNDlhOS04YzY1LWFjMTE2
-        OGM5MDM3ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMi
-        LCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjc0YTI5MzRlLWM0ZDMtNDJkYi04ZDQ2LWE2ZGU5M2Y3YTE1YiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBl
-        IjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdhYzcw
-        YWViLWVmYzAtNDQxYi1iZDBlLTQ1MDNjOWNjYWNmOSIsICJudW1fcHJvY2Vz
-        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
-        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTI5NWFhZDAt
-        NDY5MC00YzcwLWI3MGYtNmRkZmNiZTg2N2M3IiwgIm51bV9wcm9jZXNzZWQi
-        OiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Yjhj
-        NTU0YzE5ZmY1MDc5ODIzZjI4NSJ9LCAiaWQiOiAiNTZiOGM1NTRjMTlmZjUw
-        Nzk4MjNmMjg1In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:41:57 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/eaae280c-fbc7-4eff-9424-ce59c4f8a1ab/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="nQhxPpmkEX1AO8QC4h5f2uVWZ1ZEy2epTq7xZtC8y8",
-        oauth_signature="aRvjgCIfBcK%2BwlpW8idelS%2BPy5s%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949718", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:41:58 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lYWFlMjgwYy1mYmM3LTRlZmYtOTQyNC1jZTU5YzRmOGEx
-        YWIvIiwgInRhc2tfaWQiOiAiZWFhZTI4MGMtZmJjNy00ZWZmLTk0MjQtY2U1
-        OWM0ZjhhMWFiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI4YzU1
-        NmMxOWZmNTA3OTgyM2YyODYifSwgImlkIjogIjU2YjhjNTU2YzE5ZmY1MDc5
-        ODIzZjI4NiJ9
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:41:58 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/eaae280c-fbc7-4eff-9424-ce59c4f8a1ab/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="tReLMETh2JbGn4RnQqiPnsgqxjLZqBxJoHc8kDUwV8",
-        oauth_signature="tm48jm9xQJy9VQVd4yM%2FDeYLfnM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949718", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:41:58 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '700'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lYWFlMjgwYy1mYmM3LTRlZmYtOTQyNC1jZTU5YzRmOGEx
-        YWIvIiwgInRhc2tfaWQiOiAiZWFhZTI4MGMtZmJjNy00ZWZmLTk0MjQtY2U1
-        OWM0ZjhhMWFiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA4VDE2OjQxOjU4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA4VDE2OjQxOjU4WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20uZHEiLCAic3Rh
-        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUu
-        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNTZiOGM1NTZjMTlmZjUwNzk4MjNmMjg2In0sICJpZCI6ICI1
-        NmI4YzU1NmMxOWZmNTA3OTgyM2YyODYifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:41:58 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/4a5b5eb4-4f8e-4933-a929-71736f596362/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="CkrEMcrM4GIE7LstMstOrsSMPJWNz0Il1nxJc4a8E",
-        oauth_signature="B4W1NTLKisBAa6dsCaCJ9tCcFnk%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949720", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:42:00 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80YTViNWViNC00ZjhlLTQ5MzMtYTkyOS03MTczNmY1OTYz
-        NjIvIiwgInRhc2tfaWQiOiAiNGE1YjVlYjQtNGY4ZS00OTMzLWE5MjktNzE3
-        MzZmNTk2MzYyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiOGM1NThj
-        MTlmZjUwNzk4MjNmMjg4In0sICJpZCI6ICI1NmI4YzU1OGMxOWZmNTA3OTgy
-        M2YyODgifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:42:00 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/4a5b5eb4-4f8e-4933-a929-71736f596362/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="XoBLKwCPn0YoxcH6d9c7FUDEykyxbF73WlevX4o1he0",
-        oauth_signature="LCaQxVwA3MsbuyfPyMP4quw2pDg%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949720", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:42:00 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80YTViNWViNC00ZjhlLTQ5MzMtYTkyOS03MTczNmY1OTYz
-        NjIvIiwgInRhc2tfaWQiOiAiNGE1YjVlYjQtNGY4ZS00OTMzLWE5MjktNzE3
-        MzZmNTk2MzYyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo0MjowMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo0MjowMFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMTM0MDc2ZDEtMjI2Zi00MTZjLWJkNjUtMDRiMzA3YWJi
-        NTZmLyIsICJ0YXNrX2lkIjogIjEzNDA3NmQxLTIyNmYtNDE2Yy1iZDY1LTA0
-        YjMwN2FiYjU2ZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjNTU3MTdmMjVlMGRhNWE3YzgyZiJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NDI6MDBaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo0MjowMFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjNTU4MTdmMjVlMTEyYWU4OGFlNyIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNTU4YzE5ZmY1
-        MDc5ODIzZjI4OCJ9LCAiaWQiOiAiNTZiOGM1NThjMTlmZjUwNzk4MjNmMjg4
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:42:00 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/134076d1-226f-416c-bd65-04b307abb56f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="Ot5nVS8CLVIjLa4wUWX3rk6M19KkHXn1YBQ3ejSn9Ak",
-        oauth_signature="Fl1p8KE8zqPQ%2BKdyqrU2nGIKi%2Bs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949720", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:42:00 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '670'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8xMzQwNzZkMS0yMjZmLTQxNmMtYmQ2NS0wNGIz
-        MDdhYmI1NmYvIiwgInRhc2tfaWQiOiAiMTM0MDc2ZDEtMjI2Zi00MTZjLWJk
-        NjUtMDRiMzA3YWJiNTZmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiBudWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBb
-        XSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRf
-        cmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1w
-        bGUuY29tLmRxIiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUi
-        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3
-        LWRldmVsLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiOGM1NThjMTlmZjUwNzk4MjNm
-        Mjk4In0sICJpZCI6ICI1NmI4YzU1OGMxOWZmNTA3OTgyM2YyOTgifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:42:00 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/4a5b5eb4-4f8e-4933-a929-71736f596362/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="NB8SZ7XsiOL3NsyQUEjgc4C9vsGDqiqkSW41DOghI",
-        oauth_signature="peLKQKlSv0dNHVcU4x%2BeVWEl4LE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949721", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:42:01 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80YTViNWViNC00ZjhlLTQ5MzMtYTkyOS03MTczNmY1OTYz
-        NjIvIiwgInRhc2tfaWQiOiAiNGE1YjVlYjQtNGY4ZS00OTMzLWE5MjktNzE3
-        MzZmNTk2MzYyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo0MjowMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo0MjowMFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMTM0MDc2ZDEtMjI2Zi00MTZjLWJkNjUtMDRiMzA3YWJi
-        NTZmLyIsICJ0YXNrX2lkIjogIjEzNDA3NmQxLTIyNmYtNDE2Yy1iZDY1LTA0
-        YjMwN2FiYjU2ZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjNTU3MTdmMjVlMGRhNWE3YzgyZiJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NDI6MDBaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo0MjowMFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjNTU4MTdmMjVlMTEyYWU4OGFlNyIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNTU4YzE5ZmY1
-        MDc5ODIzZjI4OCJ9LCAiaWQiOiAiNTZiOGM1NThjMTlmZjUwNzk4MjNmMjg4
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:42:01 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/134076d1-226f-416c-bd65-04b307abb56f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="Rt46Kuo0HGi62u3H4ACCkOfoA3Jhi3UXc4ZEQw2tnY",
-        oauth_signature="jmrSkXuceW4sodHQKdVEmCk20X8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949721", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:42:01 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6941'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8xMzQwNzZkMS0yMjZmLTQxNmMtYmQ2NS0wNGIz
-        MDdhYmI1NmYvIiwgInRhc2tfaWQiOiAiMTM0MDc2ZDEtMjI2Zi00MTZjLWJk
-        NjUtMDRiMzA3YWJiNTZmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wOFQxNjo0MjowMVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo0MjowMVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJhMjYwMjM5ZC04NDQ2LTRlMDItODNkZi0zYzJmYTZm
-        OTE4ZTAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZjFlOGFkZGQtMTJjZi00MzY5LWI5YWMtMTUyZDFiOGQ5N2JiIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZDA0NzYwYjItYmE2Yi00MWE5LTlmNzUt
-        OGEzOTYwZmYxYWUwIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTMz
-        ZGYyNGMtOWU3NC00ZmEyLTk4N2MtMWZhYzlhODY4MmJjIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjkwZTA1MGJmLWI3NWEtNDc0Ni04NTA0LTMxM2Qy
-        YWEwZmM0OSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiNTY5ZDY5
-        Mi0wZWZlLTQ3NzUtYTliZi04OGVhNjQzMmEzZDUiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIxZTc0MzdiZi1iYWMzLTQ3ZjktOGRjNy1kZTc0
-        M2JlMjQ5MTEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIwZTU4NDVmZi0xZmIzLTQ4MTAtYTJlMy0xNmE2ODY2YzBjMTki
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0NTI2
-        NGQ0Zi05N2YwLTQ0YzEtOWQzNS04MTI4YmY4ZjgzYjMiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5M2NmN2VhNS1iMjg4
-        LTQ5YzYtOGZhMS1jNmNkNDMzY2NiYTEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjFkY2M0MGY3LTJhNWUtNGEz
-        MS05ZGMzLWQyMmU4YzI4YWU4ZiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Y2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAy
-        LTA4VDE2OjQyOjAxWiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMi
-        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMDhUMTY6NDI6MDFaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0
-        cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJ
-        UFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQi
-        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjog
-        IkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklO
-        SVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hf
-        ZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIs
-        ICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51
-        bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZi
-        OGM1NTkxN2YyNWUxMTJhZTg4YWU4IiwgImRldGFpbHMiOiBbeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
-        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
-        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImEyNjAyMzlkLTg0NDYtNGUwMi04M2Rm
-        LTNjMmZhNmY5MThlMCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
-        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJmMWU4YWRkZC0xMmNmLTQzNjktYjlhYy0xNTJkMWI4
-        ZDk3YmIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        OCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
-        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkMDQ3NjBiMi1iYTZiLTQx
-        YTktOWY3NS04YTM5NjBmZjFhZTAiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7
-        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI5MzNkZjI0Yy05ZTc0LTRmYTItOTg3Yy0xZmFjOWE4NjgyYmMiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
-        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTBlMDUwYmYtYjc1YS00NzQ2LTg1
-        MDQtMzEzZDJhYTBmYzQ5IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBz
-        IGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjog
-        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImI1NjlkNjkyLTBlZmUtNDc3NS1hOWJmLTg4ZWE2NDMyYTNkNSIsICJudW1f
-        cHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjFlNzQzN2JmLWJhYzMtNDdmOS04
-        ZGM3LWRlNzQzYmUyNDkxMSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjBlNTg0NWZmLTFmYjMtNDgxMC1hMmUzLTE2YTY4
-        NjZjMGMxOSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMi
-        LCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjQ1MjY0ZDRmLTk3ZjAtNDRjMS05ZDM1LTgxMjhiZjhmODNiMyIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBl
-        IjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjkzY2Y3
-        ZWE1LWIyODgtNDljNi04ZmExLWM2Y2Q0MzNjY2JhMSIsICJudW1fcHJvY2Vz
-        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
-        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMWRjYzQwZjct
-        MmE1ZS00YTMxLTlkYzMtZDIyZThjMjhhZThmIiwgIm51bV9wcm9jZXNzZWQi
-        OiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Yjhj
-        NTU4YzE5ZmY1MDc5ODIzZjI5OCJ9LCAiaWQiOiAiNTZiOGM1NThjMTlmZjUw
-        Nzk4MjNmMjk4In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:42:01 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/e06a366e-2b0b-4c11-bda9-39b219bd6fa9/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="mkbcYSbr9jIf3DtEzE86Aqk7mlAfNG7wwDuhCjhYGU",
-        oauth_signature="44UlrhvSqM8rqWDZWPTIs7yQ2Ws%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949722", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:42:02 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lMDZhMzY2ZS0yYjBiLTRjMTEtYmRhOS0zOWIyMTliZDZm
-        YTkvIiwgInRhc2tfaWQiOiAiZTA2YTM2NmUtMmIwYi00YzExLWJkYTktMzli
-        MjE5YmQ2ZmE5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI4YzU1
-        YWMxOWZmNTA3OTgyM2YyOTkifSwgImlkIjogIjU2YjhjNTVhYzE5ZmY1MDc5
-        ODIzZjI5OSJ9
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:42:02 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/e06a366e-2b0b-4c11-bda9-39b219bd6fa9/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="r2EnMDOoQkxzXriUsuPT5mboDcvKReg7JuyFagY32Q",
-        oauth_signature="5Nd1uW7a7P9nnhL4vCGArxSOkhY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949723", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:42:03 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '700'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lMDZhMzY2ZS0yYjBiLTRjMTEtYmRhOS0zOWIyMTliZDZm
-        YTkvIiwgInRhc2tfaWQiOiAiZTA2YTM2NmUtMmIwYi00YzExLWJkYTktMzli
-        MjE5YmQ2ZmE5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA4VDE2OjQyOjAyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA4VDE2OjQyOjAyWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20uZHEiLCAic3Rh
-        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUu
-        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNTZiOGM1NWFjMTlmZjUwNzk4MjNmMjk5In0sICJpZCI6ICI1
-        NmI4YzU1YWMxOWZmNTA3OTgyM2YyOTkifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:42:03 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/19e9443b-1a4d-4bda-8968-7793b28bb66f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="qRdPlh9StjMmsZvzSlTp9PdDXt5Qdoz1eGljRigz8",
-        oauth_signature="O3TMyoqQEil7myoDqj6EQhwPGCs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949724", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:42:04 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xOWU5NDQzYi0xYTRkLTRiZGEtODk2OC03NzkzYjI4YmI2
-        NmYvIiwgInRhc2tfaWQiOiAiMTllOTQ0M2ItMWE0ZC00YmRhLTg5NjgtNzc5
-        M2IyOGJiNjZmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiOGM1NWNj
-        MTlmZjUwNzk4MjNmMjliIn0sICJpZCI6ICI1NmI4YzU1Y2MxOWZmNTA3OTgy
-        M2YyOWIifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:42:04 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/19e9443b-1a4d-4bda-8968-7793b28bb66f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="HKQnKO4A2oCiKp6r9o70rdPXlHLfRfOQ7xB1t2UzPHw",
-        oauth_signature="Fmuaod8aH9DDB9Y8dsuD4FgH%2FHQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949725", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:42:05 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1096'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xOWU5NDQzYi0xYTRkLTRiZGEtODk2OC03NzkzYjI4YmI2
-        NmYvIiwgInRhc2tfaWQiOiAiMTllOTQ0M2ItMWE0ZC00YmRhLTg5NjgtNzc5
-        M2IyOGJiNjZmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0wOFQxNjo0MjowNFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJO
-        T1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIklOX1BS
-        T0dSRVNTIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
-        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
-        by1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1
-        bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29tIiwgInJl
-        c3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiOGM1NWNjMTlmZjUwNzk4MjNmMjliIn0sICJpZCI6ICI1NmI4YzU1Y2Mx
-        OWZmNTA3OTgyM2YyOWIifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:42:05 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/19e9443b-1a4d-4bda-8968-7793b28bb66f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="X38jIZbzNfSrhw1BPUwaSiL8130uRMeecMaJvo3wYD8",
-        oauth_signature="wscOdlv%2FKhrXNcEPQGhzmEkMrn4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949725", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:42:05 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xOWU5NDQzYi0xYTRkLTRiZGEtODk2OC03NzkzYjI4YmI2
-        NmYvIiwgInRhc2tfaWQiOiAiMTllOTQ0M2ItMWE0ZC00YmRhLTg5NjgtNzc5
-        M2IyOGJiNjZmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo0MjowNVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo0MjowNFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNDg5ZmQ1OGUtYzJjNi00YmY3LWE0ZmMtMDhhODFmMWZj
-        ZTQ0LyIsICJ0YXNrX2lkIjogIjQ4OWZkNThlLWMyYzYtNGJmNy1hNGZjLTA4
-        YTgxZjFmY2U0NCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjNTVjMTdmMjVlMGRhNDhiODQ0NSJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NDI6MDRaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo0MjowNVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjNTVkMTdmMjVlMTEyYWU4OGFlYyIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNTVjYzE5ZmY1
-        MDc5ODIzZjI5YiJ9LCAiaWQiOiAiNTZiOGM1NWNjMTlmZjUwNzk4MjNmMjli
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:42:05 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/489fd58e-c2c6-4bf7-a4fc-08a81f1fce44/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="5hHnbMVqfUEdEpz539KnTUyUOQCL9JQn74D4zuW15hA",
-        oauth_signature="ZDhHrVXqTzFd0Ol6BgzeO4F%2FllA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949725", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:42:05 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6941'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80ODlmZDU4ZS1jMmM2LTRiZjctYTRmYy0wOGE4
-        MWYxZmNlNDQvIiwgInRhc2tfaWQiOiAiNDg5ZmQ1OGUtYzJjNi00YmY3LWE0
-        ZmMtMDhhODFmMWZjZTQ0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wOFQxNjo0MjowNVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo0MjowNVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJiNWM2YjA1OC05ZmZkLTRjZGMtODE5OS1jZDlkMzdl
-        MDk2NWEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZWZhYmJmMzUtYWI2Ny00MWUxLTg1NWYtNTQ0YzQ0MGNkZmM0Iiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMTQ0MjMwOWMtMGU4ZC00NzhhLTgzNjMt
-        Y2Q1OGVhN2FkNTUyIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOGY4
-        YWZhODgtNzVhYi00NmJiLTg3YTYtZmU5NWU1ZWMyYjliIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjVmODkyMmRlLTZhNzYtNDRhMS05NmMwLWZiNjFm
-        Njk4MmU3MyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxOGM5MTM1
-        NS1kMjZhLTQ0OGMtYTZlMy02Y2Y3NGM1NjA3MjMiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJjNmY0MWUxYy1kNjUyLTQ2OWQtYTVhYy1mODU5
-        NDJkNWI2NGEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIxYmViYTMyYy04ODFiLTQwZWMtYThkNC02YWNiZGM4NWMyODQi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0Yzhi
-        MzdiYS1mZmQ5LTQzMWUtYjNhNi02NTE2MjlmNzA5YzQiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlZDFjNDg2MS0xNjNl
-        LTQyYmYtOWM0Yy1lYzY2NmRmYTU3OTMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBhM2VhOWM5LWU0MGEtNGFh
-        YS1hMDhkLTg1NzVhMGYwNmJkYyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Y2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAy
-        LTA4VDE2OjQyOjA1WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMi
-        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMDhUMTY6NDI6MDVaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0
-        cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJ
-        UFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQi
-        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjog
-        IkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklO
-        SVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hf
-        ZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIs
-        ICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51
-        bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZi
-        OGM1NWQxN2YyNWUxMTJhZTg4YWVkIiwgImRldGFpbHMiOiBbeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
-        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
-        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImI1YzZiMDU4LTlmZmQtNGNkYy04MTk5
-        LWNkOWQzN2UwOTY1YSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
-        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJlZmFiYmYzNS1hYjY3LTQxZTEtODU1Zi01NDRjNDQw
-        Y2RmYzQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        OCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
-        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNDQyMzA5Yy0wZThkLTQ3
-        OGEtODM2My1jZDU4ZWE3YWQ1NTIiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7
-        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI4ZjhhZmE4OC03NWFiLTQ2YmItODdhNi1mZTk1ZTVlYzJiOWIiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
-        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNWY4OTIyZGUtNmE3Ni00NGExLTk2
-        YzAtZmI2MWY2OTgyZTczIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBz
-        IGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjog
-        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjE4YzkxMzU1LWQyNmEtNDQ4Yy1hNmUzLTZjZjc0YzU2MDcyMyIsICJudW1f
-        cHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM2ZjQxZTFjLWQ2NTItNDY5ZC1h
-        NWFjLWY4NTk0MmQ1YjY0YSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjFiZWJhMzJjLTg4MWItNDBlYy1hOGQ0LTZhY2Jk
-        Yzg1YzI4NCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMi
-        LCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjRjOGIzN2JhLWZmZDktNDMxZS1iM2E2LTY1MTYyOWY3MDljNCIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBl
-        IjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVkMWM0
-        ODYxLTE2M2UtNDJiZi05YzRjLWVjNjY2ZGZhNTc5MyIsICJudW1fcHJvY2Vz
-        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
-        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGEzZWE5Yzkt
-        ZTQwYS00YWFhLWEwOGQtODU3NWEwZjA2YmRjIiwgIm51bV9wcm9jZXNzZWQi
-        OiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Yjhj
-        NTVkYzE5ZmY1MDc5ODIzZjJhYiJ9LCAiaWQiOiAiNTZiOGM1NWRjMTlmZjUw
-        Nzk4MjNmMmFiIn0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:42:05 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/70c6f5c0-ca7a-4d26-a4d5-4392154b3f9c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="vYhyyw43p4m96zdGF8Jy2YnVV6rgC4x1MIW2LGi84",
-        oauth_signature="s2p%2BChS6ddRmLyh5s09x5NljWEI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949726", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:42:06 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83MGM2ZjVjMC1jYTdhLTRkMjYtYTRkNS00MzkyMTU0YjNm
-        OWMvIiwgInRhc2tfaWQiOiAiNzBjNmY1YzAtY2E3YS00ZDI2LWE0ZDUtNDM5
-        MjE1NGIzZjljIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI4YzU1
-        ZWMxOWZmNTA3OTgyM2YyYWMifSwgImlkIjogIjU2YjhjNTVlYzE5ZmY1MDc5
-        ODIzZjJhYyJ9
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:42:06 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/70c6f5c0-ca7a-4d26-a4d5-4392154b3f9c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="bpJoVf2bPuhQSNSp5OMIEsTwHlyt1jSrw01iRVz8",
-        oauth_signature="szTz1gCo8LKukfcQvdMPsUgMbXo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949727", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:42:07 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '700'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83MGM2ZjVjMC1jYTdhLTRkMjYtYTRkNS00MzkyMTU0YjNm
-        OWMvIiwgInRhc2tfaWQiOiAiNzBjNmY1YzAtY2E3YS00ZDI2LWE0ZDUtNDM5
-        MjE1NGIzZjljIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA4VDE2OjQyOjA3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA4VDE2OjQyOjA2WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20uZHEiLCAic3Rh
-        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUu
-        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNTZiOGM1NWVjMTlmZjUwNzk4MjNmMmFjIn0sICJpZCI6ICI1
-        NmI4YzU1ZWMxOWZmNTA3OTgyM2YyYWMifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:42:07 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/1d7edd96-7893-43ad-96ae-33ead7ceadc6/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="DXmIzlPzb1WhDyHS7mNEzB4RMElFuaR7K973HxvYOk",
-        oauth_signature="DYfsbdpQ3uGCnjkOpPeiIvORWpA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949729", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:42:09 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xZDdlZGQ5Ni03ODkzLTQzYWQtOTZhZS0zM2VhZDdjZWFk
-        YzYvIiwgInRhc2tfaWQiOiAiMWQ3ZWRkOTYtNzg5My00M2FkLTk2YWUtMzNl
-        YWQ3Y2VhZGM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiOGM1NjFj
-        MTlmZjUwNzk4MjNmMmFlIn0sICJpZCI6ICI1NmI4YzU2MWMxOWZmNTA3OTgy
-        M2YyYWUifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:42:09 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/1d7edd96-7893-43ad-96ae-33ead7ceadc6/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="raNgpNU1ZbBaFGa3Kk5FbMrndLLmY8CWEvvW1DSo",
-        oauth_signature="Tb41DpvPHNVGHdXbpcq77zlKNo4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949729", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:42:09 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xZDdlZGQ5Ni03ODkzLTQzYWQtOTZhZS0zM2VhZDdjZWFk
-        YzYvIiwgInRhc2tfaWQiOiAiMWQ3ZWRkOTYtNzg5My00M2FkLTk2YWUtMzNl
-        YWQ3Y2VhZGM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo0MjowOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo0MjowOVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvOGZiNjc4NjQtN2ZjOC00M2MxLWFjNWQtYTQ2YmM0MmFk
-        M2YxLyIsICJ0YXNrX2lkIjogIjhmYjY3ODY0LTdmYzgtNDNjMS1hYzVkLWE0
-        NmJjNDJhZDNmMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjNTYwMTdmMjVlMGRhNWE3YzgzOCJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NDI6MDlaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo0MjowOVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjNTYxMTdmMjVlMTEyYWU4OGFmMSIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNTYxYzE5ZmY1
-        MDc5ODIzZjJhZSJ9LCAiaWQiOiAiNTZiOGM1NjFjMTlmZjUwNzk4MjNmMmFl
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:42:09 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/8fb67864-7fc8-43c1-ac5d-a46bc42ad3f1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="KnQbPzn1nqOPgq7AqP1BYuaTOUlETbFymLA8pNXJg",
-        oauth_signature="c5i9l8Kna0sfw%2F0D0IgpO6paAR8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949729", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:42:09 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6941'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84ZmI2Nzg2NC03ZmM4LTQzYzEtYWM1ZC1hNDZi
-        YzQyYWQzZjEvIiwgInRhc2tfaWQiOiAiOGZiNjc4NjQtN2ZjOC00M2MxLWFj
-        NWQtYTQ2YmM0MmFkM2YxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wOFQxNjo0MjowOVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo0MjowOVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI5ZTkzZTgyMy0zNzczLTRiMmEtYTlhNy04YjY4OGJl
-        ZDNmMDgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZmIwMDFkMmMtYzM0ZC00ZTE2LWIzMzItZWE0NzRjOGEzMTRmIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiOTNmMjY2NzYtZWI1ZS00MmZjLTlhNGEt
-        Nzk3YjExNjQ2YWIwIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjc1
-        ZDA5YmMtNGNjZi00NjEzLWI2ZGEtY2FlM2FmNmZjYWMyIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjdkODZlOGE3LTIwZjUtNDk1Yy04ODliLTAzNzVi
-        MTlhZDBlOSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1NzQwNTRh
-        Zi02ZTYwLTQ2ZDQtOGM2Mi0zMDQ5OTJiOTc2YzkiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI4MzIxMjBmNy1iZTE2LTQzZWYtOGJmMy1jMTBj
-        NzgzNzUyMmQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJlZWYzN2ViNi03MjcyLTQ1NTctYWExNi0xOTY3N2E0Mjg5MzYi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyYzRm
-        MDRmMi0xMDM5LTQ2MjQtYmMwNS1hMjA1MDgyOWQ0NjgiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwY2NlOTVjNy1jY2Zj
-        LTQxMGItYmRlZi1jOWI5MTYyN2ZhNzgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjVlNGRlZTQwLTk4ODItNDVk
-        Ni1iZjFkLTE2OTZlNDk5YjNmMiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Y2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAy
-        LTA4VDE2OjQyOjA5WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMi
-        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMDhUMTY6NDI6MDlaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0
-        cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJ
-        UFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQi
-        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjog
-        IkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklO
-        SVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hf
-        ZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIs
-        ICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51
-        bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZi
-        OGM1NjExN2YyNWUxMTJhZTg4YWYyIiwgImRldGFpbHMiOiBbeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
-        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
-        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjllOTNlODIzLTM3NzMtNGIyYS1hOWE3
-        LThiNjg4YmVkM2YwOCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
-        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJmYjAwMWQyYy1jMzRkLTRlMTYtYjMzMi1lYTQ3NGM4
-        YTMxNGYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        OCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
-        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5M2YyNjY3Ni1lYjVlLTQy
-        ZmMtOWE0YS03OTdiMTE2NDZhYjAiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7
-        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI2NzVkMDliYy00Y2NmLTQ2MTMtYjZkYS1jYWUzYWY2ZmNhYzIiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
-        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiN2Q4NmU4YTctMjBmNS00OTVjLTg4
-        OWItMDM3NWIxOWFkMGU5IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBz
-        IGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjog
-        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjU3NDA1NGFmLTZlNjAtNDZkNC04YzYyLTMwNDk5MmI5NzZjOSIsICJudW1f
-        cHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjgzMjEyMGY3LWJlMTYtNDNlZi04
-        YmYzLWMxMGM3ODM3NTIyZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImVlZjM3ZWI2LTcyNzItNDU1Ny1hYTE2LTE5Njc3
-        YTQyODkzNiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMi
-        LCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjJjNGYwNGYyLTEwMzktNDYyNC1iYzA1LWEyMDUwODI5ZDQ2OCIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBl
-        IjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBjY2U5
-        NWM3LWNjZmMtNDEwYi1iZGVmLWM5YjkxNjI3ZmE3OCIsICJudW1fcHJvY2Vz
-        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
-        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNWU0ZGVlNDAt
-        OTg4Mi00NWQ2LWJmMWQtMTY5NmU0OTliM2YyIiwgIm51bV9wcm9jZXNzZWQi
-        OiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Yjhj
-        NTYxYzE5ZmY1MDc5ODIzZjJiZSJ9LCAiaWQiOiAiNTZiOGM1NjFjMTlmZjUw
-        Nzk4MjNmMmJlIn0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:42:09 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/7c781436-1195-4ec7-ac78-c393ea8d38ba/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="h7F7rFWhtr5i96TbnFGKAvhBjAb9iIyZXUdwHgQ8E",
-        oauth_signature="vOQ1bz5qnjWL%2BhVftniEr8ELyEU%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949730", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:42:10 GMT
+      - Tue, 23 Feb 2016 16:47:17 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -13132,24 +367,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83Yzc4MTQzNi0xMTk1LTRlYzctYWM3OC1jMzkzZWE4ZDM4
-        YmEvIiwgInRhc2tfaWQiOiAiN2M3ODE0MzYtMTE5NS00ZWM3LWFjNzgtYzM5
-        M2VhOGQzOGJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9mNzg0MTgxZC1jOTIzLTRhNmYtYjEzYS05ODBlODJhZDRl
+        MTIvIiwgInRhc2tfaWQiOiAiZjc4NDE4MWQtYzkyMy00YTZmLWIxM2EtOTgw
+        ZTgyYWQ0ZTEyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20u
-        ZHEiLCAic3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwu
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ3OjE3WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
         ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
-        Il9pZCI6IHsiJG9pZCI6ICI1NmI4YzU2MmMxOWZmNTA3OTgyM2YyYmYifSwg
-        ImlkIjogIjU2YjhjNTYyYzE5ZmY1MDc5ODIzZjJiZiJ9
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQxNTk4OTA1NGZjNDhiYTJlNjAifSwg
+        ImlkIjogIjU2Y2M4ZDE1OTg5MDU0ZmM0OGJhMmU2MCJ9
     http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:42:10 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:17 GMT
 - request:
     method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/7c781436-1195-4ec7-ac78-c393ea8d38ba/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/f784181d-c923-4a6f-b13a-980e82ad4e12/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -13160,12 +395,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="opTayXECHtqlWRMzswrzKGzYiBUp11cpSZihQAXxQ",
-        oauth_signature="Vnp9s5kMMkFn6D5FaXL%2FrGJysnE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949731", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -13174,13 +403,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 08 Feb 2016 16:42:11 GMT
+      - Tue, 23 Feb 2016 16:47:18 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '700'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -13190,561 +419,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83Yzc4MTQzNi0xMTk1LTRlYzctYWM3OC1jMzkzZWE4ZDM4
-        YmEvIiwgInRhc2tfaWQiOiAiN2M3ODE0MzYtMTE5NS00ZWM3LWFjNzgtYzM5
-        M2VhOGQzOGJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9mNzg0MTgxZC1jOTIzLTRhNmYtYjEzYS05ODBlODJhZDRl
+        MTIvIiwgInRhc2tfaWQiOiAiZjc4NDE4MWQtYzkyMy00YTZmLWIxM2EtOTgw
+        ZTgyYWQ0ZTEyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA4VDE2OjQyOjEwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA4VDE2OjQyOjEwWiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ3OjE3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ3OjE3WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20uZHEiLCAic3Rh
-        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUu
-        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNTZiOGM1NjJjMTlmZjUwNzk4MjNmMmJmIn0sICJpZCI6ICI1
-        NmI4YzU2MmMxOWZmNTA3OTgyM2YyYmYifQ==
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMTU5
+        ODkwNTRmYzQ4YmEyZTYwIn0sICJpZCI6ICI1NmNjOGQxNTk4OTA1NGZjNDhi
+        YTJlNjAifQ==
     http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:42:11 GMT
-- request:
-    method: post
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
-        IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRp
-        c3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwi
-        OiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3Rl
-        Y3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJleHBvcnRfZGlzdHJpYnV0
-        b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBz
-        IjpmYWxzZSwicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIn0sImF1dG9fcHVi
-        bGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1
-        dG9yIn1dfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb",
-        oauth_nonce="dDh89Xpll5WIqoYvaYwYVDwWoPA0Wa2euTwOEvyKE", oauth_signature="BQwHE7fw5qRMYXcORJ1rrcht%2B3Q%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454949732", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '817'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:42:12 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '320'
-      Location:
-      - https://katello-centos7-devel.example.com/pulp/api/v2/repositories/Fedora_17/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: US-ASCII
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiOGM1NjQxN2YyNWUwZGE1YTdjODNjIn0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:42:12 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:18 GMT
 - request:
     method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/9f39e2c6-88d6-4d48-8ff4-ab41206e9bec/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="ypfvBoWmRg1q8UWrZ6xTbN1g3JXuipfjp2CnaoDiA",
-        oauth_signature="3gq6QYXSuXYEBf2sIgLYGLwPGNY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949733", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:42:13 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '661'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85ZjM5ZTJjNi04OGQ2LTRkNDgtOGZmNC1hYjQxMjA2ZTli
-        ZWMvIiwgInRhc2tfaWQiOiAiOWYzOWUyYzYtODhkNi00ZDQ4LThmZjQtYWI0
-        MTIwNmU5YmVjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRx
-        IiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
-        ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
-        aWQiOiB7IiRvaWQiOiAiNTZiOGM1NjVjMTlmZjUwNzk4MjNmMmMxIn0sICJp
-        ZCI6ICI1NmI4YzU2NWMxOWZmNTA3OTgyM2YyYzEifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:42:13 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/9f39e2c6-88d6-4d48-8ff4-ab41206e9bec/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="TH7vgQSWVSyqqKfm9dVpMDVXBIwqJWv4l85u3IMRLE",
-        oauth_signature="7Hyr5DUGeHpcLHAErYyMS8dLEVU%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949733", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:42:13 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85ZjM5ZTJjNi04OGQ2LTRkNDgtOGZmNC1hYjQxMjA2ZTli
-        ZWMvIiwgInRhc2tfaWQiOiAiOWYzOWUyYzYtODhkNi00ZDQ4LThmZjQtYWI0
-        MTIwNmU5YmVjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo0MjoxM1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo0MjoxM1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNzZiODI5MzItNDgzMi00MjU1LWE3OTgtZjEyODI2MGNm
-        ODRjLyIsICJ0YXNrX2lkIjogIjc2YjgyOTMyLTQ4MzItNDI1NS1hNzk4LWYx
-        MjgyNjBjZjg0YyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjNTY0MTdmMjVlMGRhNWE3YzgzZCJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NDI6MTNaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo0MjoxM1oiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjNTY1MTdmMjVlMTEyYWU4OGFmNiIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNTY1YzE5ZmY1
-        MDc5ODIzZjJjMSJ9LCAiaWQiOiAiNTZiOGM1NjVjMTlmZjUwNzk4MjNmMmMx
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:42:13 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/76b82932-4832-4255-a798-f128260cf84c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="Od9DFwlBQA5rUCHmZS4CmPlpPsxoL7dXYqlht2qv7Z8",
-        oauth_signature="jeZYMkagCfTo%2BiET5NoZcnoKOqc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949733", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:42:13 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6941'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy83NmI4MjkzMi00ODMyLTQyNTUtYTc5OC1mMTI4
-        MjYwY2Y4NGMvIiwgInRhc2tfaWQiOiAiNzZiODI5MzItNDgzMi00MjU1LWE3
-        OTgtZjEyODI2MGNmODRjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wOFQxNjo0MjoxM1oiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo0MjoxM1oiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI1MmM0MDY1NC01YWUyLTQ0MTYtYmQ2YS1kZjVjNTU3
-        YjY4MjMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNTcyYWVhM2MtZDkwNy00ZmY2LTg3OTEtNTU4MjkzMTc2YWZiIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNmE3NDdkY2QtYjE1Zi00MjhiLTlmZDAt
-        Y2IzNDY5MzkxMWU1IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjQ4
-        MGQ4MGQtYzJhOS00YTVjLWExYzgtNjZkZTg2Y2RiZjJiIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImE5ZTVlM2Q2LTk5ZTEtNDA3Ni1hNjFlLTI5ZmY5
-        ZjE4MDM4OSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwMTk1NTIx
-        OC1lNmFiLTQ4MzYtYmNiMi1mZTY2OTMxOTZmNjAiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJhODA1NGVjOC1hYzAxLTQ3NDktYTlkMS1lNDA4
-        YTZiNTE3ZjciLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJkZGNhNDFiNS1jNzUyLTQyYjItODlkZS0zYmNkNjQ3NjdkMTQi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNGM5
-        NDFlZS1kOWI1LTQyZGQtODQxNS00MWE1N2VmOGIyY2EiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkNmFlZjEzOS00Mzg4
-        LTRhYjktYWExYy1lNzIyYWIwZGE5NTgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjJmY2RkZmVhLWUwOTUtNDAw
-        Mi04YTRhLTQwNTM3MzZlMjE2ZSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Y2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAy
-        LTA4VDE2OjQyOjEzWiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMi
-        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMDhUMTY6NDI6MTNaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0
-        cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJ
-        UFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQi
-        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjog
-        IkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklO
-        SVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hf
-        ZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIs
-        ICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51
-        bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZi
-        OGM1NjUxN2YyNWUxMTJhZTg4YWY3IiwgImRldGFpbHMiOiBbeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
-        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
-        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjUyYzQwNjU0LTVhZTItNDQxNi1iZDZh
-        LWRmNWM1NTdiNjgyMyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
-        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI1NzJhZWEzYy1kOTA3LTRmZjYtODc5MS01NTgyOTMx
-        NzZhZmIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        OCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
-        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2YTc0N2RjZC1iMTVmLTQy
-        OGItOWZkMC1jYjM0NjkzOTExZTUiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7
-        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI2NDgwZDgwZC1jMmE5LTRhNWMtYTFjOC02NmRlODZjZGJmMmIiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
-        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTllNWUzZDYtOTllMS00MDc2LWE2
-        MWUtMjlmZjlmMTgwMzg5IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBz
-        IGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjog
-        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjAxOTU1MjE4LWU2YWItNDgzNi1iY2IyLWZlNjY5MzE5NmY2MCIsICJudW1f
-        cHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE4MDU0ZWM4LWFjMDEtNDc0OS1h
-        OWQxLWU0MDhhNmI1MTdmNyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImRkY2E0MWI1LWM3NTItNDJiMi04OWRlLTNiY2Q2
-        NDc2N2QxNCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMi
-        LCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjA0Yzk0MWVlLWQ5YjUtNDJkZC04NDE1LTQxYTU3ZWY4YjJjYSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBl
-        IjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ2YWVm
-        MTM5LTQzODgtNGFiOS1hYTFjLWU3MjJhYjBkYTk1OCIsICJudW1fcHJvY2Vz
-        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
-        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmZjZGRmZWEt
-        ZTA5NS00MDAyLThhNGEtNDA1MzczNmUyMTZlIiwgIm51bV9wcm9jZXNzZWQi
-        OiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Yjhj
-        NTY1YzE5ZmY1MDc5ODIzZjJkMSJ9LCAiaWQiOiAiNTZiOGM1NjVjMTlmZjUw
-        Nzk4MjNmMmQxIn0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:42:13 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/3e9ac17d-7832-4011-b588-66317332482c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="tc1CviUqlQOR9tJQbVcp2HqXVoafGT5LADGWJiKLs",
-        oauth_signature="Xt1WVON%2B2afHN1jI838NNKh5pTM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949734", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:42:14 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zZTlhYzE3ZC03ODMyLTQwMTEtYjU4OC02NjMxNzMzMjQ4
-        MmMvIiwgInRhc2tfaWQiOiAiM2U5YWMxN2QtNzgzMi00MDExLWI1ODgtNjYz
-        MTczMzI0ODJjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI4YzU2
-        NmMxOWZmNTA3OTgyM2YyZDIifSwgImlkIjogIjU2YjhjNTY2YzE5ZmY1MDc5
-        ODIzZjJkMiJ9
-    http_version:
-  recorded_at: Mon, 08 Feb 2016 16:42:14 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/3e9ac17d-7832-4011-b588-66317332482c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="fJh2ACBFd6JnR2Z0qKKbbnvAEqRl1Khoue7Ms3pwnSs",
-        oauth_signature="O7SKKg0eFD%2B2O2onruGnY8ZJNz4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454949735", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:42:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '700'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zZTlhYzE3ZC03ODMyLTQwMTEtYjU4OC02NjMxNzMzMjQ4
-        MmMvIiwgInRhc2tfaWQiOiAiM2U5YWMxN2QtNzgzMi00MDExLWI1ODgtNjYz
-        MTczMzI0ODJjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA4VDE2OjQyOjE0WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA4VDE2OjQyOjE0WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20uZHEiLCAic3Rh
-        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUu
-        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNTZiOGM1NjZjMTlmZjUwNzk4MjNmMmQyIn0sICJpZCI6ICI1
-        NmI4YzU2NmMxOWZmNTA3OTgyM2YyZDIifQ==
-    http_version:
-  recorded_at: Mon, 08 Feb 2016 16:42:15 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/378e23e0-4a88-4f97-8c7c-fb07f43b5b29/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/06de39d2-a1f4-4eff-a72f-c51630281461/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -13763,7 +456,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:02 GMT
+      - Tue, 23 Feb 2016 16:47:19 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -13779,22 +472,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zNzhlMjNlMC00YTg4LTRmOTctOGM3Yy1mYjA3ZjQzYjVi
-        MjkvIiwgInRhc2tfaWQiOiAiMzc4ZTIzZTAtNGE4OC00Zjk3LThjN2MtZmIw
-        N2Y0M2I1YjI5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8wNmRlMzlkMi1hMWY0LTRlZmYtYTcyZi1jNTE2MzAyODE0
+        NjEvIiwgInRhc2tfaWQiOiAiMDZkZTM5ZDItYTFmNC00ZWZmLWE3MmYtYzUx
+        NjMwMjgxNDYxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
         ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiZDA0MjYz
-        NDQ3MWU0MDA3MGIwOTgwIn0sICJpZCI6ICI1NmJkMDQyNjM0NDcxZTQwMDcw
-        YjA5ODAifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:02 GMT
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMTc5
+        ODkwNTRmYzQ4YmEyZTYyIn0sICJpZCI6ICI1NmNjOGQxNzk4OTA1NGZjNDhi
+        YTJlNjIifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:19 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/378e23e0-4a88-4f97-8c7c-fb07f43b5b29/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/06de39d2-a1f4-4eff-a72f-c51630281461/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -13813,13 +506,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:02 GMT
+      - Tue, 23 Feb 2016 16:47:19 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2324'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -13829,16 +522,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zNzhlMjNlMC00YTg4LTRmOTctOGM3Yy1mYjA3ZjQzYjVi
-        MjkvIiwgInRhc2tfaWQiOiAiMzc4ZTIzZTAtNGE4OC00Zjk3LThjN2MtZmIw
-        N2Y0M2I1YjI5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8wNmRlMzlkMi1hMWY0LTRlZmYtYTcyZi1jNTE2MzAyODE0
+        NjEvIiwgInRhc2tfaWQiOiAiMDZkZTM5ZDItYTFmNC00ZWZmLWE3MmYtYzUx
+        NjMwMjgxNDYxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMTo1OTowMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMTo1OTowMloiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0NzoxOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0NzoxOVoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvOTFhMTBkYjQtODc1YS00ZTlhLTljNmMtZGUzMDNkZjY5
-        YjgwLyIsICJ0YXNrX2lkIjogIjkxYTEwZGI0LTg3NWEtNGU5YS05YzZjLWRl
-        MzAzZGY2OWI4MCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvZDQwMTlkZmYtNjNhYi00MjVmLWEzYTItZDU2N2YxM2Nk
+        NTc0LyIsICJ0YXNrX2lkIjogImQ0MDE5ZGZmLTYzYWItNDI1Zi1hM2EyLWQ1
+        NjdmMTNjZDU3NCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -13849,41 +542,41 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDQy
-        NTY3N2M3NDJkMDZjY2NkZmUifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIxOjU5OjAyWiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjE6NTk6MDJa
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA0MjY2NzdjNzQwODEyMzIyM2YwIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNDI2MzQ0NzFlNDAwNzBiMDk4MCJ9LCAiaWQi
-        OiAiNTZiZDA0MjYzNDQ3MWU0MDA3MGIwOTgwIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:02 GMT
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQxNmRlMDQw
+        MzNmNDM1MTRmNTEifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ3OjE5WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDc6MTlaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkMTdk
+        ZTA0MDMwODk3NThhODU2IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDE3OTg5MDU0ZmM0OGJhMmU2MiJ9LCAiaWQiOiAiNTZj
+        YzhkMTc5ODkwNTRmYzQ4YmEyZTYyIn0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:19 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/91a10db4-875a-4e9a-9c6c-de303df69b80/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/d4019dff-63ab-425f-a3a2-d567f13cd574/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -13902,13 +595,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:02 GMT
+      - Tue, 23 Feb 2016 16:47:19 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '3529'
+      - '6923'
       Connection:
       - close
       Content-Type:
@@ -13918,1009 +611,163 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy85MWExMGRiNC04NzVhLTRlOWEtOWM2Yy1kZTMw
-        M2RmNjliODAvIiwgInRhc2tfaWQiOiAiOTFhMTBkYjQtODc1YS00ZTlhLTlj
-        NmMtZGUzMDNkZjY5YjgwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy9kNDAxOWRmZi02M2FiLTQyNWYtYTNhMi1kNTY3
+        ZjEzY2Q1NzQvIiwgInRhc2tfaWQiOiAiZDQwMTlkZmYtNjNhYi00MjVmLWEz
+        YTItZDU2N2YxM2NkNTc0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0xMVQyMTo1OTowMloiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJk
-        ZTRlMDhiZi0xYzYwLTQ4YTEtODQ4Mi0xYzlmYjhhNjU1ZDkiLCAibnVtX3By
-        b2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlw
-        ZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDIwYzhl
-        NmYtYjViYy00YzkyLTg2YjMtMmVkYjAxZjY2MWJiIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNf
-        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiMjlkYmU4ODMtNzE1Ny00ZWQ0LWE5YmUtMjk1NGQ5MjQx
-        YjhiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3Rl
-        cF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjU5MTlkZWQw
-        LTljNjEtNGQ1MC04NWY3LTk1Mjc1ZDViYWZhMSIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVt
-        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJkMjVkOTAyMC1kMDE3LTRiNWItOThjZi01YmIxNWEy
-        NGQ1NTYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJz
-        dGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTE5MjVh
-        ZDYtOWIyNi00MzczLTk4NmUtMjFkMDkxNjg0YjJiIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEi
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMWFlYzgwZDEtZTVkMC00Zjc2LTlhZTIt
-        ZTUyZDA3OTAwYjI2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRh
-        dGEiLCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiODhlOWI0ZjYtZmI2Zi00ZWNmLTk5MmMtYWI1ZTNl
-        OWI0YTRhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
-        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIs
-        ICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjI5YzA0ODk1LTJjYjQtNDAyYi1hODZmLTZhYWJjOTk4NTgxMCIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
-        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90
-        eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjEwZWZiMThjLTQxNmItNGRmNC05NDgxLTFjZWZhNDAxMWNlMyIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJp
-        bml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        ODExMzkwMjYtYzJkOS00YmFhLThhMTUtZGFlNWI4Y2QzYjVkIiwgIm51bV9w
-        cm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tLmRxIiwgInN0
-        YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwg
-        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNTZiZDA0MjYzNDQ3MWU0MDA3MGIwOTkwIn0sICJpZCI6ICI1NmJkMDQy
-        NjM0NDcxZTQwMDcwYjA5OTAifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:02 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/378e23e0-4a88-4f97-8c7c-fb07f43b5b29/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:59:03 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2324'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zNzhlMjNlMC00YTg4LTRmOTctOGM3Yy1mYjA3ZjQzYjVi
-        MjkvIiwgInRhc2tfaWQiOiAiMzc4ZTIzZTAtNGE4OC00Zjk3LThjN2MtZmIw
-        N2Y0M2I1YjI5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMTo1OTowMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMTo1OTowMloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvOTFhMTBkYjQtODc1YS00ZTlhLTljNmMtZGUzMDNkZjY5
-        YjgwLyIsICJ0YXNrX2lkIjogIjkxYTEwZGI0LTg3NWEtNGU5YS05YzZjLWRl
-        MzAzZGY2OWI4MCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDQy
-        NTY3N2M3NDJkMDZjY2NkZmUifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIxOjU5OjAyWiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjE6NTk6MDJa
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA0MjY2NzdjNzQwODEyMzIyM2YwIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNDI2MzQ0NzFlNDAwNzBiMDk4MCJ9LCAiaWQi
-        OiAiNTZiZDA0MjYzNDQ3MWU0MDA3MGIwOTgwIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:03 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/91a10db4-875a-4e9a-9c6c-de303df69b80/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:59:03 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy85MWExMGRiNC04NzVhLTRlOWEtOWM2Yy1kZTMw
-        M2RmNjliODAvIiwgInRhc2tfaWQiOiAiOTFhMTBkYjQtODc1YS00ZTlhLTlj
-        NmMtZGUzMDNkZjY5YjgwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0xMVQyMTo1OTowM1oiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMTo1OTowMloiLCAi
+        bWUiOiAiMjAxNi0wMi0yM1QxNjo0NzoxOVoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0NzoxOVoiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJkZTRlMDhiZi0xYzYwLTQ4YTEtODQ4Mi0xYzlmYjhh
-        NjU1ZDkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICI0ODljYzdkMS1mNjc1LTQ4YzAtODVhYi02NWI5ZjFm
+        MTU4Y2MiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZDIwYzhlNmYtYjViYy00YzkyLTg2YjMtMmVkYjAxZjY2MWJiIiwg
+        aWQiOiAiY2UxOGNjN2YtMDEwNi00ODlhLTk3YjUtOWFkYjQ5ZWIwMTQ4Iiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
         bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMjlkYmU4ODMtNzE1Ny00ZWQ0LWE5YmUt
-        Mjk1NGQ5MjQxYjhiIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiYjg3MmNkYWItMzFkNC00MzYyLWJlNmYt
+        NGZiOTU1M2E3ZGUwIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
         TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTkx
-        OWRlZDAtOWM2MS00ZDUwLTg1ZjctOTUyNzVkNWJhZmExIiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOWI5
+        MzZjOTEtOTQzOC00MWQ3LWJmYmEtODU2ZTM4ZjFkMTBkIiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImQyNWQ5MDIwLWQwMTctNGI1Yi05OGNmLTViYjE1
-        YTI0ZDU1NiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        IDAsICJzdGVwX2lkIjogImFjYmE3ZDNhLWRmM2ItNGFiZS04MDE3LTIyNzli
+        NzljMjc5ZCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
         OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
         InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhMTkyNWFk
-        Ni05YjI2LTQzNzMtOTg2ZS0yMWQwOTE2ODRiMmIiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1YmExNjFj
+        ZS00ZWE1LTQ1MDktOTgzNS00ZjkzNGVlZjMzMzMiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
         Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIxYWVjODBkMS1lNWQwLTRmNzYtOWFlMi1lNTJk
-        MDc5MDBiMjYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICI2ZjhlNjA5Mi0yNDk5LTQ1NGUtOTcyYS04MTZm
+        YmJkOGYyN2MiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
         ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI4OGU5YjRmNi1mYjZmLTRlY2YtOTkyYy1hYjVlM2U5YjRhNGEi
+        cF9pZCI6ICJiNDU5ZjUyMS1kNjQ2LTQ3NGUtOWU5Ni1iODgzYThmYWQ1OWUi
         LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
         dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
         c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyOWMw
-        NDg5NS0yY2I0LTQwMmItYTg2Zi02YWFiYzk5ODU4MTAiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNzRj
+        NzE3ZS00NTcxLTRiZTctYWU2YS00M2JiMjUwMjkzMTgiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
         aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxMGVmYjE4Yy00MTZi
-        LTRkZjQtOTQ4MS0xY2VmYTQwMTFjZTMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3YWQ4OTAyNy1jZTdi
+        LTQxZGEtYTE2Yi1iM2ZmNDViMmVjMDUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
         TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
         X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjgxMTM5MDI2LWMyZDktNGJh
-        YS04YTE1LWRhZTViOGNkM2I1ZCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8t
-        YnVycml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBr
-        YXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTExVDIxOjU5OjAy
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMTFUMjE6NTk6MDNaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiZDA0Mjc2NzdjNzQw
-        ODEyMzIyM2YxIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImRlNGUwOGJmLTFjNjAtNDhhMS04NDgyLTFjOWZiOGE2NTVk
-        OSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJkMjBjOGU2Zi1iNWJjLTRjOTItODZiMy0yZWRiMDFmNjYxYmIiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIyOWRiZTg4My03MTU3LTRlZDQtYTliZS0yOTU0
-        ZDkyNDFiOGIiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1OTE5ZGVk
-        MC05YzYxLTRkNTAtODVmNy05NTI3NWQ1YmFmYTEiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiZDI1ZDkwMjAtZDAxNy00YjViLTk4Y2YtNWJiMTVhMjRk
-        NTU2IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImExOTI1YWQ2LTli
-        MjYtNDM3My05ODZlLTIxZDA5MTY4NGIyYiIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjFhZWM4MGQxLWU1ZDAtNGY3Ni05YWUyLWU1MmQwNzkw
-        MGIyNiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjg0MGMyZWRlLThhZjctNGE3
+        ZS1iZTU2LWE4MzYxYWM4ZGM0YyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
+        c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
+        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ3OjE5WiIsICJf
+        bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
+        MTYtMDItMjNUMTY6NDc6MTlaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
+        cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
+        IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
+        X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
+        RCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1z
+        IjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0
+        aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
+        SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
+        U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
+        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZjYzhkMTdkZTA0MDMwODk3NThh
+        ODU3IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
         IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjg4ZTliNGY2LWZiNmYtNGVjZi05OTJjLWFiNWUzZTliNGE0YSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI5YzA0ODk1
-        LTJjYjQtNDAyYi1hODZmLTZhYWJjOTk4NTgxMCIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjEwZWZiMThjLTQxNmItNGRm
-        NC05NDgxLTFjZWZhNDAxMWNlMyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODExMzkwMjYtYzJkOS00YmFhLThh
-        MTUtZGFlNWI4Y2QzYjVkIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmQwNDI2MzQ0NzFlNDAw
-        NzBiMDk5MCJ9LCAiaWQiOiAiNTZiZDA0MjYzNDQ3MWU0MDA3MGIwOTkwIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:03 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/0a3a8031-17d3-49d9-a761-7a0864076efd/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:59:04 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '669'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wYTNhODAzMS0xN2QzLTQ5ZDktYTc2MS03YTA4NjQwNzZl
-        ZmQvIiwgInRhc2tfaWQiOiAiMGEzYTgwMzEtMTdkMy00OWQ5LWE3NjEtN2Ew
-        ODY0MDc2ZWZkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
-        LTAyLTExVDIxOjU5OjA0WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
-        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRlbGxvLWJ1cnJpdG8u
-        ZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRlbGxvLWJ1
-        cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjog
-        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJkMDQyODM0NDcxZTQwMDcwYjA5
-        OTEifSwgImlkIjogIjU2YmQwNDI4MzQ0NzFlNDAwNzBiMDk5MSJ9
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:04 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/0a3a8031-17d3-49d9-a761-7a0864076efd/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:59:05 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wYTNhODAzMS0xN2QzLTQ5ZDktYTc2MS03YTA4NjQwNzZl
-        ZmQvIiwgInRhc2tfaWQiOiAiMGEzYTgwMzEtMTdkMy00OWQ5LWE3NjEtN2Ew
-        ODY0MDc2ZWZkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTExVDIxOjU5OjA0WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTExVDIxOjU5OjA0WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZDA0MjgzNDQ3MWU0MDA3MGIwOTkxIn0sICJpZCI6ICI1NmJkMDQyODM0NDcx
-        ZTQwMDcwYjA5OTEifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:05 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/336bb950-7aca-406d-8fde-fadfcec7580d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:59:06 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '649'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zMzZiYjk1MC03YWNhLTQwNmQtOGZkZS1mYWRmY2VjNzU4
-        MGQvIiwgInRhc2tfaWQiOiAiMzM2YmI5NTAtN2FjYS00MDZkLThmZGUtZmFk
-        ZmNlYzc1ODBkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tLmRxIiwgInN0
-        YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwg
-        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNTZiZDA0MmEzNDQ3MWU0MDA3MGIwOTkzIn0sICJpZCI6ICI1NmJkMDQy
-        YTM0NDcxZTQwMDcwYjA5OTMifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:06 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/336bb950-7aca-406d-8fde-fadfcec7580d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:59:07 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2324'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zMzZiYjk1MC03YWNhLTQwNmQtOGZkZS1mYWRmY2VjNzU4
-        MGQvIiwgInRhc2tfaWQiOiAiMzM2YmI5NTAtN2FjYS00MDZkLThmZGUtZmFk
-        ZmNlYzc1ODBkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMTo1OTowN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMTo1OTowNloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNDhjYmRjY2EtNTIzMy00YTcwLThlYTctZGIyMGIyM2Iy
-        YWU0LyIsICJ0YXNrX2lkIjogIjQ4Y2JkY2NhLTUyMzMtNGE3MC04ZWE3LWRi
-        MjBiMjNiMmFlNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDQy
-        YTY3N2M3NDJkMDZjY2NlMDIifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIxOjU5OjA2WiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjE6NTk6MDda
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA0MmI2NzdjNzQwODEyMzIyM2Y1IiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNDJhMzQ0NzFlNDAwNzBiMDk5MyJ9LCAiaWQi
-        OiAiNTZiZDA0MmEzNDQ3MWU0MDA3MGIwOTkzIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:07 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/48cbdcca-5233-4a70-8ea7-db20b23b2ae4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:59:07 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3507'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80OGNiZGNjYS01MjMzLTRhNzAtOGVhNy1kYjIw
-        YjIzYjJhZTQvIiwgInRhc2tfaWQiOiAiNDhjYmRjY2EtNTIzMy00YTcwLThl
-        YTctZGIyMGIyM2IyYWU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0xMVQyMTo1OTowN1oiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        IjogIjQ4OWNjN2QxLWY2NzUtNDhjMC04NWFiLTY1YjlmMWYxNThjYyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiODRj
-        OWUyYy05MzQ0LTQ5ZDEtYmMxNS0xMzVmNGU0Mjg2NjciLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNmFlYWU4MTgtNTM2
-        Ny00OTMzLWE4NjAtMjU4YzVhMWQ3ZmVjIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiNGE1MTMyOGQtZDMwNC00YjRlLTk0YTktM2IxMDZiZWYwNDM4IiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjBkZTEzOTEtODJlZS00NGI0LTg2
-        ZTItNGY3NjNkYTdlYTUxIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBh
-        ZWQ5ZTkzLTljNmYtNGJjNy04YzNkLWRhY2JmZmNkMmQ4MCIsICJudW1fcHJv
-        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJjNjgzMTA2ZC0wYmY1LTQxMDQtOGQ2NS05
-        YjZlNjFjZTMyOWIiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEu
-        IiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJi
-        ZDJiMDI1Mi1lMGY5LTRiODctYmE1My04N2U0OTg5YjYyZWYiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xv
-        c2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmMmU0ZTJh
-        NS0yNzZhLTQzYTktYmZhNC0zNGZlZTJlMDcxOGEiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdl
-        bmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0
-        ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
-        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOGU4OTlmYjUtMmVmZC00
-        OWUwLTg2NDUtOGUwY2E2OWU2ZjEyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
-        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
-        IGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rv
-        cnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTRhM2IyZDEtNTAwYS00OTM2LTg0
-        MDYtMDhiYTI3YTUwYTY2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3Rpbmdz
-        IEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0
-        YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3NWNlMDc1Mi1lZmFmLTQxM2YtOGEz
-        OS0yNGY2ZjlkZmI4ZDEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1
-        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRlbGxvLWJ1cnJp
-        dG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3Jr
-        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRlbGxv
-        LWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9y
-        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJkMDQyYjM0NDcxZTQwMDcw
-        YjA5YTMifSwgImlkIjogIjU2YmQwNDJiMzQ0NzFlNDAwNzBiMDlhMyJ9
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:07 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/336bb950-7aca-406d-8fde-fadfcec7580d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:59:08 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2324'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zMzZiYjk1MC03YWNhLTQwNmQtOGZkZS1mYWRmY2VjNzU4
-        MGQvIiwgInRhc2tfaWQiOiAiMzM2YmI5NTAtN2FjYS00MDZkLThmZGUtZmFk
-        ZmNlYzc1ODBkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMTo1OTowN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMTo1OTowNloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNDhjYmRjY2EtNTIzMy00YTcwLThlYTctZGIyMGIyM2Iy
-        YWU0LyIsICJ0YXNrX2lkIjogIjQ4Y2JkY2NhLTUyMzMtNGE3MC04ZWE3LWRi
-        MjBiMjNiMmFlNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDQy
-        YTY3N2M3NDJkMDZjY2NlMDIifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIxOjU5OjA2WiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjE6NTk6MDda
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA0MmI2NzdjNzQwODEyMzIyM2Y1IiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNDJhMzQ0NzFlNDAwNzBiMDk5MyJ9LCAiaWQi
-        OiAiNTZiZDA0MmEzNDQ3MWU0MDA3MGIwOTkzIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:08 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/48cbdcca-5233-4a70-8ea7-db20b23b2ae4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:59:08 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80OGNiZGNjYS01MjMzLTRhNzAtOGVhNy1kYjIw
-        YjIzYjJhZTQvIiwgInRhc2tfaWQiOiAiNDhjYmRjY2EtNTIzMy00YTcwLThl
-        YTctZGIyMGIyM2IyYWU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0xMVQyMTo1OTowN1oiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMTo1OTowN1oiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJiODRjOWUyYy05MzQ0LTQ5ZDEtYmMxNS0xMzVmNGU0
-        Mjg2NjciLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjZTE4
+        Y2M3Zi0wMTA2LTQ4OWEtOTdiNS05YWRiNDllYjAxNDgiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICJiODcyY2RhYi0zMWQ0LTQzNjItYmU2Zi00ZmI5NTUzYTdk
+        ZTAiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5YjkzNmM5MS05NDM4
+        LTQxZDctYmZiYS04NTZlMzhmMWQxMGQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNmFlYWU4MTgtNTM2Ny00OTMzLWE4NjAtMjU4YzVhMWQ3ZmVjIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNGE1MTMyOGQtZDMwNC00YjRlLTk0YTkt
-        M2IxMDZiZWYwNDM4IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjBk
-        ZTEzOTEtODJlZS00NGI0LTg2ZTItNGY3NjNkYTdlYTUxIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjBhZWQ5ZTkzLTljNmYtNGJjNy04YzNkLWRhY2Jm
-        ZmNkMmQ4MCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjNjgzMTA2
-        ZC0wYmY1LTQxMDQtOGQ2NS05YjZlNjFjZTMyOWIiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJiZDJiMDI1Mi1lMGY5LTRiODctYmE1My04N2U0
-        OTg5YjYyZWYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJmMmU0ZTJhNS0yNzZhLTQzYTktYmZhNC0zNGZlZTJlMDcxOGEi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4ZTg5
-        OWZiNS0yZWZkLTQ5ZTAtODY0NS04ZTBjYTY5ZTZmMTIiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5NGEzYjJkMS01MDBh
-        LTQ5MzYtODQwNi0wOGJhMjdhNTBhNjYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        aWQiOiAiYWNiYTdkM2EtZGYzYi00YWJlLTgwMTctMjI3OWI3OWMyNzlkIiwg
+        Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
+        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc1Y2UwNzUyLWVmYWYtNDEz
-        Zi04YTM5LTI0ZjZmOWRmYjhkMSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8t
-        YnVycml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBr
-        YXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTExVDIxOjU5OjA3
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMTFUMjE6NTk6MDdaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiZDA0MmI2NzdjNzQw
-        ODEyMzIyM2Y2IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImI4NGM5ZTJjLTkzNDQtNDlkMS1iYzE1LTEzNWY0ZTQyODY2
-        NyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI2YWVhZTgxOC01MzY3LTQ5MzMtYTg2MC0yNThjNWExZDdmZWMiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI0YTUxMzI4ZC1kMzA0LTRiNGUtOTRhOS0zYjEw
-        NmJlZjA0MzgiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmMGRlMTM5
-        MS04MmVlLTQ0YjQtODZlMi00Zjc2M2RhN2VhNTEiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiMGFlZDllOTMtOWM2Zi00YmM3LThjM2QtZGFjYmZmY2Qy
-        ZDgwIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM2ODMxMDZkLTBi
-        ZjUtNDEwNC04ZDY1LTliNmU2MWNlMzI5YiIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImJkMmIwMjUyLWUwZjktNGI4Ny1iYTUzLTg3ZTQ5ODli
-        NjJlZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImYyZTRlMmE1LTI3NmEtNDNhOS1iZmE0LTM0ZmVlMmUwNzE4YSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjhlODk5ZmI1
-        LTJlZmQtNDllMC04NjQ1LThlMGNhNjllNmYxMiIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjk0YTNiMmQxLTUwMGEtNDkz
-        Ni04NDA2LTA4YmEyN2E1MGE2NiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzVjZTA3NTItZWZhZi00MTNmLThh
-        MzktMjRmNmY5ZGZiOGQxIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmQwNDJiMzQ0NzFlNDAw
-        NzBiMDlhMyJ9LCAiaWQiOiAiNTZiZDA0MmIzNDQ3MWU0MDA3MGIwOWEzIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:08 GMT
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjViYTE2MWNlLTRlYTUtNDUw
+        OS05ODM1LTRmOTM0ZWVmMzMzMyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
+        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjZmOGU2MDkyLTI0OTktNDU0ZS05NzJhLTgxNmZiYmQ4ZjI3YyIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI0
+        NTlmNTIxLWQ2NDYtNDc0ZS05ZTk2LWI4ODNhOGZhZDU5ZSIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
+        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
+        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA3NGM3MTdlLTQ1NzEt
+        NGJlNy1hZTZhLTQzYmIyNTAyOTMxOCIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
+        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjdhZDg5MDI3LWNlN2ItNDFkYS1hMTZi
+        LWIzZmY0NWIyZWMwNSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
+        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiODQwYzJlZGUtOGFmNy00YTdlLWJlNTYtYTgz
+        NjFhYzhkYzRjIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDE3OTg5MDU0ZmM0OGJhMmU3
+        MiJ9LCAiaWQiOiAiNTZjYzhkMTc5ODkwNTRmYzQ4YmEyZTcyIn0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:19 GMT
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/actions/content/install//
+    uri: https://katello-yoda.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/actions/content/install//
     body:
       encoding: UTF-8
       base64_string: |
@@ -14943,7 +790,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:09 GMT
+      - Tue, 23 Feb 2016 16:47:20 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -14956,14 +803,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzc1NzU3MDE0LWY1MmYtNDJkNi04NmVlLTJmNmQxMzRiNDkzOS8iLCAi
-        dGFza19pZCI6ICI3NTc1NzAxNC1mNTJmLTQyZDYtODZlZS0yZjZkMTM0YjQ5
-        MzkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:09 GMT
+        c2tzLzliY2M1OGUxLTg0OGUtNDNlYi1hMTJjLWViNGQ3ZDk3NjY2Yy8iLCAi
+        dGFza19pZCI6ICI5YmNjNThlMS04NDhlLTQzZWItYTEyYy1lYjRkN2Q5NzY2
+        NmMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:20 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/477286a5-8c61-445c-a451-10f8f2c5fcb1/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/f75feb8f-fcc1-41ed-806f-e4d51d6a7950/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -14982,13 +829,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:10 GMT
+      - Tue, 23 Feb 2016 16:47:20 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '663'
       Connection:
       - close
       Content-Type:
@@ -14998,22 +845,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NzcyODZhNS04YzYxLTQ0NWMtYTQ1MS0xMGY4ZjJjNWZj
-        YjEvIiwgInRhc2tfaWQiOiAiNDc3Mjg2YTUtOGM2MS00NDVjLWE0NTEtMTBm
-        OGYyYzVmY2IxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9mNzVmZWI4Zi1mY2MxLTQxZWQtODA2Zi1lNGQ1MWQ2YTc5
+        NTAvIiwgInRhc2tfaWQiOiAiZjc1ZmViOGYtZmNjMS00MWVkLTgwNmYtZTRk
+        NTFkNmE3OTUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJkMDQy
-        ZTM0NDcxZTQwMDcwYjA5YTUifSwgImlkIjogIjU2YmQwNDJlMzQ0NzFlNDAw
-        NzBiMDlhNSJ9
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:10 GMT
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ3OjIwWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQxODk4OTA1NGZjNDhiYTJlNzMifSwg
+        ImlkIjogIjU2Y2M4ZDE4OTg5MDU0ZmM0OGJhMmU3MyJ9
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:20 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/477286a5-8c61-445c-a451-10f8f2c5fcb1/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/f75feb8f-fcc1-41ed-806f-e4d51d6a7950/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -15032,13 +881,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:10 GMT
+      - Tue, 23 Feb 2016 16:47:21 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '688'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -15048,25 +897,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NzcyODZhNS04YzYxLTQ0NWMtYTQ1MS0xMGY4ZjJjNWZj
-        YjEvIiwgInRhc2tfaWQiOiAiNDc3Mjg2YTUtOGM2MS00NDVjLWE0NTEtMTBm
-        OGYyYzVmY2IxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9mNzVmZWI4Zi1mY2MxLTQxZWQtODA2Zi1lNGQ1MWQ2YTc5
+        NTAvIiwgInRhc2tfaWQiOiAiZjc1ZmViOGYtZmNjMS00MWVkLTgwNmYtZTRk
+        NTFkNmE3OTUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTExVDIxOjU5OjEwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTExVDIxOjU5OjEwWiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ3OjIwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ3OjIwWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZDA0MmUzNDQ3MWU0MDA3MGIwOWE1In0sICJpZCI6ICI1NmJkMDQyZTM0NDcx
-        ZTQwMDcwYjA5YTUifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:10 GMT
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMTg5
+        ODkwNTRmYzQ4YmEyZTczIn0sICJpZCI6ICI1NmNjOGQxODk4OTA1NGZjNDhi
+        YTJlNzMifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:21 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/736d6f61-5500-4435-be47-dc2d6a449687/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/0b17bd5c-e968-4b39-a606-039de3f8b42f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -15085,13 +934,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:12 GMT
+      - Tue, 23 Feb 2016 16:47:22 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '661'
       Connection:
       - close
       Content-Type:
@@ -15101,22 +950,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83MzZkNmY2MS01NTAwLTQ0MzUtYmU0Ny1kYzJkNmE0NDk2
-        ODcvIiwgInRhc2tfaWQiOiAiNzM2ZDZmNjEtNTUwMC00NDM1LWJlNDctZGMy
-        ZDZhNDQ5Njg3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8wYjE3YmQ1Yy1lOTY4LTRiMzktYTYwNi0wMzlkZTNmOGI0
+        MmYvIiwgInRhc2tfaWQiOiAiMGIxN2JkNWMtZTk2OC00YjM5LWE2MDYtMDM5
+        ZGUzZjhiNDJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiZDA0MzAz
-        NDQ3MWU0MDA3MGIwOWE3In0sICJpZCI6ICI1NmJkMDQzMDM0NDcxZTQwMDcw
-        YjA5YTcifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:12 GMT
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0NzoyMloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4
+        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNTZjYzhkMWE5ODkwNTRmYzQ4YmEyZTc1In0sICJp
+        ZCI6ICI1NmNjOGQxYTk4OTA1NGZjNDhiYTJlNzUifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:22 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/736d6f61-5500-4435-be47-dc2d6a449687/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/0b17bd5c-e968-4b39-a606-039de3f8b42f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -15135,13 +986,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:12 GMT
+      - Tue, 23 Feb 2016 16:47:22 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2324'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -15151,16 +1002,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83MzZkNmY2MS01NTAwLTQ0MzUtYmU0Ny1kYzJkNmE0NDk2
-        ODcvIiwgInRhc2tfaWQiOiAiNzM2ZDZmNjEtNTUwMC00NDM1LWJlNDctZGMy
-        ZDZhNDQ5Njg3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8wYjE3YmQ1Yy1lOTY4LTRiMzktYTYwNi0wMzlkZTNmOGI0
+        MmYvIiwgInRhc2tfaWQiOiAiMGIxN2JkNWMtZTk2OC00YjM5LWE2MDYtMDM5
+        ZGUzZjhiNDJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMTo1OToxMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMTo1OToxMloiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0NzoyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0NzoyMloiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYWMzMGE1MGQtZWUyMy00YjU4LWI1MmUtOTJhY2U2ZGNj
-        ODM0LyIsICJ0YXNrX2lkIjogImFjMzBhNTBkLWVlMjMtNGI1OC1iNTJlLTky
-        YWNlNmRjYzgzNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvMGFhNmE4MjAtZjFiNC00MGZkLWJkMGMtZTNkZDRjMWJl
+        OGMyLyIsICJ0YXNrX2lkIjogIjBhYTZhODIwLWYxYjQtNDBmZC1iZDBjLWUz
+        ZGQ0YzFiZThjMiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -15171,41 +1022,41 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDQy
-        ZjY3N2M3NDJkMDQ5YjAwYmIifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIxOjU5OjEyWiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjE6NTk6MTJa
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA0MzA2NzdjNzQwODEyMzIyM2ZhIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNDMwMzQ0NzFlNDAwNzBiMDlhNyJ9LCAiaWQi
-        OiAiNTZiZDA0MzAzNDQ3MWU0MDA3MGIwOWE3In0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:12 GMT
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQxOWRlMDQw
+        MzNmNDI2MmNhODQifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ3OjIyWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDc6MjJaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkMWFk
+        ZTA0MDMwODk3NThhODViIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDFhOTg5MDU0ZmM0OGJhMmU3NSJ9LCAiaWQiOiAiNTZj
+        YzhkMWE5ODkwNTRmYzQ4YmEyZTc1In0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:22 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/ac30a50d-ee23-4b58-b52e-92ace6dcc834/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/0aa6a820-f1b4-40fd-bd0c-e3dd4c1be8c2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -15224,13 +1075,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:12 GMT
+      - Tue, 23 Feb 2016 16:47:22 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '676'
+      - '6923'
       Connection:
       - close
       Content-Type:
@@ -15240,305 +1091,163 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9hYzMwYTUwZC1lZTIzLTRiNTgtYjUyZS05MmFj
-        ZTZkY2M4MzQvIiwgInRhc2tfaWQiOiAiYWMzMGE1MGQtZWUyMy00YjU4LWI1
-        MmUtOTJhY2U2ZGNjODM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy8wYWE2YTgyMC1mMWI0LTQwZmQtYmQwYy1lM2Rk
+        NGMxYmU4YzIvIiwgInRhc2tfaWQiOiAiMGFhNmE4MjAtZjFiNC00MGZkLWJk
+        MGMtZTNkZDRjMWJlOGMyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0xMVQyMTo1OToxMloiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1i
-        dXJyaXRvLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAi
-        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAa2F0
-        ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJl
-        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiZDA0MzAzNDQ3MWU0
-        MDA3MGIwOWI3In0sICJpZCI6ICI1NmJkMDQzMDM0NDcxZTQwMDcwYjA5Yjci
-        fQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:12 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/736d6f61-5500-4435-be47-dc2d6a449687/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:59:13 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2324'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83MzZkNmY2MS01NTAwLTQ0MzUtYmU0Ny1kYzJkNmE0NDk2
-        ODcvIiwgInRhc2tfaWQiOiAiNzM2ZDZmNjEtNTUwMC00NDM1LWJlNDctZGMy
-        ZDZhNDQ5Njg3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMTo1OToxMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMTo1OToxMloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYWMzMGE1MGQtZWUyMy00YjU4LWI1MmUtOTJhY2U2ZGNj
-        ODM0LyIsICJ0YXNrX2lkIjogImFjMzBhNTBkLWVlMjMtNGI1OC1iNTJlLTky
-        YWNlNmRjYzgzNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDQy
-        ZjY3N2M3NDJkMDQ5YjAwYmIifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIxOjU5OjEyWiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjE6NTk6MTJa
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA0MzA2NzdjNzQwODEyMzIyM2ZhIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNDMwMzQ0NzFlNDAwNzBiMDlhNyJ9LCAiaWQi
-        OiAiNTZiZDA0MzAzNDQ3MWU0MDA3MGIwOWE3In0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:13 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/ac30a50d-ee23-4b58-b52e-92ace6dcc834/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:59:13 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9hYzMwYTUwZC1lZTIzLTRiNTgtYjUyZS05MmFj
-        ZTZkY2M4MzQvIiwgInRhc2tfaWQiOiAiYWMzMGE1MGQtZWUyMy00YjU4LWI1
-        MmUtOTJhY2U2ZGNjODM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0xMVQyMTo1OToxMloiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMTo1OToxMloiLCAi
+        bWUiOiAiMjAxNi0wMi0yM1QxNjo0NzoyMloiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0NzoyMloiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI3N2ZlNTY4Yi1hNmRlLTRkMGMtYTFiYi1hMTRkY2Q2
-        MWZhODEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICI0ZThkYzIxMS01M2RlLTRjZWYtYjMzYi02YzVmYjk2
+        MmE0YTYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYzAyNWY4NDItODQyYi00MGQ4LWJlNjYtNDFlNDQ2OTI5M2I3Iiwg
+        aWQiOiAiNWIwNmFkMWMtZWM1Mi00ZTU4LWJkYTEtZmY0ZDA4MTliNWEyIiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
         bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiY2U0MGQ0MDAtN2E2NC00YTlkLTg3Yzkt
-        ZDdlN2ZmYjJiNTEwIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNmJkZTM5NjMtNTdmNS00NmZiLTkyNmUt
+        OTJkMjllODcxYWU2IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
         TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNThh
-        MjczMGItZTM2OS00N2NiLTlkNjktMjM0NDJkZjk1OTQ4IiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzRm
+        ODRmNDctYTdmYi00Y2QyLWI0ODQtYzg2NTg3YTkxNDA5IiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImU3M2NkNDc0LTEzN2MtNDY3MC1iNmI4LTY2N2Q2
-        NTY2NzI2NiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        IDAsICJzdGVwX2lkIjogImNhMTFjMTNhLWE5MjQtNDMwOS1hZTRkLTc1MzY0
+        OGRhODU5YiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
         OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
         InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkYzY2Mzk0
-        Ni0zOGExLTQyZjQtYThkYy01Mzg1YzEzY2Y3YTAiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1NWIzMmVj
+        NC1hYTBhLTRmZTMtODFkYS04YWIyYjZmMTRmMTAiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
         Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI0Nzc4MDE0Ni1lYTE0LTQ0YTgtYjRkYi1hNjE0
-        NzZhOTg4ODYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICJjZDk0ZGIyNS0yZTY0LTQ4MWEtOTc0OS0wNzkw
+        NWE2OTljMTciLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
         ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIxMjQyMTFkMC0zN2Q4LTQxYzQtODMyNi00MGFkZjdhZGU5NDEi
+        cF9pZCI6ICIyY2I1N2YzMi1iOTgzLTRhZmMtOThhOC05NDg4NmFlNTFmODci
         LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
         dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
         c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkNDJk
-        ZGM5MC1hYTY5LTRiZWUtOGFmMi00NDc4YTcwY2ExNWEiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmN2Fj
+        MWU3Yi00NjgzLTRhMjctYjYxZi0zZmI0ZjA4M2IxN2MiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
         aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5MDA2MjA2Ny1hM2I2
-        LTQ5NDgtYjhhOS1mYmQ5OGI1NWY0YTYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlYWUzYmQ0NC0zY2Q2
+        LTQ5MzktOWZkMi1mMzk4NDFmNjU2YWYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
         TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
         X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE4MjZmOTE3LTI0MjEtNDEw
-        ZS05NTI2LTI5ZGYxOGYyYjQzYSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8t
-        YnVycml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBr
-        YXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTExVDIxOjU5OjEy
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMTFUMjE6NTk6MTJaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiZDA0MzA2NzdjNzQw
-        ODEyMzIyM2ZiIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjc3ZmU1NjhiLWE2ZGUtNGQwYy1hMWJiLWExNGRjZDYxZmE4
-        MSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJjMDI1Zjg0Mi04NDJiLTQwZDgtYmU2Ni00MWU0NDY5MjkzYjciLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJjZTQwZDQwMC03YTY0LTRhOWQtODdjOS1kN2U3
-        ZmZiMmI1MTAiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1OGEyNzMw
-        Yi1lMzY5LTQ3Y2ItOWQ2OS0yMzQ0MmRmOTU5NDgiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiZTczY2Q0NzQtMTM3Yy00NjcwLWI2YjgtNjY3ZDY1NjY3
-        MjY2IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImRjNjYzOTQ2LTM4
-        YTEtNDJmNC1hOGRjLTUzODVjMTNjZjdhMCIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjQ3NzgwMTQ2LWVhMTQtNDRhOC1iNGRiLWE2MTQ3NmE5
-        ODg4NiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjMxMGQxYmE4LThkNGYtNGVi
+        OS04MTRlLTIzNmU1ZWYxMDYwYyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
+        c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
+        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ3OjIyWiIsICJf
+        bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
+        MTYtMDItMjNUMTY6NDc6MjJaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
+        cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
+        IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
+        X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
+        RCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1z
+        IjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0
+        aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
+        SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
+        U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
+        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZjYzhkMWFkZTA0MDMwODk3NThh
+        ODVjIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
         IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjEyNDIxMWQwLTM3ZDgtNDFjNC04MzI2LTQwYWRmN2FkZTk0MSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ0MmRkYzkw
-        LWFhNjktNGJlZS04YWYyLTQ0NzhhNzBjYTE1YSIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        IjogIjRlOGRjMjExLTUzZGUtNGNlZi1iMzNiLTZjNWZiOTYyYTRhNiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1YjA2
+        YWQxYy1lYzUyLTRlNTgtYmRhMS1mZjRkMDgxOWI1YTIiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI2YmRlMzk2My01N2Y1LTQ2ZmItOTI2ZS05MmQyOWU4NzFh
+        ZTYiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3NGY4NGY0Ny1hN2Zi
+        LTRjZDItYjQ4NC1jODY1ODdhOTE0MDkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiY2ExMWMxM2EtYTkyNC00MzA5LWFlNGQtNzUzNjQ4ZGE4NTliIiwg
+        Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
+        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjkwMDYyMDY3LWEzYjYtNDk0
-        OC1iOGE5LWZiZDk4YjU1ZjRhNiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTgyNmY5MTctMjQyMS00MTBlLTk1
-        MjYtMjlkZjE4ZjJiNDNhIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmQwNDMwMzQ0NzFlNDAw
-        NzBiMDliNyJ9LCAiaWQiOiAiNTZiZDA0MzAzNDQ3MWU0MDA3MGIwOWI3In0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:13 GMT
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjU1YjMyZWM0LWFhMGEtNGZl
+        My04MWRhLThhYjJiNmYxNGYxMCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
+        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogImNkOTRkYjI1LTJlNjQtNDgxYS05NzQ5LTA3OTA1YTY5OWMxNyIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjJj
+        YjU3ZjMyLWI5ODMtNGFmYy05OGE4LTk0ODg2YWU1MWY4NyIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
+        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
+        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImY3YWMxZTdiLTQ2ODMt
+        NGEyNy1iNjFmLTNmYjRmMDgzYjE3YyIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
+        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImVhZTNiZDQ0LTNjZDYtNDkzOS05ZmQy
+        LWYzOTg0MWY2NTZhZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
+        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiMzEwZDFiYTgtOGQ0Zi00ZWI5LTgxNGUtMjM2
+        ZTVlZjEwNjBjIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDFhOTg5MDU0ZmM0OGJhMmU4
+        NSJ9LCAiaWQiOiAiNTZjYzhkMWE5ODkwNTRmYzQ4YmEyZTg1In0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:22 GMT
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/actions/content/install//
+    uri: https://katello-yoda.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/actions/content/install//
     body:
       encoding: UTF-8
       base64_string: |
@@ -15562,7 +1271,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:14 GMT
+      - Tue, 23 Feb 2016 16:47:23 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -15575,14 +1284,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzM5NjY5ODk5LWY5MDUtNDYwNS05N2FkLWZjOTRkM2QxOTk0YS8iLCAi
-        dGFza19pZCI6ICIzOTY2OTg5OS1mOTA1LTQ2MDUtOTdhZC1mYzk0ZDNkMTk5
-        NGEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:14 GMT
+        c2tzL2ViNTMyNDZiLWEzMTItNDU5My1hMzI2LTIxZGI1NjZhNjdmMS8iLCAi
+        dGFza19pZCI6ICJlYjUzMjQ2Yi1hMzEyLTQ1OTMtYTMyNi0yMWRiNTY2YTY3
+        ZjEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:23 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/95557b70-67dd-4a0c-a336-38c8a54114b9/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/7fb4c41b-e590-4cfd-b1ef-afea6c67dfa4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -15601,13 +1310,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:14 GMT
+      - Tue, 23 Feb 2016 16:47:23 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '651'
+      - '663'
       Connection:
       - close
       Content-Type:
@@ -15617,24 +1326,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85NTU1N2I3MC02N2RkLTRhMGMtYTMzNi0zOGM4YTU0MTE0
-        YjkvIiwgInRhc2tfaWQiOiAiOTU1NTdiNzAtNjdkZC00YTBjLWEzMzYtMzhj
-        OGE1NDExNGI5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy83ZmI0YzQxYi1lNTkwLTRjZmQtYjFlZi1hZmVhNmM2N2Rm
+        YTQvIiwgInRhc2tfaWQiOiAiN2ZiNGM0MWItZTU5MC00Y2ZkLWIxZWYtYWZl
+        YTZjNjdkZmE0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAi
-        c3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
-        ZXNvdXJjZV93b3JrZXItMEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20i
-        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmJkMDQzMjM0NDcxZTQwMDcwYjA5YjgifSwgImlkIjogIjU2YmQw
-        NDMyMzQ0NzFlNDAwNzBiMDliOCJ9
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:14 GMT
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ3OjIzWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQxYjk4OTA1NGZjNDhiYTJlODYifSwg
+        ImlkIjogIjU2Y2M4ZDFiOTg5MDU0ZmM0OGJhMmU4NiJ9
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:23 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/95557b70-67dd-4a0c-a336-38c8a54114b9/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/7fb4c41b-e590-4cfd-b1ef-afea6c67dfa4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -15653,13 +1362,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:15 GMT
+      - Tue, 23 Feb 2016 16:47:24 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '688'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -15669,25 +1378,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85NTU1N2I3MC02N2RkLTRhMGMtYTMzNi0zOGM4YTU0MTE0
-        YjkvIiwgInRhc2tfaWQiOiAiOTU1NTdiNzAtNjdkZC00YTBjLWEzMzYtMzhj
-        OGE1NDExNGI5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy83ZmI0YzQxYi1lNTkwLTRjZmQtYjFlZi1hZmVhNmM2N2Rm
+        YTQvIiwgInRhc2tfaWQiOiAiN2ZiNGM0MWItZTU5MC00Y2ZkLWIxZWYtYWZl
+        YTZjNjdkZmE0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTExVDIxOjU5OjE0WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTExVDIxOjU5OjE0WiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ3OjIzWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ3OjIzWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZDA0MzIzNDQ3MWU0MDA3MGIwOWI4In0sICJpZCI6ICI1NmJkMDQzMjM0NDcx
-        ZTQwMDcwYjA5YjgifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:15 GMT
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMWI5
+        ODkwNTRmYzQ4YmEyZTg2In0sICJpZCI6ICI1NmNjOGQxYjk4OTA1NGZjNDhi
+        YTJlODYifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:24 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/f1616970-0819-498f-a455-cea91d6e16f5/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/1d543ada-3298-4561-8a83-1291d74fb180/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -15706,13 +1415,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:16 GMT
+      - Tue, 23 Feb 2016 16:47:25 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '649'
+      - '661'
       Connection:
       - close
       Content-Type:
@@ -15722,24 +1431,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mMTYxNjk3MC0wODE5LTQ5OGYtYTQ1NS1jZWE5MWQ2ZTE2
-        ZjUvIiwgInRhc2tfaWQiOiAiZjE2MTY5NzAtMDgxOS00OThmLWE0NTUtY2Vh
-        OTFkNmUxNmY1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xZDU0M2FkYS0zMjk4LTQ1NjEtOGE4My0xMjkxZDc0ZmIx
+        ODAvIiwgInRhc2tfaWQiOiAiMWQ1NDNhZGEtMzI5OC00NTYxLThhODMtMTI5
+        MWQ3NGZiMTgwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tLmRxIiwgInN0
-        YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwg
-        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNTZiZDA0MzQzNDQ3MWU0MDA3MGIwOWJhIn0sICJpZCI6ICI1NmJkMDQz
-        NDM0NDcxZTQwMDcwYjA5YmEifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:16 GMT
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0NzoyNVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4
+        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNTZjYzhkMWQ5ODkwNTRmYzQ4YmEyZTg4In0sICJp
+        ZCI6ICI1NmNjOGQxZDk4OTA1NGZjNDhiYTJlODgifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:25 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/f1616970-0819-498f-a455-cea91d6e16f5/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/1d543ada-3298-4561-8a83-1291d74fb180/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -15758,13 +1467,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:17 GMT
+      - Tue, 23 Feb 2016 16:47:25 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2324'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -15774,16 +1483,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mMTYxNjk3MC0wODE5LTQ5OGYtYTQ1NS1jZWE5MWQ2ZTE2
-        ZjUvIiwgInRhc2tfaWQiOiAiZjE2MTY5NzAtMDgxOS00OThmLWE0NTUtY2Vh
-        OTFkNmUxNmY1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xZDU0M2FkYS0zMjk4LTQ1NjEtOGE4My0xMjkxZDc0ZmIx
+        ODAvIiwgInRhc2tfaWQiOiAiMWQ1NDNhZGEtMzI5OC00NTYxLThhODMtMTI5
+        MWQ3NGZiMTgwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMTo1OToxN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMTo1OToxNloiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0NzoyNVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0NzoyNVoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNzkzNzM0YzEtZjgxNC00MGM1LWFhM2EtM2ZiNDk3Zjhj
-        YTc3LyIsICJ0YXNrX2lkIjogIjc5MzczNGMxLWY4MTQtNDBjNS1hYTNhLTNm
-        YjQ5N2Y4Y2E3NyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNjczYzQ0NzgtMWRmNC00MWFlLThlY2UtOTZiMmEwM2Zj
+        YmM1LyIsICJ0YXNrX2lkIjogIjY3M2M0NDc4LTFkZjQtNDFhZS04ZWNlLTk2
+        YjJhMDNmY2JjNSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -15794,41 +1503,41 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDQz
-        NDY3N2M3NDJkMDVhZjM3ZDQifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIxOjU5OjE2WiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjE6NTk6MTda
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA0MzU2NzdjNzQwODEyMzIyM2ZmIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNDM0MzQ0NzFlNDAwNzBiMDliYSJ9LCAiaWQi
-        OiAiNTZiZDA0MzQzNDQ3MWU0MDA3MGIwOWJhIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:17 GMT
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQxY2RlMDQw
+        MzNmNDFkMmEzZGMifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ3OjI1WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDc6MjVaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkMWRk
+        ZTA0MDMwODk3NThhODYwIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDFkOTg5MDU0ZmM0OGJhMmU4OCJ9LCAiaWQiOiAiNTZj
+        YzhkMWQ5ODkwNTRmYzQ4YmEyZTg4In0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:25 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/793734c1-f814-40c5-aa3a-3fb497f8ca77/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/673c4478-1df4-41ae-8ece-96b2a03fcbc5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -15847,13 +1556,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:17 GMT
+      - Tue, 23 Feb 2016 16:47:25 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '658'
+      - '6923'
       Connection:
       - close
       Content-Type:
@@ -15863,304 +1572,163 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy83OTM3MzRjMS1mODE0LTQwYzUtYWEzYS0zZmI0
-        OTdmOGNhNzcvIiwgInRhc2tfaWQiOiAiNzkzNzM0YzEtZjgxNC00MGM1LWFh
-        M2EtM2ZiNDk3ZjhjYTc3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy82NzNjNDQ3OC0xZGY0LTQxYWUtOGVjZS05NmIy
+        YTAzZmNiYzUvIiwgInRhc2tfaWQiOiAiNjczYzQ0NzgtMWRmNC00MWFlLThl
+        Y2UtOTZiMmEwM2ZjYmM1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiBudWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBb
-        XSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRf
-        cmVzb3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29t
-        LmRxIiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVz
-        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQi
-        OiB7IiRvaWQiOiAiNTZiZDA0MzUzNDQ3MWU0MDA3MGIwOWNhIn0sICJpZCI6
-        ICI1NmJkMDQzNTM0NDcxZTQwMDcwYjA5Y2EifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:17 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/f1616970-0819-498f-a455-cea91d6e16f5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:59:18 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2324'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mMTYxNjk3MC0wODE5LTQ5OGYtYTQ1NS1jZWE5MWQ2ZTE2
-        ZjUvIiwgInRhc2tfaWQiOiAiZjE2MTY5NzAtMDgxOS00OThmLWE0NTUtY2Vh
-        OTFkNmUxNmY1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMTo1OToxN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMTo1OToxNloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNzkzNzM0YzEtZjgxNC00MGM1LWFhM2EtM2ZiNDk3Zjhj
-        YTc3LyIsICJ0YXNrX2lkIjogIjc5MzczNGMxLWY4MTQtNDBjNS1hYTNhLTNm
-        YjQ5N2Y4Y2E3NyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDQz
-        NDY3N2M3NDJkMDVhZjM3ZDQifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIxOjU5OjE2WiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjE6NTk6MTda
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA0MzU2NzdjNzQwODEyMzIyM2ZmIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNDM0MzQ0NzFlNDAwNzBiMDliYSJ9LCAiaWQi
-        OiAiNTZiZDA0MzQzNDQ3MWU0MDA3MGIwOWJhIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:18 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/793734c1-f814-40c5-aa3a-3fb497f8ca77/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:59:18 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy83OTM3MzRjMS1mODE0LTQwYzUtYWEzYS0zZmI0
-        OTdmOGNhNzcvIiwgInRhc2tfaWQiOiAiNzkzNzM0YzEtZjgxNC00MGM1LWFh
-        M2EtM2ZiNDk3ZjhjYTc3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0xMVQyMTo1OToxOFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMTo1OToxN1oiLCAi
+        bWUiOiAiMjAxNi0wMi0yM1QxNjo0NzoyNVoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0NzoyNVoiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI2MmU3OTVlMC03NWJmLTQ2MzktYmNiMy1kY2RiNTgy
-        YThjYTciLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICJlNDU3Y2ZlNC03MjgzLTQwN2QtOTA3ZC02Zjk0YjNj
+        YWJlMDQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZDIyZGFkMmYtZDQ0ZS00YTJjLWFiNWQtM2EwNWJhM2NjMDkzIiwg
+        aWQiOiAiZGJjNzFkOWEtZTMzOC00OGJmLTkyYjAtYWJhNTY2ZDUyMDYzIiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
         bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiOGQ0YWNlM2UtZDBlNi00MWNjLTg0NWEt
-        MTMyZmZiYTNiMmZlIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiOGZmODU2YWUtMzE1Zi00NTc1LWE5NzUt
+        N2Y5NzljNzVjZTFiIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
         TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzU3
-        YjAyMDMtYjA5Zi00NTE3LTg0MDItNjA0ZTJjYjI4NmEzIiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjNh
+        ZGJjNjktZTNhNi00ZjUwLWI4YzYtZGNkMzc0ZWEzY2Y2IiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjg2NTNjYzNhLWM4NGItNDQ4Yy1hMWVjLTkyOWQ4
-        N2NhMjZiMCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        IDAsICJzdGVwX2lkIjogIjNlMzRkYmE1LTJjN2YtNDllYi1iZDZkLWZlNTcw
+        MDM1ODA0NyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
         OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
         InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4YjNhMGE3
-        NC1kZjY1LTRlYzQtYTBkZC1mMjg0MTA2Mjc1MTUiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjNDY1ZWY5
+        Yy1hYjQ2LTQ0OGYtYTc3Yy03YzQwZDU1MDcyOWYiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
         Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI2ZWUwZjNmZi0wZWJkLTQ2MzMtYmM2OS0wYzY0
-        NWY5NWY0NDgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICJjNmE3MmY2NC1lNWM0LTQ1ODYtOWNmMi04N2Iw
+        ZDM1M2JmNzEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
         ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJkOTk0MTZkZi1mOThhLTQ3NDEtODUwNS0zNDY1MjkyNDJmYTYi
+        cF9pZCI6ICIwYjJmZmJkMi02MDJiLTQwMzMtOWFkZi05ZGMxZWI1M2ZhYjYi
         LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
         dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
         c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhMTll
-        MDc0OC05ODMyLTQ1NzMtOWQwNS0wZjk5M2VlYTVkM2YiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0YTc2
+        M2YxZS0zMWJkLTQ3YzEtOWM1My01MjliMGM1OTY1MTIiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
         aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlY2E2OTYwYi1iNzkx
-        LTQ5YTYtYjQwMS03ZTRiMzRjMzdiYTEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjOTBhOGJmMy00MzQ0
+        LTQ3NDQtOGYxNy03NWU5MGYxOTg4OTYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
         TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
         X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjY2MTBiZDQ4LTc1MmQtNDc5
-        Ni1iY2NmLTY5MGNiZjY3MmQ0MyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8t
-        YnVycml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBr
-        YXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTExVDIxOjU5OjE3
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMTFUMjE6NTk6MThaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiZDA0MzY2NzdjNzQw
-        ODEyMzIyNDAwIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjYyZTc5NWUwLTc1YmYtNDYzOS1iY2IzLWRjZGI1ODJhOGNh
-        NyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJkMjJkYWQyZi1kNDRlLTRhMmMtYWI1ZC0zYTA1YmEzY2MwOTMiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI4ZDRhY2UzZS1kMGU2LTQxY2MtODQ1YS0xMzJm
-        ZmJhM2IyZmUiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjNTdiMDIw
-        My1iMDlmLTQ1MTctODQwMi02MDRlMmNiMjg2YTMiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiODY1M2NjM2EtYzg0Yi00NDhjLWExZWMtOTI5ZDg3Y2Ey
-        NmIwIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjhiM2EwYTc0LWRm
-        NjUtNGVjNC1hMGRkLWYyODQxMDYyNzUxNSIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjZlZTBmM2ZmLTBlYmQtNDYzMy1iYzY5LTBjNjQ1Zjk1
-        ZjQ0OCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRmMTBmM2Q4LTVmYzYtNDdj
+        OC05ZjhiLWM1NmMyNzg0YzRlMSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
+        c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
+        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ3OjI1WiIsICJf
+        bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
+        MTYtMDItMjNUMTY6NDc6MjVaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
+        cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
+        IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
+        X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
+        RCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1z
+        IjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0
+        aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
+        SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
+        U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
+        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZjYzhkMWRkZTA0MDMwODk3NThh
+        ODYxIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
         IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImQ5OTQxNmRmLWY5OGEtNDc0MS04NTA1LTM0NjUyOTI0MmZhNiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImExOWUwNzQ4
-        LTk4MzItNDU3My05ZDA1LTBmOTkzZWVhNWQzZiIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        IjogImU0NTdjZmU0LTcyODMtNDA3ZC05MDdkLTZmOTRiM2NhYmUwNCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkYmM3
+        MWQ5YS1lMzM4LTQ4YmYtOTJiMC1hYmE1NjZkNTIwNjMiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI4ZmY4NTZhZS0zMTVmLTQ1NzUtYTk3NS03Zjk3OWM3NWNl
+        MWIiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmM2FkYmM2OS1lM2E2
+        LTRmNTAtYjhjNi1kY2QzNzRlYTNjZjYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiM2UzNGRiYTUtMmM3Zi00OWViLWJkNmQtZmU1NzAwMzU4MDQ3Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
+        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVjYTY5NjBiLWI3OTEtNDlh
-        Ni1iNDAxLTdlNGIzNGMzN2JhMSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjYxMGJkNDgtNzUyZC00Nzk2LWJj
-        Y2YtNjkwY2JmNjcyZDQzIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmQwNDM1MzQ0NzFlNDAw
-        NzBiMDljYSJ9LCAiaWQiOiAiNTZiZDA0MzUzNDQ3MWU0MDA3MGIwOWNhIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:18 GMT
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM0NjVlZjljLWFiNDYtNDQ4
+        Zi1hNzdjLTdjNDBkNTUwNzI5ZiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
+        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogImM2YTcyZjY0LWU1YzQtNDU4Ni05Y2YyLTg3YjBkMzUzYmY3MSIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBi
+        MmZmYmQyLTYwMmItNDAzMy05YWRmLTlkYzFlYjUzZmFiNiIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
+        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
+        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRhNzYzZjFlLTMxYmQt
+        NDdjMS05YzUzLTUyOWIwYzU5NjUxMiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
+        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImM5MGE4YmYzLTQzNDQtNDc0NC04ZjE3
+        LTc1ZTkwZjE5ODg5NiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
+        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiNGYxMGYzZDgtNWZjNi00N2M4LTlmOGItYzU2
+        YzI3ODRjNGUxIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDFkOTg5MDU0ZmM0OGJhMmU5
+        OCJ9LCAiaWQiOiAiNTZjYzhkMWQ5ODkwNTRmYzQ4YmEyZTk4In0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:25 GMT
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/actions/content/uninstall//
+    uri: https://katello-yoda.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/actions/content/uninstall//
     body:
       encoding: UTF-8
       base64_string: |
@@ -16183,7 +1751,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:19 GMT
+      - Tue, 23 Feb 2016 16:47:26 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -16196,14 +1764,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzQyMzcwNTg2LTQ5MTMtNDNjNy1hMTk2LTliYjgwN2YxMTJlMy8iLCAi
-        dGFza19pZCI6ICI0MjM3MDU4Ni00OTEzLTQzYzctYTE5Ni05YmI4MDdmMTEy
-        ZTMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:19 GMT
+        c2tzLzdiMzZhOTY4LTIyZWItNGE3My1iNjcxLThjYzhkMzdlZTRlMi8iLCAi
+        dGFza19pZCI6ICI3YjM2YTk2OC0yMmViLTRhNzMtYjY3MS04Y2M4ZDM3ZWU0
+        ZTIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:26 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/df41d767-b118-4328-b1e3-d5949ecb9d6f/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/7882ffe9-2c08-4e58-bcf9-8b4d315cb8a1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -16222,13 +1790,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:21 GMT
+      - Tue, 23 Feb 2016 16:47:26 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '645'
       Connection:
       - close
       Content-Type:
@@ -16238,22 +1806,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kZjQxZDc2Ny1iMTE4LTQzMjgtYjFlMy1kNTk0OWVjYjlk
-        NmYvIiwgInRhc2tfaWQiOiAiZGY0MWQ3NjctYjExOC00MzI4LWIxZTMtZDU5
-        NDllY2I5ZDZmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy83ODgyZmZlOS0yYzA4LTRlNTgtYmNmOS04YjRkMzE1Y2I4
+        YTEvIiwgInRhc2tfaWQiOiAiNzg4MmZmZTktMmMwOC00ZTU4LWJjZjktOGI0
+        ZDMxNWNiOGExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
         bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
         ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJkMDQz
-        OTM0NDcxZTQwMDcwYjA5Y2IifSwgImlkIjogIjU2YmQwNDM5MzQ0NzFlNDAw
-        NzBiMDljYiJ9
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:21 GMT
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3Rh
+        dGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        NmNjOGQxZTk4OTA1NGZjNDhiYTJlOTkifSwgImlkIjogIjU2Y2M4ZDFlOTg5
+        MDU0ZmM0OGJhMmU5OSJ9
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:26 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/df41d767-b118-4328-b1e3-d5949ecb9d6f/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/7882ffe9-2c08-4e58-bcf9-8b4d315cb8a1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -16272,13 +1842,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:22 GMT
+      - Tue, 23 Feb 2016 16:47:27 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '688'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -16288,25 +1858,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kZjQxZDc2Ny1iMTE4LTQzMjgtYjFlMy1kNTk0OWVjYjlk
-        NmYvIiwgInRhc2tfaWQiOiAiZGY0MWQ3NjctYjExOC00MzI4LWIxZTMtZDU5
-        NDllY2I5ZDZmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy83ODgyZmZlOS0yYzA4LTRlNTgtYmNmOS04YjRkMzE1Y2I4
+        YTEvIiwgInRhc2tfaWQiOiAiNzg4MmZmZTktMmMwOC00ZTU4LWJjZjktOGI0
+        ZDMxNWNiOGExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTExVDIxOjU5OjIxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTExVDIxOjU5OjIxWiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ3OjI2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ3OjI2WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZDA0MzkzNDQ3MWU0MDA3MGIwOWNiIn0sICJpZCI6ICI1NmJkMDQzOTM0NDcx
-        ZTQwMDcwYjA5Y2IifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:22 GMT
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMWU5
+        ODkwNTRmYzQ4YmEyZTk5In0sICJpZCI6ICI1NmNjOGQxZTk4OTA1NGZjNDhi
+        YTJlOTkifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:27 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/67483e72-57d9-4f9b-bb30-393977195642/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/4c539049-c702-4eea-9b15-4d742ba5b971/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -16325,13 +1895,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:23 GMT
+      - Tue, 23 Feb 2016 16:47:28 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '643'
       Connection:
       - close
       Content-Type:
@@ -16341,22 +1911,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NzQ4M2U3Mi01N2Q5LTRmOWItYmIzMC0zOTM5NzcxOTU2
-        NDIvIiwgInRhc2tfaWQiOiAiNjc0ODNlNzItNTdkOS00ZjliLWJiMzAtMzkz
-        OTc3MTk1NjQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy80YzUzOTA0OS1jNzAyLTRlZWEtOWIxNS00ZDc0MmJhNWI5
+        NzEvIiwgInRhc2tfaWQiOiAiNGM1MzkwNDktYzcwMi00ZWVhLTliMTUtNGQ3
+        NDJiYTViOTcxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiZDA0M2Iz
-        NDQ3MWU0MDA3MGIwOWNkIn0sICJpZCI6ICI1NmJkMDQzYjM0NDcxZTQwMDcw
-        YjA5Y2QifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:23 GMT
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZj
+        YzhkMjA5ODkwNTRmYzQ4YmEyZTliIn0sICJpZCI6ICI1NmNjOGQyMDk4OTA1
+        NGZjNDhiYTJlOWIifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:28 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/67483e72-57d9-4f9b-bb30-393977195642/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/4c539049-c702-4eea-9b15-4d742ba5b971/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -16375,13 +1947,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:24 GMT
+      - Tue, 23 Feb 2016 16:47:28 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2324'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -16391,16 +1963,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NzQ4M2U3Mi01N2Q5LTRmOWItYmIzMC0zOTM5NzcxOTU2
-        NDIvIiwgInRhc2tfaWQiOiAiNjc0ODNlNzItNTdkOS00ZjliLWJiMzAtMzkz
-        OTc3MTk1NjQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy80YzUzOTA0OS1jNzAyLTRlZWEtOWIxNS00ZDc0MmJhNWI5
+        NzEvIiwgInRhc2tfaWQiOiAiNGM1MzkwNDktYzcwMi00ZWVhLTliMTUtNGQ3
+        NDJiYTViOTcxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMTo1OToyNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMTo1OToyM1oiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0NzoyOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0NzoyOFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYzUyMmEyYTYtOGE5YS00NWYxLTliMDktZjlkOTg2YmJi
-        MmViLyIsICJ0YXNrX2lkIjogImM1MjJhMmE2LThhOWEtNDVmMS05YjA5LWY5
-        ZDk4NmJiYjJlYiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvN2RiNzFjMjQtOWU2NS00NDdkLWE2YzctZDQ5OTZhZDY5
+        ZTU1LyIsICJ0YXNrX2lkIjogIjdkYjcxYzI0LTllNjUtNDQ3ZC1hNmM3LWQ0
+        OTk2YWQ2OWU1NSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -16411,41 +1983,41 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDQz
-        YjY3N2M3NDJkMDZjY2NlMTAifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIxOjU5OjIzWiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjE6NTk6MjRa
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA0M2M2NzdjNzQwODEyMzIyNDA0IiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNDNiMzQ0NzFlNDAwNzBiMDljZCJ9LCAiaWQi
-        OiAiNTZiZDA0M2IzNDQ3MWU0MDA3MGIwOWNkIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:24 GMT
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQxZmRlMDQw
+        MzNmNDI2MmNhOTEifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ3OjI4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDc6MjhaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkMjBk
+        ZTA0MDMwODk3NThhODY1IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDIwOTg5MDU0ZmM0OGJhMmU5YiJ9LCAiaWQiOiAiNTZj
+        YzhkMjA5ODkwNTRmYzQ4YmEyZTliIn0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:28 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/c522a2a6-8a9a-45f1-9b09-f9d986bbb2eb/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/7db71c24-9e65-447d-a6c7-d4996ad69e55/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -16464,13 +2036,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:24 GMT
+      - Tue, 23 Feb 2016 16:47:28 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '3507'
+      - '6923'
       Connection:
       - close
       Content-Type:
@@ -16480,367 +2052,163 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9jNTIyYTJhNi04YTlhLTQ1ZjEtOWIwOS1mOWQ5
-        ODZiYmIyZWIvIiwgInRhc2tfaWQiOiAiYzUyMmEyYTYtOGE5YS00NWYxLTli
-        MDktZjlkOTg2YmJiMmViIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy83ZGI3MWMyNC05ZTY1LTQ0N2QtYTZjNy1kNDk5
+        NmFkNjllNTUvIiwgInRhc2tfaWQiOiAiN2RiNzFjMjQtOWU2NS00NDdkLWE2
+        YzctZDQ5OTZhZDY5ZTU1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0xMVQyMTo1OToyNFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhMzE4
-        NThjNy01MzUwLTQ0ZmEtYmQ4ZC1lNmE2NjcyMzhjYmIiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDczMGI0YzQtZTFi
-        My00ZmYwLWE4ODctODhkODViMmJhNmEyIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiOWQ1MzE1NDYtOWIyNy00OWJkLThkNDktYjYyNjg4YmFjM2UwIiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMWI3ZWY5Y2QtODkxMi00NTM4LThl
-        OTMtMTc4MjljYmZmZTcwIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjAx
-        MDNjOWM5LWFjNDYtNGQxYy04ODFlLTE1MDk0YjY3ODc3YyIsICJudW1fcHJv
-        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI1Yzg1NjNhYi0zODk5LTQ1MmQtOTk5Zi05
-        ODczMDU4NWUyNmUiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEu
-        IiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIz
-        YjZmOTY2ZS1jNWM3LTQ4NGMtODc1MC0wMDg3NWZhMjZiY2MiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9u
-        IjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xv
-        c2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhMWJjNWNm
-        ZC0zZjlhLTQzMjMtODVmOS0wMDdlODRmYWQwZTYiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdl
-        bmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0
-        ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
-        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmNmMGRiNDItNmVlYy00
-        ODc3LWI2ZmEtNGE2NGMzYTY2MzE3IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
-        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
-        IGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rv
-        cnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGJjZDJhMTAtYTlkMi00NTg4LWJh
-        ZWYtMGM1YWJhY2MwYzIxIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3Rpbmdz
-        IEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0
-        YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmMzU5ZDUyNC1kYzk5LTQwOTgtOGU5
-        ZS04MTdjM2Q5MDRkY2QiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1
-        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRlbGxvLWJ1cnJp
-        dG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3Jr
-        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRlbGxv
-        LWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9y
-        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJkMDQzYzM0NDcxZTQwMDcw
-        YjA5ZGQifSwgImlkIjogIjU2YmQwNDNjMzQ0NzFlNDAwNzBiMDlkZCJ9
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:24 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/67483e72-57d9-4f9b-bb30-393977195642/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:59:24 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2324'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NzQ4M2U3Mi01N2Q5LTRmOWItYmIzMC0zOTM5NzcxOTU2
-        NDIvIiwgInRhc2tfaWQiOiAiNjc0ODNlNzItNTdkOS00ZjliLWJiMzAtMzkz
-        OTc3MTk1NjQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMTo1OToyNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMTo1OToyM1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYzUyMmEyYTYtOGE5YS00NWYxLTliMDktZjlkOTg2YmJi
-        MmViLyIsICJ0YXNrX2lkIjogImM1MjJhMmE2LThhOWEtNDVmMS05YjA5LWY5
-        ZDk4NmJiYjJlYiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDQz
-        YjY3N2M3NDJkMDZjY2NlMTAifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIxOjU5OjIzWiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjE6NTk6MjRa
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA0M2M2NzdjNzQwODEyMzIyNDA0IiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNDNiMzQ0NzFlNDAwNzBiMDljZCJ9LCAiaWQi
-        OiAiNTZiZDA0M2IzNDQ3MWU0MDA3MGIwOWNkIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:24 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/c522a2a6-8a9a-45f1-9b09-f9d986bbb2eb/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:59:24 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9jNTIyYTJhNi04YTlhLTQ1ZjEtOWIwOS1mOWQ5
-        ODZiYmIyZWIvIiwgInRhc2tfaWQiOiAiYzUyMmEyYTYtOGE5YS00NWYxLTli
-        MDktZjlkOTg2YmJiMmViIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0xMVQyMTo1OToyNFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMTo1OToyNFoiLCAi
+        bWUiOiAiMjAxNi0wMi0yM1QxNjo0NzoyOFoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0NzoyOFoiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJhMzE4NThjNy01MzUwLTQ0ZmEtYmQ4ZC1lNmE2Njcy
-        MzhjYmIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICI2MDI1ZjkxNC0wMDFiLTQ0Y2ItYTFlMi02NzU5N2Q4
+        ZGQ5NzYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZDczMGI0YzQtZTFiMy00ZmYwLWE4ODctODhkODViMmJhNmEyIiwg
+        aWQiOiAiZjdiNTAyYzEtNWQ3ZS00YWZkLTgzNjQtMWM1N2ZkOWI0OThmIiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
         bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiOWQ1MzE1NDYtOWIyNy00OWJkLThkNDkt
-        YjYyNjg4YmFjM2UwIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZmZhZWU2NzctOTczNy00YzVlLTgxYmYt
+        N2EyZWI3MWYwMmNkIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
         TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMWI3
-        ZWY5Y2QtODkxMi00NTM4LThlOTMtMTc4MjljYmZmZTcwIiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTQ1
+        ZmNjNjUtMDJhMy00MWE1LWFiNTYtMDQxYWE3MDVmNWIwIiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjAxMDNjOWM5LWFjNDYtNGQxYy04ODFlLTE1MDk0
-        YjY3ODc3YyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        IDAsICJzdGVwX2lkIjogIjNhNTkxNzRiLTZlODktNDI5Yi05MTk4LWVlNzFi
+        YjYwNWZmYyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
         OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
         InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1Yzg1NjNh
-        Yi0zODk5LTQ1MmQtOTk5Zi05ODczMDU4NWUyNmUiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiZDk4ZmUy
+        OS0zZTdiLTRlNjQtOWIxYy1mOTM4MmNiODU4YTAiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
         Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIzYjZmOTY2ZS1jNWM3LTQ4NGMtODc1MC0wMDg3
-        NWZhMjZiY2MiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICJmYzA0MzdiZS1hMjE3LTRmMWMtOTg0Ni03MWUy
+        YzdlOGNhMmQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
         ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJhMWJjNWNmZC0zZjlhLTQzMjMtODVmOS0wMDdlODRmYWQwZTYi
+        cF9pZCI6ICIzYjBkNTZiZC0xMWIxLTQxYzItYmVhYi1lMjEwZTdhNGJkM2Yi
         LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
         dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
         c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmY2Yw
-        ZGI0Mi02ZWVjLTQ4NzctYjZmYS00YTY0YzNhNjYzMTciLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmNjJi
+        NzBhOC04NjczLTQ3ZTQtOWFmYi01ODM4ZTk3YzQzODIiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
         aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0YmNkMmExMC1hOWQy
-        LTQ1ODgtYmFlZi0wYzVhYmFjYzBjMjEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmMjc2YWViOC1lNTgy
+        LTRiM2EtODQzYS00NjczNWJiZGEyZTEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
         TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
         X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImYzNTlkNTI0LWRjOTktNDA5
-        OC04ZTllLTgxN2MzZDkwNGRjZCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8t
-        YnVycml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBr
-        YXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTExVDIxOjU5OjI0
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMTFUMjE6NTk6MjRaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiZDA0M2M2NzdjNzQw
-        ODEyMzIyNDA1IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImEzMTg1OGM3LTUzNTAtNDRmYS1iZDhkLWU2YTY2NzIzOGNi
-        YiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJkNzMwYjRjNC1lMWIzLTRmZjAtYTg4Ny04OGQ4NWIyYmE2YTIiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI5ZDUzMTU0Ni05YjI3LTQ5YmQtOGQ0OS1iNjI2
-        ODhiYWMzZTAiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxYjdlZjlj
-        ZC04OTEyLTQ1MzgtOGU5My0xNzgyOWNiZmZlNzAiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiMDEwM2M5YzktYWM0Ni00ZDFjLTg4MWUtMTUwOTRiNjc4
-        NzdjIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjVjODU2M2FiLTM4
-        OTktNDUyZC05OTlmLTk4NzMwNTg1ZTI2ZSIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjNiNmY5NjZlLWM1YzctNDg0Yy04NzUwLTAwODc1ZmEy
-        NmJjYyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjJlMmZjNjE1LTQ2Y2UtNGU3
+        Ni04NDhmLTc0NTAwYmRmZmYzOSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
+        c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
+        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ3OjI4WiIsICJf
+        bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
+        MTYtMDItMjNUMTY6NDc6MjhaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
+        cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
+        IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
+        X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
+        RCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1z
+        IjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0
+        aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
+        SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
+        U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
+        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZjYzhkMjBkZTA0MDMwODk3NThh
+        ODY2IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
         IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImExYmM1Y2ZkLTNmOWEtNDMyMy04NWY5LTAwN2U4NGZhZDBlNiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZjZjBkYjQy
-        LTZlZWMtNDg3Ny1iNmZhLTRhNjRjM2E2NjMxNyIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        IjogIjYwMjVmOTE0LTAwMWItNDRjYi1hMWUyLTY3NTk3ZDhkZDk3NiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmN2I1
+        MDJjMS01ZDdlLTRhZmQtODM2NC0xYzU3ZmQ5YjQ5OGYiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICJmZmFlZTY3Ny05NzM3LTRjNWUtODFiZi03YTJlYjcxZjAy
+        Y2QiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNDVmY2M2NS0wMmEz
+        LTQxYTUtYWI1Ni0wNDFhYTcwNWY1YjAiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiM2E1OTE3NGItNmU4OS00MjliLTkxOTgtZWU3MWJiNjA1ZmZjIiwg
+        Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
+        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRiY2QyYTEwLWE5ZDItNDU4
-        OC1iYWVmLTBjNWFiYWNjMGMyMSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjM1OWQ1MjQtZGM5OS00MDk4LThl
-        OWUtODE3YzNkOTA0ZGNkIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmQwNDNjMzQ0NzFlNDAw
-        NzBiMDlkZCJ9LCAiaWQiOiAiNTZiZDA0M2MzNDQ3MWU0MDA3MGIwOWRkIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:24 GMT
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJkOThmZTI5LTNlN2ItNGU2
+        NC05YjFjLWY5MzgyY2I4NThhMCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
+        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogImZjMDQzN2JlLWEyMTctNGYxYy05ODQ2LTcxZTJjN2U4Y2EyZCIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNi
+        MGQ1NmJkLTExYjEtNDFjMi1iZWFiLWUyMTBlN2E0YmQzZiIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
+        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
+        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImY2MmI3MGE4LTg2NzMt
+        NDdlNC05YWZiLTU4MzhlOTdjNDM4MiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
+        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImYyNzZhZWI4LWU1ODItNGIzYS04NDNh
+        LTQ2NzM1YmJkYTJlMSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
+        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiMmUyZmM2MTUtNDZjZS00ZTc2LTg0OGYtNzQ1
+        MDBiZGZmZjM5IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDIwOTg5MDU0ZmM0OGJhMmVh
+        YiJ9LCAiaWQiOiAiNTZjYzhkMjA5ODkwNTRmYzQ4YmEyZWFiIn0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:28 GMT
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/actions/content/uninstall//
+    uri: https://katello-yoda.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/actions/content/uninstall//
     body:
       encoding: UTF-8
       base64_string: |
@@ -16863,7 +2231,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:25 GMT
+      - Tue, 23 Feb 2016 16:47:29 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -16876,14 +2244,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzdiZDE3OWM4LTk3YTUtNDFkZi1hZjQxLTgzZWZlNDFhMzRlZS8iLCAi
-        dGFza19pZCI6ICI3YmQxNzljOC05N2E1LTQxZGYtYWY0MS04M2VmZTQxYTM0
-        ZWUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:26 GMT
+        c2tzL2I4MTliYWZiLTFkMmItNDRmZS04MmYwLTQyNzZjNGU0YTYyZi8iLCAi
+        dGFza19pZCI6ICJiODE5YmFmYi0xZDJiLTQ0ZmUtODJmMC00Mjc2YzRlNGE2
+        MmYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:29 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/8c965edf-6409-4b8b-9ecd-9f5709eb0e00/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/e9566bb6-343f-4bbc-87df-58242992439b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -16902,13 +2270,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:26 GMT
+      - Tue, 23 Feb 2016 16:47:29 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '663'
       Connection:
       - close
       Content-Type:
@@ -16918,22 +2286,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84Yzk2NWVkZi02NDA5LTRiOGItOWVjZC05ZjU3MDllYjBl
-        MDAvIiwgInRhc2tfaWQiOiAiOGM5NjVlZGYtNjQwOS00YjhiLTllY2QtOWY1
-        NzA5ZWIwZTAwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9lOTU2NmJiNi0zNDNmLTRiYmMtODdkZi01ODI0Mjk5MjQz
+        OWIvIiwgInRhc2tfaWQiOiAiZTk1NjZiYjYtMzQzZi00YmJjLTg3ZGYtNTgy
+        NDI5OTI0MzliIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJkMDQz
-        ZTM0NDcxZTQwMDcwYjA5ZGUifSwgImlkIjogIjU2YmQwNDNlMzQ0NzFlNDAw
-        NzBiMDlkZSJ9
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:26 GMT
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ3OjI5WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQyMTk4OTA1NGZjNDhiYTJlYWMifSwg
+        ImlkIjogIjU2Y2M4ZDIxOTg5MDU0ZmM0OGJhMmVhYyJ9
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:29 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/8c965edf-6409-4b8b-9ecd-9f5709eb0e00/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/e9566bb6-343f-4bbc-87df-58242992439b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -16952,13 +2322,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:26 GMT
+      - Tue, 23 Feb 2016 16:47:30 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '688'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -16968,25 +2338,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84Yzk2NWVkZi02NDA5LTRiOGItOWVjZC05ZjU3MDllYjBl
-        MDAvIiwgInRhc2tfaWQiOiAiOGM5NjVlZGYtNjQwOS00YjhiLTllY2QtOWY1
-        NzA5ZWIwZTAwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9lOTU2NmJiNi0zNDNmLTRiYmMtODdkZi01ODI0Mjk5MjQz
+        OWIvIiwgInRhc2tfaWQiOiAiZTk1NjZiYjYtMzQzZi00YmJjLTg3ZGYtNTgy
+        NDI5OTI0MzliIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTExVDIxOjU5OjI2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTExVDIxOjU5OjI2WiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ3OjI5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ3OjI5WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZDA0M2UzNDQ3MWU0MDA3MGIwOWRlIn0sICJpZCI6ICI1NmJkMDQzZTM0NDcx
-        ZTQwMDcwYjA5ZGUifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:26 GMT
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMjE5
+        ODkwNTRmYzQ4YmEyZWFjIn0sICJpZCI6ICI1NmNjOGQyMTk4OTA1NGZjNDhi
+        YTJlYWMifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:30 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/f2422d87-9694-4208-9f57-079ecdc9ffcc/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/db81e817-f2b6-47ce-a434-eeee033ce8b5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -17005,13 +2375,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:28 GMT
+      - Tue, 23 Feb 2016 16:47:31 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '661'
       Connection:
       - close
       Content-Type:
@@ -17021,22 +2391,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mMjQyMmQ4Ny05Njk0LTQyMDgtOWY1Ny0wNzllY2RjOWZm
-        Y2MvIiwgInRhc2tfaWQiOiAiZjI0MjJkODctOTY5NC00MjA4LTlmNTctMDc5
-        ZWNkYzlmZmNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYjgxZTgxNy1mMmI2LTQ3Y2UtYTQzNC1lZWVlMDMzY2U4
+        YjUvIiwgInRhc2tfaWQiOiAiZGI4MWU4MTctZjJiNi00N2NlLWE0MzQtZWVl
+        ZTAzM2NlOGI1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiZDA0NDAz
-        NDQ3MWU0MDA3MGIwOWUwIn0sICJpZCI6ICI1NmJkMDQ0MDM0NDcxZTQwMDcw
-        YjA5ZTAifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:28 GMT
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0NzozMVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4
+        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNTZjYzhkMjM5ODkwNTRmYzQ4YmEyZWFlIn0sICJp
+        ZCI6ICI1NmNjOGQyMzk4OTA1NGZjNDhiYTJlYWUifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:31 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/f2422d87-9694-4208-9f57-079ecdc9ffcc/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/db81e817-f2b6-47ce-a434-eeee033ce8b5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -17055,13 +2427,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:29 GMT
+      - Tue, 23 Feb 2016 16:47:31 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2324'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -17071,16 +2443,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mMjQyMmQ4Ny05Njk0LTQyMDgtOWY1Ny0wNzllY2RjOWZm
-        Y2MvIiwgInRhc2tfaWQiOiAiZjI0MjJkODctOTY5NC00MjA4LTlmNTctMDc5
-        ZWNkYzlmZmNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYjgxZTgxNy1mMmI2LTQ3Y2UtYTQzNC1lZWVlMDMzY2U4
+        YjUvIiwgInRhc2tfaWQiOiAiZGI4MWU4MTctZjJiNi00N2NlLWE0MzQtZWVl
+        ZTAzM2NlOGI1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMTo1OToyOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMTo1OToyOFoiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0NzozMVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0NzozMVoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZTA2NTMzNDItNTI4ZC00YTJmLWFkMzEtMWI4ZjhiMTQz
-        YmMzLyIsICJ0YXNrX2lkIjogImUwNjUzMzQyLTUyOGQtNGEyZi1hZDMxLTFi
-        OGY4YjE0M2JjMyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvOTZkNzM3YTktMTc0OC00YjYzLTkxNmItMzk5MjU4NmEz
+        MmRjLyIsICJ0YXNrX2lkIjogIjk2ZDczN2E5LTE3NDgtNGI2My05MTZiLTM5
+        OTI1ODZhMzJkYyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -17091,41 +2463,41 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDQ0
-        MDY3N2M3NDJkMDZjY2NlMTgifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIxOjU5OjI4WiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjE6NTk6Mjla
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA0NDE2NzdjNzQwODEyMzIyNDA5IiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNDQwMzQ0NzFlNDAwNzBiMDllMCJ9LCAiaWQi
-        OiAiNTZiZDA0NDAzNDQ3MWU0MDA3MGIwOWUwIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:29 GMT
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQyMmRlMDQw
+        MzNmNDFkMmEzZTcifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ3OjMxWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDc6MzFaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkMjNk
+        ZTA0MDMwODk3NThhODZhIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDIzOTg5MDU0ZmM0OGJhMmVhZSJ9LCAiaWQiOiAiNTZj
+        YzhkMjM5ODkwNTRmYzQ4YmEyZWFlIn0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:31 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/e0653342-528d-4a2f-ad31-1b8f8b143bc3/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/96d737a9-1748-4b63-916b-3992586a32dc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -17144,13 +2516,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:29 GMT
+      - Tue, 23 Feb 2016 16:47:31 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '3529'
+      - '6923'
       Connection:
       - close
       Content-Type:
@@ -17160,368 +2532,163 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9lMDY1MzM0Mi01MjhkLTRhMmYtYWQzMS0xYjhm
-        OGIxNDNiYzMvIiwgInRhc2tfaWQiOiAiZTA2NTMzNDItNTI4ZC00YTJmLWFk
-        MzEtMWI4ZjhiMTQzYmMzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy85NmQ3MzdhOS0xNzQ4LTRiNjMtOTE2Yi0zOTky
+        NTg2YTMyZGMvIiwgInRhc2tfaWQiOiAiOTZkNzM3YTktMTc0OC00YjYzLTkx
+        NmItMzk5MjU4NmEzMmRjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0xMVQyMTo1OToyOVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3
-        NzE4NjBhMi1mYTMyLTRkNGQtYjEzMy05N2QyOGEyYTM4ZDEiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlw
-        ZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGNkOTRm
-        NDAtN2NmMy00YTllLTgzNDctNTFkZWZmZDk2ZThkIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNf
-        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiYzg1ZGNkYzYtMDkwOC00NTZmLThlMjYtYzE5NmViOWQz
-        NTUyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3Rl
-        cF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE2YmYxZTFk
-        LWMyOTQtNGMzYi05ZjVkLWRjNDY0YzFmNGViYSIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVt
-        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI2ZWZiYTNiZi1hZjlhLTRlZjMtYTg0ZC04MTBmYmEz
-        MzkzMDciLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJz
-        dGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTVmMzdi
-        MmQtNTczOC00YzYxLTkxODMtYTBiZTlmNDUyYmE2IiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEi
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNzA4NmYyYWItM2M3Zi00OGUzLWE4ZTIt
-        MjY1ZjJjNTQ2NGY2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRh
-        dGEiLCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiM2FlN2FhMzItNjY3Yi00NmFkLTk1ZjAtNzE3NzA5
-        ODE1MmJmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
-        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIs
-        ICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjJlYmNlMGM5LWUxOWQtNGQ1Yi1hMDcxLWYxYjQ4MTQzZTk1OSIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
-        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90
-        eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        Ijc5NzhiOTUwLTY0MjUtNGFlYi1hY2Y0LTAxZjhkNjZjM2RmMCIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJp
-        bml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        NWUyYzk4MDItMGEwYS00NDIxLTlmMDAtZDdiNjYwZmZiNmY0IiwgIm51bV9w
-        cm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tLmRxIiwgInN0
-        YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwg
-        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNTZiZDA0NDEzNDQ3MWU0MDA3MGIwOWYwIn0sICJpZCI6ICI1NmJkMDQ0
-        MTM0NDcxZTQwMDcwYjA5ZjAifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:29 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/f2422d87-9694-4208-9f57-079ecdc9ffcc/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:59:29 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2324'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mMjQyMmQ4Ny05Njk0LTQyMDgtOWY1Ny0wNzllY2RjOWZm
-        Y2MvIiwgInRhc2tfaWQiOiAiZjI0MjJkODctOTY5NC00MjA4LTlmNTctMDc5
-        ZWNkYzlmZmNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMTo1OToyOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMTo1OToyOFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZTA2NTMzNDItNTI4ZC00YTJmLWFkMzEtMWI4ZjhiMTQz
-        YmMzLyIsICJ0YXNrX2lkIjogImUwNjUzMzQyLTUyOGQtNGEyZi1hZDMxLTFi
-        OGY4YjE0M2JjMyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDQ0
-        MDY3N2M3NDJkMDZjY2NlMTgifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIxOjU5OjI4WiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjE6NTk6Mjla
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA0NDE2NzdjNzQwODEyMzIyNDA5IiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNDQwMzQ0NzFlNDAwNzBiMDllMCJ9LCAiaWQi
-        OiAiNTZiZDA0NDAzNDQ3MWU0MDA3MGIwOWUwIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:29 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/e0653342-528d-4a2f-ad31-1b8f8b143bc3/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:59:29 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9lMDY1MzM0Mi01MjhkLTRhMmYtYWQzMS0xYjhm
-        OGIxNDNiYzMvIiwgInRhc2tfaWQiOiAiZTA2NTMzNDItNTI4ZC00YTJmLWFk
-        MzEtMWI4ZjhiMTQzYmMzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0xMVQyMTo1OToyOVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMTo1OToyOVoiLCAi
+        bWUiOiAiMjAxNi0wMi0yM1QxNjo0NzozMVoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0NzozMVoiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI3NzE4NjBhMi1mYTMyLTRkNGQtYjEzMy05N2QyOGEy
-        YTM4ZDEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICJjYTIyNDQ4Mi1kZTBiLTRkMTAtYTdiYi1mMzFmYjRj
+        MDEwMzYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNGNkOTRmNDAtN2NmMy00YTllLTgzNDctNTFkZWZmZDk2ZThkIiwg
+        aWQiOiAiODZiM2M4MmItY2MyNS00MWZkLTk0MGItNzY4MDYyYzMwYzAwIiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
         bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiYzg1ZGNkYzYtMDkwOC00NTZmLThlMjYt
-        YzE5NmViOWQzNTUyIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNWEyMjRiZjYtNzcyZC00MzVjLWExOWQt
+        NzgzZjQ3NWUwZmRiIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
         TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTZi
-        ZjFlMWQtYzI5NC00YzNiLTlmNWQtZGM0NjRjMWY0ZWJhIiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODVm
+        MTFmYjEtZTBkNy00Zjk4LWJkNDMtODkzYWIxMzcxOGNlIiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjZlZmJhM2JmLWFmOWEtNGVmMy1hODRkLTgxMGZi
-        YTMzOTMwNyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        IDAsICJzdGVwX2lkIjogIjNiZDk5ZmMxLTdjMTAtNDI1Yy05ZWFhLTI3MWRk
+        N2JlZWE2YSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
         OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
         InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNWYzN2Iy
-        ZC01NzM4LTRjNjEtOTE4My1hMGJlOWY0NTJiYTYiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwMjAzMzFk
+        NS1mNTJhLTQxYjEtOTZjZC1lMWE3ZmNjYzk4NzEiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
         Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI3MDg2ZjJhYi0zYzdmLTQ4ZTMtYThlMi0yNjVm
-        MmM1NDY0ZjYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICI4NWQ5MzczNC03MDcxLTRhMTQtYTYzOS1lNDNi
+        MWIzZjdmYWEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
         ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIzYWU3YWEzMi02NjdiLTQ2YWQtOTVmMC03MTc3MDk4MTUyYmYi
+        cF9pZCI6ICJkNjQ3MjMxZi1kMGIzLTRlMDAtYjhmOS1jYzk1YjQ0YWY3ZjAi
         LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
         dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
         c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyZWJj
-        ZTBjOS1lMTlkLTRkNWItYTA3MS1mMWI0ODE0M2U5NTkiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhMWE3
+        ODBmYS01MWExLTRjODMtODY3MS02YmM5M2Y1Zjk4MDgiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
         aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3OTc4Yjk1MC02NDI1
-        LTRhZWItYWNmNC0wMWY4ZDY2YzNkZjAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2M2ZhNGUyZS04NTA3
+        LTQ2ODQtYTU1MC0wMGU2MGEzMjY4OTUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
         TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
         X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjVlMmM5ODAyLTBhMGEtNDQy
-        MS05ZjAwLWQ3YjY2MGZmYjZmNCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8t
-        YnVycml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBr
-        YXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTExVDIxOjU5OjI5
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMTFUMjE6NTk6MjlaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiZDA0NDE2NzdjNzQw
-        ODEyMzIyNDBhIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjc3MTg2MGEyLWZhMzItNGQ0ZC1iMTMzLTk3ZDI4YTJhMzhk
-        MSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI0Y2Q5NGY0MC03Y2YzLTRhOWUtODM0Ny01MWRlZmZkOTZlOGQiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJjODVkY2RjNi0wOTA4LTQ1NmYtOGUyNi1jMTk2
-        ZWI5ZDM1NTIiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNmJmMWUx
-        ZC1jMjk0LTRjM2ItOWY1ZC1kYzQ2NGMxZjRlYmEiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiNmVmYmEzYmYtYWY5YS00ZWYzLWE4NGQtODEwZmJhMzM5
-        MzA3IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE1ZjM3YjJkLTU3
-        MzgtNGM2MS05MTgzLWEwYmU5ZjQ1MmJhNiIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjcwODZmMmFiLTNjN2YtNDhlMy1hOGUyLTI2NWYyYzU0
-        NjRmNiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI0NDMxMDgzLTllMjAtNDU1
+        Mi04MmQwLTFlODJjZTFlMTk5MyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
+        c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
+        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ3OjMxWiIsICJf
+        bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
+        MTYtMDItMjNUMTY6NDc6MzFaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
+        cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
+        IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
+        X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
+        RCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1z
+        IjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0
+        aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
+        SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
+        U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
+        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZjYzhkMjNkZTA0MDMwODk3NThh
+        ODZiIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
         IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjNhZTdhYTMyLTY2N2ItNDZhZC05NWYwLTcxNzcwOTgxNTJiZiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjJlYmNlMGM5
-        LWUxOWQtNGQ1Yi1hMDcxLWYxYjQ4MTQzZTk1OSIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        IjogImNhMjI0NDgyLWRlMGItNGQxMC1hN2JiLWYzMWZiNGMwMTAzNiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4NmIz
+        YzgyYi1jYzI1LTQxZmQtOTQwYi03NjgwNjJjMzBjMDAiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI1YTIyNGJmNi03NzJkLTQzNWMtYTE5ZC03ODNmNDc1ZTBm
+        ZGIiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4NWYxMWZiMS1lMGQ3
+        LTRmOTgtYmQ0My04OTNhYjEzNzE4Y2UiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiM2JkOTlmYzEtN2MxMC00MjVjLTllYWEtMjcxZGQ3YmVlYTZhIiwg
+        Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
+        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc5NzhiOTUwLTY0MjUtNGFl
-        Yi1hY2Y0LTAxZjhkNjZjM2RmMCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNWUyYzk4MDItMGEwYS00NDIxLTlm
-        MDAtZDdiNjYwZmZiNmY0IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmQwNDQxMzQ0NzFlNDAw
-        NzBiMDlmMCJ9LCAiaWQiOiAiNTZiZDA0NDEzNDQ3MWU0MDA3MGIwOWYwIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:29 GMT
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjAyMDMzMWQ1LWY1MmEtNDFi
+        MS05NmNkLWUxYTdmY2NjOTg3MSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
+        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjg1ZDkzNzM0LTcwNzEtNGExNC1hNjM5LWU0M2IxYjNmN2ZhYSIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ2
+        NDcyMzFmLWQwYjMtNGUwMC1iOGY5LWNjOTViNDRhZjdmMCIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
+        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
+        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImExYTc4MGZhLTUxYTEt
+        NGM4My04NjcxLTZiYzkzZjVmOTgwOCIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
+        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjYzZmE0ZTJlLTg1MDctNDY4NC1hNTUw
+        LTAwZTYwYTMyNjg5NSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
+        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiYjQ0MzEwODMtOWUyMC00NTUyLTgyZDAtMWU4
+        MmNlMWUxOTkzIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDIzOTg5MDU0ZmM0OGJhMmVi
+        ZSJ9LCAiaWQiOiAiNTZjYzhkMjM5ODkwNTRmYzQ4YmEyZWJlIn0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:31 GMT
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/actions/content/update//
+    uri: https://katello-yoda.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/actions/content/update//
     body:
       encoding: UTF-8
       base64_string: |
@@ -17544,7 +2711,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:30 GMT
+      - Tue, 23 Feb 2016 16:47:32 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -17557,14 +2724,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzAxZWFiMmE3LTY5ZDYtNDYxYi05ZDYzLTlhMzEyOTUzYWIxMy8iLCAi
-        dGFza19pZCI6ICIwMWVhYjJhNy02OWQ2LTQ2MWItOWQ2My05YTMxMjk1M2Fi
-        MTMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:30 GMT
+        c2tzLzhhNGUwMjlkLTljZmYtNDhjNi1hMjk3LWVjMzlhYjQ0MTM0My8iLCAi
+        dGFza19pZCI6ICI4YTRlMDI5ZC05Y2ZmLTQ4YzYtYTI5Ny1lYzM5YWI0NDEz
+        NDMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:32 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/70f2a662-f435-4114-821d-f9aef1c331c4/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/efd91840-ad3f-488e-b628-515a79acd04a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -17583,13 +2750,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:31 GMT
+      - Tue, 23 Feb 2016 16:47:32 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '645'
       Connection:
       - close
       Content-Type:
@@ -17599,22 +2766,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83MGYyYTY2Mi1mNDM1LTQxMTQtODIxZC1mOWFlZjFjMzMx
-        YzQvIiwgInRhc2tfaWQiOiAiNzBmMmE2NjItZjQzNS00MTE0LTgyMWQtZjlh
-        ZWYxYzMzMWM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9lZmQ5MTg0MC1hZDNmLTQ4OGUtYjYyOC01MTVhNzlhY2Qw
+        NGEvIiwgInRhc2tfaWQiOiAiZWZkOTE4NDAtYWQzZi00ODhlLWI2MjgtNTE1
+        YTc5YWNkMDRhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
         bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
         ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJkMDQ0
-        MzM0NDcxZTQwMDcwYjA5ZjEifSwgImlkIjogIjU2YmQwNDQzMzQ0NzFlNDAw
-        NzBiMDlmMSJ9
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:31 GMT
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3Rh
+        dGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        NmNjOGQyNDk4OTA1NGZjNDhiYTJlYmYifSwgImlkIjogIjU2Y2M4ZDI0OTg5
+        MDU0ZmM0OGJhMmViZiJ9
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:32 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/70f2a662-f435-4114-821d-f9aef1c331c4/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/efd91840-ad3f-488e-b628-515a79acd04a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -17633,13 +2802,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:31 GMT
+      - Tue, 23 Feb 2016 16:47:33 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '688'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -17649,25 +2818,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83MGYyYTY2Mi1mNDM1LTQxMTQtODIxZC1mOWFlZjFjMzMx
-        YzQvIiwgInRhc2tfaWQiOiAiNzBmMmE2NjItZjQzNS00MTE0LTgyMWQtZjlh
-        ZWYxYzMzMWM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9lZmQ5MTg0MC1hZDNmLTQ4OGUtYjYyOC01MTVhNzlhY2Qw
+        NGEvIiwgInRhc2tfaWQiOiAiZWZkOTE4NDAtYWQzZi00ODhlLWI2MjgtNTE1
+        YTc5YWNkMDRhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTExVDIxOjU5OjMxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTExVDIxOjU5OjMxWiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ3OjMyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ3OjMyWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZDA0NDMzNDQ3MWU0MDA3MGIwOWYxIn0sICJpZCI6ICI1NmJkMDQ0MzM0NDcx
-        ZTQwMDcwYjA5ZjEifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:31 GMT
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMjQ5
+        ODkwNTRmYzQ4YmEyZWJmIn0sICJpZCI6ICI1NmNjOGQyNDk4OTA1NGZjNDhi
+        YTJlYmYifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:33 GMT
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -17676,16 +2845,20 @@ http_interactions:
         b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
         ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
         IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
-        IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRp
-        c3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwi
-        OiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3Rl
-        Y3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifV19
+        IjpudWxsLCJyZW1vdmVfbWlzc2luZyI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
+        LXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1
+        dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9j
+        b25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIiwiaHR0cCI6ZmFs
+        c2UsImh0dHBzIjp0cnVlLCJwcm90ZWN0ZWQiOnRydWV9LCJhdXRvX3B1Ymxp
+        c2giOnRydWUsImRpc3RyaWJ1dG9yX2lkIjoiRmVkb3JhXzE3In0seyJkaXN0
+        cmlidXRvcl90eXBlX2lkIjoieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwiZGlz
+        dHJpYnV0b3JfY29uZmlnIjp7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lk
+        IjoiRmVkb3JhXzE3In0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1
+        dG9yX2lkIjoiRmVkb3JhXzE3X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBl
+        X2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmln
+        Ijp7Imh0dHAiOmZhbHNlLCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6
+        InRlc3RfcGF0aCJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRv
+        cl9pZCI6ImV4cG9ydF9kaXN0cmlidXRvciJ9XX0=
     headers:
       Accept:
       - application/json
@@ -17694,7 +2867,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '636'
+      - '839'
       User-Agent:
       - Ruby
   response:
@@ -17703,13 +2876,13 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:32 GMT
+      - Tue, 23 Feb 2016 16:47:33 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
       - '320'
       Location:
-      - https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/
+      - https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/
       Connection:
       - close
       Content-Type:
@@ -17722,14 +2895,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiZDA0NDQ2NzdjNzQyZDA2Y2NjZTIxIn0sICJpZCI6ICJGZWRvcmFfMTci
+        NTZjYzhkMjVkZTA0MDMzZjQzNTE0ZjYwIn0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:32 GMT
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:33 GMT
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -17752,7 +2925,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:33 GMT
+      - Tue, 23 Feb 2016 16:47:34 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -17765,14 +2938,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2JjZDRlNDcyLTQ3OTMtNGVmMi04Mzg2LWJjZGQ4ODRiM2EwNy8iLCAi
-        dGFza19pZCI6ICJiY2Q0ZTQ3Mi00NzkzLTRlZjItODM4Ni1iY2RkODg0YjNh
-        MDcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:33 GMT
+        c2tzL2Q4Nzg0MDdlLTAwNTItNDNlMy05Y2IzLTVlOWU2ZmRlOTZlNS8iLCAi
+        dGFza19pZCI6ICJkODc4NDA3ZS0wMDUyLTQzZTMtOWNiMy01ZTllNmZkZTk2
+        ZTUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:34 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/bcd4e472-4793-4ef2-8386-bcdd884b3a07/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/d878407e-0052-43e3-9cb3-5e9e6fde96e5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -17791,13 +2964,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:33 GMT
+      - Tue, 23 Feb 2016 16:47:34 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '661'
       Connection:
       - close
       Content-Type:
@@ -17807,85 +2980,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iY2Q0ZTQ3Mi00NzkzLTRlZjItODM4Ni1iY2RkODg0YjNh
-        MDcvIiwgInRhc2tfaWQiOiAiYmNkNGU0NzItNDc5My00ZWYyLTgzODYtYmNk
-        ZDg4NGIzYTA3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiZDA0NDUz
-        NDQ3MWU0MDA3MGIwOWYzIn0sICJpZCI6ICI1NmJkMDQ0NTM0NDcxZTQwMDcw
-        YjA5ZjMifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:33 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/bcd4e472-4793-4ef2-8386-bcdd884b3a07/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 21:59:33 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1127'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iY2Q0ZTQ3Mi00NzkzLTRlZjItODM4Ni1iY2RkODg0YjNh
-        MDcvIiwgInRhc2tfaWQiOiAiYmNkNGU0NzItNDc5My00ZWYyLTgzODYtYmNk
-        ZDg4NGIzYTA3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kODc4NDA3ZS0wMDUyLTQzZTMtOWNiMy01ZTllNmZkZTk2
+        ZTUvIiwgInRhc2tfaWQiOiAiZDg3ODQwN2UtMDA1Mi00M2UzLTljYjMtNWU5
+        ZTZmZGU5NmU1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0xMVQyMTo1OTozM1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJJ
-        Tl9QUk9HUkVTUyJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        Tk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwi
-        OiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8t
-        YnVycml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGth
-        dGVsbG8tYnVycml0by5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmQwNDQ1MzQ0NzFl
-        NDAwNzBiMDlmMyJ9LCAiaWQiOiAiNTZiZDA0NDUzNDQ3MWU0MDA3MGIwOWYz
-        In0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:33 GMT
+        Mi0yM1QxNjo0NzozNFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4
+        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNTZjYzhkMjY5ODkwNTRmYzQ4YmEyZWMxIn0sICJp
+        ZCI6ICI1NmNjOGQyNjk4OTA1NGZjNDhiYTJlYzEifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:34 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/bcd4e472-4793-4ef2-8386-bcdd884b3a07/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/d878407e-0052-43e3-9cb3-5e9e6fde96e5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -17904,13 +3016,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:34 GMT
+      - Tue, 23 Feb 2016 16:47:34 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2324'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -17920,16 +3032,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iY2Q0ZTQ3Mi00NzkzLTRlZjItODM4Ni1iY2RkODg0YjNh
-        MDcvIiwgInRhc2tfaWQiOiAiYmNkNGU0NzItNDc5My00ZWYyLTgzODYtYmNk
-        ZDg4NGIzYTA3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kODc4NDA3ZS0wMDUyLTQzZTMtOWNiMy01ZTllNmZkZTk2
+        ZTUvIiwgInRhc2tfaWQiOiAiZDg3ODQwN2UtMDA1Mi00M2UzLTljYjMtNWU5
+        ZTZmZGU5NmU1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMTo1OTozM1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMTo1OTozM1oiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0NzozNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0NzozNFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYzgzYzljMjAtMDNkYS00MjQ1LTkyZWItZmEyMGMzYTlj
-        ZGY0LyIsICJ0YXNrX2lkIjogImM4M2M5YzIwLTAzZGEtNDI0NS05MmViLWZh
-        MjBjM2E5Y2RmNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvZTkyYjhjOTEtZTcyZi00OTcyLTkyODAtMWQzYzcyYjU0
+        ZjljLyIsICJ0YXNrX2lkIjogImU5MmI4YzkxLWU3MmYtNDk3Mi05MjgwLTFk
+        M2M3MmI1NGY5YyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -17940,41 +3052,41 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDQ0
-        NDY3N2M3NDJkMDZjY2NlMjIifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIxOjU5OjMzWiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjE6NTk6MzNa
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA0NDU2NzdjNzQwODEyMzIyNDBlIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNDQ1MzQ0NzFlNDAwNzBiMDlmMyJ9LCAiaWQi
-        OiAiNTZiZDA0NDUzNDQ3MWU0MDA3MGIwOWYzIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:34 GMT
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQyNWRlMDQw
+        MzNmNDM1MTRmNjEifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ3OjM0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDc6MzRaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkMjZk
+        ZTA0MDMwODk3NThhODZmIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDI2OTg5MDU0ZmM0OGJhMmVjMSJ9LCAiaWQiOiAiNTZj
+        YzhkMjY5ODkwNTRmYzQ4YmEyZWMxIn0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:34 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/c83c9c20-03da-4245-92eb-fa20c3a9cdf4/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/e92b8c91-e72f-4972-9280-1d3c72b54f9c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -17993,13 +3105,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:34 GMT
+      - Tue, 23 Feb 2016 16:47:34 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '6929'
+      - '6923'
       Connection:
       - close
       Content-Type:
@@ -18009,163 +3121,163 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9jODNjOWMyMC0wM2RhLTQyNDUtOTJlYi1mYTIw
-        YzNhOWNkZjQvIiwgInRhc2tfaWQiOiAiYzgzYzljMjAtMDNkYS00MjQ1LTky
-        ZWItZmEyMGMzYTljZGY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy9lOTJiOGM5MS1lNzJmLTQ5NzItOTI4MC0xZDNj
+        NzJiNTRmOWMvIiwgInRhc2tfaWQiOiAiZTkyYjhjOTEtZTcyZi00OTcyLTky
+        ODAtMWQzYzcyYjU0ZjljIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0xMVQyMTo1OTozNFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMTo1OTozM1oiLCAi
+        bWUiOiAiMjAxNi0wMi0yM1QxNjo0NzozNFoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0NzozNFoiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJkZjA5YWI0Mi02NmY3LTQyYWYtOTRmYS1mM2U3MzYx
-        ZWM2MGMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICIwZmU5MzQ1ZS03ZDY3LTQwZTktYWRmYS01ZTkxZGY2
+        YjU1OGMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNmM5ZDJkYTEtYzk3Yi00ZjIyLWJiMDAtNGViMDgxYWVjOTJkIiwg
+        aWQiOiAiNmNhMDNjNjctNGNmZC00NDY1LTg0YTctYmIwNWE2ZmI3ZTg4Iiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
         bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNDVlZDkxMzgtMmMzYS00M2M5LTkxMWUt
-        NTYwNGRiZjdkOWUyIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiY2I5MGM0MWYtNTM3ZS00ZTZkLWIwMTEt
+        NmE3ZThkYjg2ZWFmIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
         TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDZi
-        YmFjOTYtMTMzOC00MzY1LWJhM2EtYWRiZGM3ZWE1NjYzIiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzZk
+        NzQzOWQtNjc1My00NzlmLWEwZTgtNTY1ZmU2MGI1ZjQ2IiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImMzZGY3M2RlLTQyMDctNDRlZS1hY2YzLWYzNzI3
-        OTI1NThlZCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        IDAsICJzdGVwX2lkIjogImMwYWY2ZGJhLThmNDYtNDYwNy1iNTUxLTE3Mjcy
+        OWE1ODg2MyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
         OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
         InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhYjgwMTRj
-        My01Yjg3LTQ5NzktODk3MC1lN2ZiMTM2ODMyNjAiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2MDBmM2Jl
+        OC0xZjNlLTQwNjEtOTc1MS00ZTQ1YTEyOTFiNGQiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
         Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI5MDM0NzdmOC05NTRmLTQyMTItYTAxZC02ZTEy
-        ZmFkN2IwOWEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICI2YWRkYzVkMi02MjA4LTQ1MDEtODI2ZC02YTMy
+        YmI1YjkxNjUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
         ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJjMzU3NTNkZC00MjIyLTQxYjAtOTliOC0zMGQ4ZTA1NzM4M2Ei
+        cF9pZCI6ICJhNDE4ZTc0Yy05MDU5LTQxYmUtOGMzMS00NDdjNmQxODNmYjMi
         LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
         dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
         c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjNjJi
-        YjAzYS04ZGRhLTQ1NzgtODk2Mi1mMTU1NWVkZTRlZmQiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkYTBh
+        NDIxOS1jODdkLTRjNmMtOGViMi02ZDBlZTg3ZDJkNGQiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
         aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkYmYyZTNmOC1kOTkw
-        LTRkNTAtOWVhNi0zNzU4MWVlZTk1ZjIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2MWI2NzFmOC04N2Uz
+        LTRlN2YtOWIxYy00MTRhN2NjNGM5MTgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
         TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
         X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ2OGU1M2Q4LWEwYjktNDRj
-        Zi1iNWNhLWZlODNkYzI0YmI3MSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8t
-        YnVycml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBr
-        YXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTExVDIxOjU5OjMz
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMTFUMjE6NTk6MzRaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiZDA0NDY2NzdjNzQw
-        ODEyMzIyNDBmIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImRmMDlhYjQyLTY2ZjctNDJhZi05NGZhLWYzZTczNjFlYzYw
-        YyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI2YzlkMmRhMS1jOTdiLTRmMjItYmIwMC00ZWIwODFhZWM5MmQiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI0NWVkOTEzOC0yYzNhLTQzYzktOTExZS01NjA0
-        ZGJmN2Q5ZTIiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkNmJiYWM5
-        Ni0xMzM4LTQzNjUtYmEzYS1hZGJkYzdlYTU2NjMiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiYzNkZjczZGUtNDIwNy00NGVlLWFjZjMtZjM3Mjc5MjU1
-        OGVkIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFiODAxNGMzLTVi
-        ODctNDk3OS04OTcwLWU3ZmIxMzY4MzI2MCIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjkwMzQ3N2Y4LTk1NGYtNDIxMi1hMDFkLTZlMTJmYWQ3
-        YjA5YSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImU0NzQ1YmUxLWQ1YjktNDgy
+        Mi1iOGZmLTE4NmQ2NDRkMGIyMCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
+        c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
+        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ3OjM0WiIsICJf
+        bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
+        MTYtMDItMjNUMTY6NDc6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
+        cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
+        IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
+        X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
+        RCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1z
+        IjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0
+        aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
+        SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
+        U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
+        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZjYzhkMjZkZTA0MDMwODk3NThh
+        ODcwIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
         IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImMzNTc1M2RkLTQyMjItNDFiMC05OWI4LTMwZDhlMDU3MzgzYSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM2MmJiMDNh
-        LThkZGEtNDU3OC04OTYyLWYxNTU1ZWRlNGVmZCIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        IjogIjBmZTkzNDVlLTdkNjctNDBlOS1hZGZhLTVlOTFkZjZiNTU4YyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2Y2Ew
+        M2M2Ny00Y2ZkLTQ0NjUtODRhNy1iYjA1YTZmYjdlODgiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICJjYjkwYzQxZi01MzdlLTRlNmQtYjAxMS02YTdlOGRiODZl
+        YWYiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzNmQ3NDM5ZC02NzUz
+        LTQ3OWYtYTBlOC01NjVmZTYwYjVmNDYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiYzBhZjZkYmEtOGY0Ni00NjA3LWI1NTEtMTcyNzI5YTU4ODYzIiwg
+        Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
+        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImRiZjJlM2Y4LWQ5OTAtNGQ1
-        MC05ZWE2LTM3NTgxZWVlOTVmMiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDY4ZTUzZDgtYTBiOS00NGNmLWI1
-        Y2EtZmU4M2RjMjRiYjcxIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmQwNDQ1MzQ0NzFlNDAw
-        NzBiMGEwMyJ9LCAiaWQiOiAiNTZiZDA0NDUzNDQ3MWU0MDA3MGIwYTAzIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 21:59:34 GMT
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjYwMGYzYmU4LTFmM2UtNDA2
+        MS05NzUxLTRlNDVhMTI5MWI0ZCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
+        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjZhZGRjNWQyLTYyMDgtNDUwMS04MjZkLTZhMzJiYjViOTE2NSIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE0
+        MThlNzRjLTkwNTktNDFiZS04YzMxLTQ0N2M2ZDE4M2ZiMyIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
+        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
+        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImRhMGE0MjE5LWM4N2Qt
+        NGM2Yy04ZWIyLTZkMGVlODdkMmQ0ZCIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
+        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjYxYjY3MWY4LTg3ZTMtNGU3Zi05YjFj
+        LTQxNGE3Y2M0YzkxOCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
+        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiZTQ3NDViZTEtZDViOS00ODIyLWI4ZmYtMTg2
+        ZDY0NGQwYjIwIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDI2OTg5MDU0ZmM0OGJhMmVk
+        MSJ9LCAiaWQiOiAiNTZjYzhkMjY5ODkwNTRmYzQ4YmEyZWQxIn0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:34 GMT
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/consumers/
+    uri: https://katello-yoda.example.com/pulp/api/v2/consumers/
     body:
       encoding: UTF-8
       base64_string: |
@@ -18189,13 +3301,13 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:34 GMT
+      - Tue, 23 Feb 2016 16:47:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
       - '2184'
       Location:
-      - https://katello-burrito.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
+      - https://katello-yoda.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
       Connection:
       - close
       Content-Type:
@@ -18207,56 +3319,56 @@ http_interactions:
         MTFFMi04MUMxLTA4MDAyMDBDOUE2NiIsICJkZXNjcmlwdGlvbiI6IG51bGws
         ICJfbnMiOiAiY29uc3VtZXJzIiwgIm5vdGVzIjoge30sICJyc2FfcHViIjog
         bnVsbCwgImNhcGFiaWxpdGllcyI6IHt9LCAiX2lkIjogeyIkb2lkIjogIjU2
-        YmQwNDQ2Njc3Yzc0MmQwNWFmMzdkYSJ9LCAiaWQiOiAiMDEwRTk5QzAtMzI3
+        Y2M4ZDI3ZGUwNDAzM2Y0MjYyY2E5OSJ9LCAiaWQiOiAiMDEwRTk5QzAtMzI3
         Ni0xMUUyLTgxQzEtMDgwMDIwMEM5QTY2IiwgIl9ocmVmIjogIi9wdWxwL2Fw
         aS92Mi9jb25zdW1lcnMvMDEwRTk5QzAtMzI3Ni0xMUUyLTgxQzEtMDgwMDIw
         MEM5QTY2LyJ9LCAiY2VydGlmaWNhdGUiOiAiLS0tLS1CRUdJTiBSU0EgUFJJ
-        VkFURSBLRVktLS0tLVxuTUlJQ1d3SUJBQUtCZ1FDbFNRMU9tYkdrU21rU1Ba
-        eHhhQm5zU3JxdWVyUmt0elJMTTl3cGszTURBeVVmcWdQL1xuV0ZwM1Q1a1pD
-        QmFTajlwMkVEcDRmUzJVa2QrdHhaU2RZREwvNzRzTHNjdytLbnkvRXdYczJL
-        aFhmYXJEV2V3UlxuY25SeEFOdHRUMmVBZmxxQVNic29UWmYzL2JoWm5VRVhC
-        TEw5WGd5ZHR5dHZ2MytwWjI5Qi9KUDZWd0lEQVFBQlxuQW9HQUw0Q09QWCs0
-        YVNJbGptTjhtYTgwZkErQ0ZYRVlkVFdkNXRzUnREVTNRYTlldFBuMHlpY0hZ
-        UERVYkRoQlxuM0g5Ulpzc0ZNdW11OXRyeHNReHV5TWdELzhueXd4cGFkQzZW
-        dFhYZFZxSFR4QmRDV0dJZFJoTk5DdEQyNklpc1xuRDBLQTNCTmE0YVJvc2o5
-        UWxNbVVsL1hjY2d2emcwV2RTVzlwVVB3TVRlbklOU0VDUVFEVnNwc2R1czdK
-        V1UraFxuRVZWRW0vV0N6TFpxcmtlUW9TYllvbjRPSDVLSEJTNityc3NDWk5v
-        T1d6QlE4MXJackpEcU9PMWJWSVdtczNEclxuWlBIUHJFM25Ba0VBeGdFWGho
-        Mk5Oblkvd2ZJSHRTMzREekhWc1FsblRxT1lRVW9OcWxZK0dHTC9YVjM3bERX
-        MFxuTzJseVpHSU1HNzRUZ0xzL2VsRnhid2JuZ0FoR1kyRUNFUUpBZldNOUxP
-        YU5xd3NpZEFtdGxJSkdQaWRMNmJDMVxuQVNIdG56Tkk3NVNLNzNxVkFRR2kw
-        SmJJYzZBQjY1Mis4dllVV2JwcFd5dHUrRzlWbEdrNGtYZ3loUUpBUVcycVxu
-        OEU1amsxT1B6ZTdFVFVKYmJlbnh5d1pvZEx2cVcraTBpMHprUi9xdWw1T3V4
-        bExZczZrc2U2OUtnUUJXUVh1ZVxuaGpUVFh2VFJHcVdoWE1WNWdRSkFlS1RG
-        RkFaSFpUVVpGdFVZbDZ6V3htR3lXV05VNEIzQ2k0ZXpqZHFySnRIQ1xuQkQ1
-        cjloK25pY1RXVGsrNFowTEhQSUJrMklyMW5iZ0tHTHhhSC9jSDN3PT1cbi0t
+        VkFURSBLRVktLS0tLVxuTUlJQ1d3SUJBQUtCZ1FDdGJnVU9XRFhEWEJBRytU
+        WDY3T09HakJTbnJaSGF0WGZJbnZEcUlVRFV0NE5MU1FMWlxueUJjaUhlRWZ1
+        MWhQUGdmNWhCOUY1YUxnSFhZZHl2aDFyUDI5dWdhOTVnSE4zZXptbGVJbHp4
+        c1JDak1mYXVFd1xudjZsQ21xTkdoOElFUXA2V0QwZlhVamtjdStDSHNLZHpY
+        cnJDT0FZNE50Z2N6bjdxTUJOV1J0cXBnUUlEQVFBQlxuQW9HQWRQZEdvYTRN
+        VkgyNnNYbFNWckY5b2pqSGxXOFNkNWI3K21wM3dQQThjVHB6YWtzTGlTWFJ0
+        RWpDbEV3ZFxuK3hPeS9TMkdpZldlSzlpeTJOVVRUUW9tOXJraFgyeGlkOHU4
+        VXZQTE9BLzVQaGp6WWpsQkdrWTMxbzlyM2xWelxudlZUK1BGcjNYMHN3bEgx
+        SWV1VEM0Y1J6YXdFM3FpTGxibkNEZXZEdU41RjY0NEVDUVFEbXozVU95eU5S
+        bzZnMVxuL1VNUjZVWkx5OHBOMUFzQkhyOXpOK2loNXB4UU1ITGMxZFZsd3pZ
+        Rm1oRG96N2ZSQjhaanE0SU14YWwySDBadFxud212VUdUTVZBa0VBd0Z0c0tT
+        cytYZFd4TVE5bUZHOTVqV3RNZzhHbHhYcWpYR21Tbm9rbFJGUmVGT2lRdG5z
+        dlxuYkhzOUJGNXZ3T3BiWkRWa2dlenBYemhUNWdpVmtJam52UUpBWkJEYlFp
+        K2x2MVpCcmk1Lzduc0JSQWsxU3lxOFxuSHA4ekI0UGNzcHhsZG9xYXNjMXZP
+        REE2OHBESjlmVmdUeHFjMDBkZkdhUjBoTWFvWlJ1ZVhoVVN4UUpBYTVkM1xu
+        VXp1MTRhUnlQTi9CR0RNV0NTejRHa1pKWThEcCtQbXdJZTdTSW5zU09KMnd1
+        L0VCSUt0NkFLU1YyNUQ2VjMycFxuM3laVmpvWWlIMnV6eEtsZS9RSkFEUVhu
+        Nk5PMkh1SVd0Y0FQTXNBNURnaHNmODR1dFJiOUlocHlxVWhXNWVmY1xuRVNS
+        OFpmRWpHT292SVhmamxHWlcrTWVqU3J3RTRlalNrR1pIL3B1dktRPT1cbi0t
         LS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tXG4tLS0tLUJFR0lOIENFUlRJ
-        RklDQVRFLS0tLS1cbk1JSUNmakNDQVdZQ0FUSXdEUVlKS29aSWh2Y05BUUVG
-        QlFBd05URWtNQ0lHQTFVRUF3d2JhMkYwWld4c2J5MWlcbmRYSnlhWFJ2TG1W
-        NFlXMXdiR1V1WTI5dE1RMHdDd1lEVlFRS0RBUlFWVXhRTUI0WERURTJNREl4
-        TVRJeE5Ua3pcbk5Gb1hEVEkyTURJd09ESXhOVGt6TkZvd1dURXRNQ3NHQTFV
-        RUF4TWtNREV3UlRrNVF6QXRNekkzTmkweE1VVXlcbkxUZ3hRekV0TURnd01E
-        SXdNRU01UVRZMk1TZ3dKZ1lLQ1pJbWlaUHlMR1FCQVJNWU5UWmlaREEwTkRZ
-        Mk56ZGpcbk56UXlaREExWVdZek4yUmhNSUdmTUEwR0NTcUdTSWIzRFFFQkFR
-        VUFBNEdOQURDQmlRS0JnUUNsU1ExT21iR2tcblNta1NQWnh4YUJuc1NycXVl
-        clJrdHpSTE05d3BrM01EQXlVZnFnUC9XRnAzVDVrWkNCYVNqOXAyRURwNGZT
-        MlVcbmtkK3R4WlNkWURMLzc0c0xzY3crS255L0V3WHMyS2hYZmFyRFdld1Jj
-        blJ4QU50dFQyZUFmbHFBU2Jzb1RaZjNcbi9iaFpuVUVYQkxMOVhneWR0eXR2
-        djMrcFoyOUIvSlA2VndJREFRQUJNQTBHQ1NxR1NJYjNEUUVCQlFVQUE0SUJc
-        bkFRQmQrUDNPNkNpaGtIVldPNkNKWXU1allIR3F3Y0piVDh3OHZpYUpPT3RP
-        U0JmNVFaUWZzREo4MGdLeGY2WmJcbit3TzYvZTM3eUtiMWw5bU52dG9FTnhv
-        NmFlTDI5ME5FYU4vVkxObUI4dzB1c2ZYdnFqYUFVZDM4ZjJLREk2RzNcblJU
-        QS9RZG5mUldTRks3Tk1RUVhEQWJ6Y0QrZ2RaeVZFYnFGTTdkVTdUaDJVdmZj
-        QWVjenZkL1dsdEFFdzN4T2RcbkhJYjc0cUVoVDNHczlxMHVZRHB1SW9MRlJ2
-        TlpzSlhuSHAxQkpMQVN6bzkrcmJ1cDY5QnZKUkdzeUlEbXA0dDhcbmMzemlX
-        YXRmYTkwM2txUTE3bmhleFBoR0ZoN0lvUVhYdG5CZklYSGtBcUNZUE5mc3cx
-        QitFQWhrOUJVZElZY3FcbndnaUIzMUJlOEVYNkVyTElsME5yZzJIWlxuLS0t
+        RklDQVRFLS0tLS1cbk1JSUNmRENDQVdRQ0FnRXdNQTBHQ1NxR1NJYjNEUUVC
+        QlFVQU1ESXhJVEFmQmdOVkJBTU1HR3RoZEdWc2JHOHRcbmVXOWtZUzVsZUdG
+        dGNHeGxMbU52YlRFTk1Bc0dBMVVFQ2d3RVVGVk1VREFlRncweE5qQXlNak14
+        TmpRM016VmFcbkZ3MHlOakF5TWpBeE5qUTNNelZhTUZreExUQXJCZ05WQkFN
+        VEpEQXhNRVU1T1VNd0xUTXlOell0TVRGRk1pMDRcbk1VTXhMVEE0TURBeU1E
+        QkRPVUUyTmpFb01DWUdDZ21TSm9tVDhpeGtBUUVUR0RVMlkyTTRaREkzWkdV
+        d05EQXpcbk0yWTBNall5WTJFNU9UQ0JuekFOQmdrcWhraUc5dzBCQVFFRkFB
+        T0JqUUF3Z1lrQ2dZRUFyVzRGRGxnMXcxd1FcbkJ2azErdXpqaG93VXA2MlIy
+        clYzeUo3dzZpRkExTGVEUzBrQzJjZ1hJaDNoSDd0WVR6NEgrWVFmUmVXaTRC
+        MTJcbkhjcjRkYXo5dmJvR3ZlWUJ6ZDNzNXBYaUpjOGJFUW96SDJyaE1MK3BR
+        cHFqUm9mQ0JFS2VsZzlIMTFJNUhMdmdcbmg3Q25jMTY2d2pnR09EYllITTUr
+        NmpBVFZrYmFxWUVDQXdFQUFUQU5CZ2txaGtpRzl3MEJBUVVGQUFPQ0FRRUFc
+        bm1qREFpM25lSDdtNFpOS2FHQXNkL1MwRHJRQ2NEMG9LNlBIVE5ldVMyUFZK
+        QjAwVjFuNWt6bDA1UlExRFRZc1lcbmF4Rk1WbVZmMldKTGRYcUNHYUgwUGlZ
+        bU84ekUxUWp0cUpHMWN5RElGMXZoamZZVERyM2JJVThERHJ0VWhGczJcbm5I
+        MVZ6YTFDVkxNQTFnQ0lnRjNyaGtlTWEwWmRHaDBIZGZrbkhxcDJuSzVSNEVT
+        dzVDVUxuM2twdVFpVjhJdXdcblVhTWE2TXB5SnNnYWZSajVwc3RORllBbEh0
+        Sm5lZDR2Wk40TGJobVNndkYrUUZNcS9NSFlMQUVFVlkrNXZWYmRcbjVWa0to
+        ckxvaEdSbmJpTHVlNDZnYk9welAwcml0Rjl3TC92Qm1HeXRtSVVFZDBSZklS
+        U0h4ZmI2dDZPeTJFV1NcbjF1RmRYQ2UrM29zZThFQjVxdURiU2c9PVxuLS0t
         LS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:59:34 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:35 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/bindings//
+    uri: https://katello-yoda.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/bindings//
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -18275,7 +3387,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:35 GMT
+      - Tue, 23 Feb 2016 16:47:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -18289,10 +3401,10 @@ http_interactions:
       base64_string: |
         W10=
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:59:35 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:35 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -18311,13 +3423,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:35 GMT
+      - Tue, 23 Feb 2016 16:47:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1707'
+      - '2095'
       Connection:
       - close
       Content-Type:
@@ -18329,45 +3441,54 @@ http_interactions:
         ZGlzcGxheV9uYW1lIjogIkZlZG9yYSAxNyB4ODZfNjQiLCAiZGVzY3JpcHRp
         b24iOiBudWxsLCAiZGlzdHJpYnV0b3JzIjogW3sicmVwb19pZCI6ICJGZWRv
         cmFfMTciLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9G
-        ZWRvcmFfMTcvZGlzdHJpYnV0b3JzL0ZlZG9yYV8xN19jbG9uZS8iLCAiX25z
-        IjogInJlcG9fZGlzdHJpYnV0b3JzIiwgImxhc3RfcHVibGlzaCI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9jbG9uZV9kaXN0cmlidXRv
+        ZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9kaXN0cmlidXRvci8iLCAi
+        X25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgImxhc3RfcHVibGlzaCI6IG51
+        bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4cG9ydF9kaXN0cmlidXRv
         ciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hwYWQiOiB7fSwg
-        Il9pZCI6IHsiJG9pZCI6ICI1NmJkMDQ0NDY3N2M3NDJkMDZjY2NlMjQifSwg
-        ImNvbmZpZyI6IHsiZGVzdGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiAiRmVk
-        b3JhXzE3In0sICJpZCI6ICJGZWRvcmFfMTdfY2xvbmUifSwgeyJyZXBvX2lk
-        IjogIkZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3Np
-        dG9yaWVzL0ZlZG9yYV8xNy9kaXN0cmlidXRvcnMvRmVkb3JhXzE3LyIsICJf
-        bnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAibGFzdF9wdWJsaXNoIjogIjIw
-        MTYtMDItMTFUMjE6NTk6MzRaIiwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAi
-        eXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IHRydWUsICJzY3Jh
-        dGNocGFkIjoge30sICJfaWQiOiB7IiRvaWQiOiAiNTZiZDA0NDQ2NzdjNzQy
-        ZDA2Y2NjZTIzIn0sICJjb25maWciOiB7ImNoZWNrc3VtX3R5cGUiOiAic2hh
-        MjU2IiwgInByb3RlY3RlZCI6IHRydWUsICJodHRwIjogZmFsc2UsICJodHRw
-        cyI6IHRydWUsICJyZWxhdGl2ZV91cmwiOiAidGVzdF9wYXRoIn0sICJpZCI6
-        ICJGZWRvcmFfMTcifV0sICJsYXN0X3VuaXRfYWRkZWQiOiBudWxsLCAibm90
-        ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwgImxhc3RfdW5pdF9y
-        ZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3VudHMiOiB7InBhY2th
-        Z2VfZ3JvdXAiOiAyLCAiZGlzdHJpYnV0aW9uIjogMSwgInBhY2thZ2VfY2F0
-        ZWdvcnkiOiAxLCAicnBtIjogOCwgImVycmF0dW0iOiAzfSwgIl9ucyI6ICJy
-        ZXBvcyIsICJpbXBvcnRlcnMiOiBbeyJzY3JhdGNocGFkIjogeyJyZXBvbWRf
-        cmV2aXNpb24iOiAxMzIxODkzODAwLCAicHJldmlvdXNfc2tpcF9saXN0Ijog
-        W119LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRv
-        cmFfMTcvaW1wb3J0ZXJzL3l1bV9pbXBvcnRlci8iLCAiX25zIjogInJlcG9f
-        aW1wb3J0ZXJzIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImxhc3Rfc3luYyI6ICIyMDE2LTAyLTExVDIxOjU5OjMzWiIsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJfaWQiOiB7IiRvaWQiOiAiNTZiZDA0NDQ2
-        NzdjNzQyZDA2Y2NjZTIyIn0sICJjb25maWciOiB7ImZlZWQiOiAiZmlsZTov
-        Ly92YXIvd3d3L3Rlc3RfcmVwb3Mvem9vIn0sICJpZCI6ICJ5dW1faW1wb3J0
-        ZXIifV0sICJsb2NhbGx5X3N0b3JlZF91bml0cyI6IDE1LCAiX2lkIjogeyIk
-        b2lkIjogIjU2YmQwNDQ0Njc3Yzc0MmQwNmNjY2UyMSJ9LCAidG90YWxfcmVw
-        b3NpdG9yeV91bml0cyI6IDE1LCAiaWQiOiAiRmVkb3JhXzE3IiwgIl9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvRmVkb3JhXzE3LyJ9
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQyNWRlMDQwMzNmNDM1MTRmNjQifSwg
+        ImNvbmZpZyI6IHsiaHR0cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogInRl
+        c3RfcGF0aCIsICJodHRwcyI6IGZhbHNlfSwgImlkIjogImV4cG9ydF9kaXN0
+        cmlidXRvciJ9LCB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIl9ocmVmIjog
+        Ii9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1
+        dG9ycy9GZWRvcmFfMTdfY2xvbmUvIiwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1
+        dG9ycyIsICJsYXN0X3B1Ymxpc2giOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlw
+        ZV9pZCI6ICJ5dW1fY2xvbmVfZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJsaXNo
+        IjogZmFsc2UsICJzY3JhdGNocGFkIjoge30sICJfaWQiOiB7IiRvaWQiOiAi
+        NTZjYzhkMjVkZTA0MDMzZjQzNTE0ZjYzIn0sICJjb25maWciOiB7ImRlc3Rp
+        bmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8xNyJ9LCAiaWQiOiAi
+        RmVkb3JhXzE3X2Nsb25lIn0sIHsicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcv
+        ZGlzdHJpYnV0b3JzL0ZlZG9yYV8xNy8iLCAiX25zIjogInJlcG9fZGlzdHJp
+        YnV0b3JzIiwgImxhc3RfcHVibGlzaCI6ICIyMDE2LTAyLTIzVDE2OjQ3OjM0
+        WiIsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIs
+        ICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAic2NyYXRjaHBhZCI6IHt9LCAiX2lk
+        IjogeyIkb2lkIjogIjU2Y2M4ZDI1ZGUwNDAzM2Y0MzUxNGY2MiJ9LCAiY29u
+        ZmlnIjogeyJjaGVja3N1bV90eXBlIjogInNoYTI1NiIsICJwcm90ZWN0ZWQi
+        OiB0cnVlLCAiaHR0cCI6IGZhbHNlLCAiaHR0cHMiOiB0cnVlLCAicmVsYXRp
+        dmVfdXJsIjogInRlc3RfcGF0aCJ9LCAiaWQiOiAiRmVkb3JhXzE3In1dLCAi
+        bGFzdF91bml0X2FkZGVkIjogbnVsbCwgIm5vdGVzIjogeyJfcmVwby10eXBl
+        IjogInJwbS1yZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJj
+        b250ZW50X3VuaXRfY291bnRzIjogeyJwYWNrYWdlX2dyb3VwIjogMiwgImRp
+        c3RyaWJ1dGlvbiI6IDEsICJwYWNrYWdlX2NhdGVnb3J5IjogMSwgInJwbSI6
+        IDgsICJlcnJhdHVtIjogM30sICJfbnMiOiAicmVwb3MiLCAiaW1wb3J0ZXJz
+        IjogW3sic2NyYXRjaHBhZCI6IHsicmVwb21kX3JldmlzaW9uIjogMTMyMTg5
+        MzgwMCwgInByZXZpb3VzX3NraXBfbGlzdCI6IFtdfSwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvRmVkb3JhXzE3L2ltcG9ydGVycy95
+        dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBvX2ltcG9ydGVycyIsICJpbXBv
+        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJsYXN0X3N5bmMiOiAi
+        MjAxNi0wMi0yM1QxNjo0NzozNFoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
+        LCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDI1ZGUwNDAzM2Y0MzUxNGY2MSJ9
+        LCAiY29uZmlnIjogeyJmZWVkIjogImZpbGU6Ly8vdmFyL3d3dy90ZXN0X3Jl
+        cG9zL3pvbyJ9LCAiaWQiOiAieXVtX2ltcG9ydGVyIn1dLCAibG9jYWxseV9z
+        dG9yZWRfdW5pdHMiOiAxNCwgIl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQyNWRl
+        MDQwMzNmNDM1MTRmNjAifSwgInRvdGFsX3JlcG9zaXRvcnlfdW5pdHMiOiAx
+        NSwgImlkIjogIkZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIv
+        cmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8ifQ==
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:59:35 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:35 GMT
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/bindings//
+    uri: https://katello-yoda.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/bindings//
     body:
       encoding: UTF-8
       base64_string: |
@@ -18390,7 +3511,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:35 GMT
+      - Tue, 23 Feb 2016 16:47:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -18410,13 +3531,13 @@ http_interactions:
         dG9yX2lkIjogIkZlZG9yYV8xNyIsICJjb25zdW1lcl9pZCI6ICIwMTBFOTlD
         MC0zMjc2LTExRTItODFDMS0wODAwMjAwQzlBNjYiLCAiY29uc3VtZXJfYWN0
         aW9ucyI6IFtdLCAiYmluZGluZ19jb25maWciOiB7fSwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmJkMDQ0NzY3N2M3NDJkMDQ5YjAwYzgifSwgImlkIjogIjU2YmQw
-        NDQ3Njc3Yzc0MmQwNDliMDBjOCJ9LCAiZXJyb3IiOiBudWxsfQ==
+        ZCI6ICI1NmNjOGQyN2RlMDQwMzNmNDM1MTRmNjUifSwgImlkIjogIjU2Y2M4
+        ZDI3ZGUwNDAzM2Y0MzUxNGY2NSJ9LCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:59:35 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:35 GMT
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/actions/content/update//
+    uri: https://katello-yoda.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/actions/content/update//
     body:
       encoding: UTF-8
       base64_string: |
@@ -18439,7 +3560,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:35 GMT
+      - Tue, 23 Feb 2016 16:47:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -18452,14 +3573,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzQ4YTVkMzA4LTk4NDEtNGIwNy1iZTEzLWQ1OGU1YmFkMjM4My8iLCAi
-        dGFza19pZCI6ICI0OGE1ZDMwOC05ODQxLTRiMDctYmUxMy1kNThlNWJhZDIz
-        ODMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzczMzc4NDZmLTVjMTEtNDA5NC1hZjIwLTE0OGNlY2Y4MjQ4MC8iLCAi
+        dGFza19pZCI6ICI3MzM3ODQ2Zi01YzExLTQwOTQtYWYyMC0xNDhjZWNmODI0
+        ODAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:59:35 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:35 GMT
 - request:
     method: delete
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -18478,7 +3599,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:35 GMT
+      - Tue, 23 Feb 2016 16:47:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -18491,14 +3612,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzY2M2I2NTc1LWM1ODctNDJjOS1iNTE3LTMzMjM3NjU4MTY2Yi8iLCAi
-        dGFza19pZCI6ICI2NjNiNjU3NS1jNTg3LTQyYzktYjUxNy0zMzIzNzY1ODE2
-        NmIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2RjNzRiNmExLTEzZjctNDE5Zi1hOWEzLTlhYjEwOGViZjVjMC8iLCAi
+        dGFza19pZCI6ICJkYzc0YjZhMS0xM2Y3LTQxOWYtYTlhMy05YWIxMDhlYmY1
+        YzAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:59:35 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:35 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/663b6575-c587-42c9-b517-33237658166b/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/dc74b6a1-13f7-419f-a9a3-9ab108ebf5c0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -18517,13 +3638,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:35 GMT
+      - Tue, 23 Feb 2016 16:47:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '651'
+      - '663'
       Connection:
       - close
       Content-Type:
@@ -18533,24 +3654,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NjNiNjU3NS1jNTg3LTQyYzktYjUxNy0zMzIzNzY1ODE2
-        NmIvIiwgInRhc2tfaWQiOiAiNjYzYjY1NzUtYzU4Ny00MmM5LWI1MTctMzMy
-        Mzc2NTgxNjZiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYzc0YjZhMS0xM2Y3LTQxOWYtYTlhMy05YWIxMDhlYmY1
+        YzAvIiwgInRhc2tfaWQiOiAiZGM3NGI2YTEtMTNmNy00MTlmLWE5YTMtOWFi
+        MTA4ZWJmNWMwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAi
-        c3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
-        ZXNvdXJjZV93b3JrZXItMEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20i
-        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmJkMDQ0NzM0NDcxZTQwMDcwYjBhMDQifSwgImlkIjogIjU2YmQw
-        NDQ3MzQ0NzFlNDAwNzBiMGEwNCJ9
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ3OjM1WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQyNzk4OTA1NGZjNDhiYTJlZDIifSwg
+        ImlkIjogIjU2Y2M4ZDI3OTg5MDU0ZmM0OGJhMmVkMiJ9
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:59:35 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:35 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/663b6575-c587-42c9-b517-33237658166b/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/dc74b6a1-13f7-419f-a9a3-9ab108ebf5c0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -18569,13 +3690,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:36 GMT
+      - Tue, 23 Feb 2016 16:47:36 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '688'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -18585,25 +3706,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NjNiNjU3NS1jNTg3LTQyYzktYjUxNy0zMzIzNzY1ODE2
-        NmIvIiwgInRhc2tfaWQiOiAiNjYzYjY1NzUtYzU4Ny00MmM5LWI1MTctMzMy
-        Mzc2NTgxNjZiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYzc0YjZhMS0xM2Y3LTQxOWYtYTlhMy05YWIxMDhlYmY1
+        YzAvIiwgInRhc2tfaWQiOiAiZGM3NGI2YTEtMTNmNy00MTlmLWE5YTMtOWFi
+        MTA4ZWJmNWMwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTExVDIxOjU5OjM1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTExVDIxOjU5OjM1WiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ3OjM1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ3OjM1WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZDA0NDczNDQ3MWU0MDA3MGIwYTA0In0sICJpZCI6ICI1NmJkMDQ0NzM0NDcx
-        ZTQwMDcwYjBhMDQifQ==
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMjc5
+        ODkwNTRmYzQ4YmEyZWQyIn0sICJpZCI6ICI1NmNjOGQyNzk4OTA1NGZjNDhi
+        YTJlZDIifQ==
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:59:36 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:36 GMT
 - request:
     method: delete
-    uri: https://katello-burrito.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
+    uri: https://katello-yoda.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -18622,7 +3743,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:59:36 GMT
+      - Tue, 23 Feb 2016 16:47:36 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -18636,5 +3757,5 @@ http_interactions:
       base64_string: |
         bnVsbA==
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:59:36 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:36 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/pulp/consumer/create.yml
+++ b/test/fixtures/vcr_cassettes/pulp/consumer/create.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/consumers/
+    uri: https://katello-yoda.example.com/pulp/api/v2/consumers/
     body:
       encoding: UTF-8
       base64_string: |
@@ -26,13 +26,13 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:58:57 GMT
+      - Tue, 23 Feb 2016 16:47:13 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
-      - '2184'
+      - '2188'
       Location:
-      - https://katello-burrito.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
+      - https://katello-yoda.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
       Connection:
       - close
       Content-Type:
@@ -44,56 +44,56 @@ http_interactions:
         MTFFMi04MUMxLTA4MDAyMDBDOUE2NiIsICJkZXNjcmlwdGlvbiI6IG51bGws
         ICJfbnMiOiAiY29uc3VtZXJzIiwgIm5vdGVzIjoge30sICJyc2FfcHViIjog
         bnVsbCwgImNhcGFiaWxpdGllcyI6IHt9LCAiX2lkIjogeyIkb2lkIjogIjU2
-        YmQwNDIxNjc3Yzc0MmQwNDliMDBhZSJ9LCAiaWQiOiAiMDEwRTk5QzAtMzI3
+        Y2M4ZDExZGUwNDAzM2Y0MWQyYTNjMCJ9LCAiaWQiOiAiMDEwRTk5QzAtMzI3
         Ni0xMUUyLTgxQzEtMDgwMDIwMEM5QTY2IiwgIl9ocmVmIjogIi9wdWxwL2Fw
         aS92Mi9jb25zdW1lcnMvMDEwRTk5QzAtMzI3Ni0xMUUyLTgxQzEtMDgwMDIw
         MEM5QTY2LyJ9LCAiY2VydGlmaWNhdGUiOiAiLS0tLS1CRUdJTiBSU0EgUFJJ
-        VkFURSBLRVktLS0tLVxuTUlJQ1hRSUJBQUtCZ1FETmNFN1duS1ZYOW80cHFp
-        TTVQTnNSUzhXUjM3b0FmMnMyZ2NudEJoOUhsbFhRdmNUelxuVWltczdZZE9H
-        TTVnUnEyWkt1enoySjdJYmZITG9ITG94U3FXc3BJMW53ZDkwSStJdXQyYnF5
-        OCtzUCtjeGNvalxuMEpQNHZPQncxVGRQS3grdVB1Sm5UcHh1MDYrSHZwRmJI
-        K1RqTDFhUHppTkoxQ0pQYW5kSXZ3RHcyd0lEQVFBQlxuQW9HQU5Vc0NHS2hR
-        T0M1c21LQmJQTmp0bDJJSm9acmhISW54WFJWME5YbVdHYk1GRmY1MG5nNWRZ
-        MC9HL3RwdVxuaHdrdXRZSXVMOStzNlIra1R3ZVRaNURtUi9SY0YreUdhMG11
-        dnNlRGFGbi9lY25HVGhvQ3BKQVAwNGpJRjBGR1xua3pTOVdiaENWYWU4ejk3
-        ekRKSGhzWm9NWVNSdGJzbGN6b2FIYlBLbjhqeUEvdEVDUVFEejBnTURldFNV
-        NDFpalxuWlQvdXlJSGFpZHZZUWFmRG1COVlvbDFCVG0xV1VDSWNaMmJ5Mno4
-        dFE0WTQ5OFowTWgvcVpRejRQVlBMM3hOZFxuRUlXL0VmMnBBa0VBMTdONExs
-        Z1l2RS9rQzVKUi9NTDBwMXQ2dVJjVzlNZWlaQTFvbnBhZEJ0NjRDTklvZE9U
-        MFxuWXJqOVJzM3FOQ04zODlGUVlTVXBNYkFROExQY0o1OWs0d0pCQUxVd05l
-        a2FHR3ZrWHZSZHc1cnhDZjZiUC9KL1xuSitxa1czY0VnWVNNZ1pnSXlMQ083
-        dVErcGI0L1ZibHo5OWhWZjM0eVJlY2J1Ky9mQUliQ1JvSHRIckVDUUJHMVxu
-        M2FkSWVuZHp3OUNqYWZIcisvU0YwVlRETFpKWmxkN0xMd3plWnZRNmN6ZmVN
-        WTR2Z2xWY3hRYjhQeithcmUycVxuQVFTSTdaSHoxK0E3bEZiNGdtc0NRUUNp
-        cEJ3ekx0VXF1ZE0wYW11K0Q5ZG5MeVB5azNaSFc4d3RDa1RzQXdxOVxuQUYv
-        VTJtYms1cVpmWWJjZjFmU2xycXJaVmxmckNISzVwY25jQlY4V3hKUU9cbi0t
-        LS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tXG4tLS0tLUJFR0lOIENFUlRJ
-        RklDQVRFLS0tLS1cbk1JSUNmakNDQVdZQ0FTZ3dEUVlKS29aSWh2Y05BUUVG
-        QlFBd05URWtNQ0lHQTFVRUF3d2JhMkYwWld4c2J5MWlcbmRYSnlhWFJ2TG1W
-        NFlXMXdiR1V1WTI5dE1RMHdDd1lEVlFRS0RBUlFWVXhRTUI0WERURTJNREl4
-        TVRJeE5UZzFcbk4xb1hEVEkyTURJd09ESXhOVGcxTjFvd1dURXRNQ3NHQTFV
-        RUF4TWtNREV3UlRrNVF6QXRNekkzTmkweE1VVXlcbkxUZ3hRekV0TURnd01E
-        SXdNRU01UVRZMk1TZ3dKZ1lLQ1pJbWlaUHlMR1FCQVJNWU5UWmlaREEwTWpF
-        Mk56ZGpcbk56UXlaREEwT1dJd01HRmxNSUdmTUEwR0NTcUdTSWIzRFFFQkFR
-        VUFBNEdOQURDQmlRS0JnUUROY0U3V25LVlhcbjlvNHBxaU01UE5zUlM4V1Iz
-        N29BZjJzMmdjbnRCaDlIbGxYUXZjVHpVaW1zN1lkT0dNNWdScTJaS3V6ejJK
-        N0lcbmJmSExvSExveFNxV3NwSTFud2Q5MEkrSXV0MmJxeTgrc1ArY3hjb2ow
-        SlA0dk9CdzFUZFBLeCt1UHVKblRweHVcbjA2K0h2cEZiSCtUakwxYVB6aU5K
-        MUNKUGFuZEl2d0R3MndJREFRQUJNQTBHQ1NxR1NJYjNEUUVCQlFVQUE0SUJc
-        bkFRQ0hDQi9hZ1dHSGdOUzdrdVRxWExyUzZqNXVPdzd3Q2JoRTZudUFjcDFo
-        MmpaVU50QTVmbkJUSXlnYWZQZGNcbnhGMVdOWVZweFZScWFrTk5NRFd5aUpo
-        MWhSR0ZPYURkNVhDVnNZbnhoTUtyRHFYMjlnMmthYkgxUGJncWtOU2JcbnY0
-        TmowdGlTM0wvWHUvcC9xVjVjdU5zRmdScHlOK3U3b3BhYnVaMENtZnhMVGFl
-        UklOVFIxLzJqeHlNLzRIK0lcbnEzRW40eDVBaUJnOGpQV2R2WGgxdmRDUllm
-        dWttbFB2TDhINjVCMXdvd000UFlsaVBWbHBmTTM2VVBZNktuYzdcbjNCd3gy
-        TW5HbUJIbllCV3JDREpibThOb213U2lnYm9Xb3RkeTNxSkFWamRZZnpEMzh3
-        M0cvUnFwUzZ1ejZRVndcbjlyb3hwNmVLZU5GbWZnYkIyKzA1ckNSQVxuLS0t
-        LS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9
+        VkFURSBLRVktLS0tLVxuTUlJQ1hnSUJBQUtCZ1FDY01GMzdBWW5teTUxbzNl
+        eUcvWHdOOFFtc1JlaHVxQlEwZXp2WExid2h0L0hHdUU4a1xuVjBVYitmK0xu
+        UU5zbFpqM1lzN2hXVm5YZUlVT1JKTmx3cjh2NUtJeXFNWXN0UUdwdGpUdzV0
+        eGtWcXh1Z0p3a1xuN0JtdGxVZVVCNWphRUVzcG9lVlBxd1pKTFhkU2wyS0RP
+        c0ZmMXZRZ2ZRbzhJaU02alhmSzM3NHJxUUlEQVFBQlxuQW9HQUhhc3VYdnpH
+        MWpsOVdDczN2OWlzMVBVaGNrRUJTdXZRa3J1Si9YRHBtTG9aU2pjK2lWZXVn
+        QWI0SE93aFxuZDJIZlliYTZONkpDWjZTMEdhYTdIUXhtUm9XK0NEcU83RmE1
+        RFpqWkdmRWR1Uko3R2M1ZDFzTjdKdTZkQmtQclxuZE0rbjVKdWtvNEc2d3VW
+        Tzl2a2s5U0dUb0NybVNDMytaQzJidy9HTWlsb29Ja1VDUVFESjROWTBLcDVr
+        aEE4Z1xuWitLOEMxb2VnUm5MeEQ4YUlONFdFYzByRW5ZbXRuSzJCMWlNSFlJ
+        cnlpYUN1Zzl2ZlVKOXA3NlNkY0lZaUd2dVxuMG5USWN5NERBa0VBeGcvUUlz
+        ZmZqSkgvSlFqbWpvUnFPbUw0ak1yTHZSU3FoeURJbHdaUzUxMjRvMEEzYitK
+        cFxuQnpEQk9ubjQ1S1dkQk8rZCtsSDRNbkllei8wL3ZvZDE0d0pCQUx6MlY0
+        bzgya1g3MXF6ZWtMeXpZNGRxRUZ0TFxuTmtXZXZrS3FKd0ZLSm8zVitVbXBW
+        cGpRaGllMjhKVXMwNFhvR1hURXJ2MG9mS1c2REUxZmNUQ3ZuMEVDUVFEQlxu
+        dVpuVlN6YW5JZTR6NVQ3TnkwcTBEVFliVUFoenl4RDQxdUljaGp6MHZNRHFQ
+        TmQ4Z2pKRXJEVno0dlhGZncvVVxuVWlOdFFsdkh5OFBEb0d1SENxd05Ba0VB
+        aGIzTEZXRVhMTHJYUEVMd3FobnJ1eFFnQlhPS0ZmeWRMY244TExCVVxuM2Y5
+        L3R6WDQ4dEQ3Nlp5bVY2L3ZrS1BUVDhDUWV1T1JnNnhNdGp1NUpybyt4UT09
+        XG4tLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLVxuLS0tLS1CRUdJTiBD
+        RVJUSUZJQ0FURS0tLS0tXG5NSUlDZkRDQ0FXUUNBZ0VtTUEwR0NTcUdTSWIz
+        RFFFQkJRVUFNREl4SVRBZkJnTlZCQU1NR0d0aGRHVnNiRzh0XG5lVzlrWVM1
+        bGVHRnRjR3hsTG1OdmJURU5NQXNHQTFVRUNnd0VVRlZNVURBZUZ3MHhOakF5
+        TWpNeE5qUTNNVE5hXG5GdzB5TmpBeU1qQXhOalEzTVROYU1Ga3hMVEFyQmdO
+        VkJBTVRKREF4TUVVNU9VTXdMVE15TnpZdE1URkZNaTA0XG5NVU14TFRBNE1E
+        QXlNREJET1VFMk5qRW9NQ1lHQ2dtU0pvbVQ4aXhrQVFFVEdEVTJZMk00WkRF
+        eFpHVXdOREF6XG5NMlkwTVdReVlUTmpNRENCbnpBTkJna3Foa2lHOXcwQkFR
+        RUZBQU9CalFBd2dZa0NnWUVBbkRCZCt3R0o1c3VkXG5hTjNzaHYxOERmRUpy
+        RVhvYnFnVU5IczcxeTI4SWJmeHhyaFBKRmRGRy9uL2k1MERiSldZOTJMTzRW
+        bFoxM2lGXG5Ea1NUWmNLL0wrU2lNcWpHTExVQnFiWTA4T2JjWkZhc2JvQ2NK
+        T3daclpWSGxBZVkyaEJMS2FIbFQ2c0dTUzEzXG5VcGRpZ3pyQlg5YjBJSDBL
+        UENJak9vMTN5dCsrSzZrQ0F3RUFBVEFOQmdrcWhraUc5dzBCQVFVRkFBT0NB
+        UUVBXG5USHpFTW1aeDMweFdKWXdJaFd5MmN1Q1RZdWdIdW9RRzk3NEs4dTBW
+        b1U1SjF2YlRRN0VCdjVTNkJMNDRNRVhoXG5hYy9qVC83dnFvT3ludGVhR3J2
+        amNTOTc5d3FmTllpSDJ4bzc0UUFCUUhoTG9FWUF4ZGloallXY2QrdjhsQk9C
+        XG5leGhpdDdDNEZScVlTcHRJL0tTQnFXRFo2aFlKcVlTYmJ2ZjBYRDFSazk2
+        MTVvS2dEMmpwNTVJTk0yekVyeS8vXG5NYkkvdVMvdmxJMFlkVWk3VEl1UGhR
+        NW1RSGQvVURmSjJjbU1pN3VRV2srS3MxblNWdjJ3Q3laYnAyWHh5WkdVXG5v
+        RFllUlJTQmpRNzhWak9KK01LcDIrRFdvdEp6K0NqNjhqYXhXc1dFeUEyWWJ4
+        OXRCUk9mWFZMM2duZkdZdkZvXG5Ma2dpYlJrLzd0RmQrYnFoRklFTWZRPT1c
+        bi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0ifQ==
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:58:57 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:13 GMT
 - request:
     method: delete
-    uri: https://katello-burrito.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
+    uri: https://katello-yoda.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -112,7 +112,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:58:57 GMT
+      - Tue, 23 Feb 2016 16:47:13 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -126,5 +126,5 @@ http_interactions:
       base64_string: |
         bnVsbA==
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:58:57 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:13 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/pulp/consumer/delete.yml
+++ b/test/fixtures/vcr_cassettes/pulp/consumer/delete.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/consumers/
+    uri: https://katello-yoda.example.com/pulp/api/v2/consumers/
     body:
       encoding: UTF-8
       base64_string: |
@@ -26,13 +26,13 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:58:58 GMT
+      - Tue, 23 Feb 2016 16:47:14 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
       - '2188'
       Location:
-      - https://katello-burrito.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
+      - https://katello-yoda.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
       Connection:
       - close
       Content-Type:
@@ -44,56 +44,56 @@ http_interactions:
         MTFFMi04MUMxLTA4MDAyMDBDOUE2NiIsICJkZXNjcmlwdGlvbiI6IG51bGws
         ICJfbnMiOiAiY29uc3VtZXJzIiwgIm5vdGVzIjoge30sICJyc2FfcHViIjog
         bnVsbCwgImNhcGFiaWxpdGllcyI6IHt9LCAiX2lkIjogeyIkb2lkIjogIjU2
-        YmQwNDIyNjc3Yzc0MmQwNmNjY2RmNyJ9LCAiaWQiOiAiMDEwRTk5QzAtMzI3
+        Y2M4ZDEyZGUwNDAzM2Y0MWQyYTNjNCJ9LCAiaWQiOiAiMDEwRTk5QzAtMzI3
         Ni0xMUUyLTgxQzEtMDgwMDIwMEM5QTY2IiwgIl9ocmVmIjogIi9wdWxwL2Fw
         aS92Mi9jb25zdW1lcnMvMDEwRTk5QzAtMzI3Ni0xMUUyLTgxQzEtMDgwMDIw
         MEM5QTY2LyJ9LCAiY2VydGlmaWNhdGUiOiAiLS0tLS1CRUdJTiBSU0EgUFJJ
-        VkFURSBLRVktLS0tLVxuTUlJQ1hnSUJBQUtCZ1FEaXVXY3RBN1RzWkxXc0R4
-        a2gxTmJVd3pLNm5RTGVkeCsrdTVKbHJTWk15dlNUOHowMFxuTjFMT21vbW5S
-        TkZQTlJkTmxrYnZXcXhnWWtnWnJxa0ZqazUySTdUMmtuTEE1cVlyWmZ1Mit3
-        QmlsQ3BsTHN2WFxudEJ3akUzOVo1M2FEMDY1cEF5SkJMOWVpQlBkNk9mMG5Y
-        K1crUzhkZ2grNHZiaTBveHljQ3Ava25md0lEQVFBQlxuQW9HQkFLRGRzOXM0
-        bWhKd2tvWjJYL3FsTFpqZ3R3bTVoZU9hMmlkV3AxVUZPZnVhdFZhVWE0UzFE
-        RWdUVmtBY1xuai9hSFVQVjMvdlN0ZlVrVjh0cG1GdjhlTFlSSGJuOVhody92
-        bFl5WUhCbEt3VGVlOXhjYTJTTW0wL21Xd2JSK1xubVZYaVM3SDV0RnRabHJT
-        MUVlZzMzTjlYS0I5Y3pFNFk5bzcrU2NxcGI4SVVxMFdCQWtFQTl1QVJRbGJP
-        RTRhL1xuenpTWVJwT21kRmIzZFhOYmE1bnp0Q1BFcUtHanduQnhzalBadWhp
-        dEhFOFg0MmxuczlMK21CMHhDdlVlNWRNdlxuOGd4cGNiWURVUUpCQU9zYXFx
-        aVVEb2tESHlTb2x5V09zM0prUUszcVIyTkUvQ2hPMEl3MGZXOWdFMjROaVdn
-        SlxuaCtkU2N2b0phZngvck9Qd0VObHFZekphYUQ1VTAzVGNxYzhDUVFDTE9S
-        dWluTStFcFlaQU5UbjIrMGR3N3FhSlxuUHUvOGc0cXpPVVNya05TSVQ5OWVq
-        dTBuak1qN1lRTm94VVd0WEwwbFRia2RvOVN6NldCdGtXQlp0enF4QWtFQVxu
-        eG53SDhqUzFKTVVtNk1zUWVCdkdzZCtqbjNCMy9uNENLSUdKbmFTKzlXVjJZ
-        ZVk1eUVTcm9RYkJuUWlQbXlXclxuTC9EQU9OMlJpN1E1NTgyempDaXpqd0pB
-        WGV6UTRoSWZOT1UvdDQyeHlQcDFBaXF1eG5MMjJ1b2NwenZ5YU9FY1xuZzFR
-        dVBaWDRFUjhzWWF0UUJTVUNLWk9MT3FBalFuM1drcWk3Vk9Wa3BML3dSUT09
+        VkFURSBLRVktLS0tLVxuTUlJQ1hnSUJBQUtCZ1FEZ3pxS05Ea1N6VVY0UnRu
+        d0dtUk4yMklRQm1iYWthdTA0NlhQNUNVR2lFbFkxbWxRVFxuVHp0NVgvRW42
+        NVZIdXFEaC9PQzRVNXRGUWZTUW1nbFRySENiMjYxNVhkZTZBeWlXcXJwQW5B
+        Ry9VZVY5U05hZFxuekV6VTVGN3BMMzdDL01aamUxaEJ2SW45ald5dWJtUWFR
+        TW5abnhIYmt2SnpOb3VhbUVYdkVsVkszUUlEQVFBQlxuQW9HQkFOOEZIODIv
+        OGZmVEtQZDVpZUVoeTJXRHRyRy94S21vU2w3RGV3SDhaTmhjU0pvMDJHT3Zu
+        dGp5alZPRlxuS3p0VnNuVi9ZWkI3b1BZOFVGdUQ5T3pGalkrMURTOFBkM0dz
+        eldsM3dXdC9lMFZmRjY4VllYdnVBaHFxWUR1UFxuQ3JxVXlocHJ2c290cmxh
+        WjgrZkYxNnBZWDZtblo0VXhXMGRFOTdNVW9OWFVDUWtCQWtFQSt3bytNL2tX
+        c1BnbFxucE9nZmxZOTBZRHBtdVlrMWQ1MFIzekdSTzVRK2F2dkhtQ1NVYlhJ
+        UXlheUtnUm9tS1g4K0JuakZ0SS9vdHE1RlxuUm8za3ZjZTB4UUpCQU9VL3RP
+        UjdNQ3dMNEhzTlhobWFiNkhUMnpHbW5EYVVreDludUpqemRScmNXTFRrWmxw
+        K1xua1BrQno1Zzl3eVBTREs4OTZCQjN6UTdRdTYxT0tNMlVqemtDUVFEZ0Zx
+        dWg3emF2TUVOQ0tpYVBkZWUzUWtxU1xuVWdXVlNYTTduZDU3cFgvMk5keGNW
+        a0xjVTViaXY0OC9ZUjB4cTdDdFREK0hSM0svSjE4VmRQSDc2bm5WQWtFQVxu
+        c1NaSWo2S04rQXQ1ZlQwNE1RckJKc2xDZ1p5ZzdDQmxqQWduZ3JIbkZVbWVs
+        ckpFVWJ1cUpYRjd6TVkxVERIZFxuc1hGaUtZK1orcy9icHpGVm9IOGpLUUpB
+        UUc0ZXpYWHBSM2c0L1M3djRrRmNsa0FnNGRZZGNiMEY2OUc0dmljRFxuaDFX
+        MUh1R3o1enliMDBmLzRIU1ZWT3Q5OEJkd3BqRzkyaWlsdWd6K0tVUkV2QT09
         XG4tLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLVxuLS0tLS1CRUdJTiBD
-        RVJUSUZJQ0FURS0tLS0tXG5NSUlDZmpDQ0FXWUNBU2t3RFFZSktvWklodmNO
-        QVFFRkJRQXdOVEVrTUNJR0ExVUVBd3diYTJGMFpXeHNieTFpXG5kWEp5YVhS
-        dkxtVjRZVzF3YkdVdVkyOXRNUTB3Q3dZRFZRUUtEQVJRVlV4UU1CNFhEVEUy
-        TURJeE1USXhOVGcxXG5PRm9YRFRJMk1ESXdPREl4TlRnMU9Gb3dXVEV0TUNz
-        R0ExVUVBeE1rTURFd1JUazVRekF0TXpJM05pMHhNVVV5XG5MVGd4UXpFdE1E
-        Z3dNREl3TUVNNVFUWTJNU2d3SmdZS0NaSW1pWlB5TEdRQkFSTVlOVFppWkRB
-        ME1qSTJOemRqXG5OelF5WkRBMlkyTmpaR1kzTUlHZk1BMEdDU3FHU0liM0RR
-        RUJBUVVBQTRHTkFEQ0JpUUtCZ1FEaXVXY3RBN1RzXG5aTFdzRHhraDFOYlV3
-        eks2blFMZWR4Kyt1NUpsclNaTXl2U1Q4ejAwTjFMT21vbW5STkZQTlJkTmxr
-        YnZXcXhnXG5Za2dacnFrRmprNTJJN1Qya25MQTVxWXJaZnUyK3dCaWxDcGxM
-        c3ZYdEJ3akUzOVo1M2FEMDY1cEF5SkJMOWVpXG5CUGQ2T2YwblgrVytTOGRn
-        aCs0dmJpMG94eWNDcC9rbmZ3SURBUUFCTUEwR0NTcUdTSWIzRFFFQkJRVUFB
-        NElCXG5BUUNLUzFDOW1BamZGbDE0S21uT3JJTkxYeUczbStBUWNQZEZXblpN
-        T2h2TUNSZU1jRmhhd2M4WDBHZGJmVWNiXG5sZ29FMkFRYk9LRE93N0hlL2pQ
-        QWRqbzc2R05sa2hTVGlDdmxSTGUrcEplcHM1ZHVEZUw0TWVjaVdlVnBwY2pK
-        XG51R0Q1UldaTHZwbUxpN1ZERkZ1WC82eThtZGE0ZUNqekxGa1FKVGpuTjB6
-        aVJnN3pkOVhtZlV5RHBzbjYxSC9zXG5Na2Rua01VWk5JSVJkUnJuV1pBSDVM
-        YjZnaXFuL2hSNFhJL29XUmUySWp2OHV0WjVGTGJWT0pNY3ZXcUlMaDVhXG5Z
-        YWN3eXJoVnNidXREdHl2akNjMW12RXRrVFhOREdDYy8rdDZISmlmN0MxYnRS
-        OHZDK29td3BsbVJqb2c1VGU1XG5zTXJmTXV3cWJWRDV0cUdnc1BiU0U0ZTVc
+        RVJUSUZJQ0FURS0tLS0tXG5NSUlDZkRDQ0FXUUNBZ0VuTUEwR0NTcUdTSWIz
+        RFFFQkJRVUFNREl4SVRBZkJnTlZCQU1NR0d0aGRHVnNiRzh0XG5lVzlrWVM1
+        bGVHRnRjR3hsTG1OdmJURU5NQXNHQTFVRUNnd0VVRlZNVURBZUZ3MHhOakF5
+        TWpNeE5qUTNNVFJhXG5GdzB5TmpBeU1qQXhOalEzTVRSYU1Ga3hMVEFyQmdO
+        VkJBTVRKREF4TUVVNU9VTXdMVE15TnpZdE1URkZNaTA0XG5NVU14TFRBNE1E
+        QXlNREJET1VFMk5qRW9NQ1lHQ2dtU0pvbVQ4aXhrQVFFVEdEVTJZMk00WkRF
+        eVpHVXdOREF6XG5NMlkwTVdReVlUTmpORENCbnpBTkJna3Foa2lHOXcwQkFR
+        RUZBQU9CalFBd2dZa0NnWUVBNE02aWpRNUVzMUZlXG5FYlo4QnBrVGR0aUVB
+        Wm0ycEdydE9PbHorUWxCb2hKV05acFVFMDg3ZVYveEordVZSN3FnNGZ6Z3VG
+        T2JSVUgwXG5rSm9KVTZ4d205dXRlVjNYdWdNb2xxcTZRSndCdjFIbGZValdu
+        Y3hNMU9SZTZTOSt3dnpHWTN0WVFieUovWTFzXG5ybTVrR2tESjJaOFIyNUx5
+        Y3phTG1waEY3eEpWU3QwQ0F3RUFBVEFOQmdrcWhraUc5dzBCQVFVRkFBT0NB
+        UUVBXG5BbklGeVJrRUtxakRGMEk5bUVVM0RZdWZKbkZzN2NqRzF0MGtsdTVj
+        NWJWaTR0SkxzSEdDY3BKV2NGNE56ZnRqXG45TFQ2NTRYbk91aFkrdGF0QlRy
+        ekd5S2pGN1g2b3ZxR2hhLzFPTnRTRUZmUEFYSlVmUWlTSmpHNmFYSnNUbjF6
+        XG5ET25iQmJnYlpVT1RWdTVzdGw1Zk1YUkxiQWcrR1JBOWVxQ0I1NHlaNm1p
+        VzJ6RElKRFNCbFQ1L2poOGJRMUp2XG5uZDA2TUo3R1ZWUmprNy9mbHRGUThU
+        SU5VbHlzY3BTRXlOa0RMUlZlN3VLbXE4akJ2Y3kySitEaVE3dHVCNXZlXG4v
+        eXc3b0U5ZVd6Q1FISmNYVHJ0NlhTMjRtUnp6SjhUQ2lsSm00VUxZMEY2S1BD
+        MWw5L0xhL0lhMFVzRHMzYWhYXG5HT09aZjZtYkpVcE95NHRISGloUitBPT1c
         bi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0ifQ==
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:58:58 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:14 GMT
 - request:
     method: delete
-    uri: https://katello-burrito.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
+    uri: https://katello-yoda.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -112,7 +112,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 21:58:58 GMT
+      - Tue, 23 Feb 2016 16:47:14 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -126,5 +126,5 @@ http_interactions:
       base64_string: |
         bnVsbA==
     http_version: 
-  recorded_at: Thu, 11 Feb 2016 21:58:58 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:14 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/pulp/repository/contents.yml
+++ b/test/fixtures/vcr_cassettes/pulp/repository/contents.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/8aaa2696-f2df-4b29-bb3f-a84d8148e2d6/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/2df93647-4d09-481d-b46a-9d47c9c5b73c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -21,13 +21,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:40 GMT
+      - Tue, 23 Feb 2016 16:47:55 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '661'
       Connection:
       - close
       Content-Type:
@@ -37,22 +37,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84YWFhMjY5Ni1mMmRmLTRiMjktYmIzZi1hODRkODE0OGUy
-        ZDYvIiwgInRhc2tfaWQiOiAiOGFhYTI2OTYtZjJkZi00YjI5LWJiM2YtYTg0
-        ZDgxNDhlMmQ2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8yZGY5MzY0Ny00ZDA5LTQ4MWQtYjQ2YS05ZDQ3YzljNWI3
+        M2MvIiwgInRhc2tfaWQiOiAiMmRmOTM2NDctNGQwOS00ODFkLWI0NmEtOWQ0
+        N2M5YzViNzNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNTBk
-        YjAzYzJiYTdjOTFiMjlmIn0sICJpZCI6ICI1NmM0ZGE1MGRiMDNjMmJhN2M5
-        MWIyOWYifQ==
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0Nzo1NVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4
+        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNTZjYzhkM2I5ODkwNTRmYzQ4YmEyZWYyIn0sICJp
+        ZCI6ICI1NmNjOGQzYjk4OTA1NGZjNDhiYTJlZjIifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:40 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:55 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/8aaa2696-f2df-4b29-bb3f-a84d8148e2d6/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/2df93647-4d09-481d-b46a-9d47c9c5b73c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -71,13 +73,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:40 GMT
+      - Tue, 23 Feb 2016 16:47:55 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '641'
+      - '1133'
       Connection:
       - close
       Content-Type:
@@ -87,24 +89,35 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84YWFhMjY5Ni1mMmRmLTRiMjktYmIzZi1hODRkODE0OGUy
-        ZDYvIiwgInRhc2tfaWQiOiAiOGFhYTI2OTYtZjJkZi00YjI5LWJiM2YtYTg0
-        ZDgxNDhlMmQ2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8yZGY5MzY0Ny00ZDA5LTQ4MWQtYjQ2YS05ZDQ3YzljNWI3
+        M2MvIiwgInRhc2tfaWQiOiAiMmRmOTM2NDctNGQwOS00ODFkLWI0NmEtOWQ0
+        N2M5YzViNzNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAYWJlZC51c2Vyc3lzLnJlZGhhdC5jb20uZHEiLCAic3RhdGUi
-        OiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQi
-        OiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRk
-        YTUwZGIwM2MyYmE3YzkxYjI5ZiJ9LCAiaWQiOiAiNTZjNGRhNTBkYjAzYzJi
-        YTdjOTFiMjlmIn0=
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0Nzo1NVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
+        T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDNi
+        OTg5MDU0ZmM0OGJhMmVmMiJ9LCAiaWQiOiAiNTZjYzhkM2I5ODkwNTRmYzQ4
+        YmEyZWYyIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:40 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:55 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/8aaa2696-f2df-4b29-bb3f-a84d8148e2d6/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/2df93647-4d09-481d-b46a-9d47c9c5b73c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -123,13 +136,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:41 GMT
+      - Tue, 23 Feb 2016 16:47:56 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2316'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -139,16 +152,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84YWFhMjY5Ni1mMmRmLTRiMjktYmIzZi1hODRkODE0OGUy
-        ZDYvIiwgInRhc2tfaWQiOiAiOGFhYTI2OTYtZjJkZi00YjI5LWJiM2YtYTg0
-        ZDgxNDhlMmQ2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8yZGY5MzY0Ny00ZDA5LTQ4MWQtYjQ2YS05ZDQ3YzljNWI3
+        M2MvIiwgInRhc2tfaWQiOiAiMmRmOTM2NDctNGQwOS00ODFkLWI0NmEtOWQ0
+        N2M5YzViNzNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xN1QyMDozODo0MVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDozODo0MFoiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0Nzo1NVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0Nzo1NVoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvODlmODY0OGQtMDYwNy00ZDM5LWEwNTAtNDljYTVjMDMy
-        MmUwLyIsICJ0YXNrX2lkIjogIjg5Zjg2NDhkLTA2MDctNGQzOS1hMDUwLTQ5
-        Y2E1YzAzMjJlMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvODU5YWEyOTItNmE1Ny00MzM0LWE1ZWItNDQ1Y2VmZDI5
+        N2JlLyIsICJ0YXNrX2lkIjogIjg1OWFhMjkyLTZhNTctNDMzNC1hNWViLTQ0
+        NWNlZmQyOTdiZSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -159,41 +172,41 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5
-        cy5yZWRoYXQuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNl
-        cnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNTA1Y2EwMTMx
-        ODRlMjhmYmVlIn0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAx
-        Ni0wMi0xN1QyMDozODo0MFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRz
-        IiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM4OjQxWiIsICJpbXBv
-        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdl
-        IjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
-        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
-        cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3Vu
-        dCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YzRkYTUxNWNh
-        MDEzMThmMzBjYjAzZSIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXpl
-        X3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
-        bHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3Rv
-        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
-        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
-        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmM0ZGE1MGRiMDNjMmJhN2M5MWIyOWYifSwgImlkIjogIjU2YzRk
-        YTUwZGIwM2MyYmE3YzkxYjI5ZiJ9
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQzYmRlMDQw
+        MzNmNDI2MmNhYjEifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ3OjU1WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDc6NTVaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkM2Jk
+        ZTA0MDMwODk3NThhODgwIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDNiOTg5MDU0ZmM0OGJhMmVmMiJ9LCAiaWQiOiAiNTZj
+        YzhkM2I5ODkwNTRmYzQ4YmEyZWYyIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:41 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:56 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/764fedae-0365-4ffe-a104-ef4c7aa02627/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/35274bc4-420d-4ead-bdc5-e75f8260809b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -212,13 +225,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:42 GMT
+      - Tue, 23 Feb 2016 16:47:56 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '643'
+      - '663'
       Connection:
       - close
       Content-Type:
@@ -228,24 +241,344 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83NjRmZWRhZS0wMzY1LTRmZmUtYTEwNC1lZjRjN2FhMDI2
-        MjcvIiwgInRhc2tfaWQiOiAiNzY0ZmVkYWUtMDM2NS00ZmZlLWExMDQtZWY0
-        YzdhYTAyNjI3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8zNTI3NGJjNC00MjBkLTRlYWQtYmRjNS1lNzVmODI2MDgw
+        OWIvIiwgInRhc2tfaWQiOiAiMzUyNzRiYzQtNDIwZC00ZWFkLWJkYzUtZTc1
+        ZjgyNjA4MDliIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ3OjU2WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQzYzk4OTA1NGZjNDhiYTJmMDMifSwg
+        ImlkIjogIjU2Y2M4ZDNjOTg5MDU0ZmM0OGJhMmYwMyJ9
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:56 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/35274bc4-420d-4ead-bdc5-e75f8260809b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:47:57 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '682'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNTI3NGJjNC00MjBkLTRlYWQtYmRjNS1lNzVmODI2MDgw
+        OWIvIiwgInRhc2tfaWQiOiAiMzUyNzRiYzQtNDIwZC00ZWFkLWJkYzUtZTc1
+        ZjgyNjA4MDliIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTIzVDE2OjQ3OjU3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ3OjU2WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkM2M5
+        ODkwNTRmYzQ4YmEyZjAzIn0sICJpZCI6ICI1NmNjOGQzYzk4OTA1NGZjNDhi
+        YTJmMDMifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:57 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/fadb7f9a-1fba-4b00-83db-fb6e61de6ed2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:47:57 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1133'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mYWRiN2Y5YS0xZmJhLTRiMDAtODNkYi1mYjZlNjFkZTZl
+        ZDIvIiwgInRhc2tfaWQiOiAiZmFkYjdmOWEtMWZiYS00YjAwLTgzZGItZmI2
+        ZTYxZGU2ZWQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0Nzo1N1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIk5PVF9T
+        VEFSVEVEIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDNk
+        OTg5MDU0ZmM0OGJhMmYwNCJ9LCAiaWQiOiAiNTZjYzhkM2Q5ODkwNTRmYzQ4
+        YmEyZjA0In0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:57 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/fadb7f9a-1fba-4b00-83db-fb6e61de6ed2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:47:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1133'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mYWRiN2Y5YS0xZmJhLTRiMDAtODNkYi1mYjZlNjFkZTZl
+        ZDIvIiwgInRhc2tfaWQiOiAiZmFkYjdmOWEtMWZiYS00YjAwLTgzZGItZmI2
+        ZTYxZGU2ZWQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0Nzo1N1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
+        T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDNk
+        OTg5MDU0ZmM0OGJhMmYwNCJ9LCAiaWQiOiAiNTZjYzhkM2Q5ODkwNTRmYzQ4
+        YmEyZjA0In0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:58 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/fadb7f9a-1fba-4b00-83db-fb6e61de6ed2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:47:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2318'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mYWRiN2Y5YS0xZmJhLTRiMDAtODNkYi1mYjZlNjFkZTZl
+        ZDIvIiwgInRhc2tfaWQiOiAiZmFkYjdmOWEtMWZiYS00YjAwLTgzZGItZmI2
+        ZTYxZGU2ZWQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0yM1QxNjo0Nzo1OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0Nzo1N1oiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNzliODAyODctMzhhMi00YWRhLThjODEtYWJjNWNiZjBm
+        YmI3LyIsICJ0YXNrX2lkIjogIjc5YjgwMjg3LTM4YTItNGFkYS04YzgxLWFi
+        YzVjYmYwZmJiNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQzZGRlMDQw
+        MzNmNDI2MmNhYjYifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ3OjU3WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDc6NThaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkM2Vk
+        ZTA0MDMwODk3NThhODhiIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDNkOTg5MDU0ZmM0OGJhMmYwNCJ9LCAiaWQiOiAiNTZj
+        YzhkM2Q5ODkwNTRmYzQ4YmEyZjA0In0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:59 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/50ec37cc-3f09-4ac4-ba81-33d95dfa3033/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:47:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '645'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81MGVjMzdjYy0zZjA5LTRhYzQtYmE4MS0zM2Q5NWRmYTMw
+        MzMvIiwgInRhc2tfaWQiOiAiNTBlYzM3Y2MtM2YwOS00YWM0LWJhODEtMzNk
+        OTVkZmEzMDMzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
         bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
         ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
         Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0
-        ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZj
-        NGRhNTJkYjAzYzJiYTdjOTFiMmIwIn0sICJpZCI6ICI1NmM0ZGE1MmRiMDNj
-        MmJhN2M5MWIyYjAifQ==
+        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3Rh
+        dGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        NmNjOGQzZjk4OTA1NGZjNDhiYTJmMTUifSwgImlkIjogIjU2Y2M4ZDNmOTg5
+        MDU0ZmM0OGJhMmYxNSJ9
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:42 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:59 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/764fedae-0365-4ffe-a104-ef4c7aa02627/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/50ec37cc-3f09-4ac4-ba81-33d95dfa3033/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -264,13 +597,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:43 GMT
+      - Tue, 23 Feb 2016 16:48:00 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '680'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -280,25 +613,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83NjRmZWRhZS0wMzY1LTRmZmUtYTEwNC1lZjRjN2FhMDI2
-        MjcvIiwgInRhc2tfaWQiOiAiNzY0ZmVkYWUtMDM2NS00ZmZlLWExMDQtZWY0
-        YzdhYTAyNjI3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy81MGVjMzdjYy0zZjA5LTRhYzQtYmE4MS0zM2Q5NWRmYTMw
+        MzMvIiwgInRhc2tfaWQiOiAiNTBlYzM3Y2MtM2YwOS00YWM0LWJhODEtMzNk
+        OTVkZmEzMDMzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM4OjQyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM4OjQyWiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ3OjU5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ3OjU5WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTUyZGIw
-        M2MyYmE3YzkxYjJiMCJ9LCAiaWQiOiAiNTZjNGRhNTJkYjAzYzJiYTdjOTFi
-        MmIwIn0=
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkM2Y5
+        ODkwNTRmYzQ4YmEyZjE1In0sICJpZCI6ICI1NmNjOGQzZjk4OTA1NGZjNDhi
+        YTJmMTUifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:43 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:00 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/326fbe78-e403-414b-bcf4-457a33564dcb/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/a09ee6ad-31d1-43ed-a816-83039cdfa1a3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -317,13 +650,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:43 GMT
+      - Tue, 23 Feb 2016 16:48:00 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '1133'
       Connection:
       - close
       Content-Type:
@@ -333,22 +666,35 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zMjZmYmU3OC1lNDAzLTQxNGItYmNmNC00NTdhMzM1NjRk
-        Y2IvIiwgInRhc2tfaWQiOiAiMzI2ZmJlNzgtZTQwMy00MTRiLWJjZjQtNDU3
-        YTMzNTY0ZGNiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hMDllZTZhZC0zMWQxLTQzZWQtYTgxNi04MzAzOWNkZmEx
+        YTMvIiwgInRhc2tfaWQiOiAiYTA5ZWU2YWQtMzFkMS00M2VkLWE4MTYtODMw
+        MzljZGZhMWEzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNTNk
-        YjAzYzJiYTdjOTFiMmIxIn0sICJpZCI6ICI1NmM0ZGE1M2RiMDNjMmJhN2M5
-        MWIyYjEifQ==
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0ODowMFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIk5PVF9T
+        VEFSVEVEIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDQw
+        OTg5MDU0ZmM0OGJhMmYxNiJ9LCAiaWQiOiAiNTZjYzhkNDA5ODkwNTRmYzQ4
+        YmEyZjE2In0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:43 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:00 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/326fbe78-e403-414b-bcf4-457a33564dcb/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/a09ee6ad-31d1-43ed-a816-83039cdfa1a3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -367,13 +713,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:43 GMT
+      - Tue, 23 Feb 2016 16:48:01 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '1133'
       Connection:
       - close
       Content-Type:
@@ -383,22 +729,35 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zMjZmYmU3OC1lNDAzLTQxNGItYmNmNC00NTdhMzM1NjRk
-        Y2IvIiwgInRhc2tfaWQiOiAiMzI2ZmJlNzgtZTQwMy00MTRiLWJjZjQtNDU3
-        YTMzNTY0ZGNiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hMDllZTZhZC0zMWQxLTQzZWQtYTgxNi04MzAzOWNkZmEx
+        YTMvIiwgInRhc2tfaWQiOiAiYTA5ZWU2YWQtMzFkMS00M2VkLWE4MTYtODMw
+        MzljZGZhMWEzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNTNk
-        YjAzYzJiYTdjOTFiMmIxIn0sICJpZCI6ICI1NmM0ZGE1M2RiMDNjMmJhN2M5
-        MWIyYjEifQ==
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0ODowMFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
+        T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDQw
+        OTg5MDU0ZmM0OGJhMmYxNiJ9LCAiaWQiOiAiNTZjYzhkNDA5ODkwNTRmYzQ4
+        YmEyZjE2In0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:43 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:01 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/326fbe78-e403-414b-bcf4-457a33564dcb/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/a09ee6ad-31d1-43ed-a816-83039cdfa1a3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -417,13 +776,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:44 GMT
+      - Tue, 23 Feb 2016 16:48:02 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2316'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -433,16 +792,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zMjZmYmU3OC1lNDAzLTQxNGItYmNmNC00NTdhMzM1NjRk
-        Y2IvIiwgInRhc2tfaWQiOiAiMzI2ZmJlNzgtZTQwMy00MTRiLWJjZjQtNDU3
-        YTMzNTY0ZGNiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hMDllZTZhZC0zMWQxLTQzZWQtYTgxNi04MzAzOWNkZmEx
+        YTMvIiwgInRhc2tfaWQiOiAiYTA5ZWU2YWQtMzFkMS00M2VkLWE4MTYtODMw
+        MzljZGZhMWEzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xN1QyMDozODo0NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDozODo0M1oiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0ODowMVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0ODowMFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvOGM1NDFhYWQtNzU3Ni00ZGQ4LWFlMmQtNGM0OGE5YmJi
-        NzIwLyIsICJ0YXNrX2lkIjogIjhjNTQxYWFkLTc1NzYtNGRkOC1hZTJkLTRj
-        NDhhOWJiYjcyMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvMDJkNmRiN2EtMmI2ZC00MzRmLTkwNGItNDBlYmE0MWFj
+        OTYzLyIsICJ0YXNrX2lkIjogIjAyZDZkYjdhLTJiNmQtNDM0Zi05MDRiLTQw
+        ZWJhNDFhYzk2MyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -453,333 +812,41 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5
-        cy5yZWRoYXQuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNl
-        cnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNTM1Y2EwMTMx
-        ODRkYzgxNWQ2In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAx
-        Ni0wMi0xN1QyMDozODo0M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRz
-        IiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM4OjQ0WiIsICJpbXBv
-        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdl
-        IjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
-        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
-        cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3Vu
-        dCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YzRkYTU0NWNh
-        MDEzMThmMzBjYjA0MyIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXpl
-        X3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
-        bHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3Rv
-        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
-        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
-        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmM0ZGE1M2RiMDNjMmJhN2M5MWIyYjEifSwgImlkIjogIjU2YzRk
-        YTUzZGIwM2MyYmE3YzkxYjJiMSJ9
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ0MGRlMDQw
+        MzNmNDM1MTRmODAifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjAwWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6MDFaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkNDFk
+        ZTA0MDMwODk3NThhODk2IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDQwOTg5MDU0ZmM0OGJhMmYxNiJ9LCAiaWQiOiAiNTZj
+        YzhkNDA5ODkwNTRmYzQ4YmEyZjE2In0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:44 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/9e58040d-55a4-4372-877d-fe657e5aa6a7/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:45 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85ZTU4MDQwZC01NWE0LTQzNzItODc3ZC1mZTY1N2U1YWE2
-        YTcvIiwgInRhc2tfaWQiOiAiOWU1ODA0MGQtNTVhNC00MzcyLTg3N2QtZmU2
-        NTdlNWFhNmE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE1
-        NWRiMDNjMmJhN2M5MWIyYzIifSwgImlkIjogIjU2YzRkYTU1ZGIwM2MyYmE3
-        YzkxYjJjMiJ9
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:45 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/9e58040d-55a4-4372-877d-fe657e5aa6a7/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:46 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '680'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85ZTU4MDQwZC01NWE0LTQzNzItODc3ZC1mZTY1N2U1YWE2
-        YTcvIiwgInRhc2tfaWQiOiAiOWU1ODA0MGQtNTVhNC00MzcyLTg3N2QtZmU2
-        NTdlNWFhNmE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM4OjQ1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM4OjQ1WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTU1ZGIw
-        M2MyYmE3YzkxYjJjMiJ9LCAiaWQiOiAiNTZjNGRhNTVkYjAzYzJiYTdjOTFi
-        MmMyIn0=
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:46 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/70bd986b-95fd-45e8-b5b8-9510143d4e31/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:46 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83MGJkOTg2Yi05NWZkLTQ1ZTgtYjViOC05NTEwMTQzZDRl
-        MzEvIiwgInRhc2tfaWQiOiAiNzBiZDk4NmItOTVmZC00NWU4LWI1YjgtOTUx
-        MDE0M2Q0ZTMxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNTZk
-        YjAzYzJiYTdjOTFiMmMzIn0sICJpZCI6ICI1NmM0ZGE1NmRiMDNjMmJhN2M5
-        MWIyYzMifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:46 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/70bd986b-95fd-45e8-b5b8-9510143d4e31/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:46 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83MGJkOTg2Yi05NWZkLTQ1ZTgtYjViOC05NTEwMTQzZDRl
-        MzEvIiwgInRhc2tfaWQiOiAiNzBiZDk4NmItOTVmZC00NWU4LWI1YjgtOTUx
-        MDE0M2Q0ZTMxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNTZk
-        YjAzYzJiYTdjOTFiMmMzIn0sICJpZCI6ICI1NmM0ZGE1NmRiMDNjMmJhN2M5
-        MWIyYzMifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:46 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/70bd986b-95fd-45e8-b5b8-9510143d4e31/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:47 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2316'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83MGJkOTg2Yi05NWZkLTQ1ZTgtYjViOC05NTEwMTQzZDRl
-        MzEvIiwgInRhc2tfaWQiOiAiNzBiZDk4NmItOTVmZC00NWU4LWI1YjgtOTUx
-        MDE0M2Q0ZTMxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xN1QyMDozODo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDozODo0NloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNWQxYmNlMTktMGQ4MS00MWNlLWIxNzgtMzhkMWNmOTIw
-        NmFmLyIsICJ0YXNrX2lkIjogIjVkMWJjZTE5LTBkODEtNDFjZS1iMTc4LTM4
-        ZDFjZjkyMDZhZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5
-        cy5yZWRoYXQuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNl
-        cnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNTY1Y2EwMTMx
-        ODRkYzgxNWRjIn0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAx
-        Ni0wMi0xN1QyMDozODo0NloiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRz
-        IiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM4OjQ3WiIsICJpbXBv
-        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdl
-        IjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
-        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
-        cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3Vu
-        dCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YzRkYTU3NWNh
-        MDEzMThmMzBjYjA0OCIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXpl
-        X3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
-        bHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3Rv
-        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
-        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
-        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmM0ZGE1NmRiMDNjMmJhN2M5MWIyYzMifSwgImlkIjogIjU2YzRk
-        YTU2ZGIwM2MyYmE3YzkxYjJjMyJ9
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:47 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:02 GMT
 - request:
     method: post
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -804,13 +871,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:48 GMT
+      - Tue, 23 Feb 2016 16:48:02 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '3107'
+      - '3131'
       Connection:
       - close
       Content-Type:
@@ -865,34 +932,34 @@ http_interactions:
         ICAgIDxycG06ZW50cnkgbmFtZT1cIi9iaW4vc2hcIiBwcmU9XCIxXCIgLz5c
         biAgICA8L3JwbTpyZXF1aXJlcz5cbiAgPC9mb3JtYXQ+XG48L3BhY2thZ2U+
         XG4ifSwgImRlc2NyaXB0aW9uIjogIkEgZHVtbXkgcGFja2FnZSBvZiBlbGVw
-        aGFudCIsICJfbGFzdF91cGRhdGVkIjogMTQ1NTc0MTUxMywgInRpbWUiOiAx
+        aGFudCIsICJfbGFzdF91cGRhdGVkIjogMTQ1NTgzNzk3MSwgInRpbWUiOiAx
         MzIxODkxMDI3LCAiZG93bmxvYWRlZCI6IHRydWUsICJoZWFkZXJfcmFuZ2Ui
         OiB7InN0YXJ0IjogMjgwLCAiZW5kIjogMjAyOH0sICJhcmNoIjogIm5vYXJj
         aCIsICJuYW1lIjogImVsZXBoYW50IiwgIl9zdG9yYWdlX3BhdGgiOiAiL3Zh
-        ci9saWIvcHVscC9jb250ZW50L3VuaXRzL3JwbS85MDQyLzkwNDIwNmEzLWQ1
-        MjAtNGY1Ny1iODRhLTc4YjNhZjE1OTdjZC9lbGVwaGFudC0wLjMtMC44Lm5v
-        YXJjaC5ycG0iLCAic291cmNlcnBtIjogImVsZXBoYW50LTAuMy0wLjguc3Jj
-        LnJwbSIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2IiwgInJlbGVhc2Vfc29y
-        dF9pbmRleCI6ICIwMS0wLjAxLTgiLCAiY2hhbmdlbG9nIjogW10sICJ1cmwi
-        OiAiaHR0cDovL3RzdHJhY2hvdGEuZmVkb3JhcGVvcGxlLm9yZyIsICJjaGVj
-        a3N1bSI6ICIzZTFjNzBjZDFiNDIxMzI4YWNhZjYzOTdjYjNkMTYxNDUzMDZi
-        Yjk1ZjY1ZDFiMDk1ZmMzMTM3MmEwYTcwMWYzIiwgInN1bW1hcnkiOiAiQSBk
-        dW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwgInJlbGF0aXZlcGF0aCI6ICJl
-        bGVwaGFudC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAicmVsZWFzZSI6ICIwLjgi
-        LCAiX2lkIjogIjkwNDIwNmEzLWQ1MjAtNGY1Ny1iODRhLTc4YjNhZjE1OTdj
-        ZCIsICJyZXF1aXJlcyI6IFt7InJlbGVhc2UiOiBudWxsLCAiZXBvY2giOiBu
-        dWxsLCAidmVyc2lvbiI6IG51bGwsICJmbGFncyI6IG51bGwsICJuYW1lIjog
-        Ii9iaW4vc2gifV19LCAidXBkYXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM4OjQ2
-        WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTYt
-        MDItMTdUMjA6Mzg6NDZaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5p
-        dF9pZCI6ICI5MDQyMDZhMy1kNTIwLTRmNTctYjg0YS03OGIzYWYxNTk3Y2Qi
-        LCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTU2ZGIwM2MyYmE3YzkxYjJjOCJ9
-        fV0=
+        ci9saWIvcHVscC9jb250ZW50L3VuaXRzL3JwbS9mYi80MGU3ZjdjYjQwMWMz
+        OTAzYTEzMjkwMGQ2MjM0MTA4ZjdmNDU4MzEzNjQ4YTIyZWYyZGEzMTNjNjhh
+        YzZkMi9lbGVwaGFudC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAic291cmNlcnBt
+        IjogImVsZXBoYW50LTAuMy0wLjguc3JjLnJwbSIsICJjaGVja3N1bXR5cGUi
+        OiAic2hhMjU2IiwgInJlbGVhc2Vfc29ydF9pbmRleCI6ICIwMS0wLjAxLTgi
+        LCAiY2hhbmdlbG9nIjogW10sICJ1cmwiOiAiaHR0cDovL3RzdHJhY2hvdGEu
+        ZmVkb3JhcGVvcGxlLm9yZyIsICJjaGVja3N1bSI6ICIzZTFjNzBjZDFiNDIx
+        MzI4YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3MmEw
+        YTcwMWYzIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBo
+        YW50IiwgInJlbGF0aXZlcGF0aCI6ICJlbGVwaGFudC0wLjMtMC44Lm5vYXJj
+        aC5ycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjg4MTJmNmM4LTk4
+        NTgtNGJkNi05MzhiLTRkOTgyMzQwMGRhNCIsICJyZXF1aXJlcyI6IFt7InJl
+        bGVhc2UiOiBudWxsLCAiZXBvY2giOiBudWxsLCAidmVyc2lvbiI6IG51bGws
+        ICJmbGFncyI6IG51bGwsICJuYW1lIjogIi9iaW4vc2gifV19LCAidXBkYXRl
+        ZCI6ICIyMDE2LTAyLTIzVDE2OjQ4OjAxWiIsICJyZXBvX2lkIjogIkZlZG9y
+        YV8xNyIsICJjcmVhdGVkIjogIjIwMTYtMDItMjNUMTY6NDg6MDFaIiwgInVu
+        aXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI4ODEyZjZjOC05ODU4
+        LTRiZDYtOTM4Yi00ZDk4MjM0MDBkYTQiLCAiX2lkIjogeyIkb2lkIjogIjU2
+        Y2M4ZDQxOTg5MDU0ZmM0OGJhMmYxOCJ9fV0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:48 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:02 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/b4ecaed7-84ad-4033-bc8e-63fdc91e4b92/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/7398500c-fcc5-40d4-a3d1-52c3a1b68faf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -911,13 +978,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:48 GMT
+      - Tue, 23 Feb 2016 16:48:02 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '663'
       Connection:
       - close
       Content-Type:
@@ -927,22 +994,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iNGVjYWVkNy04NGFkLTQwMzMtYmM4ZS02M2ZkYzkxZTRi
-        OTIvIiwgInRhc2tfaWQiOiAiYjRlY2FlZDctODRhZC00MDMzLWJjOGUtNjNm
-        ZGM5MWU0YjkyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy83Mzk4NTAwYy1mY2M1LTQwZDQtYTNkMS01MmMzYTFiNjhm
+        YWYvIiwgInRhc2tfaWQiOiAiNzM5ODUwMGMtZmNjNS00MGQ0LWEzZDEtNTJj
+        M2ExYjY4ZmFmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE1
-        OGRiMDNjMmJhN2M5MWIyZDQifSwgImlkIjogIjU2YzRkYTU4ZGIwM2MyYmE3
-        YzkxYjJkNCJ9
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ4OjAyWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ0Mjk4OTA1NGZjNDhiYTJmMjcifSwg
+        ImlkIjogIjU2Y2M4ZDQyOTg5MDU0ZmM0OGJhMmYyNyJ9
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:48 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:02 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/b4ecaed7-84ad-4033-bc8e-63fdc91e4b92/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/7398500c-fcc5-40d4-a3d1-52c3a1b68faf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -961,13 +1030,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:48 GMT
+      - Tue, 23 Feb 2016 16:48:03 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '680'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -977,25 +1046,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iNGVjYWVkNy04NGFkLTQwMzMtYmM4ZS02M2ZkYzkxZTRi
-        OTIvIiwgInRhc2tfaWQiOiAiYjRlY2FlZDctODRhZC00MDMzLWJjOGUtNjNm
-        ZGM5MWU0YjkyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy83Mzk4NTAwYy1mY2M1LTQwZDQtYTNkMS01MmMzYTFiNjhm
+        YWYvIiwgInRhc2tfaWQiOiAiNzM5ODUwMGMtZmNjNS00MGQ0LWEzZDEtNTJj
+        M2ExYjY4ZmFmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM4OjQ4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM4OjQ4WiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ4OjAyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjAyWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTU4ZGIw
-        M2MyYmE3YzkxYjJkNCJ9LCAiaWQiOiAiNTZjNGRhNThkYjAzYzJiYTdjOTFi
-        MmQ0In0=
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNDI5
+        ODkwNTRmYzQ4YmEyZjI3In0sICJpZCI6ICI1NmNjOGQ0Mjk4OTA1NGZjNDhi
+        YTJmMjcifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:48 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:03 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/d2af83e3-3da9-4546-bd39-4a1c0043b5a3/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/87ae8bbe-7401-495c-98f5-17d665d5821f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1014,13 +1083,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:49 GMT
+      - Tue, 23 Feb 2016 16:48:03 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '643'
       Connection:
       - close
       Content-Type:
@@ -1030,22 +1099,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kMmFmODNlMy0zZGE5LTQ1NDYtYmQzOS00YTFjMDA0M2I1
-        YTMvIiwgInRhc2tfaWQiOiAiZDJhZjgzZTMtM2RhOS00NTQ2LWJkMzktNGEx
-        YzAwNDNiNWEzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy84N2FlOGJiZS03NDAxLTQ5NWMtOThmNS0xN2Q2NjVkNTgy
+        MWYvIiwgInRhc2tfaWQiOiAiODdhZThiYmUtNzQwMS00OTVjLTk4ZjUtMTdk
+        NjY1ZDU4MjFmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNTlk
-        YjAzYzJiYTdjOTFiMmQ1In0sICJpZCI6ICI1NmM0ZGE1OWRiMDNjMmJhN2M5
-        MWIyZDUifQ==
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZj
+        YzhkNDM5ODkwNTRmYzQ4YmEyZjI4In0sICJpZCI6ICI1NmNjOGQ0Mzk4OTA1
+        NGZjNDhiYTJmMjgifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:49 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:03 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/d2af83e3-3da9-4546-bd39-4a1c0043b5a3/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/87ae8bbe-7401-495c-98f5-17d665d5821f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1064,13 +1135,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:49 GMT
+      - Tue, 23 Feb 2016 16:48:03 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '1133'
       Connection:
       - close
       Content-Type:
@@ -1080,22 +1151,35 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kMmFmODNlMy0zZGE5LTQ1NDYtYmQzOS00YTFjMDA0M2I1
-        YTMvIiwgInRhc2tfaWQiOiAiZDJhZjgzZTMtM2RhOS00NTQ2LWJkMzktNGEx
-        YzAwNDNiNWEzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy84N2FlOGJiZS03NDAxLTQ5NWMtOThmNS0xN2Q2NjVkNTgy
+        MWYvIiwgInRhc2tfaWQiOiAiODdhZThiYmUtNzQwMS00OTVjLTk4ZjUtMTdk
+        NjY1ZDU4MjFmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNTlk
-        YjAzYzJiYTdjOTFiMmQ1In0sICJpZCI6ICI1NmM0ZGE1OWRiMDNjMmJhN2M5
-        MWIyZDUifQ==
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0ODowM1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
+        T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDQz
+        OTg5MDU0ZmM0OGJhMmYyOCJ9LCAiaWQiOiAiNTZjYzhkNDM5ODkwNTRmYzQ4
+        YmEyZjI4In0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:49 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:03 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/d2af83e3-3da9-4546-bd39-4a1c0043b5a3/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/87ae8bbe-7401-495c-98f5-17d665d5821f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1114,13 +1198,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:50 GMT
+      - Tue, 23 Feb 2016 16:48:04 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2316'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -1130,16 +1214,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kMmFmODNlMy0zZGE5LTQ1NDYtYmQzOS00YTFjMDA0M2I1
-        YTMvIiwgInRhc2tfaWQiOiAiZDJhZjgzZTMtM2RhOS00NTQ2LWJkMzktNGEx
-        YzAwNDNiNWEzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy84N2FlOGJiZS03NDAxLTQ5NWMtOThmNS0xN2Q2NjVkNTgy
+        MWYvIiwgInRhc2tfaWQiOiAiODdhZThiYmUtNzQwMS00OTVjLTk4ZjUtMTdk
+        NjY1ZDU4MjFmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xN1QyMDozODo1MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDozODo0OVoiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0ODowNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0ODowM1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZjlhZTBhNjktYTc3MS00YmRkLTgwNzItYzk0YzY5YTJj
-        OWM4LyIsICJ0YXNrX2lkIjogImY5YWUwYTY5LWE3NzEtNGJkZC04MDcyLWM5
-        NGM2OWEyYzljOCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvZTk3ZDNhZjktZjBjNC00OTgyLTgwZDEtZDU0N2FmZGIx
+        YzAyLyIsICJ0YXNrX2lkIjogImU5N2QzYWY5LWYwYzQtNDk4Mi04MGQxLWQ1
+        NDdhZmRiMWMwMiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -1150,41 +1234,41 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5
-        cy5yZWRoYXQuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNl
-        cnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNTk1Y2EwMTMx
-        ODRlMjhmYmY1In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAx
-        Ni0wMi0xN1QyMDozODo0OVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRz
-        IiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM4OjUwWiIsICJpbXBv
-        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdl
-        IjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
-        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
-        cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3Vu
-        dCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YzRkYTVhNWNh
-        MDEzMThmMzBjYjA0ZCIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXpl
-        X3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
-        bHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3Rv
-        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
-        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
-        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmM0ZGE1OWRiMDNjMmJhN2M5MWIyZDUifSwgImlkIjogIjU2YzRk
-        YTU5ZGIwM2MyYmE3YzkxYjJkNSJ9
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ0M2RlMDQw
+        MzNmNDFkMmE0MDAifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjAzWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6MDRaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkNDRk
+        ZTA0MDMwODk3NThhOGExIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDQzOTg5MDU0ZmM0OGJhMmYyOCJ9LCAiaWQiOiAiNTZj
+        YzhkNDM5ODkwNTRmYzQ4YmEyZjI4In0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:50 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:04 GMT
 - request:
     method: post
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1210,13 +1294,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:51 GMT
+      - Tue, 23 Feb 2016 16:48:05 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '3107'
+      - '3131'
       Connection:
       - close
       Content-Type:
@@ -1271,34 +1355,34 @@ http_interactions:
         ICAgIDxycG06ZW50cnkgbmFtZT1cIi9iaW4vc2hcIiBwcmU9XCIxXCIgLz5c
         biAgICA8L3JwbTpyZXF1aXJlcz5cbiAgPC9mb3JtYXQ+XG48L3BhY2thZ2U+
         XG4ifSwgImRlc2NyaXB0aW9uIjogIkEgZHVtbXkgcGFja2FnZSBvZiBlbGVw
-        aGFudCIsICJfbGFzdF91cGRhdGVkIjogMTQ1NTc0MTUxMywgInRpbWUiOiAx
+        aGFudCIsICJfbGFzdF91cGRhdGVkIjogMTQ1NTgzNzk3MSwgInRpbWUiOiAx
         MzIxODkxMDI3LCAiZG93bmxvYWRlZCI6IHRydWUsICJoZWFkZXJfcmFuZ2Ui
         OiB7InN0YXJ0IjogMjgwLCAiZW5kIjogMjAyOH0sICJhcmNoIjogIm5vYXJj
         aCIsICJuYW1lIjogImVsZXBoYW50IiwgIl9zdG9yYWdlX3BhdGgiOiAiL3Zh
-        ci9saWIvcHVscC9jb250ZW50L3VuaXRzL3JwbS85MDQyLzkwNDIwNmEzLWQ1
-        MjAtNGY1Ny1iODRhLTc4YjNhZjE1OTdjZC9lbGVwaGFudC0wLjMtMC44Lm5v
-        YXJjaC5ycG0iLCAic291cmNlcnBtIjogImVsZXBoYW50LTAuMy0wLjguc3Jj
-        LnJwbSIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2IiwgInJlbGVhc2Vfc29y
-        dF9pbmRleCI6ICIwMS0wLjAxLTgiLCAiY2hhbmdlbG9nIjogW10sICJ1cmwi
-        OiAiaHR0cDovL3RzdHJhY2hvdGEuZmVkb3JhcGVvcGxlLm9yZyIsICJjaGVj
-        a3N1bSI6ICIzZTFjNzBjZDFiNDIxMzI4YWNhZjYzOTdjYjNkMTYxNDUzMDZi
-        Yjk1ZjY1ZDFiMDk1ZmMzMTM3MmEwYTcwMWYzIiwgInN1bW1hcnkiOiAiQSBk
-        dW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwgInJlbGF0aXZlcGF0aCI6ICJl
-        bGVwaGFudC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAicmVsZWFzZSI6ICIwLjgi
-        LCAiX2lkIjogIjkwNDIwNmEzLWQ1MjAtNGY1Ny1iODRhLTc4YjNhZjE1OTdj
-        ZCIsICJyZXF1aXJlcyI6IFt7InJlbGVhc2UiOiBudWxsLCAiZXBvY2giOiBu
-        dWxsLCAidmVyc2lvbiI6IG51bGwsICJmbGFncyI6IG51bGwsICJuYW1lIjog
-        Ii9iaW4vc2gifV19LCAidXBkYXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM4OjQ5
-        WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTYt
-        MDItMTdUMjA6Mzg6NDlaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5p
-        dF9pZCI6ICI5MDQyMDZhMy1kNTIwLTRmNTctYjg0YS03OGIzYWYxNTk3Y2Qi
-        LCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTU5ZGIwM2MyYmE3YzkxYjJkYSJ9
-        fV0=
+        ci9saWIvcHVscC9jb250ZW50L3VuaXRzL3JwbS9mYi80MGU3ZjdjYjQwMWMz
+        OTAzYTEzMjkwMGQ2MjM0MTA4ZjdmNDU4MzEzNjQ4YTIyZWYyZGEzMTNjNjhh
+        YzZkMi9lbGVwaGFudC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAic291cmNlcnBt
+        IjogImVsZXBoYW50LTAuMy0wLjguc3JjLnJwbSIsICJjaGVja3N1bXR5cGUi
+        OiAic2hhMjU2IiwgInJlbGVhc2Vfc29ydF9pbmRleCI6ICIwMS0wLjAxLTgi
+        LCAiY2hhbmdlbG9nIjogW10sICJ1cmwiOiAiaHR0cDovL3RzdHJhY2hvdGEu
+        ZmVkb3JhcGVvcGxlLm9yZyIsICJjaGVja3N1bSI6ICIzZTFjNzBjZDFiNDIx
+        MzI4YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3MmEw
+        YTcwMWYzIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBo
+        YW50IiwgInJlbGF0aXZlcGF0aCI6ICJlbGVwaGFudC0wLjMtMC44Lm5vYXJj
+        aC5ycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjg4MTJmNmM4LTk4
+        NTgtNGJkNi05MzhiLTRkOTgyMzQwMGRhNCIsICJyZXF1aXJlcyI6IFt7InJl
+        bGVhc2UiOiBudWxsLCAiZXBvY2giOiBudWxsLCAidmVyc2lvbiI6IG51bGws
+        ICJmbGFncyI6IG51bGwsICJuYW1lIjogIi9iaW4vc2gifV19LCAidXBkYXRl
+        ZCI6ICIyMDE2LTAyLTIzVDE2OjQ4OjA0WiIsICJyZXBvX2lkIjogIkZlZG9y
+        YV8xNyIsICJjcmVhdGVkIjogIjIwMTYtMDItMjNUMTY6NDg6MDRaIiwgInVu
+        aXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI4ODEyZjZjOC05ODU4
+        LTRiZDYtOTM4Yi00ZDk4MjM0MDBkYTQiLCAiX2lkIjogeyIkb2lkIjogIjU2
+        Y2M4ZDQ0OTg5MDU0ZmM0OGJhMmYyYSJ9fV0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:51 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:05 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/c33f2861-e315-4874-91bd-1627da473a82/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/7a87bf65-f437-4eb6-bf11-688a95a9bcd7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1317,13 +1401,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:51 GMT
+      - Tue, 23 Feb 2016 16:48:05 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '663'
       Connection:
       - close
       Content-Type:
@@ -1333,22 +1417,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jMzNmMjg2MS1lMzE1LTQ4NzQtOTFiZC0xNjI3ZGE0NzNh
-        ODIvIiwgInRhc2tfaWQiOiAiYzMzZjI4NjEtZTMxNS00ODc0LTkxYmQtMTYy
-        N2RhNDczYTgyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy83YTg3YmY2NS1mNDM3LTRlYjYtYmYxMS02ODhhOTVhOWJj
+        ZDcvIiwgInRhc2tfaWQiOiAiN2E4N2JmNjUtZjQzNy00ZWI2LWJmMTEtNjg4
+        YTk1YTliY2Q3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE1
-        YmRiMDNjMmJhN2M5MWIyZTYifSwgImlkIjogIjU2YzRkYTViZGIwM2MyYmE3
-        YzkxYjJlNiJ9
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ4OjA1WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ0NTk4OTA1NGZjNDhiYTJmMzkifSwg
+        ImlkIjogIjU2Y2M4ZDQ1OTg5MDU0ZmM0OGJhMmYzOSJ9
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:51 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:05 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/c33f2861-e315-4874-91bd-1627da473a82/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/7a87bf65-f437-4eb6-bf11-688a95a9bcd7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1367,13 +1453,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:51 GMT
+      - Tue, 23 Feb 2016 16:48:06 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '680'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -1383,25 +1469,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jMzNmMjg2MS1lMzE1LTQ4NzQtOTFiZC0xNjI3ZGE0NzNh
-        ODIvIiwgInRhc2tfaWQiOiAiYzMzZjI4NjEtZTMxNS00ODc0LTkxYmQtMTYy
-        N2RhNDczYTgyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy83YTg3YmY2NS1mNDM3LTRlYjYtYmYxMS02ODhhOTVhOWJj
+        ZDcvIiwgInRhc2tfaWQiOiAiN2E4N2JmNjUtZjQzNy00ZWI2LWJmMTEtNjg4
+        YTk1YTliY2Q3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM4OjUxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM4OjUxWiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ4OjA1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjA1WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTViZGIw
-        M2MyYmE3YzkxYjJlNiJ9LCAiaWQiOiAiNTZjNGRhNWJkYjAzYzJiYTdjOTFi
-        MmU2In0=
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNDU5
+        ODkwNTRmYzQ4YmEyZjM5In0sICJpZCI6ICI1NmNjOGQ0NTk4OTA1NGZjNDhi
+        YTJmMzkifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:51 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:06 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/deab4e74-561f-4bd6-b413-14fed4c97312/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/18bf1033-7532-4f2c-b74e-a2702a1a3797/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1420,13 +1506,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:52 GMT
+      - Tue, 23 Feb 2016 16:48:06 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '643'
       Connection:
       - close
       Content-Type:
@@ -1436,22 +1522,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kZWFiNGU3NC01NjFmLTRiZDYtYjQxMy0xNGZlZDRjOTcz
-        MTIvIiwgInRhc2tfaWQiOiAiZGVhYjRlNzQtNTYxZi00YmQ2LWI0MTMtMTRm
-        ZWQ0Yzk3MzEyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xOGJmMTAzMy03NTMyLTRmMmMtYjc0ZS1hMjcwMmExYTM3
+        OTcvIiwgInRhc2tfaWQiOiAiMThiZjEwMzMtNzUzMi00ZjJjLWI3NGUtYTI3
+        MDJhMWEzNzk3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNWNk
-        YjAzYzJiYTdjOTFiMmU3In0sICJpZCI6ICI1NmM0ZGE1Y2RiMDNjMmJhN2M5
-        MWIyZTcifQ==
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZj
+        YzhkNDY5ODkwNTRmYzQ4YmEyZjNhIn0sICJpZCI6ICI1NmNjOGQ0Njk4OTA1
+        NGZjNDhiYTJmM2EifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:52 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:06 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/deab4e74-561f-4bd6-b413-14fed4c97312/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/18bf1033-7532-4f2c-b74e-a2702a1a3797/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1470,13 +1558,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:52 GMT
+      - Tue, 23 Feb 2016 16:48:06 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '1133'
       Connection:
       - close
       Content-Type:
@@ -1486,22 +1574,35 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kZWFiNGU3NC01NjFmLTRiZDYtYjQxMy0xNGZlZDRjOTcz
-        MTIvIiwgInRhc2tfaWQiOiAiZGVhYjRlNzQtNTYxZi00YmQ2LWI0MTMtMTRm
-        ZWQ0Yzk3MzEyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xOGJmMTAzMy03NTMyLTRmMmMtYjc0ZS1hMjcwMmExYTM3
+        OTcvIiwgInRhc2tfaWQiOiAiMThiZjEwMzMtNzUzMi00ZjJjLWI3NGUtYTI3
+        MDJhMWEzNzk3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNWNk
-        YjAzYzJiYTdjOTFiMmU3In0sICJpZCI6ICI1NmM0ZGE1Y2RiMDNjMmJhN2M5
-        MWIyZTcifQ==
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0ODowNloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
+        T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDQ2
+        OTg5MDU0ZmM0OGJhMmYzYSJ9LCAiaWQiOiAiNTZjYzhkNDY5ODkwNTRmYzQ4
+        YmEyZjNhIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:52 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:06 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/deab4e74-561f-4bd6-b413-14fed4c97312/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/18bf1033-7532-4f2c-b74e-a2702a1a3797/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1520,13 +1621,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:53 GMT
+      - Tue, 23 Feb 2016 16:48:07 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2316'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -1536,16 +1637,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kZWFiNGU3NC01NjFmLTRiZDYtYjQxMy0xNGZlZDRjOTcz
-        MTIvIiwgInRhc2tfaWQiOiAiZGVhYjRlNzQtNTYxZi00YmQ2LWI0MTMtMTRm
-        ZWQ0Yzk3MzEyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xOGJmMTAzMy03NTMyLTRmMmMtYjc0ZS1hMjcwMmExYTM3
+        OTcvIiwgInRhc2tfaWQiOiAiMThiZjEwMzMtNzUzMi00ZjJjLWI3NGUtYTI3
+        MDJhMWEzNzk3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xN1QyMDozODo1M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDozODo1MloiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0ODowN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0ODowNloiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNzU1OTMzZTgtN2UzNC00ZGVhLThkMGEtNGM5MjI4NGMy
-        OTNkLyIsICJ0YXNrX2lkIjogIjc1NTkzM2U4LTdlMzQtNGRlYS04ZDBhLTRj
-        OTIyODRjMjkzZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvODVkMWNkYjgtZTE0OC00YTYyLThjNmItNzA3OTE5ZmQ5
+        OGM3LyIsICJ0YXNrX2lkIjogIjg1ZDFjZGI4LWUxNDgtNGE2Mi04YzZiLTcw
+        NzkxOWZkOThjNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -1556,41 +1657,41 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5
-        cy5yZWRoYXQuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNl
-        cnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNWM1Y2EwMTMx
-        ODRkYzgxNWUzIn0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAx
-        Ni0wMi0xN1QyMDozODo1MloiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRz
-        IiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM4OjUzWiIsICJpbXBv
-        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdl
-        IjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
-        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
-        cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3Vu
-        dCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YzRkYTVkNWNh
-        MDEzMThmMzBjYjA1MiIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXpl
-        X3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
-        bHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3Rv
-        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
-        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
-        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmM0ZGE1Y2RiMDNjMmJhN2M5MWIyZTcifSwgImlkIjogIjU2YzRk
-        YTVjZGIwM2MyYmE3YzkxYjJlNyJ9
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ0NmRlMDQw
+        MzNmNDM1MTRmODUifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjA2WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6MDdaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkNDdk
+        ZTA0MDMwODk3NThhOGFjIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDQ2OTg5MDU0ZmM0OGJhMmYzYSJ9LCAiaWQiOiAiNTZj
+        YzhkNDY5ODkwNTRmYzQ4YmEyZjNhIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:53 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:07 GMT
 - request:
     method: post
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1612,13 +1713,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:53 GMT
+      - Tue, 23 Feb 2016 16:48:08 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1174'
+      - '1198'
       Connection:
       - close
       Content-Type:
@@ -1637,27 +1738,27 @@ http_interactions:
         c2hhMjU2IiwgImNoZWNrc3VtIjogImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRj
         ODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifV0s
         ICJfc3RvcmFnZV9wYXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0
-        cy9kaXN0cmlidXRpb24vMmRkOS8yZGQ5YjEyNy0xYmFmLTQ4YTgtOWNjYy05
-        MmY0YWJlYzMzMDQiLCAiZmFtaWx5IjogIlRlc3QgRmFtaWx5IiwgImRvd25s
-        b2FkZWQiOiBmYWxzZSwgInRpbWVzdGFtcCI6IDEzMjMxMTIxNTMuMDksICJf
-        bGFzdF91cGRhdGVkIjogMTQ1NTc0MTUzMiwgIl9jb250ZW50X3R5cGVfaWQi
-        OiAiZGlzdHJpYnV0aW9uIiwgInZhcmlhbnQiOiAiVGVzdFZhcmlhbnQiLCAi
-        aWQiOiAia3MtVGVzdCBGYW1pbHktVGVzdFZhcmlhbnQtMTYteDg2XzY0Iiwg
-        InZlcnNpb24iOiAiMTYiLCAidmVyc2lvbl9zb3J0X2luZGV4IjogIjAyLTE2
-        IiwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAicGFja2FnZWRpciI6ICIi
-        LCAiX2lkIjogIjJkZDliMTI3LTFiYWYtNDhhOC05Y2NjLTkyZjRhYmVjMzMw
-        NCIsICJhcmNoIjogIng4Nl82NCIsICJfbnMiOiAidW5pdHNfZGlzdHJpYnV0
-        aW9uIn0sICJ1cGRhdGVkIjogIjIwMTYtMDItMTdUMjA6Mzg6NTJaIiwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAxNi0wMi0xN1Qy
-        MDozODo1MloiLCAidW5pdF90eXBlX2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1
-        bml0X2lkIjogIjJkZDliMTI3LTFiYWYtNDhhOC05Y2NjLTkyZjRhYmVjMzMw
-        NCIsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNWNkYjAzYzJiYTdjOTFiMmYw
-        In19XQ==
+        cy9kaXN0cmlidXRpb24vOWIvODMxMjU2YTEyNDcxOGJmMzkxNjZiNTY0ZDhl
+        Njg5OTU0ZmYwYThmMGY0NzliYTI0Y2ZhMjYzNTAxMDliYzUiLCAiZmFtaWx5
+        IjogIlRlc3QgRmFtaWx5IiwgImRvd25sb2FkZWQiOiBmYWxzZSwgInRpbWVz
+        dGFtcCI6IDEzMjMxMTIxNTMuMDksICJfbGFzdF91cGRhdGVkIjogMTQ1NjI0
+        NjA4NiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInZh
+        cmlhbnQiOiAiVGVzdFZhcmlhbnQiLCAiaWQiOiAia3MtVGVzdCBGYW1pbHkt
+        VGVzdFZhcmlhbnQtMTYteDg2XzY0IiwgInZlcnNpb24iOiAiMTYiLCAidmVy
+        c2lvbl9zb3J0X2luZGV4IjogIjAyLTE2IiwgInB1bHBfdXNlcl9tZXRhZGF0
+        YSI6IHt9LCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogIjA5MjlkOTdlLTRi
+        NDYtNGEzMi05YzY1LTMzN2M0NmQ3ZjAwMCIsICJhcmNoIjogIng4Nl82NCIs
+        ICJfbnMiOiAidW5pdHNfZGlzdHJpYnV0aW9uIn0sICJ1cGRhdGVkIjogIjIw
+        MTYtMDItMjNUMTY6NDg6MDZaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
+        ImNyZWF0ZWQiOiAiMjAxNi0wMi0yM1QxNjo0ODowNloiLCAidW5pdF90eXBl
+        X2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogIjA5MjlkOTdlLTRi
+        NDYtNGEzMi05YzY1LTMzN2M0NmQ3ZjAwMCIsICJfaWQiOiB7IiRvaWQiOiAi
+        NTZjYzhkNDY5ODkwNTRmYzQ4YmEyZjQzIn19XQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:53 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:08 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/f289387c-ac75-4c89-ac87-a6f5cd65957f/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/1afc45f0-7730-4b5e-be23-4c653b7d10a2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1676,13 +1777,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:54 GMT
+      - Tue, 23 Feb 2016 16:48:08 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '663'
       Connection:
       - close
       Content-Type:
@@ -1692,22 +1793,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mMjg5Mzg3Yy1hYzc1LTRjODktYWM4Ny1hNmY1Y2Q2NTk1
-        N2YvIiwgInRhc2tfaWQiOiAiZjI4OTM4N2MtYWM3NS00Yzg5LWFjODctYTZm
-        NWNkNjU5NTdmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xYWZjNDVmMC03NzMwLTRiNWUtYmUyMy00YzY1M2I3ZDEw
+        YTIvIiwgInRhc2tfaWQiOiAiMWFmYzQ1ZjAtNzczMC00YjVlLWJlMjMtNGM2
+        NTNiN2QxMGEyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE1
-        ZWRiMDNjMmJhN2M5MWIyZjgifSwgImlkIjogIjU2YzRkYTVlZGIwM2MyYmE3
-        YzkxYjJmOCJ9
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ4OjA4WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ0ODk4OTA1NGZjNDhiYTJmNGIifSwg
+        ImlkIjogIjU2Y2M4ZDQ4OTg5MDU0ZmM0OGJhMmY0YiJ9
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:54 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:08 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/f289387c-ac75-4c89-ac87-a6f5cd65957f/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/1afc45f0-7730-4b5e-be23-4c653b7d10a2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1726,13 +1829,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:54 GMT
+      - Tue, 23 Feb 2016 16:48:09 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '680'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -1742,25 +1845,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mMjg5Mzg3Yy1hYzc1LTRjODktYWM4Ny1hNmY1Y2Q2NTk1
-        N2YvIiwgInRhc2tfaWQiOiAiZjI4OTM4N2MtYWM3NS00Yzg5LWFjODctYTZm
-        NWNkNjU5NTdmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xYWZjNDVmMC03NzMwLTRiNWUtYmUyMy00YzY1M2I3ZDEw
+        YTIvIiwgInRhc2tfaWQiOiAiMWFmYzQ1ZjAtNzczMC00YjVlLWJlMjMtNGM2
+        NTNiN2QxMGEyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM4OjU0WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM4OjU0WiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ4OjA4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjA4WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTVlZGIw
-        M2MyYmE3YzkxYjJmOCJ9LCAiaWQiOiAiNTZjNGRhNWVkYjAzYzJiYTdjOTFi
-        MmY4In0=
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNDg5
+        ODkwNTRmYzQ4YmEyZjRiIn0sICJpZCI6ICI1NmNjOGQ0ODk4OTA1NGZjNDhi
+        YTJmNGIifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:54 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:09 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/ebb3c1d5-0e01-406a-9bcb-9b9fe3d812c8/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/04098cec-8613-4046-81ea-09d7282e87ca/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1779,13 +1882,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:55 GMT
+      - Tue, 23 Feb 2016 16:48:09 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '641'
+      - '661'
       Connection:
       - close
       Content-Type:
@@ -1795,64 +1898,64 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lYmIzYzFkNS0wZTAxLTQwNmEtOWJjYi05YjlmZTNkODEy
-        YzgvIiwgInRhc2tfaWQiOiAiZWJiM2MxZDUtMGUwMS00MDZhLTliY2ItOWI5
-        ZmUzZDgxMmM4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAYWJlZC51c2Vyc3lzLnJlZGhhdC5jb20uZHEiLCAic3RhdGUi
-        OiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQi
-        OiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRk
-        YTVmZGIwM2MyYmE3YzkxYjJmOSJ9LCAiaWQiOiAiNTZjNGRhNWZkYjAzYzJi
-        YTdjOTFiMmY5In0=
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:55 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/ebb3c1d5-0e01-406a-9bcb-9b9fe3d812c8/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:55 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1131'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lYmIzYzFkNS0wZTAxLTQwNmEtOWJjYi05YjlmZTNkODEy
-        YzgvIiwgInRhc2tfaWQiOiAiZWJiM2MxZDUtMGUwMS00MDZhLTliY2ItOWI5
-        ZmUzZDgxMmM4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8wNDA5OGNlYy04NjEzLTQwNDYtODFlYS0wOWQ3MjgyZTg3
+        Y2EvIiwgInRhc2tfaWQiOiAiMDQwOThjZWMtODYxMy00MDQ2LTgxZWEtMDlk
+        NzI4MmU4N2NhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0xN1QyMDozODo1NVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        Mi0yM1QxNjo0ODowOVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4
+        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNTZjYzhkNDk5ODkwNTRmYzQ4YmEyZjRjIn0sICJp
+        ZCI6ICI1NmNjOGQ0OTk4OTA1NGZjNDhiYTJmNGMifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:09 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/04098cec-8613-4046-81ea-09d7282e87ca/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:09 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1133'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wNDA5OGNlYy04NjEzLTQwNDYtODFlYS0wOWQ3MjgyZTg3
+        Y2EvIiwgInRhc2tfaWQiOiAiMDQwOThjZWMtODYxMy00MDQ2LTgxZWEtMDlk
+        NzI4MmU4N2NhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0ODowOVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
         dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
         IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
         T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
@@ -1863,19 +1966,19 @@ http_interactions:
         OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
         YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
         cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIk5PVF9T
-        VEFSVEVEIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tLmRxIiwgInN0YXRlIjogInJ1
-        bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTBAYWJlZC51c2Vyc3lzLnJlZGhhdC5jb20iLCAicmVzdWx0IjogbnVs
-        bCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE1ZmRi
-        MDNjMmJhN2M5MWIyZjkifSwgImlkIjogIjU2YzRkYTVmZGIwM2MyYmE3Yzkx
-        YjJmOSJ9
+        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
+        T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDQ5
+        OTg5MDU0ZmM0OGJhMmY0YyJ9LCAiaWQiOiAiNTZjYzhkNDk5ODkwNTRmYzQ4
+        YmEyZjRjIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:55 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:09 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/ebb3c1d5-0e01-406a-9bcb-9b9fe3d812c8/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/04098cec-8613-4046-81ea-09d7282e87ca/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1894,13 +1997,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:56 GMT
+      - Tue, 23 Feb 2016 16:48:10 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2316'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -1910,16 +2013,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lYmIzYzFkNS0wZTAxLTQwNmEtOWJjYi05YjlmZTNkODEy
-        YzgvIiwgInRhc2tfaWQiOiAiZWJiM2MxZDUtMGUwMS00MDZhLTliY2ItOWI5
-        ZmUzZDgxMmM4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8wNDA5OGNlYy04NjEzLTQwNDYtODFlYS0wOWQ3MjgyZTg3
+        Y2EvIiwgInRhc2tfaWQiOiAiMDQwOThjZWMtODYxMy00MDQ2LTgxZWEtMDlk
+        NzI4MmU4N2NhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xN1QyMDozODo1NloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDozODo1NVoiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0ODowOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0ODowOVoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvODA5MjNhZTYtNjlhYS00YmExLWI4NTQtMDE2NDQ4ZDk1
-        M2JlLyIsICJ0YXNrX2lkIjogIjgwOTIzYWU2LTY5YWEtNGJhMS1iODU0LTAx
-        NjQ0OGQ5NTNiZSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvODAzODk5NDctMDEwOS00NjIzLWI1NGQtMGQ5NGJlMWY1
+        ZjYwLyIsICJ0YXNrX2lkIjogIjgwMzg5OTQ3LTAxMDktNDYyMy1iNTRkLTBk
+        OTRiZTFmNWY2MCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -1930,41 +2033,41 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5
-        cy5yZWRoYXQuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNl
-        cnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNWY1Y2EwMTMx
-        ODRlMjhmYmZhIn0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAx
-        Ni0wMi0xN1QyMDozODo1NVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRz
-        IiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM4OjU2WiIsICJpbXBv
-        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdl
-        IjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
-        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
-        cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3Vu
-        dCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YzRkYTYwNWNh
-        MDEzMThmMzBjYjA1NyIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXpl
-        X3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
-        bHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3Rv
-        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
-        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
-        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmM0ZGE1ZmRiMDNjMmJhN2M5MWIyZjkifSwgImlkIjogIjU2YzRk
-        YTVmZGIwM2MyYmE3YzkxYjJmOSJ9
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ0OWRlMDQw
+        MzNmNDFkMmE0MDYifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjA5WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6MDlaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkNDlk
+        ZTA0MDMwODk3NThhOGI3IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDQ5OTg5MDU0ZmM0OGJhMmY0YyJ9LCAiaWQiOiAiNTZj
+        YzhkNDk5ODkwNTRmYzQ4YmEyZjRjIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:56 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:10 GMT
 - request:
     method: post
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1987,7 +2090,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:57 GMT
+      - Tue, 23 Feb 2016 16:48:11 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -2001,33 +2104,33 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIwODcwNTVlMi1hMmM5LTRlZTctYmEy
-        YS1kMWI0YWUyNzZhZDEiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
-        In0sICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNWZkYjAzYzJiYTdjOTFiMzA1
-        In0sICJ1bml0X2lkIjogIjA4NzA1NWUyLWEyYzktNGVlNy1iYTJhLWQxYjRh
-        ZTI3NmFkMSIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
-        YXRhIjogeyJfaWQiOiAiMTFmY2RmNzUtZGM5YS00YjJkLWFkOWYtMWJlNGMx
-        ZTE1NDgzIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
-        IjogeyIkb2lkIjogIjU2YzRkYTVmZGIwM2MyYmE3YzkxYjMwMyJ9LCAidW5p
-        dF9pZCI6ICIxMWZjZGY3NS1kYzlhLTRiMmQtYWQ5Zi0xYmU0YzFlMTU0ODMi
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIyOTlhMTczZS01Mjk3LTRlYzYtODM5
+        Zi01ZGIxZWY1YzA4ZTgiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
+        In0sICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNDk5ODkwNTRmYzQ4YmEyZjU2
+        In0sICJ1bml0X2lkIjogIjI5OWExNzNlLTUyOTctNGVjNi04MzlmLTVkYjFl
+        ZjVjMDhlOCIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
+        YXRhIjogeyJfaWQiOiAiNWU2OGE3NDgtY2E3OS00OTI5LTkxYjgtMmMyMjBh
+        OWJiZGYxIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
+        IjogeyIkb2lkIjogIjU2Y2M4ZDQ5OTg5MDU0ZmM0OGJhMmY1OCJ9LCAidW5p
+        dF9pZCI6ICI1ZTY4YTc0OC1jYTc5LTQ5MjktOTFiOC0yYzIyMGE5YmJkZjEi
         LCAidW5pdF90eXBlX2lkIjogImVycmF0dW0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogImQxMTBlZjIzLTdjMTgtNGIxNS1iN2E5LThhNTM5ZDUwZjFlMiIs
+        X2lkIjogImZmOTAxYjM2LWMwNDctNDVlMi1iYjIxLTQ5ZjcwMGYwZmY4NSIs
         ICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0ifSwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmM0ZGE1ZmRiMDNjMmJhN2M5MWIzMDQifSwgInVuaXRfaWQiOiAi
-        ZDExMGVmMjMtN2MxOC00YjE1LWI3YTktOGE1MzlkNTBmMWUyIiwgInVuaXRf
+        ZCI6ICI1NmNjOGQ0OTk4OTA1NGZjNDhiYTJmNTcifSwgInVuaXRfaWQiOiAi
+        ZmY5MDFiMzYtYzA0Ny00NWUyLWJiMjEtNDlmNzAwZjBmZjg1IiwgInVuaXRf
         dHlwZV9pZCI6ICJlcnJhdHVtIn1d
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:57 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:11 GMT
 - request:
     method: post
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/content/units/erratum/search/
+    uri: https://katello-yoda.example.com/pulp/api/v2/content/units/erratum/search/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMDg3MDU1
-        ZTItYTJjOS00ZWU3LWJhMmEtZDFiNGFlMjc2YWQxIiwiMTFmY2RmNzUtZGM5
-        YS00YjJkLWFkOWYtMWJlNGMxZTE1NDgzIiwiZDExMGVmMjMtN2MxOC00YjE1
-        LWI3YTktOGE1MzlkNTBmMWUyIl19fX0sImluY2x1ZGVfcmVwb3MiOnRydWV9
+        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMjk5YTE3
+        M2UtNTI5Ny00ZWM2LTgzOWYtNWRiMWVmNWMwOGU4IiwiNWU2OGE3NDgtY2E3
+        OS00OTI5LTkxYjgtMmMyMjBhOWJiZGYxIiwiZmY5MDFiMzYtYzA0Ny00NWUy
+        LWJiMjEtNDlmNzAwZjBmZjg1Il19fX0sImluY2x1ZGVfcmVwb3MiOnRydWV9
     headers:
       Accept:
       - application/json
@@ -2045,13 +2148,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:57 GMT
+      - Tue, 23 Feb 2016 16:48:11 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '4700'
+      - '4735'
       Connection:
       - close
       Content-Type:
@@ -2059,116 +2162,117 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJf
-        aHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9lcnJhdHVtLzA4
-        NzA1NWUyLWEyYzktNGVlNy1iYTJhLWQxYjRhZTI3NmFkMS8iLCAiaXNzdWVk
-        IjogIjIwMTAtMDEtMDEgMDE6MDE6MDEiLCAicmVmZXJlbmNlcyI6IFtdLCAi
-        cHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lkIjog
-        ImVycmF0dW0iLCAiaWQiOiAiUkhFQS0yMDEwOjAwMDIiLCAiZnJvbSI6ICJs
-        emFwK3B1YkByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRsZSI6
-        ICJPbmUgcGFja2FnZSBlcnJhdGEiLCAiY2hpbGRyZW4iOiB7fSwgInZlcnNp
-        b24iOiAiMSIsICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjog
-        InNlY3VyaXR5IiwgInBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6
-        ICJodHRwOi8vd3d3LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAiZWxl
-        cGhhbnQiLCAic3VtIjogbnVsbCwgImZpbGVuYW1lIjogImVsZXBoYW50LTAu
-        My0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6IG51bGwsICJ2ZXJzaW9uIjog
-        IjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJhcmNoIjogIm5vYXJjaCJ9XSwg
-        Im5hbWUiOiAiMSIsICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxl
-        IiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjogIk9uZSBwYWNrYWdl
-        IGVycmF0YSIsICJfbGFzdF91cGRhdGVkIjogIjIwMTYtMDItMTdUMjA6Mzg6
-        NTVaIiwgInB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjogIiIsICJzb2x1dGlv
-        biI6ICIiLCAic3VtbWFyeSI6ICIiLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6
-        ICIwODcwNTVlMi1hMmM5LTRlZTctYmEyYS1kMWI0YWUyNzZhZDEifSwgeyJy
-        ZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJGZWRvcmFfMTciXSwgIl9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL2VycmF0dW0vMTFmY2Rm
-        NzUtZGM5YS00YjJkLWFkOWYtMWJlNGMxZTE1NDgzLyIsICJpc3N1ZWQiOiAi
-        MjAxMC0wMS0wMSAwMTowMTowMSIsICJyZWZlcmVuY2VzIjogW10sICJwdWxw
-        X3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJy
-        YXR1bSIsICJpZCI6ICJSSEVBLTIwMTA6MDAwMSIsICJmcm9tIjogImx6YXAr
-        cHViQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjogIkVt
-        cHR5IGVycmF0YSIsICJjaGlsZHJlbiI6IHt9LCAidmVyc2lvbiI6ICIxIiwg
-        InJlYm9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHki
-        LCAicGtnbGlzdCI6IFtdLCAic3RhdHVzIjogInN0YWJsZSIsICJ1cGRhdGVk
-        IjogIiIsICJkZXNjcmlwdGlvbiI6ICJFbXB0eSBlcnJhdGEiLCAiX2xhc3Rf
-        dXBkYXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM4OjU1WiIsICJwdXNoY291bnQi
-        OiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnki
-        OiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiMTFmY2RmNzUtZGM5YS00
-        YjJkLWFkOWYtMWJlNGMxZTE1NDgzIn0sIHsicmVwb3NpdG9yeV9tZW1iZXJz
-        aGlwcyI6IFsiRmVkb3JhXzE3Il0sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIv
-        Y29udGVudC91bml0cy9lcnJhdHVtL2QxMTBlZjIzLTdjMTgtNGIxNS1iN2E5
-        LThhNTM5ZDUwZjFlMi8iLCAiaXNzdWVkIjogIjIwMTAtMTEtMTAgMDA6MDA6
-        MDAiLCAicmVmZXJlbmNlcyI6IFt7ImhyZWYiOiAiaHR0cHM6Ly9yaG4ucmVk
-        aGF0LmNvbS9lcnJhdGEvUkhTQS0yMDEwLTA4NTguaHRtbCIsICJ0eXBlIjog
-        InNlbGYiLCAiaWQiOiBudWxsLCAidGl0bGUiOiBudWxsfSwgeyJocmVmIjog
-        Imh0dHBzOi8vYnVnemlsbGEucmVkaGF0LmNvbS9idWd6aWxsYS9zaG93X2J1
-        Zy5jZ2k/aWQ9NjI3ODgyIiwgInR5cGUiOiAiYnVnemlsbGEiLCAiaWQiOiAi
-        NjI3ODgyIiwgInRpdGxlIjogbnVsbH0sIHsiaHJlZiI6ICJodHRwczovL3d3
-        dy5yZWRoYXQuY29tL3NlY3VyaXR5L2RhdGEvY3ZlL0NWRS0yMDEwLTA0MDUu
-        aHRtbCIsICJ0eXBlIjogImN2ZSIsICJpZCI6ICJDVkUtMjAxMC0wNDA1Iiwg
-        InRpdGxlIjogbnVsbH0sIHsiaHJlZiI6ICJodHRwOi8vd3d3LnJlZGhhdC5j
-        b20vc2VjdXJpdHkvdXBkYXRlcy9jbGFzc2lmaWNhdGlvbi8jaW1wb3J0YW50
-        IiwgInR5cGUiOiAib3RoZXIiLCAiaWQiOiBudWxsLCAidGl0bGUiOiBudWxs
-        fV0sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAiZXJyYXR1bSIsICJpZCI6ICJSSFNBLTIwMTA6MDg1OCIsICJmcm9t
-        IjogInNlY3VyaXR5QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiSW1wb3J0
-        YW50IiwgInRpdGxlIjogIkltcG9ydGFudDogYnppcDIgc2VjdXJpdHkgdXBk
-        YXRlIiwgImNoaWxkcmVuIjoge30sICJ2ZXJzaW9uIjogIjMiLCAicmVib290
-        X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2ds
-        aXN0IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiYnppcDItMS4wLjUtNy5l
-        bDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDItZGV2ZWwiLCAic3VtIjog
-        WyJzaGEyNTYiLCAiZWE2N2M2NjRkYTFmZjk2YTZkYzk0ZDMzMDA5YjczZDhm
-        YWIzMWI1OTgyNDE4M2ZiNDVlOWJhMmViZjgyZDU4MyJdLCAiZmlsZW5hbWUi
-        OiAiYnppcDItZGV2ZWwtMS4wLjUtNy5lbDZfMC5pNjg2LnJwbSIsICJlcG9j
-        aCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVs
-        Nl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03
-        LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJzIiwgInN1bSI6
-        IFsic2hhMjU2IiwgImM5ZjA2NGE2ODYyNTczZmI5ZjJhNmFmZjdjMzYyMWYx
-        OTQwYjQ5MmRmMmVkZmMyZWJiZGMwYjgzMDVmNTExNDciXSwgImZpbGVuYW1l
-        IjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC5pNjg2LnJwbSIsICJlcG9j
-        aCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVs
-        Nl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03
-        LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMiIsICJzdW0iOiBbInNo
-        YTI1NiIsICJiOGEzZjcyYmMyYjBkODliYTczNzA5OWFjOThiZjhkMmFmNGJl
-        YTAyZDMxODg0YzAyZGI5N2Y3ZjY2YzNkNWMyIl0sICJmaWxlbmFtZSI6ICJi
-        emlwMi0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0iLCAiZXBvY2giOiAiMCIs
+        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsicmVpbnRlcm1lZGlhdGUi
+        LCAiRmVkb3JhXzE3Il0sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVu
+        dC91bml0cy9lcnJhdHVtLzI5OWExNzNlLTUyOTctNGVjNi04MzlmLTVkYjFl
+        ZjVjMDhlOC8iLCAiaXNzdWVkIjogIjIwMTAtMDEtMDEgMDE6MDE6MDEiLCAi
+        cmVmZXJlbmNlcyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJf
+        Y29udGVudF90eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiUkhFQS0yMDEw
+        OjAwMDEiLCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNldmVy
+        aXR5IjogIiIsICJ0aXRsZSI6ICJFbXB0eSBlcnJhdGEiLCAiY2hpbGRyZW4i
+        OiB7fSwgInZlcnNpb24iOiAiMSIsICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFs
+        c2UsICJ0eXBlIjogInNlY3VyaXR5IiwgInBrZ2xpc3QiOiBbXSwgInN0YXR1
+        cyI6ICJzdGFibGUiLCAidXBkYXRlZCI6ICIiLCAiZGVzY3JpcHRpb24iOiAi
+        RW1wdHkgZXJyYXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAiMjAxNi0wMi0yM1Qx
+        Njo0ODowOVoiLCAicHVzaGNvdW50IjogIiIsICJyaWdodHMiOiAiIiwgInNv
+        bHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxlYXNlIjogIjEiLCAi
+        X2lkIjogIjI5OWExNzNlLTUyOTctNGVjNi04MzlmLTVkYjFlZjVjMDhlOCJ9
+        LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBbInJlaW50ZXJtZWRpYXRl
+        IiwgIkZlZG9yYV8xNyJdLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRl
+        bnQvdW5pdHMvZXJyYXR1bS81ZTY4YTc0OC1jYTc5LTQ5MjktOTFiOC0yYzIy
+        MGE5YmJkZjEvIiwgImlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAxIiwg
+        InJlZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAi
+        X2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIlJIRUEtMjAx
+        MDowMDAyIiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0LmNvbSIsICJzZXZl
+        cml0eSI6ICIiLCAidGl0bGUiOiAiT25lIHBhY2thZ2UgZXJyYXRhIiwgImNo
+        aWxkcmVuIjoge30sICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dlc3Rl
+        ZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3si
+        cGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0
+        Lm9yZyIsICJuYW1lIjogImVsZXBoYW50IiwgInN1bSI6IG51bGwsICJmaWxl
+        bmFtZSI6ICJlbGVwaGFudC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2gi
+        OiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJh
+        cmNoIjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiMSIsICJzaG9ydCI6ICIifV0s
+        ICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0
+        aW9uIjogIk9uZSBwYWNrYWdlIGVycmF0YSIsICJfbGFzdF91cGRhdGVkIjog
+        IjIwMTYtMDItMjNUMTY6NDg6MDlaIiwgInB1c2hjb3VudCI6ICIiLCAicmln
+        aHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIiLCAicmVs
+        ZWFzZSI6ICIxIiwgIl9pZCI6ICI1ZTY4YTc0OC1jYTc5LTQ5MjktOTFiOC0y
+        YzIyMGE5YmJkZjEifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJG
+        ZWRvcmFfMTciXSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3Vu
+        aXRzL2VycmF0dW0vZmY5MDFiMzYtYzA0Ny00NWUyLWJiMjEtNDlmNzAwZjBm
+        Zjg1LyIsICJpc3N1ZWQiOiAiMjAxMC0xMS0xMCAwMDowMDowMCIsICJyZWZl
+        cmVuY2VzIjogW3siaHJlZiI6ICJodHRwczovL3Jobi5yZWRoYXQuY29tL2Vy
+        cmF0YS9SSFNBLTIwMTAtMDg1OC5odG1sIiwgInR5cGUiOiAic2VsZiIsICJp
+        ZCI6IG51bGwsICJ0aXRsZSI6IG51bGx9LCB7ImhyZWYiOiAiaHR0cHM6Ly9i
+        dWd6aWxsYS5yZWRoYXQuY29tL2J1Z3ppbGxhL3Nob3dfYnVnLmNnaT9pZD02
+        Mjc4ODIiLCAidHlwZSI6ICJidWd6aWxsYSIsICJpZCI6ICI2Mjc4ODIiLCAi
+        dGl0bGUiOiBudWxsfSwgeyJocmVmIjogImh0dHBzOi8vd3d3LnJlZGhhdC5j
+        b20vc2VjdXJpdHkvZGF0YS9jdmUvQ1ZFLTIwMTAtMDQwNS5odG1sIiwgInR5
+        cGUiOiAiY3ZlIiwgImlkIjogIkNWRS0yMDEwLTA0MDUiLCAidGl0bGUiOiBu
+        dWxsfSwgeyJocmVmIjogImh0dHA6Ly93d3cucmVkaGF0LmNvbS9zZWN1cml0
+        eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCAidHlwZSI6
+        ICJvdGhlciIsICJpZCI6IG51bGwsICJ0aXRsZSI6IG51bGx9XSwgInB1bHBf
+        dXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJh
+        dHVtIiwgImlkIjogIlJIU0EtMjAxMDowODU4IiwgImZyb20iOiAic2VjdXJp
+        dHlAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6ICJJbXBvcnRhbnQiLCAidGl0
+        bGUiOiAiSW1wb3J0YW50OiBiemlwMiBzZWN1cml0eSB1cGRhdGUiLCAiY2hp
+        bGRyZW4iOiB7fSwgInZlcnNpb24iOiAiMyIsICJyZWJvb3Rfc3VnZ2VzdGVk
+        IjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5IiwgInBrZ2xpc3QiOiBbeyJw
+        YWNrYWdlcyI6IFt7InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5y
+        cG0iLCAibmFtZSI6ICJiemlwMi1kZXZlbCIsICJzdW0iOiBbInNoYTI1NiIs
+        ICJlYTY3YzY2NGRhMWZmOTZhNmRjOTRkMzMwMDliNzNkOGZhYjMxYjU5ODI0
+        MTgzZmI0NWU5YmEyZWJmODJkNTgzIl0sICJmaWxlbmFtZSI6ICJiemlwMi1k
+        ZXZlbC0xLjAuNS03LmVsNl8wLmk2ODYucnBtIiwgImVwb2NoIjogIjAiLCAi
+        dmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJj
+        aCI6ICJpNjg2In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3Jj
+        LnJwbSIsICJuYW1lIjogImJ6aXAyLWxpYnMiLCAic3VtIjogWyJzaGEyNTYi
+        LCAiYzlmMDY0YTY4NjI1NzNmYjlmMmE2YWZmN2MzNjIxZjE5NDBiNDkyZGYy
+        ZWRmYzJlYmJkYzBiODMwNWY1MTE0NyJdLCAiZmlsZW5hbWUiOiAiYnppcDIt
+        bGlicy0xLjAuNS03LmVsNl8wLmk2ODYucnBtIiwgImVwb2NoIjogIjAiLCAi
+        dmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJj
+        aCI6ICJpNjg2In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3Jj
+        LnJwbSIsICJuYW1lIjogImJ6aXAyIiwgInN1bSI6IFsic2hhMjU2IiwgImI4
+        YTNmNzJiYzJiMGQ4OWJhNzM3MDk5YWM5OGJmOGQyYWY0YmVhMDJkMzE4ODRj
+        MDJkYjk3ZjdmNjZjM2Q1YzIiXSwgImZpbGVuYW1lIjogImJ6aXAyLTEuMC41
+        LTcuZWw2XzAueDg2XzY0LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24i
+        OiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAieDg2
+        XzY0In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3JjLnJwbSIs
+        ICJuYW1lIjogImJ6aXAyLWRldmVsIiwgInN1bSI6IFsic2hhMjU2IiwgIjdm
+        NjMxMjRlNDY1NWI3YzkyZDIzZWM0YzM4MjI2ZjVkMzc0NjU2ODg1M2RmZjc1
+        MGZjODVlMDU4ZTc0YjVjZjYiXSwgImZpbGVuYW1lIjogImJ6aXAyLWRldmVs
+        LTEuMC41LTcuZWw2XzAueDg2XzY0LnJwbSIsICJlcG9jaCI6ICIwIiwgInZl
+        cnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2gi
+        OiAieDg2XzY0In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3Jj
+        LnJwbSIsICJuYW1lIjogImJ6aXAyLWxpYnMiLCAic3VtIjogWyJzaGEyNTYi
+        LCAiODAyZjQzOTlkYmRkMDE0NzZlMjU0YzNiMzJjNDBhZmY1OWNmNWQyM2E0
+        NWZhNDg4YzY5MTdjZTg5MDRkNmI0ZCJdLCAiZmlsZW5hbWUiOiAiYnppcDIt
+        bGlicy0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0iLCAiZXBvY2giOiAiMCIs
         ICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJh
-        cmNoIjogIng4Nl82NCJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8w
-        LnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1kZXZlbCIsICJzdW0iOiBbInNo
-        YTI1NiIsICI3ZjYzMTI0ZTQ2NTViN2M5MmQyM2VjNGMzODIyNmY1ZDM3NDY1
-        Njg4NTNkZmY3NTBmYzg1ZTA1OGU3NGI1Y2Y2Il0sICJmaWxlbmFtZSI6ICJi
-        emlwMi1kZXZlbC0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0iLCAiZXBvY2gi
-        OiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZf
-        MCIsICJhcmNoIjogIng4Nl82NCJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03
-        LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJzIiwgInN1bSI6
-        IFsic2hhMjU2IiwgIjgwMmY0Mzk5ZGJkZDAxNDc2ZTI1NGMzYjMyYzQwYWZm
-        NTljZjVkMjNhNDVmYTQ4OGM2OTE3Y2U4OTA0ZDZiNGQiXSwgImZpbGVuYW1l
-        IjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVw
-        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcu
-        ZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQifV0sICJuYW1lIjogIlJlZCBIYXQg
-        RW50ZXJwcmlzZSBMaW51eCBTZXJ2ZXIgKHYuIDYgZm9yIDY0LWJpdCB4ODZf
-        NjQpIiwgInNob3J0IjogInJoZWwteDg2XzY0LXNlcnZlci02In1dLCAic3Rh
-        dHVzIjogImZpbmFsIiwgInVwZGF0ZWQiOiAiMjAxMC0xMS0xMCAwMDowMDow
-        MCIsICJkZXNjcmlwdGlvbiI6ICJiemlwMiBpcyBhIGZyZWVseSBhdmFpbGFi
-        bGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNvbXByZXNzb3IuIEl0IHByb3ZpZGVz
-        IGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11c3QgYmUgcmVzdGFydGVkIGZvciB0
-        aGUgdXBkYXRlIHRvIHRha2UgZWZmZWN0LiIsICJfbGFzdF91cGRhdGVkIjog
-        IjIwMTYtMDItMTdUMjA6Mzg6NTVaIiwgInB1c2hjb3VudCI6ICIiLCAicmln
-        aHRzIjogIkNvcHlyaWdodCAyMDEwIFJlZCBIYXQgSW5jIiwgInNvbHV0aW9u
-        IjogIkJlZm9yZSBhcHBseWluZyB0aGlzIHVwZGF0ZSwgbWFrZSBzdXJlIGFs
-        bCBwcmV2aW91c2x5LXJlbGVhc2VkIGVycmF0YVxucmVsZXZhbnQgdG8geW91
-        ciBzeXN0ZW0gaGF2ZSBiZWVuIGFwcGxpZWQuXG5cblRoaXMgdXBkYXRlIGlz
-        IGF2YWlsYWJsZSB2aWEgdGhlIFJlZCBIYXQgTmV0d29yay4gRGV0YWlscyBv
-        biBob3cgdG9cbnVzZSB0aGUgUmVkIEhhdCBOZXR3b3JrIHRvIGFwcGx5IHRo
-        aXMgdXBkYXRlIGFyZSBhdmFpbGFibGUgYXRcbmh0dHA6Ly9rYmFzZS5yZWRo
-        YXQuY29tL2ZhcS9kb2NzL0RPQy0xMTI1OSIsICJzdW1tYXJ5IjogIlVwZGF0
-        ZWQgYnppcDIgcGFja2FnZXMgdGhhdCBmaXggb25lIHNlY3VyaXR5IGlzc3Vl
-        IiwgInJlbGVhc2UiOiAiIiwgIl9pZCI6ICJkMTEwZWYyMy03YzE4LTRiMTUt
-        YjdhOS04YTUzOWQ1MGYxZTIifV0=
+        cmNoIjogIng4Nl82NCJ9XSwgIm5hbWUiOiAiUmVkIEhhdCBFbnRlcnByaXNl
+        IExpbnV4IFNlcnZlciAodi4gNiBmb3IgNjQtYml0IHg4Nl82NCkiLCAic2hv
+        cnQiOiAicmhlbC14ODZfNjQtc2VydmVyLTYifV0sICJzdGF0dXMiOiAiZmlu
+        YWwiLCAidXBkYXRlZCI6ICIyMDEwLTExLTEwIDAwOjAwOjAwIiwgImRlc2Ny
+        aXB0aW9uIjogImJ6aXAyIGlzIGEgZnJlZWx5IGF2YWlsYWJsZSwgaGlnaC1x
+        dWFsaXR5IGRhdGEgY29tcHJlc3Nvci4gSXQgcHJvdmlkZXMgYm90aFxubGli
+        YnoyIGxpYnJhcnkgbXVzdCBiZSByZXN0YXJ0ZWQgZm9yIHRoZSB1cGRhdGUg
+        dG8gdGFrZSBlZmZlY3QuIiwgIl9sYXN0X3VwZGF0ZWQiOiAiMjAxNi0wMi0y
+        M1QxNjo0ODowOVoiLCAicHVzaGNvdW50IjogIiIsICJyaWdodHMiOiAiQ29w
+        eXJpZ2h0IDIwMTAgUmVkIEhhdCBJbmMiLCAic29sdXRpb24iOiAiQmVmb3Jl
+        IGFwcGx5aW5nIHRoaXMgdXBkYXRlLCBtYWtlIHN1cmUgYWxsIHByZXZpb3Vz
+        bHktcmVsZWFzZWQgZXJyYXRhXG5yZWxldmFudCB0byB5b3VyIHN5c3RlbSBo
+        YXZlIGJlZW4gYXBwbGllZC5cblxuVGhpcyB1cGRhdGUgaXMgYXZhaWxhYmxl
+        IHZpYSB0aGUgUmVkIEhhdCBOZXR3b3JrLiBEZXRhaWxzIG9uIGhvdyB0b1xu
+        dXNlIHRoZSBSZWQgSGF0IE5ldHdvcmsgdG8gYXBwbHkgdGhpcyB1cGRhdGUg
+        YXJlIGF2YWlsYWJsZSBhdFxuaHR0cDovL2tiYXNlLnJlZGhhdC5jb20vZmFx
+        L2RvY3MvRE9DLTExMjU5IiwgInN1bW1hcnkiOiAiVXBkYXRlZCBiemlwMiBw
+        YWNrYWdlcyB0aGF0IGZpeCBvbmUgc2VjdXJpdHkgaXNzdWUiLCAicmVsZWFz
+        ZSI6ICIiLCAiX2lkIjogImZmOTAxYjM2LWMwNDctNDVlMi1iYjIxLTQ5Zjcw
+        MGYwZmY4NSJ9XQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:57 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:11 GMT
 - request:
     method: post
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2191,7 +2295,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:57 GMT
+      - Tue, 23 Feb 2016 16:48:11 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -2205,26 +2309,26 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIwODcwNTVlMi1hMmM5LTRlZTctYmEy
-        YS1kMWI0YWUyNzZhZDEiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
-        In0sICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNWZkYjAzYzJiYTdjOTFiMzA1
-        In0sICJ1bml0X2lkIjogIjA4NzA1NWUyLWEyYzktNGVlNy1iYTJhLWQxYjRh
-        ZTI3NmFkMSIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
-        YXRhIjogeyJfaWQiOiAiMTFmY2RmNzUtZGM5YS00YjJkLWFkOWYtMWJlNGMx
-        ZTE1NDgzIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
-        IjogeyIkb2lkIjogIjU2YzRkYTVmZGIwM2MyYmE3YzkxYjMwMyJ9LCAidW5p
-        dF9pZCI6ICIxMWZjZGY3NS1kYzlhLTRiMmQtYWQ5Zi0xYmU0YzFlMTU0ODMi
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIyOTlhMTczZS01Mjk3LTRlYzYtODM5
+        Zi01ZGIxZWY1YzA4ZTgiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
+        In0sICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNDk5ODkwNTRmYzQ4YmEyZjU2
+        In0sICJ1bml0X2lkIjogIjI5OWExNzNlLTUyOTctNGVjNi04MzlmLTVkYjFl
+        ZjVjMDhlOCIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
+        YXRhIjogeyJfaWQiOiAiNWU2OGE3NDgtY2E3OS00OTI5LTkxYjgtMmMyMjBh
+        OWJiZGYxIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
+        IjogeyIkb2lkIjogIjU2Y2M4ZDQ5OTg5MDU0ZmM0OGJhMmY1OCJ9LCAidW5p
+        dF9pZCI6ICI1ZTY4YTc0OC1jYTc5LTQ5MjktOTFiOC0yYzIyMGE5YmJkZjEi
         LCAidW5pdF90eXBlX2lkIjogImVycmF0dW0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogImQxMTBlZjIzLTdjMTgtNGIxNS1iN2E5LThhNTM5ZDUwZjFlMiIs
+        X2lkIjogImZmOTAxYjM2LWMwNDctNDVlMi1iYjIxLTQ5ZjcwMGYwZmY4NSIs
         ICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0ifSwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmM0ZGE1ZmRiMDNjMmJhN2M5MWIzMDQifSwgInVuaXRfaWQiOiAi
-        ZDExMGVmMjMtN2MxOC00YjE1LWI3YTktOGE1MzlkNTBmMWUyIiwgInVuaXRf
+        ZCI6ICI1NmNjOGQ0OTk4OTA1NGZjNDhiYTJmNTcifSwgInVuaXRfaWQiOiAi
+        ZmY5MDFiMzYtYzA0Ny00NWUyLWJiMjEtNDlmNzAwZjBmZjg1IiwgInVuaXRf
         dHlwZV9pZCI6ICJlcnJhdHVtIn1d
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:57 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:11 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/d381fd98-4d83-420d-948d-b883d4d98693/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/29df6836-4db2-41c9-8382-98b8b25a22d3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2243,13 +2347,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:57 GMT
+      - Tue, 23 Feb 2016 16:48:11 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '645'
       Connection:
       - close
       Content-Type:
@@ -2259,22 +2363,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kMzgxZmQ5OC00ZDgzLTQyMGQtOTQ4ZC1iODgzZDRkOTg2
-        OTMvIiwgInRhc2tfaWQiOiAiZDM4MWZkOTgtNGQ4My00MjBkLTk0OGQtYjg4
-        M2Q0ZDk4NjkzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8yOWRmNjgzNi00ZGIyLTQxYzktODM4Mi05OGI4YjI1YTIy
+        ZDMvIiwgInRhc2tfaWQiOiAiMjlkZjY4MzYtNGRiMi00MWM5LTgzODItOThi
+        OGIyNWEyMmQzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
         bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
         ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE2
-        MWRiMDNjMmJhN2M5MWIzMGEifSwgImlkIjogIjU2YzRkYTYxZGIwM2MyYmE3
-        YzkxYjMwYSJ9
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3Rh
+        dGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        NmNjOGQ0Yjk4OTA1NGZjNDhiYTJmNWQifSwgImlkIjogIjU2Y2M4ZDRiOTg5
+        MDU0ZmM0OGJhMmY1ZCJ9
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:57 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:11 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/d381fd98-4d83-420d-948d-b883d4d98693/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/29df6836-4db2-41c9-8382-98b8b25a22d3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2293,13 +2399,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:57 GMT
+      - Tue, 23 Feb 2016 16:48:12 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '680'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -2309,25 +2415,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kMzgxZmQ5OC00ZDgzLTQyMGQtOTQ4ZC1iODgzZDRkOTg2
-        OTMvIiwgInRhc2tfaWQiOiAiZDM4MWZkOTgtNGQ4My00MjBkLTk0OGQtYjg4
-        M2Q0ZDk4NjkzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8yOWRmNjgzNi00ZGIyLTQxYzktODM4Mi05OGI4YjI1YTIy
+        ZDMvIiwgInRhc2tfaWQiOiAiMjlkZjY4MzYtNGRiMi00MWM5LTgzODItOThi
+        OGIyNWEyMmQzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM4OjU3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM4OjU3WiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ4OjExWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjExWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTYxZGIw
-        M2MyYmE3YzkxYjMwYSJ9LCAiaWQiOiAiNTZjNGRhNjFkYjAzYzJiYTdjOTFi
-        MzBhIn0=
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNGI5
+        ODkwNTRmYzQ4YmEyZjVkIn0sICJpZCI6ICI1NmNjOGQ0Yjk4OTA1NGZjNDhi
+        YTJmNWQifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:58 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:12 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/b1ba558e-ada2-4935-880c-25f0caea5be6/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/8e188179-cab8-4cbb-b92f-e1f276ac4704/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2346,13 +2452,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:58 GMT
+      - Tue, 23 Feb 2016 16:48:12 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '643'
       Connection:
       - close
       Content-Type:
@@ -2362,22 +2468,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iMWJhNTU4ZS1hZGEyLTQ5MzUtODgwYy0yNWYwY2FlYTVi
-        ZTYvIiwgInRhc2tfaWQiOiAiYjFiYTU1OGUtYWRhMi00OTM1LTg4MGMtMjVm
-        MGNhZWE1YmU2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy84ZTE4ODE3OS1jYWI4LTRjYmItYjkyZi1lMWYyNzZhYzQ3
+        MDQvIiwgInRhc2tfaWQiOiAiOGUxODgxNzktY2FiOC00Y2JiLWI5MmYtZTFm
+        Mjc2YWM0NzA0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNjJk
-        YjAzYzJiYTdjOTFiMzBiIn0sICJpZCI6ICI1NmM0ZGE2MmRiMDNjMmJhN2M5
-        MWIzMGIifQ==
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZj
+        YzhkNGM5ODkwNTRmYzQ4YmEyZjVlIn0sICJpZCI6ICI1NmNjOGQ0Yzk4OTA1
+        NGZjNDhiYTJmNWUifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:58 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:12 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/b1ba558e-ada2-4935-880c-25f0caea5be6/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/8e188179-cab8-4cbb-b92f-e1f276ac4704/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2396,13 +2504,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:58 GMT
+      - Tue, 23 Feb 2016 16:48:12 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '1133'
       Connection:
       - close
       Content-Type:
@@ -2412,316 +2520,35 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iMWJhNTU4ZS1hZGEyLTQ5MzUtODgwYy0yNWYwY2FlYTVi
-        ZTYvIiwgInRhc2tfaWQiOiAiYjFiYTU1OGUtYWRhMi00OTM1LTg4MGMtMjVm
-        MGNhZWE1YmU2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNjJk
-        YjAzYzJiYTdjOTFiMzBiIn0sICJpZCI6ICI1NmM0ZGE2MmRiMDNjMmJhN2M5
-        MWIzMGIifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:58 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/b1ba558e-ada2-4935-880c-25f0caea5be6/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:59 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2316'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iMWJhNTU4ZS1hZGEyLTQ5MzUtODgwYy0yNWYwY2FlYTVi
-        ZTYvIiwgInRhc2tfaWQiOiAiYjFiYTU1OGUtYWRhMi00OTM1LTg4MGMtMjVm
-        MGNhZWE1YmU2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xN1QyMDozODo1OVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDozODo1OFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZWIzOTgxYjEtYzNlNi00YWJiLWEyMDAtMzQ5MmQxNTdi
-        ZjZiLyIsICJ0YXNrX2lkIjogImViMzk4MWIxLWMzZTYtNGFiYi1hMjAwLTM0
-        OTJkMTU3YmY2YiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5
-        cy5yZWRoYXQuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNl
-        cnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNjI1Y2EwMTMx
-        ODRkYzgxNWVkIn0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAx
-        Ni0wMi0xN1QyMDozODo1OFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRz
-        IiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM4OjU5WiIsICJpbXBv
-        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdl
-        IjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
-        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
-        cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3Vu
-        dCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YzRkYTYzNWNh
-        MDEzMThmMzBjYjA1YyIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXpl
-        X3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
-        bHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3Rv
-        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
-        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
-        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmM0ZGE2MmRiMDNjMmJhN2M5MWIzMGIifSwgImlkIjogIjU2YzRk
-        YTYyZGIwM2MyYmE3YzkxYjMwYiJ9
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:59 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/3c15b878-8e4c-4efd-a61f-07793a35133a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:00 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zYzE1Yjg3OC04ZTRjLTRlZmQtYTYxZi0wNzc5M2EzNTEz
-        M2EvIiwgInRhc2tfaWQiOiAiM2MxNWI4NzgtOGU0Yy00ZWZkLWE2MWYtMDc3
-        OTNhMzUxMzNhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE2
-        NGRiMDNjMmJhN2M5MWIzMWMifSwgImlkIjogIjU2YzRkYTY0ZGIwM2MyYmE3
-        YzkxYjMxYyJ9
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:00 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/3c15b878-8e4c-4efd-a61f-07793a35133a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:01 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '680'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zYzE1Yjg3OC04ZTRjLTRlZmQtYTYxZi0wNzc5M2EzNTEz
-        M2EvIiwgInRhc2tfaWQiOiAiM2MxNWI4NzgtOGU0Yy00ZWZkLWE2MWYtMDc3
-        OTNhMzUxMzNhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM5OjAwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM5OjAwWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTY0ZGIw
-        M2MyYmE3YzkxYjMxYyJ9LCAiaWQiOiAiNTZjNGRhNjRkYjAzYzJiYTdjOTFi
-        MzFjIn0=
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:01 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/c71d035b-1382-46d5-aaf3-f867c4d07e75/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:01 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jNzFkMDM1Yi0xMzgyLTQ2ZDUtYWFmMy1mODY3YzRkMDdl
-        NzUvIiwgInRhc2tfaWQiOiAiYzcxZDAzNWItMTM4Mi00NmQ1LWFhZjMtZjg2
-        N2M0ZDA3ZTc1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNjVk
-        YjAzYzJiYTdjOTFiMzFkIn0sICJpZCI6ICI1NmM0ZGE2NWRiMDNjMmJhN2M5
-        MWIzMWQifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:01 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/c71d035b-1382-46d5-aaf3-f867c4d07e75/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:01 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '659'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jNzFkMDM1Yi0xMzgyLTQ2ZDUtYWFmMy1mODY3YzRkMDdl
-        NzUvIiwgInRhc2tfaWQiOiAiYzcxZDAzNWItMTM4Mi00NmQ1LWFhZjMtZjg2
-        N2M0ZDA3ZTc1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy84ZTE4ODE3OS1jYWI4LTRjYmItYjkyZi1lMWYyNzZhYzQ3
+        MDQvIiwgInRhc2tfaWQiOiAiOGUxODgxNzktY2FiOC00Y2JiLWI5MmYtZTFm
+        Mjc2YWM0NzA0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0xN1QyMDozOTowMVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWJlZC51c2Vyc3lzLnJlZGhh
-        dC5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVk
-        aGF0LmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YzRkYTY1ZGIwM2MyYmE3YzkxYjMxZCJ9LCAiaWQi
-        OiAiNTZjNGRhNjVkYjAzYzJiYTdjOTFiMzFkIn0=
+        Mi0yM1QxNjo0ODoxMloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
+        T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDRj
+        OTg5MDU0ZmM0OGJhMmY1ZSJ9LCAiaWQiOiAiNTZjYzhkNGM5ODkwNTRmYzQ4
+        YmEyZjVlIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:01 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:12 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/c71d035b-1382-46d5-aaf3-f867c4d07e75/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/8e188179-cab8-4cbb-b92f-e1f276ac4704/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2740,13 +2567,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:02 GMT
+      - Tue, 23 Feb 2016 16:48:13 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2316'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -2756,16 +2583,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jNzFkMDM1Yi0xMzgyLTQ2ZDUtYWFmMy1mODY3YzRkMDdl
-        NzUvIiwgInRhc2tfaWQiOiAiYzcxZDAzNWItMTM4Mi00NmQ1LWFhZjMtZjg2
-        N2M0ZDA3ZTc1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy84ZTE4ODE3OS1jYWI4LTRjYmItYjkyZi1lMWYyNzZhYzQ3
+        MDQvIiwgInRhc2tfaWQiOiAiOGUxODgxNzktY2FiOC00Y2JiLWI5MmYtZTFm
+        Mjc2YWM0NzA0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xN1QyMDozOTowMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDozOTowMVoiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0ODoxM1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0ODoxMloiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvODVkMDc3MDItMGJjMi00YWNhLTgyYTgtZWYzZDU2OTA0
-        YjU2LyIsICJ0YXNrX2lkIjogIjg1ZDA3NzAyLTBiYzItNGFjYS04MmE4LWVm
-        M2Q1NjkwNGI1NiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvMmU5NjczNTctYTM0ZC00ZjI2LWJjODUtZWViNzg5ZGZi
+        OGU3LyIsICJ0YXNrX2lkIjogIjJlOTY3MzU3LWEzNGQtNGYyNi1iYzg1LWVl
+        Yjc4OWRmYjhlNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -2776,41 +2603,350 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5
-        cy5yZWRoYXQuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNl
-        cnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNjU1Y2EwMTMx
-        ODRmNmRiMTBlIn0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAx
-        Ni0wMi0xN1QyMDozOTowMVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRz
-        IiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM5OjAyWiIsICJpbXBv
-        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdl
-        IjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
-        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
-        cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3Vu
-        dCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YzRkYTY2NWNh
-        MDEzMThmMzBjYjA2MSIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXpl
-        X3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
-        bHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3Rv
-        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
-        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
-        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmM0ZGE2NWRiMDNjMmJhN2M5MWIzMWQifSwgImlkIjogIjU2YzRk
-        YTY1ZGIwM2MyYmE3YzkxYjMxZCJ9
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ0Y2RlMDQw
+        MzNmNDFkMmE0MGIifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjEyWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6MTNaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkNGRk
+        ZTA0MDMwODk3NThhOGMyIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDRjOTg5MDU0ZmM0OGJhMmY1ZSJ9LCAiaWQiOiAiNTZj
+        YzhkNGM5ODkwNTRmYzQ4YmEyZjVlIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:02 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:13 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/9a145dd7-58ff-4d07-870b-e3484b5df483/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:14 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '645'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85YTE0NWRkNy01OGZmLTRkMDctODcwYi1lMzQ4NGI1ZGY0
+        ODMvIiwgInRhc2tfaWQiOiAiOWExNDVkZDctNThmZi00ZDA3LTg3MGItZTM0
+        ODRiNWRmNDgzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3Rh
+        dGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        NmNjOGQ0ZTk4OTA1NGZjNDhiYTJmNmYifSwgImlkIjogIjU2Y2M4ZDRlOTg5
+        MDU0ZmM0OGJhMmY2ZiJ9
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:14 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/9a145dd7-58ff-4d07-870b-e3484b5df483/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:15 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '682'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85YTE0NWRkNy01OGZmLTRkMDctODcwYi1lMzQ4NGI1ZGY0
+        ODMvIiwgInRhc2tfaWQiOiAiOWExNDVkZDctNThmZi00ZDA3LTg3MGItZTM0
+        ODRiNWRmNDgzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjE0WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjE0WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNGU5
+        ODkwNTRmYzQ4YmEyZjZmIn0sICJpZCI6ICI1NmNjOGQ0ZTk4OTA1NGZjNDhi
+        YTJmNmYifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:15 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/9b0c8ea2-5134-410f-b11b-658c2a0cb136/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:15 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '661'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85YjBjOGVhMi01MTM0LTQxMGYtYjExYi02NThjMmEwY2Ix
+        MzYvIiwgInRhc2tfaWQiOiAiOWIwYzhlYTItNTEzNC00MTBmLWIxMWItNjU4
+        YzJhMGNiMTM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0ODoxNVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4
+        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNTZjYzhkNGY5ODkwNTRmYzQ4YmEyZjcwIn0sICJp
+        ZCI6ICI1NmNjOGQ0Zjk4OTA1NGZjNDhiYTJmNzAifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:16 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/9b0c8ea2-5134-410f-b11b-658c2a0cb136/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:16 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1133'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85YjBjOGVhMi01MTM0LTQxMGYtYjExYi02NThjMmEwY2Ix
+        MzYvIiwgInRhc2tfaWQiOiAiOWIwYzhlYTItNTEzNC00MTBmLWIxMWItNjU4
+        YzJhMGNiMTM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0ODoxNVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
+        T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDRm
+        OTg5MDU0ZmM0OGJhMmY3MCJ9LCAiaWQiOiAiNTZjYzhkNGY5ODkwNTRmYzQ4
+        YmEyZjcwIn0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:16 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/9b0c8ea2-5134-410f-b11b-658c2a0cb136/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2318'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85YjBjOGVhMi01MTM0LTQxMGYtYjExYi02NThjMmEwY2Ix
+        MzYvIiwgInRhc2tfaWQiOiAiOWIwYzhlYTItNTEzNC00MTBmLWIxMWItNjU4
+        YzJhMGNiMTM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0yM1QxNjo0ODoxNloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0ODoxNVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvYzcyNjAxNDQtNWM4NC00N2MyLTg5ZmEtNjAxYzc5YWJi
+        MTdlLyIsICJ0YXNrX2lkIjogImM3MjYwMTQ0LTVjODQtNDdjMi04OWZhLTYw
+        MWM3OWFiYjE3ZSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ0ZmRlMDQw
+        MzNmNDM1MTRmOGUifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjE2WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6MTZaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkNTBk
+        ZTA0MDMwODk3NThhOGNkIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDRmOTg5MDU0ZmM0OGJhMmY3MCJ9LCAiaWQiOiAiNTZj
+        YzhkNGY5ODkwNTRmYzQ4YmEyZjcwIn0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:17 GMT
 - request:
     method: post
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2833,7 +2969,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:03 GMT
+      - Tue, 23 Feb 2016 16:48:17 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -2849,22 +2985,22 @@ http_interactions:
       base64_string: |
         W3sibWV0YWRhdGEiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5hbWUi
         OiAiYWxsIiwgIl9ucyI6ICJ1bml0c19wYWNrYWdlX2NhdGVnb3J5IiwgIl9s
-        YXN0X3VwZGF0ZWQiOiAxNDU1NzQxNTEzLCAidHJhbnNsYXRlZF9uYW1lIjog
+        YXN0X3VwZGF0ZWQiOiAxNDU2MjQ2MDY4LCAidHJhbnNsYXRlZF9uYW1lIjog
         e30sICJwYWNrYWdlZ3JvdXBpZHMiOiBbIm1hbW1hbCIsICJiaXJkIl0sICJ0
         cmFuc2xhdGVkX2Rlc2NyaXB0aW9uIjoge30sICJwdWxwX3VzZXJfbWV0YWRh
         dGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAicGFja2FnZV9jYXRlZ29y
-        eSIsICJpZCI6ICJhbGwiLCAiX2lkIjogImFkOGY1NWU5LTY2ZWMtNGFhNi1i
-        ZThkLWU1NDhhNmI3YjQyZiIsICJkaXNwbGF5X29yZGVyIjogOTl9LCAidXBk
-        YXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM5OjAxWiIsICJyZXBvX2lkIjogIkZl
-        ZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTYtMDItMTdUMjA6Mzk6MDFaIiwg
+        eSIsICJpZCI6ICJhbGwiLCAiX2lkIjogIjQ5MjlkY2JiLTk1YWMtNDU5NS04
+        YWU5LWU0YTQ5YzdjZWQzYSIsICJkaXNwbGF5X29yZGVyIjogOTl9LCAidXBk
+        YXRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ4OjE2WiIsICJyZXBvX2lkIjogIkZl
+        ZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTYtMDItMjNUMTY6NDg6MTZaIiwg
         InVuaXRfdHlwZV9pZCI6ICJwYWNrYWdlX2NhdGVnb3J5IiwgInVuaXRfaWQi
-        OiAiYWQ4ZjU1ZTktNjZlYy00YWE2LWJlOGQtZTU0OGE2YjdiNDJmIiwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1NmM0ZGE2NWRiMDNjMmJhN2M5MWIzMmMifX1d
+        OiAiNDkyOWRjYmItOTVhYy00NTk1LThhZTktZTRhNDljN2NlZDNhIiwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1NmNjOGQ1MDk4OTA1NGZjNDhiYTJmN2YifX1d
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:03 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:17 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/be5b266e-260a-4c58-a02a-801b9c881648/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/1f011ce2-dbdf-46c9-a95b-b4d0dffa5381/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2883,13 +3019,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:03 GMT
+      - Tue, 23 Feb 2016 16:48:17 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '663'
       Connection:
       - close
       Content-Type:
@@ -2899,22 +3035,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iZTViMjY2ZS0yNjBhLTRjNTgtYTAyYS04MDFiOWM4ODE2
-        NDgvIiwgInRhc2tfaWQiOiAiYmU1YjI2NmUtMjYwYS00YzU4LWEwMmEtODAx
-        YjljODgxNjQ4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xZjAxMWNlMi1kYmRmLTQ2YzktYTk1Yi1iNGQwZGZmYTUz
+        ODEvIiwgInRhc2tfaWQiOiAiMWYwMTFjZTItZGJkZi00NmM5LWE5NWItYjRk
+        MGRmZmE1MzgxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE2
-        N2RiMDNjMmJhN2M5MWIzMmUifSwgImlkIjogIjU2YzRkYTY3ZGIwM2MyYmE3
-        YzkxYjMyZSJ9
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ4OjE3WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ1MTk4OTA1NGZjNDhiYTJmODEifSwg
+        ImlkIjogIjU2Y2M4ZDUxOTg5MDU0ZmM0OGJhMmY4MSJ9
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:03 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:17 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/be5b266e-260a-4c58-a02a-801b9c881648/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/1f011ce2-dbdf-46c9-a95b-b4d0dffa5381/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2933,13 +3071,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:04 GMT
+      - Tue, 23 Feb 2016 16:48:18 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '680'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -2949,25 +3087,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iZTViMjY2ZS0yNjBhLTRjNTgtYTAyYS04MDFiOWM4ODE2
-        NDgvIiwgInRhc2tfaWQiOiAiYmU1YjI2NmUtMjYwYS00YzU4LWEwMmEtODAx
-        YjljODgxNjQ4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xZjAxMWNlMi1kYmRmLTQ2YzktYTk1Yi1iNGQwZGZmYTUz
+        ODEvIiwgInRhc2tfaWQiOiAiMWYwMTFjZTItZGJkZi00NmM5LWE5NWItYjRk
+        MGRmZmE1MzgxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM5OjAzWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM5OjAzWiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ4OjE3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjE3WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTY3ZGIw
-        M2MyYmE3YzkxYjMyZSJ9LCAiaWQiOiAiNTZjNGRhNjdkYjAzYzJiYTdjOTFi
-        MzJlIn0=
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNTE5
+        ODkwNTRmYzQ4YmEyZjgxIn0sICJpZCI6ICI1NmNjOGQ1MTk4OTA1NGZjNDhi
+        YTJmODEifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:04 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:18 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/2f9f67ad-f736-40e8-ae55-6a99fbaf2111/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/4a6abc3d-056c-46df-a3e3-51abfcb33a70/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2986,7 +3124,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:04 GMT
+      - Tue, 23 Feb 2016 16:48:19 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -3002,22 +3140,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yZjlmNjdhZC1mNzM2LTQwZTgtYWU1NS02YTk5ZmJhZjIx
-        MTEvIiwgInRhc2tfaWQiOiAiMmY5ZjY3YWQtZjczNi00MGU4LWFlNTUtNmE5
-        OWZiYWYyMTExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy80YTZhYmMzZC0wNTZjLTQ2ZGYtYTNlMy01MWFiZmNiMzNh
+        NzAvIiwgInRhc2tfaWQiOiAiNGE2YWJjM2QtMDU2Yy00NmRmLWEzZTMtNTFh
+        YmZjYjMzYTcwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
         ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNjhk
-        YjAzYzJiYTdjOTFiMzJmIn0sICJpZCI6ICI1NmM0ZGE2OGRiMDNjMmJhN2M5
-        MWIzMmYifQ==
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNTI5
+        ODkwNTRmYzQ4YmEyZjgyIn0sICJpZCI6ICI1NmNjOGQ1Mjk4OTA1NGZjNDhi
+        YTJmODIifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:04 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:19 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/2f9f67ad-f736-40e8-ae55-6a99fbaf2111/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/4a6abc3d-056c-46df-a3e3-51abfcb33a70/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3036,13 +3174,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:04 GMT
+      - Tue, 23 Feb 2016 16:48:19 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '641'
+      - '1133'
       Connection:
       - close
       Content-Type:
@@ -3052,311 +3190,15 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yZjlmNjdhZC1mNzM2LTQwZTgtYWU1NS02YTk5ZmJhZjIx
-        MTEvIiwgInRhc2tfaWQiOiAiMmY5ZjY3YWQtZjczNi00MGU4LWFlNTUtNmE5
-        OWZiYWYyMTExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAYWJlZC51c2Vyc3lzLnJlZGhhdC5jb20uZHEiLCAic3RhdGUi
-        OiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQi
-        OiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRk
-        YTY4ZGIwM2MyYmE3YzkxYjMyZiJ9LCAiaWQiOiAiNTZjNGRhNjhkYjAzYzJi
-        YTdjOTFiMzJmIn0=
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:04 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/2f9f67ad-f736-40e8-ae55-6a99fbaf2111/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:05 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2316'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yZjlmNjdhZC1mNzM2LTQwZTgtYWU1NS02YTk5ZmJhZjIx
-        MTEvIiwgInRhc2tfaWQiOiAiMmY5ZjY3YWQtZjczNi00MGU4LWFlNTUtNmE5
-        OWZiYWYyMTExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xN1QyMDozOTowNVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDozOTowNFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMzFlOTg3NGQtYjM2OC00NTE3LWFlYmMtOWVlYjU4YTIw
-        YjU3LyIsICJ0YXNrX2lkIjogIjMxZTk4NzRkLWIzNjgtNDUxNy1hZWJjLTll
-        ZWI1OGEyMGI1NyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5
-        cy5yZWRoYXQuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNl
-        cnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNjg1Y2EwMTMx
-        ODRkYzgxNWYzIn0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAx
-        Ni0wMi0xN1QyMDozOTowNFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRz
-        IiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM5OjA1WiIsICJpbXBv
-        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdl
-        IjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
-        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
-        cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3Vu
-        dCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YzRkYTY5NWNh
-        MDEzMThmMzBjYjA2NiIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXpl
-        X3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
-        bHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3Rv
-        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
-        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
-        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmM0ZGE2OGRiMDNjMmJhN2M5MWIzMmYifSwgImlkIjogIjU2YzRk
-        YTY4ZGIwM2MyYmE3YzkxYjMyZiJ9
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:05 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/9f4cd12a-9da8-44b1-a80d-08b72d077107/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:06 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85ZjRjZDEyYS05ZGE4LTQ0YjEtYTgwZC0wOGI3MmQwNzcx
-        MDcvIiwgInRhc2tfaWQiOiAiOWY0Y2QxMmEtOWRhOC00NGIxLWE4MGQtMDhi
-        NzJkMDc3MTA3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE2
-        YWRiMDNjMmJhN2M5MWIzNDAifSwgImlkIjogIjU2YzRkYTZhZGIwM2MyYmE3
-        YzkxYjM0MCJ9
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:06 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/9f4cd12a-9da8-44b1-a80d-08b72d077107/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:06 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '680'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85ZjRjZDEyYS05ZGE4LTQ0YjEtYTgwZC0wOGI3MmQwNzcx
-        MDcvIiwgInRhc2tfaWQiOiAiOWY0Y2QxMmEtOWRhOC00NGIxLWE4MGQtMDhi
-        NzJkMDc3MTA3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM5OjA2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM5OjA2WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTZhZGIw
-        M2MyYmE3YzkxYjM0MCJ9LCAiaWQiOiAiNTZjNGRhNmFkYjAzYzJiYTdjOTFi
-        MzQwIn0=
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:06 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/638f4638-9c76-43b7-8f1b-04b1928aa1ae/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:07 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '659'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82MzhmNDYzOC05Yzc2LTQzYjctOGYxYi0wNGIxOTI4YWEx
-        YWUvIiwgInRhc2tfaWQiOiAiNjM4ZjQ2MzgtOWM3Ni00M2I3LThmMWItMDRi
-        MTkyOGFhMWFlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy80YTZhYmMzZC0wNTZjLTQ2ZGYtYTNlMy01MWFiZmNiMzNh
+        NzAvIiwgInRhc2tfaWQiOiAiNGE2YWJjM2QtMDU2Yy00NmRmLWEzZTMtNTFh
+        YmZjYjMzYTcwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0xN1QyMDozOTowN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWJlZC51c2Vyc3lzLnJlZGhh
-        dC5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVk
-        aGF0LmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YzRkYTZiZGIwM2MyYmE3YzkxYjM0MSJ9LCAiaWQi
-        OiAiNTZjNGRhNmJkYjAzYzJiYTdjOTFiMzQxIn0=
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:07 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/638f4638-9c76-43b7-8f1b-04b1928aa1ae/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:07 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1128'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82MzhmNDYzOC05Yzc2LTQzYjctOGYxYi0wNGIxOTI4YWEx
-        YWUvIiwgInRhc2tfaWQiOiAiNjM4ZjQ2MzgtOWM3Ni00M2I3LThmMWItMDRi
-        MTkyOGFhMWFlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0xN1QyMDozOTowN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        Mi0yM1QxNjo0ODoxOVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
         dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
-        Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
         IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
         ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
@@ -3364,19 +3206,19 @@ http_interactions:
         OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
         YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
         cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0w
-        QGFiZWQudXNlcnN5cy5yZWRoYXQuY29tLmRxIiwgInN0YXRlIjogInJ1bm5p
-        bmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTBAYWJlZC51c2Vyc3lzLnJlZGhhdC5jb20iLCAicmVzdWx0IjogbnVsbCwg
-        ImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE2YmRiMDNj
-        MmJhN2M5MWIzNDEifSwgImlkIjogIjU2YzRkYTZiZGIwM2MyYmE3YzkxYjM0
-        MSJ9
+        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
+        T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDUy
+        OTg5MDU0ZmM0OGJhMmY4MiJ9LCAiaWQiOiAiNTZjYzhkNTI5ODkwNTRmYzQ4
+        YmEyZjgyIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:07 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:19 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/638f4638-9c76-43b7-8f1b-04b1928aa1ae/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/4a6abc3d-056c-46df-a3e3-51abfcb33a70/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3395,13 +3237,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:08 GMT
+      - Tue, 23 Feb 2016 16:48:20 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2316'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -3411,16 +3253,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82MzhmNDYzOC05Yzc2LTQzYjctOGYxYi0wNGIxOTI4YWEx
-        YWUvIiwgInRhc2tfaWQiOiAiNjM4ZjQ2MzgtOWM3Ni00M2I3LThmMWItMDRi
-        MTkyOGFhMWFlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy80YTZhYmMzZC0wNTZjLTQ2ZGYtYTNlMy01MWFiZmNiMzNh
+        NzAvIiwgInRhc2tfaWQiOiAiNGE2YWJjM2QtMDU2Yy00NmRmLWEzZTMtNTFh
+        YmZjYjMzYTcwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xN1QyMDozOTowOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDozOTowN1oiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0ODoxOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0ODoxOVoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYmNjYjdiNDctMGZkMS00MTRmLTlhZjgtODhkNGRjMDU4
-        OTQxLyIsICJ0YXNrX2lkIjogImJjY2I3YjQ3LTBmZDEtNDE0Zi05YWY4LTg4
-        ZDRkYzA1ODk0MSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvMWM2ODI3ZGQtOTJkYS00OTY3LWE5NzEtYjdkYjdkMTBj
+        YmI1LyIsICJ0YXNrX2lkIjogIjFjNjgyN2RkLTkyZGEtNDk2Ny1hOTcxLWI3
+        ZGI3ZDEwY2JiNSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -3431,41 +3273,350 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5
-        cy5yZWRoYXQuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNl
-        cnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNmI1Y2EwMTMx
-        ODRlMjhmYzAwIn0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAx
-        Ni0wMi0xN1QyMDozOTowN1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRz
-        IiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM5OjA4WiIsICJpbXBv
-        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdl
-        IjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
-        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
-        cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3Vu
-        dCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YzRkYTZjNWNh
-        MDEzMThmMzBjYjA2YiIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXpl
-        X3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
-        bHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3Rv
-        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
-        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
-        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmM0ZGE2YmRiMDNjMmJhN2M5MWIzNDEifSwgImlkIjogIjU2YzRk
-        YTZiZGIwM2MyYmE3YzkxYjM0MSJ9
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ1MmRlMDQw
+        MzNmNDM1MTRmOTQifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjE5WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6MTlaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkNTNk
+        ZTA0MDMwODk3NThhOGQ4IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDUyOTg5MDU0ZmM0OGJhMmY4MiJ9LCAiaWQiOiAiNTZj
+        YzhkNTI5ODkwNTRmYzQ4YmEyZjgyIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:08 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:20 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/cf0b32ab-b3b9-4b6e-8b1d-30f00ec09011/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:20 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '663'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jZjBiMzJhYi1iM2I5LTRiNmUtOGIxZC0zMGYwMGVjMDkw
+        MTEvIiwgInRhc2tfaWQiOiAiY2YwYjMyYWItYjNiOS00YjZlLThiMWQtMzBm
+        MDBlYzA5MDExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ4OjIwWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ1NDk4OTA1NGZjNDhiYTJmOTMifSwg
+        ImlkIjogIjU2Y2M4ZDU0OTg5MDU0ZmM0OGJhMmY5MyJ9
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:20 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/cf0b32ab-b3b9-4b6e-8b1d-30f00ec09011/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '682'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jZjBiMzJhYi1iM2I5LTRiNmUtOGIxZC0zMGYwMGVjMDkw
+        MTEvIiwgInRhc2tfaWQiOiAiY2YwYjMyYWItYjNiOS00YjZlLThiMWQtMzBm
+        MDBlYzA5MDExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjIwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjIwWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNTQ5
+        ODkwNTRmYzQ4YmEyZjkzIn0sICJpZCI6ICI1NmNjOGQ1NDk4OTA1NGZjNDhi
+        YTJmOTMifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:21 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/f9445b93-5f4e-4415-94b7-2e469fe86219/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '643'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mOTQ0NWI5My01ZjRlLTQ0MTUtOTRiNy0yZTQ2OWZlODYy
+        MTkvIiwgInRhc2tfaWQiOiAiZjk0NDViOTMtNWY0ZS00NDE1LTk0YjctMmU0
+        NjlmZTg2MjE5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZj
+        YzhkNTU5ODkwNTRmYzQ4YmEyZjk0In0sICJpZCI6ICI1NmNjOGQ1NTk4OTA1
+        NGZjNDhiYTJmOTQifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:21 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/f9445b93-5f4e-4415-94b7-2e469fe86219/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:22 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1133'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mOTQ0NWI5My01ZjRlLTQ0MTUtOTRiNy0yZTQ2OWZlODYy
+        MTkvIiwgInRhc2tfaWQiOiAiZjk0NDViOTMtNWY0ZS00NDE1LTk0YjctMmU0
+        NjlmZTg2MjE5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0ODoyMVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
+        T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDU1
+        OTg5MDU0ZmM0OGJhMmY5NCJ9LCAiaWQiOiAiNTZjYzhkNTU5ODkwNTRmYzQ4
+        YmEyZjk0In0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:22 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/f9445b93-5f4e-4415-94b7-2e469fe86219/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:23 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2318'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mOTQ0NWI5My01ZjRlLTQ0MTUtOTRiNy0yZTQ2OWZlODYy
+        MTkvIiwgInRhc2tfaWQiOiAiZjk0NDViOTMtNWY0ZS00NDE1LTk0YjctMmU0
+        NjlmZTg2MjE5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0yM1QxNjo0ODoyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0ODoyMVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvM2I5NDdmN2QtYTU2ZS00NDU2LWFhOWYtZDQ1NzZjNTg4
+        M2Q4LyIsICJ0YXNrX2lkIjogIjNiOTQ3ZjdkLWE1NmUtNDQ1Ni1hYTlmLWQ0
+        NTc2YzU4ODNkOCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ1NWRlMDQw
+        MzNmNDFkMmE0MTAifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjIxWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6MjJaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkNTZk
+        ZTA0MDMwODk3NThhOGUzIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDU1OTg5MDU0ZmM0OGJhMmY5NCJ9LCAiaWQiOiAiNTZj
+        YzhkNTU5ODkwNTRmYzQ4YmEyZjk0In0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:23 GMT
 - request:
     method: post
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3488,7 +3639,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:09 GMT
+      - Tue, 23 Feb 2016 16:48:23 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -3502,60 +3653,60 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICI1ZjM4MThiYS0wZTNmLTRmMDgtYmJh
-        YS1lMTNjMzI1MTJiYzAiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
-        Il9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE2YmRiMDNjMmJhN2M5MWIzNDgifSwg
-        InVuaXRfaWQiOiAiNWYzODE4YmEtMGUzZi00ZjA4LWJiYWEtZTEzYzMyNTEy
-        YmMwIiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogIjYwYjlhOTVjLTVkOGUtNDI5OC05YjA5LTM0NTY5NmM0NWNjMCIs
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIzMzYzODQ1NC01OGE4LTQxYjAtYjA2
+        Ni05YzkxMDVkYmYzOTUiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ1Njk4OTA1NGZjNDhiYTJmOWMifSwg
+        InVuaXRfaWQiOiAiMzM2Mzg0NTQtNThhOC00MWIwLWIwNjYtOWM5MTA1ZGJm
+        Mzk1IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
+        X2lkIjogIjU3NGRiNGM0LTQ5ZDEtNDk2OS1iZTZmLTYzYjExZDQ4NWVkZSIs
         ICJfY29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjog
-        IjU2YzRkYTZiZGIwM2MyYmE3YzkxYjM0NSJ9LCAidW5pdF9pZCI6ICI2MGI5
-        YTk1Yy01ZDhlLTQyOTgtOWIwOS0zNDU2OTZjNDVjYzAiLCAidW5pdF90eXBl
-        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiOTA0MjA2YTMt
-        ZDUyMC00ZjU3LWI4NGEtNzhiM2FmMTU5N2NkIiwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNmJkYjAzYzJi
-        YTdjOTFiMzQ2In0sICJ1bml0X2lkIjogIjkwNDIwNmEzLWQ1MjAtNGY1Ny1i
-        ODRhLTc4YjNhZjE1OTdjZCIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
-        bWV0YWRhdGEiOiB7Il9pZCI6ICJhMWQ2NTAzMC0wNWVjLTRjZDMtOGExMi0w
-        NmYxNTFjZTM1NmQiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1NmM0ZGE2YmRiMDNjMmJhN2M5MWIzNDIifSwgInVu
-        aXRfaWQiOiAiYTFkNjUwMzAtMDVlYy00Y2QzLThhMTItMDZmMTUxY2UzNTZk
+        IjU2Y2M4ZDU2OTg5MDU0ZmM0OGJhMmY5OCJ9LCAidW5pdF9pZCI6ICI1NzRk
+        YjRjNC00OWQxLTQ5NjktYmU2Zi02M2IxMWQ0ODVlZGUiLCAidW5pdF90eXBl
+        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNmI0NTE5Yzgt
+        MjgxNi00YzU1LTkzNzctMmRhYWVmZTY0ZjgxIiwgIl9jb250ZW50X3R5cGVf
+        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNTY5ODkwNTRm
+        YzQ4YmEyZjliIn0sICJ1bml0X2lkIjogIjZiNDUxOWM4LTI4MTYtNGM1NS05
+        Mzc3LTJkYWFlZmU2NGY4MSIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
+        bWV0YWRhdGEiOiB7Il9pZCI6ICI4ODEyZjZjOC05ODU4LTRiZDYtOTM4Yi00
+        ZDk4MjM0MDBkYTQiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1NmNjOGQ1Njk4OTA1NGZjNDhiYTJmOTYifSwgInVu
+        aXRfaWQiOiAiODgxMmY2YzgtOTg1OC00YmQ2LTkzOGItNGQ5ODIzNDAwZGE0
         IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lk
-        IjogImMwYjQwODczLWM1Y2MtNDRkYS05YTJiLWE2YWJkZDNjOTkyZCIsICJf
+        IjogImM2OGUxNzE2LTM0YWItNDdlMS1iNThlLWRiZWU3NzlhZGZkZCIsICJf
         Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2
-        YzRkYTZiZGIwM2MyYmE3YzkxYjM0MyJ9LCAidW5pdF9pZCI6ICJjMGI0MDg3
-        My1jNWNjLTQ0ZGEtOWEyYi1hNmFiZGQzYzk5MmQiLCAidW5pdF90eXBlX2lk
-        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiYzJhNjRkYmEtOTcz
-        ZS00NzlmLWI4Y2ItOWU5OGMwNjU4NzZhIiwgIl9jb250ZW50X3R5cGVfaWQi
-        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNmJkYjAzYzJiYTdj
-        OTFiMzQ3In0sICJ1bml0X2lkIjogImMyYTY0ZGJhLTk3M2UtNDc5Zi1iOGNi
-        LTllOThjMDY1ODc2YSIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
-        YWRhdGEiOiB7Il9pZCI6ICJjYmU3OGU5OS1jMDYwLTQ4MGEtYTZhOS1mZDg2
-        ZTNiMzE1OWQiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NmM0ZGE2YmRiMDNjMmJhN2M5MWIzNDkifSwgInVuaXRf
-        aWQiOiAiY2JlNzhlOTktYzA2MC00ODBhLWE2YTktZmQ4NmUzYjMxNTlkIiwg
+        Y2M4ZDU2OTg5MDU0ZmM0OGJhMmY5NSJ9LCAidW5pdF9pZCI6ICJjNjhlMTcx
+        Ni0zNGFiLTQ3ZTEtYjU4ZS1kYmVlNzc5YWRmZGQiLCAidW5pdF90eXBlX2lk
+        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiZDc3ZGVjOGQtM2Y0
+        NC00MzZmLThhYjQtMmI0N2QyOTI4Zjg2IiwgIl9jb250ZW50X3R5cGVfaWQi
+        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNTY5ODkwNTRmYzQ4
+        YmEyZjlhIn0sICJ1bml0X2lkIjogImQ3N2RlYzhkLTNmNDQtNDM2Zi04YWI0
+        LTJiNDdkMjkyOGY4NiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
+        YWRhdGEiOiB7Il9pZCI6ICJlYTA4MTJhNC1iN2E1LTRlODMtOTYyOS01N2M3
+        MGJiOThkZTgiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
+        IHsiJG9pZCI6ICI1NmNjOGQ1Njk4OTA1NGZjNDhiYTJmOTcifSwgInVuaXRf
+        aWQiOiAiZWEwODEyYTQtYjdhNS00ZTgzLTk2MjktNTdjNzBiYjk4ZGU4Iiwg
         InVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjog
-        ImYxY2RiN2JlLWVkZTQtNGY0Yy05OTExLTViYTlmNTliNzVjOSIsICJfY29u
-        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2YzRk
-        YTZiZGIwM2MyYmE3YzkxYjM0NCJ9LCAidW5pdF9pZCI6ICJmMWNkYjdiZS1l
-        ZGU0LTRmNGMtOTkxMS01YmE5ZjU5Yjc1YzkiLCAidW5pdF90eXBlX2lkIjog
+        ImVlODExMTk3LWVmYTAtNDc1ZC1hNjM3LWQzYzZjODQzNWViMCIsICJfY29u
+        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4
+        ZDU2OTg5MDU0ZmM0OGJhMmY5OSJ9LCAidW5pdF9pZCI6ICJlZTgxMTE5Ny1l
+        ZmEwLTQ3NWQtYTYzNy1kM2M2Yzg0MzVlYjAiLCAidW5pdF90eXBlX2lkIjog
         InJwbSJ9XQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:09 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:23 GMT
 - request:
     method: post
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/content/units/rpm/search/
+    uri: https://katello-yoda.example.com/pulp/api/v2/content/units/rpm/search/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiNWYzODE4
-        YmEtMGUzZi00ZjA4LWJiYWEtZTEzYzMyNTEyYmMwIiwiNjBiOWE5NWMtNWQ4
-        ZS00Mjk4LTliMDktMzQ1Njk2YzQ1Y2MwIiwiOTA0MjA2YTMtZDUyMC00ZjU3
-        LWI4NGEtNzhiM2FmMTU5N2NkIiwiYTFkNjUwMzAtMDVlYy00Y2QzLThhMTIt
-        MDZmMTUxY2UzNTZkIiwiYzBiNDA4NzMtYzVjYy00NGRhLTlhMmItYTZhYmRk
-        M2M5OTJkIiwiYzJhNjRkYmEtOTczZS00NzlmLWI4Y2ItOWU5OGMwNjU4NzZh
-        IiwiY2JlNzhlOTktYzA2MC00ODBhLWE2YTktZmQ4NmUzYjMxNTlkIiwiZjFj
-        ZGI3YmUtZWRlNC00ZjRjLTk5MTEtNWJhOWY1OWI3NWM5Il19fSwiZmllbGRz
+        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMzM2Mzg0
+        NTQtNThhOC00MWIwLWIwNjYtOWM5MTA1ZGJmMzk1IiwiNTc0ZGI0YzQtNDlk
+        MS00OTY5LWJlNmYtNjNiMTFkNDg1ZWRlIiwiNmI0NTE5YzgtMjgxNi00YzU1
+        LTkzNzctMmRhYWVmZTY0ZjgxIiwiODgxMmY2YzgtOTg1OC00YmQ2LTkzOGIt
+        NGQ5ODIzNDAwZGE0IiwiYzY4ZTE3MTYtMzRhYi00N2UxLWI1OGUtZGJlZTc3
+        OWFkZmRkIiwiZDc3ZGVjOGQtM2Y0NC00MzZmLThhYjQtMmI0N2QyOTI4Zjg2
+        IiwiZWEwODEyYTQtYjdhNS00ZTgzLTk2MjktNTdjNzBiYjk4ZGU4IiwiZWU4
+        MTExOTctZWZhMC00NzVkLWE2MzctZDNjNmM4NDM1ZWIwIl19fSwiZmllbGRz
         IjpbIm5hbWUiLCJ2ZXJzaW9uIiwicmVsZWFzZSIsImFyY2giLCJlcG9jaCIs
         InN1bW1hcnkiLCJzb3VyY2VycG0iLCJjaGVja3N1bSIsImZpbGVuYW1lIiwi
         X2lkIl19LCJpbmNsdWRlX3JlcG9zIjp0cnVlfQ==
@@ -3576,13 +3727,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:09 GMT
+      - Tue, 23 Feb 2016 16:48:23 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '3804'
+      - '3948'
       Connection:
       - close
       Content-Type:
@@ -3590,96 +3741,99 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJz
-        b3VyY2VycG0iOiAid2FscnVzLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjog
-        IndhbHJ1cyIsICJjaGVja3N1bSI6ICI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBk
-        YzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwg
-        InN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxl
-        bmFtZSI6ICJ3YWxydXMtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjog
-        IjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lk
-        IjogIjVmMzgxOGJhLTBlM2YtNGYwOC1iYmFhLWUxM2MzMjUxMmJjMCIsICJh
-        cmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBtLzVmMzgxOGJhLTBlM2YtNGYw
-        OC1iYmFhLWUxM2MzMjUxMmJjMC8ifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNo
-        aXBzIjogWyJGZWRvcmFfMTciXSwgInNvdXJjZXJwbSI6ICJzcXVpcnJlbC0w
-        LjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJzcXVpcnJlbCIsICJjaGVja3N1
-        bSI6ICIyNTE3NjhiZGQxNWYxM2Q3ODQ4N2MyNzYzOGFhNmFlY2QwMTU1MWUy
-        NTM3NTYwOTNjZGUxYzBhZTg3OGExN2QyIiwgInN1bW1hcnkiOiAiQSBkdW1t
-        eSBwYWNrYWdlIG9mIHNxdWlycmVsIiwgImZpbGVuYW1lIjogInNxdWlycmVs
-        LTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24i
-        OiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICI2MGI5YTk1Yy01
-        ZDhlLTQyOTgtOWIwOS0zNDU2OTZjNDVjYzAiLCAiYXJjaCI6ICJub2FyY2gi
-        LCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250
-        ZW50L3VuaXRzL3JwbS82MGI5YTk1Yy01ZDhlLTQyOTgtOWIwOS0zNDU2OTZj
-        NDVjYzAvIn0sIHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3Jh
-        XzE3Il0sICJzb3VyY2VycG0iOiAiZWxlcGhhbnQtMC4zLTAuOC5zcmMucnBt
-        IiwgIm5hbWUiOiAiZWxlcGhhbnQiLCAiY2hlY2tzdW0iOiAiM2UxYzcwY2Qx
-        YjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5NWY2NWQxYjA5NWZjMzEz
-        NzJhMGE3MDFmMyIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBl
-        bGVwaGFudCIsICJmaWxlbmFtZSI6ICJlbGVwaGFudC0wLjMtMC44Lm5vYXJj
-        aC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxl
-        YXNlIjogIjAuOCIsICJfaWQiOiAiOTA0MjA2YTMtZDUyMC00ZjU3LWI4NGEt
-        NzhiM2FmMTU5N2NkIiwgImFyY2giOiAibm9hcmNoIiwgImNoaWxkcmVuIjog
-        e30sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9ycG0v
-        OTA0MjA2YTMtZDUyMC00ZjU3LWI4NGEtNzhiM2FmMTU5N2NkLyJ9LCB7InJl
-        cG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBbIkZlZG9yYV8xNyJdLCAic291cmNl
-        cnBtIjogInBlbmd1aW4tMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAicGVu
-        Z3VpbiIsICJjaGVja3N1bSI6ICIzZmNiMmM5MjdkZTllMTNiZjY4NDY5MDMy
-        YTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZkNmU0ODYzNWJlNjk0IiwgInN1
-        bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIHBlbmd1aW4iLCAiZmlsZW5h
-        bWUiOiAicGVuZ3Vpbi0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAi
-        MCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQi
-        OiAiYTFkNjUwMzAtMDVlYy00Y2QzLThhMTItMDZmMTUxY2UzNTZkIiwgImFy
-        Y2giOiAibm9hcmNoIiwgImNoaWxkcmVuIjoge30sICJfaHJlZiI6ICIvcHVs
-        cC9hcGkvdjIvY29udGVudC91bml0cy9ycG0vYTFkNjUwMzAtMDVlYy00Y2Qz
-        LThhMTItMDZmMTUxY2UzNTZkLyJ9LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hp
-        cHMiOiBbIkZlZG9yYV8xNyJdLCAic291cmNlcnBtIjogImxpb24tMC4zLTAu
-        OC5zcmMucnBtIiwgIm5hbWUiOiAibGlvbiIsICJjaGVja3N1bSI6ICIxMjQw
-        MGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4MTU4NTQzN2Fi
-        NjRjZDYyZWZhM2U0YWU0IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdl
-        IG9mIGxpb24iLCAiZmlsZW5hbWUiOiAibGlvbi0wLjMtMC44Lm5vYXJjaC5y
-        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNl
-        IjogIjAuOCIsICJfaWQiOiAiYzBiNDA4NzMtYzVjYy00NGRhLTlhMmItYTZh
-        YmRkM2M5OTJkIiwgImFyY2giOiAibm9hcmNoIiwgImNoaWxkcmVuIjoge30s
-        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9ycG0vYzBi
-        NDA4NzMtYzVjYy00NGRhLTlhMmItYTZhYmRkM2M5OTJkLyJ9LCB7InJlcG9z
-        aXRvcnlfbWVtYmVyc2hpcHMiOiBbIkZlZG9yYV8xNyJdLCAic291cmNlcnBt
-        IjogImdpcmFmZmUtMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAiZ2lyYWZm
-        ZSIsICJjaGVja3N1bSI6ICJmMjVkNjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3
-        YjQzODkxYWM0NjUzM2UzNTViODJkZTZkMTkyMjAwOWY5ZjE0IiwgInN1bW1h
-        cnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCAiZmlsZW5hbWUi
-        OiAiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIs
-        ICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAi
-        YzJhNjRkYmEtOTczZS00NzlmLWI4Y2ItOWU5OGMwNjU4NzZhIiwgImFyY2gi
-        OiAibm9hcmNoIiwgImNoaWxkcmVuIjoge30sICJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvY29udGVudC91bml0cy9ycG0vYzJhNjRkYmEtOTczZS00NzlmLWI4
-        Y2ItOWU5OGMwNjU4NzZhLyJ9LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMi
-        OiBbIkZlZG9yYV8xNyJdLCAic291cmNlcnBtIjogImNoZWV0YWgtMC4zLTAu
-        OC5zcmMucnBtIiwgIm5hbWUiOiAiY2hlZXRhaCIsICJjaGVja3N1bSI6ICI0
-        MjJkMGJhYTBjZDlkNzcxM2FlNzk2ZTg4NmEyM2UxN2Y1NzhmOTI0Zjc0ODgw
-        ZGViZGJiN2Q2NWZiMzY4ZGFlIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNr
-        YWdlIG9mIGNoZWV0YWgiLCAiZmlsZW5hbWUiOiAiY2hlZXRhaC0wLjMtMC44
-        Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIs
-        ICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiY2JlNzhlOTktYzA2MC00ODBh
-        LWE2YTktZmQ4NmUzYjMxNTlkIiwgImFyY2giOiAibm9hcmNoIiwgImNoaWxk
-        cmVuIjoge30sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0
-        cy9ycG0vY2JlNzhlOTktYzA2MC00ODBhLWE2YTktZmQ4NmUzYjMxNTlkLyJ9
-        LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBbIkZlZG9yYV8xNyJdLCAi
-        c291cmNlcnBtIjogIm1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6
-        ICJtb25rZXkiLCAiY2hlY2tzdW0iOiAiMGU4ZmE1MGQwMTI4ZmJhYmM3Y2Nj
-        NTYzMmUzZmEyNWQzOWIwMjgwMTY5ZjYxNjZjYjhlMmM4NGRlODUwMWRiMSIs
-        ICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCAiZmls
-        ZW5hbWUiOiAibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6
-        ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgIl9p
-        ZCI6ICJmMWNkYjdiZS1lZGU0LTRmNGMtOTkxMS01YmE5ZjU5Yjc1YzkiLCAi
-        YXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS9mMWNkYjdiZS1lZGU0LTRm
-        NGMtOTkxMS01YmE5ZjU5Yjc1YzkvIn1d
+        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsicmVpbnRlcm1lZGlhdGUi
+        LCAiRmVkb3JhXzE3Il0sICJzb3VyY2VycG0iOiAic3F1aXJyZWwtMC4zLTAu
+        OC5zcmMucnBtIiwgIm5hbWUiOiAic3F1aXJyZWwiLCAiY2hlY2tzdW0iOiAi
+        MjUxNzY4YmRkMTVmMTNkNzg0ODdjMjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2
+        MDkzY2RlMWMwYWU4NzhhMTdkMiIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFj
+        a2FnZSBvZiBzcXVpcnJlbCIsICJmaWxlbmFtZSI6ICJzcXVpcnJlbC0wLjMt
+        MC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAu
+        MyIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiMzM2Mzg0NTQtNThhOC00
+        MWIwLWIwNjYtOWM5MTA1ZGJmMzk1IiwgImFyY2giOiAibm9hcmNoIiwgImNo
+        aWxkcmVuIjoge30sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91
+        bml0cy9ycG0vMzM2Mzg0NTQtNThhOC00MWIwLWIwNjYtOWM5MTA1ZGJmMzk1
+        LyJ9LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBbInJlaW50ZXJtZWRp
+        YXRlIiwgIkZlZG9yYV8xNyJdLCAic291cmNlcnBtIjogIm1vbmtleS0wLjMt
+        MC44LnNyYy5ycG0iLCAibmFtZSI6ICJtb25rZXkiLCAiY2hlY2tzdW0iOiAi
+        MGU4ZmE1MGQwMTI4ZmJhYmM3Y2NjNTYzMmUzZmEyNWQzOWIwMjgwMTY5ZjYx
+        NjZjYjhlMmM4NGRlODUwMWRiMSIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFj
+        a2FnZSBvZiBtb25rZXkiLCAiZmlsZW5hbWUiOiAibW9ua2V5LTAuMy0wLjgu
+        bm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwg
+        InJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICI1NzRkYjRjNC00OWQxLTQ5Njkt
+        YmU2Zi02M2IxMWQ0ODVlZGUiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRy
+        ZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRz
+        L3JwbS81NzRkYjRjNC00OWQxLTQ5NjktYmU2Zi02M2IxMWQ0ODVlZGUvIn0s
+        IHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsicmVpbnRlcm1lZGlhdGUi
+        LCAiRmVkb3JhXzE3Il0sICJzb3VyY2VycG0iOiAid2FscnVzLTAuMy0wLjgu
+        c3JjLnJwbSIsICJuYW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6ICI2ZThk
+        NmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFk
+        ZWM3ZmI2MjFhNDYxZGZkIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdl
+        IG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6ICJ3YWxydXMtMC4zLTAuOC5ub2Fy
+        Y2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVs
+        ZWFzZSI6ICIwLjgiLCAiX2lkIjogIjZiNDUxOWM4LTI4MTYtNGM1NS05Mzc3
+        LTJkYWFlZmU2NGY4MSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6
+        IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBt
+        LzZiNDUxOWM4LTI4MTYtNGM1NS05Mzc3LTJkYWFlZmU2NGY4MS8ifSwgeyJy
+        ZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJyZWludGVybWVkaWF0ZSIsICJG
+        ZWRvcmFfMTciXSwgInNvdXJjZXJwbSI6ICJlbGVwaGFudC0wLjMtMC44LnNy
+        Yy5ycG0iLCAibmFtZSI6ICJlbGVwaGFudCIsICJjaGVja3N1bSI6ICIzZTFj
+        NzBjZDFiNDIxMzI4YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1
+        ZmMzMTM3MmEwYTcwMWYzIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdl
+        IG9mIGVsZXBoYW50IiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgu
+        bm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwg
+        InJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICI4ODEyZjZjOC05ODU4LTRiZDYt
+        OTM4Yi00ZDk4MjM0MDBkYTQiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRy
+        ZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRz
+        L3JwbS84ODEyZjZjOC05ODU4LTRiZDYtOTM4Yi00ZDk4MjM0MDBkYTQvIn0s
+        IHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsicmVpbnRlcm1lZGlhdGUi
+        LCAiRmVkb3JhXzE3Il0sICJzb3VyY2VycG0iOiAiZ2lyYWZmZS0wLjMtMC44
+        LnNyYy5ycG0iLCAibmFtZSI6ICJnaXJhZmZlIiwgImNoZWNrc3VtIjogImYy
+        NWQ2N2QxZDlkYTA0ZjEyZTU3Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4
+        MmRlNmQxOTIyMDA5ZjlmMTQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2th
+        Z2Ugb2YgZ2lyYWZmZSIsICJmaWxlbmFtZSI6ICJnaXJhZmZlLTAuMy0wLjgu
+        bm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwg
+        InJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICJjNjhlMTcxNi0zNGFiLTQ3ZTEt
+        YjU4ZS1kYmVlNzc5YWRmZGQiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRy
+        ZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRz
+        L3JwbS9jNjhlMTcxNi0zNGFiLTQ3ZTEtYjU4ZS1kYmVlNzc5YWRmZGQvIn0s
+        IHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsicmVpbnRlcm1lZGlhdGUi
+        LCAiRmVkb3JhXzE3Il0sICJzb3VyY2VycG0iOiAiY2hlZXRhaC0wLjMtMC44
+        LnNyYy5ycG0iLCAibmFtZSI6ICJjaGVldGFoIiwgImNoZWNrc3VtIjogIjQy
+        MmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIzZTE3ZjU3OGY5MjRmNzQ4ODBk
+        ZWJkYmI3ZDY1ZmIzNjhkYWUiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2th
+        Z2Ugb2YgY2hlZXRhaCIsICJmaWxlbmFtZSI6ICJjaGVldGFoLTAuMy0wLjgu
+        bm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwg
+        InJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICJkNzdkZWM4ZC0zZjQ0LTQzNmYt
+        OGFiNC0yYjQ3ZDI5MjhmODYiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRy
+        ZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRz
+        L3JwbS9kNzdkZWM4ZC0zZjQ0LTQzNmYtOGFiNC0yYjQ3ZDI5MjhmODYvIn0s
+        IHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsicmVpbnRlcm1lZGlhdGUi
+        LCAiRmVkb3JhXzE3Il0sICJzb3VyY2VycG0iOiAibGlvbi0wLjMtMC44LnNy
+        Yy5ycG0iLCAibmFtZSI6ICJsaW9uIiwgImNoZWNrc3VtIjogIjEyNDAwZGM5
+        NWMyM2E0YzE2MDcyNWE5MDg3MTZjZDNmY2RkN2E4OTgxNTg1NDM3YWI2NGNk
+        NjJlZmEzZTRhZTQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        bGlvbiIsICJmaWxlbmFtZSI6ICJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAi
+        MC44IiwgIl9pZCI6ICJlYTA4MTJhNC1iN2E1LTRlODMtOTYyOS01N2M3MGJi
+        OThkZTgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9o
+        cmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS9lYTA4MTJh
+        NC1iN2E1LTRlODMtOTYyOS01N2M3MGJiOThkZTgvIn0sIHsicmVwb3NpdG9y
+        eV9tZW1iZXJzaGlwcyI6IFsicmVpbnRlcm1lZGlhdGUiLCAiRmVkb3JhXzE3
+        Il0sICJzb3VyY2VycG0iOiAicGVuZ3Vpbi0wLjMtMC44LnNyYy5ycG0iLCAi
+        bmFtZSI6ICJwZW5ndWluIiwgImNoZWNrc3VtIjogIjNmY2IyYzkyN2RlOWUx
+        M2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFkMmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1
+        YmU2OTQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgcGVuZ3Vp
+        biIsICJmaWxlbmFtZSI6ICJwZW5ndWluLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAi
+        MC44IiwgIl9pZCI6ICJlZTgxMTE5Ny1lZmEwLTQ3NWQtYTYzNy1kM2M2Yzg0
+        MzVlYjAiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9o
+        cmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS9lZTgxMTE5
+        Ny1lZmEwLTQ3NWQtYTYzNy1kM2M2Yzg0MzVlYjAvIn1d
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:09 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:23 GMT
 - request:
     method: post
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3702,7 +3856,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:09 GMT
+      - Tue, 23 Feb 2016 16:48:23 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -3716,49 +3870,49 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICI1ZjM4MThiYS0wZTNmLTRmMDgtYmJh
-        YS1lMTNjMzI1MTJiYzAiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
-        Il9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE2YmRiMDNjMmJhN2M5MWIzNDgifSwg
-        InVuaXRfaWQiOiAiNWYzODE4YmEtMGUzZi00ZjA4LWJiYWEtZTEzYzMyNTEy
-        YmMwIiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogIjYwYjlhOTVjLTVkOGUtNDI5OC05YjA5LTM0NTY5NmM0NWNjMCIs
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIzMzYzODQ1NC01OGE4LTQxYjAtYjA2
+        Ni05YzkxMDVkYmYzOTUiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ1Njk4OTA1NGZjNDhiYTJmOWMifSwg
+        InVuaXRfaWQiOiAiMzM2Mzg0NTQtNThhOC00MWIwLWIwNjYtOWM5MTA1ZGJm
+        Mzk1IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
+        X2lkIjogIjU3NGRiNGM0LTQ5ZDEtNDk2OS1iZTZmLTYzYjExZDQ4NWVkZSIs
         ICJfY29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjog
-        IjU2YzRkYTZiZGIwM2MyYmE3YzkxYjM0NSJ9LCAidW5pdF9pZCI6ICI2MGI5
-        YTk1Yy01ZDhlLTQyOTgtOWIwOS0zNDU2OTZjNDVjYzAiLCAidW5pdF90eXBl
-        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiOTA0MjA2YTMt
-        ZDUyMC00ZjU3LWI4NGEtNzhiM2FmMTU5N2NkIiwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNmJkYjAzYzJi
-        YTdjOTFiMzQ2In0sICJ1bml0X2lkIjogIjkwNDIwNmEzLWQ1MjAtNGY1Ny1i
-        ODRhLTc4YjNhZjE1OTdjZCIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
-        bWV0YWRhdGEiOiB7Il9pZCI6ICJhMWQ2NTAzMC0wNWVjLTRjZDMtOGExMi0w
-        NmYxNTFjZTM1NmQiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1NmM0ZGE2YmRiMDNjMmJhN2M5MWIzNDIifSwgInVu
-        aXRfaWQiOiAiYTFkNjUwMzAtMDVlYy00Y2QzLThhMTItMDZmMTUxY2UzNTZk
+        IjU2Y2M4ZDU2OTg5MDU0ZmM0OGJhMmY5OCJ9LCAidW5pdF9pZCI6ICI1NzRk
+        YjRjNC00OWQxLTQ5NjktYmU2Zi02M2IxMWQ0ODVlZGUiLCAidW5pdF90eXBl
+        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNmI0NTE5Yzgt
+        MjgxNi00YzU1LTkzNzctMmRhYWVmZTY0ZjgxIiwgIl9jb250ZW50X3R5cGVf
+        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNTY5ODkwNTRm
+        YzQ4YmEyZjliIn0sICJ1bml0X2lkIjogIjZiNDUxOWM4LTI4MTYtNGM1NS05
+        Mzc3LTJkYWFlZmU2NGY4MSIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
+        bWV0YWRhdGEiOiB7Il9pZCI6ICI4ODEyZjZjOC05ODU4LTRiZDYtOTM4Yi00
+        ZDk4MjM0MDBkYTQiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1NmNjOGQ1Njk4OTA1NGZjNDhiYTJmOTYifSwgInVu
+        aXRfaWQiOiAiODgxMmY2YzgtOTg1OC00YmQ2LTkzOGItNGQ5ODIzNDAwZGE0
         IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lk
-        IjogImMwYjQwODczLWM1Y2MtNDRkYS05YTJiLWE2YWJkZDNjOTkyZCIsICJf
+        IjogImM2OGUxNzE2LTM0YWItNDdlMS1iNThlLWRiZWU3NzlhZGZkZCIsICJf
         Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2
-        YzRkYTZiZGIwM2MyYmE3YzkxYjM0MyJ9LCAidW5pdF9pZCI6ICJjMGI0MDg3
-        My1jNWNjLTQ0ZGEtOWEyYi1hNmFiZGQzYzk5MmQiLCAidW5pdF90eXBlX2lk
-        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiYzJhNjRkYmEtOTcz
-        ZS00NzlmLWI4Y2ItOWU5OGMwNjU4NzZhIiwgIl9jb250ZW50X3R5cGVfaWQi
-        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNmJkYjAzYzJiYTdj
-        OTFiMzQ3In0sICJ1bml0X2lkIjogImMyYTY0ZGJhLTk3M2UtNDc5Zi1iOGNi
-        LTllOThjMDY1ODc2YSIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
-        YWRhdGEiOiB7Il9pZCI6ICJjYmU3OGU5OS1jMDYwLTQ4MGEtYTZhOS1mZDg2
-        ZTNiMzE1OWQiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NmM0ZGE2YmRiMDNjMmJhN2M5MWIzNDkifSwgInVuaXRf
-        aWQiOiAiY2JlNzhlOTktYzA2MC00ODBhLWE2YTktZmQ4NmUzYjMxNTlkIiwg
+        Y2M4ZDU2OTg5MDU0ZmM0OGJhMmY5NSJ9LCAidW5pdF9pZCI6ICJjNjhlMTcx
+        Ni0zNGFiLTQ3ZTEtYjU4ZS1kYmVlNzc5YWRmZGQiLCAidW5pdF90eXBlX2lk
+        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiZDc3ZGVjOGQtM2Y0
+        NC00MzZmLThhYjQtMmI0N2QyOTI4Zjg2IiwgIl9jb250ZW50X3R5cGVfaWQi
+        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNTY5ODkwNTRmYzQ4
+        YmEyZjlhIn0sICJ1bml0X2lkIjogImQ3N2RlYzhkLTNmNDQtNDM2Zi04YWI0
+        LTJiNDdkMjkyOGY4NiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
+        YWRhdGEiOiB7Il9pZCI6ICJlYTA4MTJhNC1iN2E1LTRlODMtOTYyOS01N2M3
+        MGJiOThkZTgiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
+        IHsiJG9pZCI6ICI1NmNjOGQ1Njk4OTA1NGZjNDhiYTJmOTcifSwgInVuaXRf
+        aWQiOiAiZWEwODEyYTQtYjdhNS00ZTgzLTk2MjktNTdjNzBiYjk4ZGU4Iiwg
         InVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjog
-        ImYxY2RiN2JlLWVkZTQtNGY0Yy05OTExLTViYTlmNTliNzVjOSIsICJfY29u
-        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2YzRk
-        YTZiZGIwM2MyYmE3YzkxYjM0NCJ9LCAidW5pdF9pZCI6ICJmMWNkYjdiZS1l
-        ZGU0LTRmNGMtOTkxMS01YmE5ZjU5Yjc1YzkiLCAidW5pdF90eXBlX2lkIjog
+        ImVlODExMTk3LWVmYTAtNDc1ZC1hNjM3LWQzYzZjODQzNWViMCIsICJfY29u
+        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4
+        ZDU2OTg5MDU0ZmM0OGJhMmY5OSJ9LCAidW5pdF9pZCI6ICJlZTgxMTE5Ny1l
+        ZmEwLTQ3NWQtYTYzNy1kM2M2Yzg0MzVlYjAiLCAidW5pdF90eXBlX2lkIjog
         InJwbSJ9XQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:09 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:23 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/6249b644-cdcc-471f-a968-01fc9cbf7d15/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/f8954312-a396-4bf9-85d2-46b0c65cdeb0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3777,7 +3931,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:09 GMT
+      - Tue, 23 Feb 2016 16:48:24 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -3793,22 +3947,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82MjQ5YjY0NC1jZGNjLTQ3MWYtYTk2OC0wMWZjOWNiZjdk
-        MTUvIiwgInRhc2tfaWQiOiAiNjI0OWI2NDQtY2RjYy00NzFmLWE5NjgtMDFm
-        YzljYmY3ZDE1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9mODk1NDMxMi1hMzk2LTRiZjktODVkMi00NmIwYzY1Y2Rl
+        YjAvIiwgInRhc2tfaWQiOiAiZjg5NTQzMTItYTM5Ni00YmY5LTg1ZDItNDZi
+        MGM2NWNkZWIwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
         bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
         ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
         Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
         IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE2
-        ZGRiMDNjMmJhN2M5MWIzNTIifSwgImlkIjogIjU2YzRkYTZkZGIwM2MyYmE3
-        YzkxYjM1MiJ9
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ1
+        Nzk4OTA1NGZjNDhiYTJmYTUifSwgImlkIjogIjU2Y2M4ZDU3OTg5MDU0ZmM0
+        OGJhMmZhNSJ9
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:09 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:24 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/6249b644-cdcc-471f-a968-01fc9cbf7d15/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/f8954312-a396-4bf9-85d2-46b0c65cdeb0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3827,13 +3981,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:10 GMT
+      - Tue, 23 Feb 2016 16:48:24 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '680'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -3843,25 +3997,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82MjQ5YjY0NC1jZGNjLTQ3MWYtYTk2OC0wMWZjOWNiZjdk
-        MTUvIiwgInRhc2tfaWQiOiAiNjI0OWI2NDQtY2RjYy00NzFmLWE5NjgtMDFm
-        YzljYmY3ZDE1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9mODk1NDMxMi1hMzk2LTRiZjktODVkMi00NmIwYzY1Y2Rl
+        YjAvIiwgInRhc2tfaWQiOiAiZjg5NTQzMTItYTM5Ni00YmY5LTg1ZDItNDZi
+        MGM2NWNkZWIwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM5OjA5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM5OjA5WiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ4OjI0WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjI0WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTZkZGIw
-        M2MyYmE3YzkxYjM1MiJ9LCAiaWQiOiAiNTZjNGRhNmRkYjAzYzJiYTdjOTFi
-        MzUyIn0=
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNTc5
+        ODkwNTRmYzQ4YmEyZmE1In0sICJpZCI6ICI1NmNjOGQ1Nzk4OTA1NGZjNDhi
+        YTJmYTUifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:10 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:24 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/c5f1efe5-cdeb-45d6-80fa-30ce40bd0cbe/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/f3e5a9cf-129b-4517-8f3d-27a7bda45840/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3880,13 +4034,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:10 GMT
+      - Tue, 23 Feb 2016 16:48:25 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '1133'
       Connection:
       - close
       Content-Type:
@@ -3896,22 +4050,35 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jNWYxZWZlNS1jZGViLTQ1ZDYtODBmYS0zMGNlNDBiZDBj
-        YmUvIiwgInRhc2tfaWQiOiAiYzVmMWVmZTUtY2RlYi00NWQ2LTgwZmEtMzBj
-        ZTQwYmQwY2JlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9mM2U1YTljZi0xMjliLTQ1MTctOGYzZC0yN2E3YmRhNDU4
+        NDAvIiwgInRhc2tfaWQiOiAiZjNlNWE5Y2YtMTI5Yi00NTE3LThmM2QtMjdh
+        N2JkYTQ1ODQwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNmVk
-        YjAzYzJiYTdjOTFiMzUzIn0sICJpZCI6ICI1NmM0ZGE2ZWRiMDNjMmJhN2M5
-        MWIzNTMifQ==
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0ODoyNVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
+        T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDU5
+        OTg5MDU0ZmM0OGJhMmZhNiJ9LCAiaWQiOiAiNTZjYzhkNTk5ODkwNTRmYzQ4
+        YmEyZmE2In0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:10 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:25 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/c5f1efe5-cdeb-45d6-80fa-30ce40bd0cbe/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/f3e5a9cf-129b-4517-8f3d-27a7bda45840/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3930,13 +4097,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:10 GMT
+      - Tue, 23 Feb 2016 16:48:25 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '641'
+      - '1133'
       Connection:
       - close
       Content-Type:
@@ -3946,24 +4113,35 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jNWYxZWZlNS1jZGViLTQ1ZDYtODBmYS0zMGNlNDBiZDBj
-        YmUvIiwgInRhc2tfaWQiOiAiYzVmMWVmZTUtY2RlYi00NWQ2LTgwZmEtMzBj
-        ZTQwYmQwY2JlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9mM2U1YTljZi0xMjliLTQ1MTctOGYzZC0yN2E3YmRhNDU4
+        NDAvIiwgInRhc2tfaWQiOiAiZjNlNWE5Y2YtMTI5Yi00NTE3LThmM2QtMjdh
+        N2JkYTQ1ODQwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAYWJlZC51c2Vyc3lzLnJlZGhhdC5jb20uZHEiLCAic3RhdGUi
-        OiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQi
-        OiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRk
-        YTZlZGIwM2MyYmE3YzkxYjM1MyJ9LCAiaWQiOiAiNTZjNGRhNmVkYjAzYzJi
-        YTdjOTFiMzUzIn0=
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0ODoyNVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
+        T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDU5
+        OTg5MDU0ZmM0OGJhMmZhNiJ9LCAiaWQiOiAiNTZjYzhkNTk5ODkwNTRmYzQ4
+        YmEyZmE2In0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:10 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:25 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/c5f1efe5-cdeb-45d6-80fa-30ce40bd0cbe/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/f3e5a9cf-129b-4517-8f3d-27a7bda45840/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3982,13 +4160,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:11 GMT
+      - Tue, 23 Feb 2016 16:48:26 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2316'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -3998,16 +4176,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jNWYxZWZlNS1jZGViLTQ1ZDYtODBmYS0zMGNlNDBiZDBj
-        YmUvIiwgInRhc2tfaWQiOiAiYzVmMWVmZTUtY2RlYi00NWQ2LTgwZmEtMzBj
-        ZTQwYmQwY2JlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9mM2U1YTljZi0xMjliLTQ1MTctOGYzZC0yN2E3YmRhNDU4
+        NDAvIiwgInRhc2tfaWQiOiAiZjNlNWE5Y2YtMTI5Yi00NTE3LThmM2QtMjdh
+        N2JkYTQ1ODQwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xN1QyMDozOToxMVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDozOToxMFoiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0ODoyNVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0ODoyNVoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNmExZTZlNWUtZTA1Ni00MGFlLTg1NTQtYTY4NzNmNjdh
-        YzI2LyIsICJ0YXNrX2lkIjogIjZhMWU2ZTVlLWUwNTYtNDBhZS04NTU0LWE2
-        ODczZjY3YWMyNiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvYmI3NmFkOTctYzc3My00MGM1LTk2YTUtODIwMjhhMGY3
+        NmJmLyIsICJ0YXNrX2lkIjogImJiNzZhZDk3LWM3NzMtNDBjNS05NmE1LTgy
+        MDI4YTBmNzZiZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -4018,41 +4196,41 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5
-        cy5yZWRoYXQuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNl
-        cnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNmU1Y2EwMTMx
-        ODRmNmRiMTEzIn0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAx
-        Ni0wMi0xN1QyMDozOToxMFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRz
-        IiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM5OjExWiIsICJpbXBv
-        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdl
-        IjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
-        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
-        cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3Vu
-        dCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YzRkYTZmNWNh
-        MDEzMThmMzBjYjA3MCIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXpl
-        X3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
-        bHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3Rv
-        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
-        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
-        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmM0ZGE2ZWRiMDNjMmJhN2M5MWIzNTMifSwgImlkIjogIjU2YzRk
-        YTZlZGIwM2MyYmE3YzkxYjM1MyJ9
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ1OWRlMDQw
+        MzNmNDFkMmE0MTUifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjI1WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6MjVaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkNTlk
+        ZTA0MDMwODk3NThhOGVlIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDU5OTg5MDU0ZmM0OGJhMmZhNiJ9LCAiaWQiOiAiNTZj
+        YzhkNTk5ODkwNTRmYzQ4YmEyZmE2In0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:11 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:26 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/d8983cf5-245c-480a-a14a-ed9c8f4243dd/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/af8598e6-b7be-4799-b80a-5279d4b48850/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4071,7 +4249,726 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:12 GMT
+      - Tue, 23 Feb 2016 16:48:27 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '645'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hZjg1OThlNi1iN2JlLTQ3OTktYjgwYS01Mjc5ZDRiNDg4
+        NTAvIiwgInRhc2tfaWQiOiAiYWY4NTk4ZTYtYjdiZS00Nzk5LWI4MGEtNTI3
+        OWQ0YjQ4ODUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3Rh
+        dGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        NmNjOGQ1Yjk4OTA1NGZjNDhiYTJmYjcifSwgImlkIjogIjU2Y2M4ZDViOTg5
+        MDU0ZmM0OGJhMmZiNyJ9
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:27 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/af8598e6-b7be-4799-b80a-5279d4b48850/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:27 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '682'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hZjg1OThlNi1iN2JlLTQ3OTktYjgwYS01Mjc5ZDRiNDg4
+        NTAvIiwgInRhc2tfaWQiOiAiYWY4NTk4ZTYtYjdiZS00Nzk5LWI4MGEtNTI3
+        OWQ0YjQ4ODUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjI3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjI3WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNWI5
+        ODkwNTRmYzQ4YmEyZmI3In0sICJpZCI6ICI1NmNjOGQ1Yjk4OTA1NGZjNDhi
+        YTJmYjcifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:27 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/7fd8aee5-377b-4846-b981-3853c3b4b873/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:28 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '565'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83ZmQ4YWVlNS0zNzdiLTQ4NDYtYjk4MS0zODUzYzNiNGI4
+        NzMvIiwgInRhc2tfaWQiOiAiN2ZkOGFlZTUtMzc3Yi00ODQ2LWI5ODEtMzg1
+        M2MzYjRiODczIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0ODoyOFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        Tm9uZS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjog
+        bnVsbCwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNTZjYzhkNWM5ODkwNTRmYzQ4YmEyZmI4In0sICJpZCI6ICI1
+        NmNjOGQ1Yzk4OTA1NGZjNDhiYTJmYjgifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:28 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/7fd8aee5-377b-4846-b981-3853c3b4b873/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:28 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1133'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83ZmQ4YWVlNS0zNzdiLTQ4NDYtYjk4MS0zODUzYzNiNGI4
+        NzMvIiwgInRhc2tfaWQiOiAiN2ZkOGFlZTUtMzc3Yi00ODQ2LWI5ODEtMzg1
+        M2MzYjRiODczIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0ODoyOFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
+        T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDVj
+        OTg5MDU0ZmM0OGJhMmZiOCJ9LCAiaWQiOiAiNTZjYzhkNWM5ODkwNTRmYzQ4
+        YmEyZmI4In0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:28 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/7fd8aee5-377b-4846-b981-3853c3b4b873/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:29 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2318'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83ZmQ4YWVlNS0zNzdiLTQ4NDYtYjk4MS0zODUzYzNiNGI4
+        NzMvIiwgInRhc2tfaWQiOiAiN2ZkOGFlZTUtMzc3Yi00ODQ2LWI5ODEtMzg1
+        M2MzYjRiODczIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0yM1QxNjo0ODoyOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0ODoyOFoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvN2RhYWQ5ZTQtYWQ4Yi00MDUzLThlNTUtOWU4MGM2NzEw
+        YTYyLyIsICJ0YXNrX2lkIjogIjdkYWFkOWU0LWFkOGItNDA1My04ZTU1LTll
+        ODBjNjcxMGE2MiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ1Y2RlMDQw
+        MzNmNDM1MTRmOTkifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjI4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6MjhaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkNWNk
+        ZTA0MDMwODk3NThhOGY5IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDVjOTg5MDU0ZmM0OGJhMmZiOCJ9LCAiaWQiOiAiNTZj
+        YzhkNWM5ODkwNTRmYzQ4YmEyZmI4In0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:29 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/7942b223-8fab-4405-b685-e47e1658a9d3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:30 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '645'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83OTQyYjIyMy04ZmFiLTQ0MDUtYjY4NS1lNDdlMTY1OGE5
+        ZDMvIiwgInRhc2tfaWQiOiAiNzk0MmIyMjMtOGZhYi00NDA1LWI2ODUtZTQ3
+        ZTE2NThhOWQzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3Rh
+        dGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        NmNjOGQ1ZTk4OTA1NGZjNDhiYTJmYzkifSwgImlkIjogIjU2Y2M4ZDVlOTg5
+        MDU0ZmM0OGJhMmZjOSJ9
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:30 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/7942b223-8fab-4405-b685-e47e1658a9d3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:30 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '682'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83OTQyYjIyMy04ZmFiLTQ0MDUtYjY4NS1lNDdlMTY1OGE5
+        ZDMvIiwgInRhc2tfaWQiOiAiNzk0MmIyMjMtOGZhYi00NDA1LWI2ODUtZTQ3
+        ZTE2NThhOWQzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjMwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjMwWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNWU5
+        ODkwNTRmYzQ4YmEyZmM5In0sICJpZCI6ICI1NmNjOGQ1ZTk4OTA1NGZjNDhi
+        YTJmYzkifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:30 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/76fe100f-f96f-47b6-8492-d072cb3b22e9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:31 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '661'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83NmZlMTAwZi1mOTZmLTQ3YjYtODQ5Mi1kMDcyY2IzYjIy
+        ZTkvIiwgInRhc2tfaWQiOiAiNzZmZTEwMGYtZjk2Zi00N2I2LTg0OTItZDA3
+        MmNiM2IyMmU5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0ODozMVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4
+        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNTZjYzhkNWY5ODkwNTRmYzQ4YmEyZmNhIn0sICJp
+        ZCI6ICI1NmNjOGQ1Zjk4OTA1NGZjNDhiYTJmY2EifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:31 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/76fe100f-f96f-47b6-8492-d072cb3b22e9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:31 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1133'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83NmZlMTAwZi1mOTZmLTQ3YjYtODQ5Mi1kMDcyY2IzYjIy
+        ZTkvIiwgInRhc2tfaWQiOiAiNzZmZTEwMGYtZjk2Zi00N2I2LTg0OTItZDA3
+        MmNiM2IyMmU5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0ODozMVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
+        T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDVm
+        OTg5MDU0ZmM0OGJhMmZjYSJ9LCAiaWQiOiAiNTZjYzhkNWY5ODkwNTRmYzQ4
+        YmEyZmNhIn0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:31 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/76fe100f-f96f-47b6-8492-d072cb3b22e9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:32 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2318'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83NmZlMTAwZi1mOTZmLTQ3YjYtODQ5Mi1kMDcyY2IzYjIy
+        ZTkvIiwgInRhc2tfaWQiOiAiNzZmZTEwMGYtZjk2Zi00N2I2LTg0OTItZDA3
+        MmNiM2IyMmU5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0yM1QxNjo0ODozMVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0ODozMVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvYWY4YzgxMzUtZTA1MS00NmNjLTk4NjEtNWU3N2EyYzli
+        Y2QwLyIsICJ0YXNrX2lkIjogImFmOGM4MTM1LWUwNTEtNDZjYy05ODYxLTVl
+        NzdhMmM5YmNkMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ1ZmRlMDQw
+        MzNmNDM1MTRmOWUifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjMxWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6MzFaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkNWZk
+        ZTA0MDMwODk3NThhOTA0IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDVmOTg5MDU0ZmM0OGJhMmZjYSJ9LCAiaWQiOiAiNTZj
+        YzhkNWY5ODkwNTRmYzQ4YmEyZmNhIn0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:32 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/26476998-888a-4a57-874d-445c33febea3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:33 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '567'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yNjQ3Njk5OC04ODhhLTRhNTctODc0ZC00NDVjMzNmZWJl
+        YTMvIiwgInRhc2tfaWQiOiAiMjY0NzY5OTgtODg4YS00YTU3LTg3NGQtNDQ1
+        YzMzZmViZWEzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ4OjMzWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJOb25lLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiBudWxsLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6
+        IHsiJG9pZCI6ICI1NmNjOGQ2MTk4OTA1NGZjNDhiYTJmZGIifSwgImlkIjog
+        IjU2Y2M4ZDYxOTg5MDU0ZmM0OGJhMmZkYiJ9
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:33 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/26476998-888a-4a57-874d-445c33febea3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:34 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '682'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yNjQ3Njk5OC04ODhhLTRhNTctODc0ZC00NDVjMzNmZWJl
+        YTMvIiwgInRhc2tfaWQiOiAiMjY0NzY5OTgtODg4YS00YTU3LTg3NGQtNDQ1
+        YzMzZmViZWEzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjMzWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjMzWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNjE5
+        ODkwNTRmYzQ4YmEyZmRiIn0sICJpZCI6ICI1NmNjOGQ2MTk4OTA1NGZjNDhi
+        YTJmZGIifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:34 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/30232769-52ff-4987-ad52-f2078002954b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:34 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -4086,472 +4983,25 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kODk4M2NmNS0yNDVjLTQ4MGEtYTE0YS1lZDljOGY0MjQz
-        ZGQvIiwgInRhc2tfaWQiOiAiZDg5ODNjZjUtMjQ1Yy00ODBhLWExNGEtZWQ5
-        YzhmNDI0M2RkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0
-        ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZj
-        NGRhNzBkYjAzYzJiYTdjOTFiMzY0In0sICJpZCI6ICI1NmM0ZGE3MGRiMDNj
-        MmJhN2M5MWIzNjQifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:12 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/d8983cf5-245c-480a-a14a-ed9c8f4243dd/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:13 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '680'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kODk4M2NmNS0yNDVjLTQ4MGEtYTE0YS1lZDljOGY0MjQz
-        ZGQvIiwgInRhc2tfaWQiOiAiZDg5ODNjZjUtMjQ1Yy00ODBhLWExNGEtZWQ5
-        YzhmNDI0M2RkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM5OjEyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM5OjEyWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTcwZGIw
-        M2MyYmE3YzkxYjM2NCJ9LCAiaWQiOiAiNTZjNGRhNzBkYjAzYzJiYTdjOTFi
-        MzY0In0=
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:13 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/5b086fbe-5ef5-4d85-8c75-dbce86df295b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:14 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81YjA4NmZiZS01ZWY1LTRkODUtOGM3NS1kYmNlODZkZjI5
-        NWIvIiwgInRhc2tfaWQiOiAiNWIwODZmYmUtNWVmNS00ZDg1LThjNzUtZGJj
-        ZTg2ZGYyOTViIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNzJk
-        YjAzYzJiYTdjOTFiMzY1In0sICJpZCI6ICI1NmM0ZGE3MmRiMDNjMmJhN2M5
-        MWIzNjUifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:14 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/5b086fbe-5ef5-4d85-8c75-dbce86df295b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:14 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81YjA4NmZiZS01ZWY1LTRkODUtOGM3NS1kYmNlODZkZjI5
-        NWIvIiwgInRhc2tfaWQiOiAiNWIwODZmYmUtNWVmNS00ZDg1LThjNzUtZGJj
-        ZTg2ZGYyOTViIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNzJk
-        YjAzYzJiYTdjOTFiMzY1In0sICJpZCI6ICI1NmM0ZGE3MmRiMDNjMmJhN2M5
-        MWIzNjUifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:14 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/5b086fbe-5ef5-4d85-8c75-dbce86df295b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2316'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81YjA4NmZiZS01ZWY1LTRkODUtOGM3NS1kYmNlODZkZjI5
-        NWIvIiwgInRhc2tfaWQiOiAiNWIwODZmYmUtNWVmNS00ZDg1LThjNzUtZGJj
-        ZTg2ZGYyOTViIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xN1QyMDozOToxNVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDozOToxNFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZjMxZDlmODUtYjI5MS00ODUzLWI0MWYtNThkODI2Nzdm
-        ZWY1LyIsICJ0YXNrX2lkIjogImYzMWQ5Zjg1LWIyOTEtNDg1My1iNDFmLTU4
-        ZDgyNjc3ZmVmNSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5
-        cy5yZWRoYXQuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNl
-        cnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNzE1Y2EwMTMx
-        ODRkYzgxNWZjIn0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAx
-        Ni0wMi0xN1QyMDozOToxNFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRz
-        IiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM5OjE1WiIsICJpbXBv
-        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdl
-        IjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
-        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
-        cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3Vu
-        dCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YzRkYTczNWNh
-        MDEzMThmMzBjYjA3NSIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXpl
-        X3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
-        bHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3Rv
-        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
-        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
-        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmM0ZGE3MmRiMDNjMmJhN2M5MWIzNjUifSwgImlkIjogIjU2YzRk
-        YTcyZGIwM2MyYmE3YzkxYjM2NSJ9
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:15 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/7fd8890d-58d2-4add-973c-b2d9b9050bb3/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83ZmQ4ODkwZC01OGQyLTRhZGQtOTczYy1iMmQ5YjkwNTBi
-        YjMvIiwgInRhc2tfaWQiOiAiN2ZkODg5MGQtNThkMi00YWRkLTk3M2MtYjJk
-        OWI5MDUwYmIzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE3
-        M2RiMDNjMmJhN2M5MWIzNzYifSwgImlkIjogIjU2YzRkYTczZGIwM2MyYmE3
-        YzkxYjM3NiJ9
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:15 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/7fd8890d-58d2-4add-973c-b2d9b9050bb3/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:16 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '680'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83ZmQ4ODkwZC01OGQyLTRhZGQtOTczYy1iMmQ5YjkwNTBi
-        YjMvIiwgInRhc2tfaWQiOiAiN2ZkODg5MGQtNThkMi00YWRkLTk3M2MtYjJk
-        OWI5MDUwYmIzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM5OjE2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM5OjE2WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTczZGIw
-        M2MyYmE3YzkxYjM3NiJ9LCAiaWQiOiAiNTZjNGRhNzNkYjAzYzJiYTdjOTFi
-        Mzc2In0=
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:16 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/66f34c1e-0b24-4ea9-bfc0-c43fc2f4a2a7/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:17 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NmYzNGMxZS0wYjI0LTRlYTktYmZjMC1jNDNmYzJmNGEy
-        YTcvIiwgInRhc2tfaWQiOiAiNjZmMzRjMWUtMGIyNC00ZWE5LWJmYzAtYzQz
-        ZmMyZjRhMmE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNzVk
-        YjAzYzJiYTdjOTFiMzc3In0sICJpZCI6ICI1NmM0ZGE3NWRiMDNjMmJhN2M5
-        MWIzNzcifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:17 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/66f34c1e-0b24-4ea9-bfc0-c43fc2f4a2a7/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:17 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '641'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NmYzNGMxZS0wYjI0LTRlYTktYmZjMC1jNDNmYzJmNGEy
-        YTcvIiwgInRhc2tfaWQiOiAiNjZmMzRjMWUtMGIyNC00ZWE5LWJmYzAtYzQz
-        ZmMyZjRhMmE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8zMDIzMjc2OS01MmZmLTQ5ODctYWQ1Mi1mMjA3ODAwMjk1
+        NGIvIiwgInRhc2tfaWQiOiAiMzAyMzI3NjktNTJmZi00OTg3LWFkNTItZjIw
+        NzgwMDI5NTRiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAYWJlZC51c2Vyc3lzLnJlZGhhdC5jb20uZHEiLCAic3RhdGUi
-        OiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQi
-        OiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRk
-        YTc1ZGIwM2MyYmE3YzkxYjM3NyJ9LCAiaWQiOiAiNTZjNGRhNzVkYjAzYzJi
-        YTdjOTFiMzc3In0=
+        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZj
+        YzhkNjI5ODkwNTRmYzQ4YmEyZmRjIn0sICJpZCI6ICI1NmNjOGQ2Mjk4OTA1
+        NGZjNDhiYTJmZGMifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:17 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:34 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/66f34c1e-0b24-4ea9-bfc0-c43fc2f4a2a7/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/30232769-52ff-4987-ad52-f2078002954b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4570,13 +5020,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:18 GMT
+      - Tue, 23 Feb 2016 16:48:34 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2316'
+      - '1133'
       Connection:
       - close
       Content-Type:
@@ -4586,546 +5036,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NmYzNGMxZS0wYjI0LTRlYTktYmZjMC1jNDNmYzJmNGEy
-        YTcvIiwgInRhc2tfaWQiOiAiNjZmMzRjMWUtMGIyNC00ZWE5LWJmYzAtYzQz
-        ZmMyZjRhMmE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xN1QyMDozOToxN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDozOToxN1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNGU3MzlmY2UtOGYxOC00ODAwLTk1ZmEtZGI4MGNiMzcx
-        MDY1LyIsICJ0YXNrX2lkIjogIjRlNzM5ZmNlLThmMTgtNDgwMC05NWZhLWRi
-        ODBjYjM3MTA2NSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5
-        cy5yZWRoYXQuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNl
-        cnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNzU1Y2EwMTMx
-        ODRmNmRiMTE4In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAx
-        Ni0wMi0xN1QyMDozOToxN1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRz
-        IiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM5OjE3WiIsICJpbXBv
-        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdl
-        IjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
-        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
-        cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3Vu
-        dCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YzRkYTc1NWNh
-        MDEzMThmMzBjYjA3YSIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXpl
-        X3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
-        bHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3Rv
-        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
-        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
-        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmM0ZGE3NWRiMDNjMmJhN2M5MWIzNzcifSwgImlkIjogIjU2YzRk
-        YTc1ZGIwM2MyYmE3YzkxYjM3NyJ9
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:18 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/70c3400f-eb93-42d4-9f17-cd2efaac26dc/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:18 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83MGMzNDAwZi1lYjkzLTQyZDQtOWYxNy1jZDJlZmFhYzI2
-        ZGMvIiwgInRhc2tfaWQiOiAiNzBjMzQwMGYtZWI5My00MmQ0LTlmMTctY2Qy
-        ZWZhYWMyNmRjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE3
-        NmRiMDNjMmJhN2M5MWIzODgifSwgImlkIjogIjU2YzRkYTc2ZGIwM2MyYmE3
-        YzkxYjM4OCJ9
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:18 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/70c3400f-eb93-42d4-9f17-cd2efaac26dc/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:19 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '680'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83MGMzNDAwZi1lYjkzLTQyZDQtOWYxNy1jZDJlZmFhYzI2
-        ZGMvIiwgInRhc2tfaWQiOiAiNzBjMzQwMGYtZWI5My00MmQ0LTlmMTctY2Qy
-        ZWZhYWMyNmRjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM5OjE5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM5OjE5WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTc2ZGIw
-        M2MyYmE3YzkxYjM4OCJ9LCAiaWQiOiAiNTZjNGRhNzZkYjAzYzJiYTdjOTFi
-        Mzg4In0=
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:19 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/66d4c214-9db0-436a-b028-f5972a54cae3/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:20 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NmQ0YzIxNC05ZGIwLTQzNmEtYjAyOC1mNTk3MmE1NGNh
-        ZTMvIiwgInRhc2tfaWQiOiAiNjZkNGMyMTQtOWRiMC00MzZhLWIwMjgtZjU5
-        NzJhNTRjYWUzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNzhk
-        YjAzYzJiYTdjOTFiMzg5In0sICJpZCI6ICI1NmM0ZGE3OGRiMDNjMmJhN2M5
-        MWIzODkifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:20 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/66d4c214-9db0-436a-b028-f5972a54cae3/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:20 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NmQ0YzIxNC05ZGIwLTQzNmEtYjAyOC1mNTk3MmE1NGNh
-        ZTMvIiwgInRhc2tfaWQiOiAiNjZkNGMyMTQtOWRiMC00MzZhLWIwMjgtZjU5
-        NzJhNTRjYWUzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNzhk
-        YjAzYzJiYTdjOTFiMzg5In0sICJpZCI6ICI1NmM0ZGE3OGRiMDNjMmJhN2M5
-        MWIzODkifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:20 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/66d4c214-9db0-436a-b028-f5972a54cae3/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:21 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2316'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NmQ0YzIxNC05ZGIwLTQzNmEtYjAyOC1mNTk3MmE1NGNh
-        ZTMvIiwgInRhc2tfaWQiOiAiNjZkNGMyMTQtOWRiMC00MzZhLWIwMjgtZjU5
-        NzJhNTRjYWUzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xN1QyMDozOToyMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDozOToyMFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvOGJmOTdjMGQtYzAwYy00Y2QyLTkyZDktNGVmYmMxNDg4
-        MmRiLyIsICJ0YXNrX2lkIjogIjhiZjk3YzBkLWMwMGMtNGNkMi05MmQ5LTRl
-        ZmJjMTQ4ODJkYiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5
-        cy5yZWRoYXQuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNl
-        cnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNzg1Y2EwMTMx
-        ODRmNmRiMTFkIn0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAx
-        Ni0wMi0xN1QyMDozOToyMFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRz
-        IiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM5OjIwWiIsICJpbXBv
-        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdl
-        IjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
-        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
-        cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3Vu
-        dCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YzRkYTc4NWNh
-        MDEzMThmMzBjYjA3ZiIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXpl
-        X3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
-        bHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3Rv
-        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
-        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
-        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmM0ZGE3OGRiMDNjMmJhN2M5MWIzODkifSwgImlkIjogIjU2YzRk
-        YTc4ZGIwM2MyYmE3YzkxYjM4OSJ9
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:21 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/7969a8ec-5a0a-4f24-81a7-db22c8f6d994/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:22 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83OTY5YThlYy01YTBhLTRmMjQtODFhNy1kYjIyYzhmNmQ5
-        OTQvIiwgInRhc2tfaWQiOiAiNzk2OWE4ZWMtNWEwYS00ZjI0LTgxYTctZGIy
-        MmM4ZjZkOTk0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE3
-        YWRiMDNjMmJhN2M5MWIzOWEifSwgImlkIjogIjU2YzRkYTdhZGIwM2MyYmE3
-        YzkxYjM5YSJ9
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:22 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/7969a8ec-5a0a-4f24-81a7-db22c8f6d994/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:22 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '680'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83OTY5YThlYy01YTBhLTRmMjQtODFhNy1kYjIyYzhmNmQ5
-        OTQvIiwgInRhc2tfaWQiOiAiNzk2OWE4ZWMtNWEwYS00ZjI0LTgxYTctZGIy
-        MmM4ZjZkOTk0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM5OjIyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM5OjIyWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTdhZGIw
-        M2MyYmE3YzkxYjM5YSJ9LCAiaWQiOiAiNTZjNGRhN2FkYjAzYzJiYTdjOTFi
-        MzlhIn0=
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:22 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/f2c33133-4e07-4ee4-b7cb-013093b352d6/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:23 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mMmMzMzEzMy00ZTA3LTRlZTQtYjdjYi0wMTMwOTNiMzUy
-        ZDYvIiwgInRhc2tfaWQiOiAiZjJjMzMxMzMtNGUwNy00ZWU0LWI3Y2ItMDEz
-        MDkzYjM1MmQ2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhN2Jk
-        YjAzYzJiYTdjOTFiMzliIn0sICJpZCI6ICI1NmM0ZGE3YmRiMDNjMmJhN2M5
-        MWIzOWIifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:23 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/f2c33133-4e07-4ee4-b7cb-013093b352d6/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:23 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1131'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mMmMzMzEzMy00ZTA3LTRlZTQtYjdjYi0wMTMwOTNiMzUy
-        ZDYvIiwgInRhc2tfaWQiOiAiZjJjMzMxMzMtNGUwNy00ZWU0LWI3Y2ItMDEz
-        MDkzYjM1MmQ2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8zMDIzMjc2OS01MmZmLTQ5ODctYWQ1Mi1mMjA3ODAwMjk1
+        NGIvIiwgInRhc2tfaWQiOiAiMzAyMzI3NjktNTJmZi00OTg3LWFkNTItZjIw
+        NzgwMDI5NTRiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0xN1QyMDozOToyM1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        Mi0yM1QxNjo0ODozNFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
         dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
         IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
         T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
@@ -5138,17 +5054,17 @@ http_interactions:
         cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
         ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
         T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tLmRxIiwgInN0YXRlIjogInJ1
-        bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTBAYWJlZC51c2Vyc3lzLnJlZGhhdC5jb20iLCAicmVzdWx0IjogbnVs
-        bCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE3YmRi
-        MDNjMmJhN2M5MWIzOWIifSwgImlkIjogIjU2YzRkYTdiZGIwM2MyYmE3Yzkx
-        YjM5YiJ9
+        ci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDYy
+        OTg5MDU0ZmM0OGJhMmZkYyJ9LCAiaWQiOiAiNTZjYzhkNjI5ODkwNTRmYzQ4
+        YmEyZmRjIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:23 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:34 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/f2c33133-4e07-4ee4-b7cb-013093b352d6/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/30232769-52ff-4987-ad52-f2078002954b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5167,13 +5083,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:24 GMT
+      - Tue, 23 Feb 2016 16:48:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2316'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -5183,16 +5099,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mMmMzMzEzMy00ZTA3LTRlZTQtYjdjYi0wMTMwOTNiMzUy
-        ZDYvIiwgInRhc2tfaWQiOiAiZjJjMzMxMzMtNGUwNy00ZWU0LWI3Y2ItMDEz
-        MDkzYjM1MmQ2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8zMDIzMjc2OS01MmZmLTQ5ODctYWQ1Mi1mMjA3ODAwMjk1
+        NGIvIiwgInRhc2tfaWQiOiAiMzAyMzI3NjktNTJmZi00OTg3LWFkNTItZjIw
+        NzgwMDI5NTRiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xN1QyMDozOToyM1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDozOToyM1oiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0ODozNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0ODozNFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMGQ3MjNiYmEtNzMwNy00ZmVhLTkyYWQtOWE1NDQxZTVi
-        ODIzLyIsICJ0YXNrX2lkIjogIjBkNzIzYmJhLTczMDctNGZlYS05MmFkLTlh
-        NTQ0MWU1YjgyMyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvYTdkZTkzZTYtNjEyMC00NWY0LWI0ZmUtOTM1MTEwODMz
+        Mjk1LyIsICJ0YXNrX2lkIjogImE3ZGU5M2U2LTYxMjAtNDVmNC1iNGZlLTkz
+        NTExMDgzMzI5NSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -5203,41 +5119,41 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5
-        cy5yZWRoYXQuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNl
-        cnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhN2I1Y2EwMTMx
-        ODRkYzgxNjAxIn0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAx
-        Ni0wMi0xN1QyMDozOToyM1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRz
-        IiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM5OjIzWiIsICJpbXBv
-        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdl
-        IjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
-        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
-        cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3Vu
-        dCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YzRkYTdiNWNh
-        MDEzMThmMzBjYjA4NCIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXpl
-        X3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
-        bHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3Rv
-        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
-        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
-        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmM0ZGE3YmRiMDNjMmJhN2M5MWIzOWIifSwgImlkIjogIjU2YzRk
-        YTdiZGIwM2MyYmE3YzkxYjM5YiJ9
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ2MmRlMDQw
+        MzNmNDFkMmE0MWEifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjM0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6MzRaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkNjJk
+        ZTA0MDMwODk3NThhOTBmIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDYyOTg5MDU0ZmM0OGJhMmZkYyJ9LCAiaWQiOiAiNTZj
+        YzhkNjI5ODkwNTRmYzQ4YmEyZmRjIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:24 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:35 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/b15bbd54-77b5-4aab-9e0a-7048b78b60df/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/ec8e2f44-b0bd-4b4f-8d5e-e3049590a289/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5256,13 +5172,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:25 GMT
+      - Tue, 23 Feb 2016 16:48:36 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '663'
       Connection:
       - close
       Content-Type:
@@ -5272,22 +5188,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iMTViYmQ1NC03N2I1LTRhYWItOWUwYS03MDQ4Yjc4YjYw
-        ZGYvIiwgInRhc2tfaWQiOiAiYjE1YmJkNTQtNzdiNS00YWFiLTllMGEtNzA0
-        OGI3OGI2MGRmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9lYzhlMmY0NC1iMGJkLTRiNGYtOGQ1ZS1lMzA0OTU5MGEy
+        ODkvIiwgInRhc2tfaWQiOiAiZWM4ZTJmNDQtYjBiZC00YjRmLThkNWUtZTMw
+        NDk1OTBhMjg5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE3
-        ZGRiMDNjMmJhN2M5MWIzYWMifSwgImlkIjogIjU2YzRkYTdkZGIwM2MyYmE3
-        YzkxYjNhYyJ9
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ4OjM2WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ2NDk4OTA1NGZjNDhiYTJmZWQifSwg
+        ImlkIjogIjU2Y2M4ZDY0OTg5MDU0ZmM0OGJhMmZlZCJ9
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:25 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:36 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/b15bbd54-77b5-4aab-9e0a-7048b78b60df/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/ec8e2f44-b0bd-4b4f-8d5e-e3049590a289/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5306,13 +5224,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:25 GMT
+      - Tue, 23 Feb 2016 16:48:37 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '680'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -5322,25 +5240,334 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iMTViYmQ1NC03N2I1LTRhYWItOWUwYS03MDQ4Yjc4YjYw
-        ZGYvIiwgInRhc2tfaWQiOiAiYjE1YmJkNTQtNzdiNS00YWFiLTllMGEtNzA0
-        OGI3OGI2MGRmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9lYzhlMmY0NC1iMGJkLTRiNGYtOGQ1ZS1lMzA0OTU5MGEy
+        ODkvIiwgInRhc2tfaWQiOiAiZWM4ZTJmNDQtYjBiZC00YjRmLThkNWUtZTMw
+        NDk1OTBhMjg5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM5OjI1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM5OjI1WiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ4OjM2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjM2WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTdkZGIw
-        M2MyYmE3YzkxYjNhYyJ9LCAiaWQiOiAiNTZjNGRhN2RkYjAzYzJiYTdjOTFi
-        M2FjIn0=
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNjQ5
+        ODkwNTRmYzQ4YmEyZmVkIn0sICJpZCI6ICI1NmNjOGQ2NDk4OTA1NGZjNDhi
+        YTJmZWQifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:25 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:37 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/b14f17bb-c40c-49a5-abde-889ab0345904/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:37 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '643'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iMTRmMTdiYi1jNDBjLTQ5YTUtYWJkZS04ODlhYjAzNDU5
+        MDQvIiwgInRhc2tfaWQiOiAiYjE0ZjE3YmItYzQwYy00OWE1LWFiZGUtODg5
+        YWIwMzQ1OTA0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZj
+        YzhkNjU5ODkwNTRmYzQ4YmEyZmVlIn0sICJpZCI6ICI1NmNjOGQ2NTk4OTA1
+        NGZjNDhiYTJmZWUifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:37 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/b14f17bb-c40c-49a5-abde-889ab0345904/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:37 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1133'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iMTRmMTdiYi1jNDBjLTQ5YTUtYWJkZS04ODlhYjAzNDU5
+        MDQvIiwgInRhc2tfaWQiOiAiYjE0ZjE3YmItYzQwYy00OWE1LWFiZGUtODg5
+        YWIwMzQ1OTA0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0ODozN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
+        T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDY1
+        OTg5MDU0ZmM0OGJhMmZlZSJ9LCAiaWQiOiAiNTZjYzhkNjU5ODkwNTRmYzQ4
+        YmEyZmVlIn0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:37 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/b14f17bb-c40c-49a5-abde-889ab0345904/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:38 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2318'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iMTRmMTdiYi1jNDBjLTQ5YTUtYWJkZS04ODlhYjAzNDU5
+        MDQvIiwgInRhc2tfaWQiOiAiYjE0ZjE3YmItYzQwYy00OWE1LWFiZGUtODg5
+        YWIwMzQ1OTA0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0yM1QxNjo0ODozOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0ODozN1oiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvYWFjODBjZWYtNjE3OS00NDg0LWFjY2MtYmUxZjA5YTcy
+        ODg5LyIsICJ0YXNrX2lkIjogImFhYzgwY2VmLTYxNzktNDQ4NC1hY2NjLWJl
+        MWYwOWE3Mjg4OSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ2NWRlMDQw
+        MzNmNDFkMmE0MWYifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjM3WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6MzhaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkNjZk
+        ZTA0MDMwODk3NThhOTFhIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDY1OTg5MDU0ZmM0OGJhMmZlZSJ9LCAiaWQiOiAiNTZj
+        YzhkNjU5ODkwNTRmYzQ4YmEyZmVlIn0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:38 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/4454ec1a-f5cf-4951-8054-75ddd609db3d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:39 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '663'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy80NDU0ZWMxYS1mNWNmLTQ5NTEtODA1NC03NWRkZDYwOWRi
+        M2QvIiwgInRhc2tfaWQiOiAiNDQ1NGVjMWEtZjVjZi00OTUxLTgwNTQtNzVk
+        ZGQ2MDlkYjNkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ4OjM5WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ2Nzk4OTA1NGZjNDhiYTJmZmYifSwg
+        ImlkIjogIjU2Y2M4ZDY3OTg5MDU0ZmM0OGJhMmZmZiJ9
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:39 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/4454ec1a-f5cf-4951-8054-75ddd609db3d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:40 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '682'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy80NDU0ZWMxYS1mNWNmLTQ5NTEtODA1NC03NWRkZDYwOWRi
+        M2QvIiwgInRhc2tfaWQiOiAiNDQ1NGVjMWEtZjVjZi00OTUxLTgwNTQtNzVk
+        ZGQ2MDlkYjNkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjM5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjM5WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNjc5
+        ODkwNTRmYzQ4YmEyZmZmIn0sICJpZCI6ICI1NmNjOGQ2Nzk4OTA1NGZjNDhi
+        YTJmZmYifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:40 GMT
 - request:
     method: post
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -5348,21 +5575,21 @@ http_interactions:
         ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
         b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
         ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJkb3dubG9hZF9wb2xpY3kiOiJvbl9kZW1hbmQifSwibm90ZXMi
-        OnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRpc3RyaWJ1dG9ycyI6W3si
-        ZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0cmlidXRvciIsImRpc3Ry
-        aWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwiOiJ0ZXN0X3BhdGgvIiwi
-        aHR0cCI6ZmFsc2UsImh0dHBzIjp0cnVlLCJwcm90ZWN0ZWQiOnRydWUsImNo
-        ZWNrc3VtX3R5cGUiOm51bGx9LCJhdXRvX3B1Ymxpc2giOnRydWUsImRpc3Ry
-        aWJ1dG9yX2lkIjoiRmVkb3JhXzE3In0seyJkaXN0cmlidXRvcl90eXBlX2lk
-        IjoieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmln
-        Ijp7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjoiRmVkb3JhXzE3In0s
-        ImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiRmVkb3Jh
-        XzE3X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBlX2lkIjoiZXhwb3J0X2Rp
-        c3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7Imh0dHAiOmZhbHNl
-        LCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6InRlc3RfcGF0aC8ifSwi
-        YXV0b19wdWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJleHBvcnRf
-        ZGlzdHJpYnV0b3IifV19
+        IjpudWxsLCJkb3dubG9hZF9wb2xpY3kiOiJvbl9kZW1hbmQiLCJyZW1vdmVf
+        bWlzc2luZyI6dHJ1ZX0sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJycG0tcmVw
+        byJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5
+        dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsicmVsYXRp
+        dmVfdXJsIjoidGVzdF9wYXRoLyIsImh0dHAiOmZhbHNlLCJodHRwcyI6dHJ1
+        ZSwicHJvdGVjdGVkIjp0cnVlLCJjaGVja3N1bV90eXBlIjpudWxsfSwiYXV0
+        b19wdWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9pZCI6IkZlZG9yYV8xNyJ9
+        LHsiZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9jbG9uZV9kaXN0cmlidXRv
+        ciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJkZXN0aW5hdGlvbl9kaXN0cmli
+        dXRvcl9pZCI6IkZlZG9yYV8xNyJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJk
+        aXN0cmlidXRvcl9pZCI6IkZlZG9yYV8xN19jbG9uZSJ9LHsiZGlzdHJpYnV0
+        b3JfdHlwZV9pZCI6ImV4cG9ydF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9y
+        X2NvbmZpZyI6eyJodHRwIjpmYWxzZSwiaHR0cHMiOmZhbHNlLCJyZWxhdGl2
+        ZV91cmwiOiJ0ZXN0X3BhdGgvIn0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRp
+        c3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
     headers:
       Accept:
       - application/json
@@ -5371,7 +5598,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '825'
+      - '847'
       User-Agent:
       - Ruby
   response:
@@ -5380,13 +5607,13 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:26 GMT
+      - Tue, 23 Feb 2016 16:48:40 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
       - '320'
       Location:
-      - https://abed.usersys.redhat.com/pulp/api/v2/repositories/Fedora_17/
+      - https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/
       Connection:
       - close
       Content-Type:
@@ -5399,14 +5626,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZjNGRhN2U1Y2EwMTMxODRlMjhmYzA0In0sICJpZCI6ICJGZWRvcmFfMTci
+        NTZjYzhkNjhkZTA0MDMzZjQxZDJhNDIzIn0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:26 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:40 GMT
 - request:
     method: post
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -5428,7 +5655,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:26 GMT
+      - Tue, 23 Feb 2016 16:48:41 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -5441,14 +5668,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzcyZjZiMTI4LTIzOTItNDFiYS1hNmNlLTFhYjE4MDc2ZTZjNi8iLCAi
-        dGFza19pZCI6ICI3MmY2YjEyOC0yMzkyLTQxYmEtYTZjZS0xYWIxODA3NmU2
-        YzYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2NjNzhkZjU3LWIwM2EtNDQyMC05NGJiLWEwNTFhYThkOGUwNy8iLCAi
+        dGFza19pZCI6ICJjYzc4ZGY1Ny1iMDNhLTQ0MjAtOTRiYi1hMDUxYWE4ZDhl
+        MDcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:26 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:41 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/72f6b128-2392-41ba-a6ce-1ab18076e6c6/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/cc78df57-b03a-4420-94bb-a051aa8d8e07/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5467,13 +5694,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:26 GMT
+      - Tue, 23 Feb 2016 16:48:41 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '641'
+      - '643'
       Connection:
       - close
       Content-Type:
@@ -5483,24 +5710,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83MmY2YjEyOC0yMzkyLTQxYmEtYTZjZS0xYWIxODA3NmU2
-        YzYvIiwgInRhc2tfaWQiOiAiNzJmNmIxMjgtMjM5Mi00MWJhLWE2Y2UtMWFi
-        MTgwNzZlNmM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9jYzc4ZGY1Ny1iMDNhLTQ0MjAtOTRiYi1hMDUxYWE4ZDhl
+        MDcvIiwgInRhc2tfaWQiOiAiY2M3OGRmNTctYjAzYS00NDIwLTk0YmItYTA1
+        MWFhOGQ4ZTA3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAYWJlZC51c2Vyc3lzLnJlZGhhdC5jb20uZHEiLCAic3RhdGUi
-        OiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQi
-        OiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRk
-        YTdlZGIwM2MyYmE3YzkxYjNhZCJ9LCAiaWQiOiAiNTZjNGRhN2VkYjAzYzJi
-        YTdjOTFiM2FkIn0=
+        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZj
+        YzhkNjk5ODkwNTRmYzQ4YmEzMDAwIn0sICJpZCI6ICI1NmNjOGQ2OTk4OTA1
+        NGZjNDhiYTMwMDAifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:26 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:41 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/72f6b128-2392-41ba-a6ce-1ab18076e6c6/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/cc78df57-b03a-4420-94bb-a051aa8d8e07/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5519,13 +5746,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:26 GMT
+      - Tue, 23 Feb 2016 16:48:41 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '641'
+      - '1133'
       Connection:
       - close
       Content-Type:
@@ -5535,24 +5762,35 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83MmY2YjEyOC0yMzkyLTQxYmEtYTZjZS0xYWIxODA3NmU2
-        YzYvIiwgInRhc2tfaWQiOiAiNzJmNmIxMjgtMjM5Mi00MWJhLWE2Y2UtMWFi
-        MTgwNzZlNmM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9jYzc4ZGY1Ny1iMDNhLTQ0MjAtOTRiYi1hMDUxYWE4ZDhl
+        MDcvIiwgInRhc2tfaWQiOiAiY2M3OGRmNTctYjAzYS00NDIwLTk0YmItYTA1
+        MWFhOGQ4ZTA3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAYWJlZC51c2Vyc3lzLnJlZGhhdC5jb20uZHEiLCAic3RhdGUi
-        OiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQi
-        OiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRk
-        YTdlZGIwM2MyYmE3YzkxYjNhZCJ9LCAiaWQiOiAiNTZjNGRhN2VkYjAzYzJi
-        YTdjOTFiM2FkIn0=
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0ODo0MVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
+        T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDY5
+        OTg5MDU0ZmM0OGJhMzAwMCJ9LCAiaWQiOiAiNTZjYzhkNjk5ODkwNTRmYzQ4
+        YmEzMDAwIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:26 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:41 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/72f6b128-2392-41ba-a6ce-1ab18076e6c6/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/cc78df57-b03a-4420-94bb-a051aa8d8e07/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5571,13 +5809,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:27 GMT
+      - Tue, 23 Feb 2016 16:48:42 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2316'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -5587,16 +5825,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83MmY2YjEyOC0yMzkyLTQxYmEtYTZjZS0xYWIxODA3NmU2
-        YzYvIiwgInRhc2tfaWQiOiAiNzJmNmIxMjgtMjM5Mi00MWJhLWE2Y2UtMWFi
-        MTgwNzZlNmM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9jYzc4ZGY1Ny1iMDNhLTQ0MjAtOTRiYi1hMDUxYWE4ZDhl
+        MDcvIiwgInRhc2tfaWQiOiAiY2M3OGRmNTctYjAzYS00NDIwLTk0YmItYTA1
+        MWFhOGQ4ZTA3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xN1QyMDozOToyN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDozOToyNloiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0ODo0MVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0ODo0MVoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvY2ZiNDAzODEtZjFiMy00ZGE3LTk0ZWQtZjliMTQwY2M0
-        YjExLyIsICJ0YXNrX2lkIjogImNmYjQwMzgxLWYxYjMtNGRhNy05NGVkLWY5
-        YjE0MGNjNGIxMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNTMwYmJlMDItMzlkMi00MzlkLWI0ZmYtZTUyZWIzMjQx
+        MTg1LyIsICJ0YXNrX2lkIjogIjUzMGJiZTAyLTM5ZDItNDM5ZC1iNGZmLWU1
+        MmViMzI0MTE4NSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -5607,41 +5845,41 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5
-        cy5yZWRoYXQuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNl
-        cnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhN2U1Y2EwMTMx
-        ODRlMjhmYzA1In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAx
-        Ni0wMi0xN1QyMDozOToyNloiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRz
-        IiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM5OjI3WiIsICJpbXBv
-        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdl
-        IjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
-        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
-        cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3Vu
-        dCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YzRkYTdmNWNh
-        MDEzMThmMzBjYjA4OSIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXpl
-        X3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
-        bHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3Rv
-        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
-        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
-        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmM0ZGE3ZWRiMDNjMmJhN2M5MWIzYWQifSwgImlkIjogIjU2YzRk
-        YTdlZGIwM2MyYmE3YzkxYjNhZCJ9
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ2OGRlMDQw
+        MzNmNDFkMmE0MjQifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjQxWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6NDFaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkNjlk
+        ZTA0MDMwODk3NThhOTI1IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDY5OTg5MDU0ZmM0OGJhMzAwMCJ9LCAiaWQiOiAiNTZj
+        YzhkNjk5ODkwNTRmYzQ4YmEzMDAwIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:27 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:42 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/?tag=pulp:action:sync
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/?tag=pulp:action:sync
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5660,13 +5898,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:28 GMT
+      - Tue, 23 Feb 2016 16:48:42 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '81088'
+      - '299649'
       Connection:
       - close
       Content-Type:
@@ -5676,16 +5914,16 @@ http_interactions:
       base64_string: |
         W3siZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZl
         ci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYmI4MDBmODMtNjNhYS00M2FhLWJhNTctYTM0YWIwMTMy
-        OGIwLyIsICJ0YXNrX2lkIjogImJiODAwZjgzLTYzYWEtNDNhYS1iYTU3LWEz
-        NGFiMDEzMjhiMCIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3Jh
+        cGkvdjIvdGFza3MvZjFlMmNiMjQtM2E1Yi00NzZlLWJhYTctMzczZjc5OWRk
+        MTYyLyIsICJ0YXNrX2lkIjogImYxZTJjYjI0LTNhNWItNDc2ZS1iYWE3LTM3
+        M2Y3OTlkZDE2MiIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3Jh
         XzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIw
-        MTYtMDItMTdUMjA6MDI6MDlaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
-        dGFydF90aW1lIjogIjIwMTYtMDItMTdUMjA6MDI6MDlaIiwgInRyYWNlYmFj
+        MTYtMDItMTlUMDA6MDQ6NDlaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
+        dGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDQ6NDlaIiwgInRyYWNlYmFj
         ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAv
-        YXBpL3YyL3Rhc2tzL2ViNWNmZDI4LTU5MWUtNDViMi1hMDE2LTlkNjY3ZmQx
-        NTBjMC8iLCAidGFza19pZCI6ICJlYjVjZmQyOC01OTFlLTQ1YjItYTAxNi05
-        ZDY2N2ZkMTUwYzAifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        YXBpL3YyL3Rhc2tzLzhiM2RmZmU3LTMxYzItNDI3OC04ZTBmLTkyNjcxNjQz
+        NTYwZC8iLCAidGFza19pZCI6ICI4YjNkZmZlNy0zMWMyLTQyNzgtOGUwZi05
+        MjY3MTY0MzU2MGQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
         IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
@@ -5693,117 +5931,67 @@ http_interactions:
         bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
         OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
         IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
-        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
         Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJz
         dGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
-        ZXNvdXJjZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJy
-        ZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjog
-        eyIkb2lkIjogIjU2YzRkMWMwNWNhMDEzMTg0ZTI4ZmI5OCJ9LCAiZXhjZXB0
-        aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFj
-        ayI6IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMTdUMjA6MDI6MDlaIiwg
-        Il9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAx
-        Ni0wMi0xN1QyMDowMjowOVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
-        aW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5Ijog
-        eyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRf
-        Y291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3Vu
-        dCI6IDAsICJpZCI6ICI1NmM0ZDFjMTVjYTAxMzE4ZjMwY2FmZGMiLCAiZGV0
-        YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
-        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
-        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
-        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
-        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
-        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGQxYzBkYjAzYzJi
-        YTdjOTFiMTRlIn0sICJpZCI6ICI1NmM0ZDFjMGRiMDNjMmJhN2M5MWIxNGUi
-        fSwgeyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2Vy
-        dmVyLm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxw
-        L2FwaS92Mi90YXNrcy9lYTczOWZkMC00Zjg2LTQ0MDUtOGJhNS1mOTk5Zjdh
-        MTdmMTQvIiwgInRhc2tfaWQiOiAiZWE3MzlmZDAtNGY4Ni00NDA1LThiYTUt
-        Zjk5OWY3YTE3ZjE0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRv
-        cmFfMTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAi
-        MjAxNi0wMi0xN1QyMDowMjozMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwg
-        InN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDowMjoyOVoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVs
-        cC9hcGkvdjIvdGFza3MvZGE0YTdkMGUtZmU4YS00ZTVhLTgxYjItODA2NmRh
-        NzljMmI3LyIsICJ0YXNrX2lkIjogImRhNGE3ZDBlLWZlOGEtNGU1YS04MWIy
-        LTgwNjZkYTc5YzJiNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2lt
-        cG9ydGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3Rh
-        bCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6
-        ZV9sZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwi
-        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwg
-        InN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVk
-        X3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwg
-        InJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQi
-        OiB7IiRvaWQiOiAiNTZjNGQxZDU1Y2EwMTMxODRkYzgxNWI2In0sICJleGNl
-        cHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0xN1QyMDowMjoyOVoi
-        LCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIy
-        MDE2LTAyLTE3VDIwOjAyOjMwWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1
-        bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnki
-        OiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb21wcyI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRl
-        ZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2Nv
-        dW50IjogMCwgImlkIjogIjU2YzRkMWQ2NWNhMDEzMThmMzBjYWZmZiIsICJk
-        ZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1z
-        X2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwi
-        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwg
-        ImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZDFkNWRiMDNj
-        MmJhN2M5MWIxY2MifSwgImlkIjogIjU2YzRkMWQ1ZGIwM2MyYmE3YzkxYjFj
-        YyJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5z
-        ZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzLzFiYzY4YjUzLWQ3NDAtNGY3Mi1iMjhmLTdmYTI3
-        MjJhM2Q2Mi8iLCAidGFza19pZCI6ICIxYmM2OGI1My1kNzQwLTRmNzItYjI4
-        Zi03ZmEyNzIyYTNkNjIiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZl
-        ZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6
-        ICIyMDE2LTAyLTE3VDIwOjAyOjMzWiIsICJfbnMiOiAidGFza19zdGF0dXMi
-        LCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjAyOjMyWiIsICJ0cmFj
-        ZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9lMjY4MzE3My02ZGRmLTQzOTMtYTUwMS1lYTE0
-        M2Y1MjM5NDgvIiwgInRhc2tfaWQiOiAiZTI2ODMxNzMtNmRkZi00MzkzLWE1
-        MDEtZWExNDNmNTIzOTQ4In1dLCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1f
-        aW1wb3J0ZXIiOiB7ImNvbnRlbnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3Rv
-        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJz
-        aXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
-        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
-        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
-        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWJlZC51c2Vyc3lzLnJlZGhhdC5jb20i
+        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6
+        IHsiJG9pZCI6ICI1NmM2NWMyMGRlMDQwMzY4OTM3Yzc4ZmQifSwgImV4Y2Vw
+        dGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjA0OjQ5WiIs
+        ICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
+        MTYtMDItMTlUMDA6MDQ6NDlaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVt
+        X2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6
+        IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVk
+        X2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291
+        bnQiOiAwLCAiaWQiOiAiNTZjNjVjMjFkZTA0MDM2YTI3YzBiZmQ5IiwgImRl
+        dGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNf
+        bGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjog
+        MCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25l
+        IjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY1YzIxYmQ5Yjcy
+        ZTQwYzM1MTlmYSJ9LCAiaWQiOiAiNTZjNjVjMjFiZDliNzJlNDBjMzUxOWZh
+        In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNl
+        cnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVs
+        cC9hcGkvdjIvdGFza3MvZTIxMDE3ODgtYmM3ZC00NjgxLWI2YTAtN2FjNWI5
+        OWIzMTJjLyIsICJ0YXNrX2lkIjogImUyMTAxNzg4LWJjN2QtNDY4MS1iNmEw
+        LTdhYzViOTliMzEyYyIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVk
+        b3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTYtMDItMTlUMDA6MDU6MDFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDU6MDFaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzLzZkOTM5MTE2LWQ0NWItNDNlNy1iZGM0LWFiMTkw
+        MjM5YmM2Yy8iLCAidGFza19pZCI6ICI2ZDkzOTExNi1kNDViLTQzZTctYmRj
+        NC1hYjE5MDIzOWJjNmMifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
+        ZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20i
         LCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9p
-        ZCI6IHsiJG9pZCI6ICI1NmM0ZDFkODVjYTAxMzE4NGUyOGZiYjYifSwgImV4
+        ZCI6IHsiJG9pZCI6ICI1NmM2NWMyY2RlMDQwMzY4OTI5MjU3ZWQifSwgImV4
         Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFj
-        ZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE3VDIwOjAyOjMy
+        ZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjA1OjAx
         WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjog
-        IjIwMTYtMDItMTdUMjA6MDI6MzNaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAi
+        IjIwMTYtMDItMTlUMDA6MDU6MDFaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAi
         eXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFy
         eSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBz
         IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6
@@ -5811,7 +5999,7 @@ http_interactions:
         dGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFk
         ZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRf
-        Y291bnQiOiAwLCAiaWQiOiAiNTZjNGQxZDk1Y2EwMTMxOGYzMGNiMDA0Iiwg
+        Y291bnQiOiAwLCAiaWQiOiAiNTZjNjVjMmRkZTA0MDM2YTI3YzBiZmUzIiwg
         ImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRl
         bXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
         U0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
@@ -5819,23 +6007,23 @@ http_interactions:
         b25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0
         YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
         ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
-        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        bCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
         W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
         TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkMWQ4ZGIw
-        M2MyYmE3YzkxYjFkZSJ9LCAiaWQiOiAiNTZjNGQxZDhkYjAzYzJiYTdjOTFi
-        MWRlIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxw
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY1YzJkYmQ5
+        YjcyZTQwYzM1MWEyNCJ9LCAiaWQiOiAiNTZjNjVjMmRiZDliNzJlNDBjMzUx
+        YTI0In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxw
         LnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIv
-        cHVscC9hcGkvdjIvdGFza3MvZjA5M2YxMzctOGJjMi00Yjg3LWEyMzgtYzFm
-        ZmQ1M2U0MDEyLyIsICJ0YXNrX2lkIjogImYwOTNmMTM3LThiYzItNGI4Ny1h
-        MjM4LWMxZmZkNTNlNDAxMiIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6
+        cHVscC9hcGkvdjIvdGFza3MvN2VjYTRhODQtYWNjNi00M2ZiLTk0NWUtNjIz
+        Zjg3NDJkYjc3LyIsICJ0YXNrX2lkIjogIjdlY2E0YTg0LWFjYzYtNDNmYi05
+        NDVlLTYyM2Y4NzQyZGI3NyIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6
         RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1l
-        IjogIjIwMTYtMDItMTdUMjA6MDI6MDdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1
-        cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTdUMjA6MDI6MDZaIiwgInRy
+        IjogIjIwMTYtMDItMTlUMDA6MDU6MDRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1
+        cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDU6MDRaIiwgInRy
         YWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAi
-        L3B1bHAvYXBpL3YyL3Rhc2tzL2YwZTk2YzNkLWNjNDYtNDI5MC04OTA2LTNl
-        OTNmMWU2MzU0My8iLCAidGFza19pZCI6ICJmMGU5NmMzZC1jYzQ2LTQyOTAt
-        ODkwNi0zZTkzZjFlNjM1NDMifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1
+        L3B1bHAvYXBpL3YyL3Rhc2tzLzU1MDgwZjlkLWE1OGItNDMyNy1iMzFkLTE3
+        NGE5OTdkOWM4MS8iLCAidGFza19pZCI6ICI1NTA4MGY5ZC1hNThiLTQzMjct
+        YjMxZC0xNzRhOTk3ZDljODEifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1
         bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAi
         c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
         YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
@@ -5843,117 +6031,67 @@ http_interactions:
         InNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsi
         c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
         YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
-        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
         OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
         RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
         fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNv
-        bSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVy
-        X2lkIjogeyIkb2lkIjogIjU2YzRkMWJkNWNhMDEzMTg0ZjZkYjBlMSJ9LCAi
-        ZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRy
-        YWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMTdUMjA6MDI6
-        MDZaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQi
-        OiAiMjAxNi0wMi0xN1QyMDowMjowN1oiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6
-        ICJ5dW1faW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1t
-        YXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29t
-        cHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVz
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAi
-        YWRkZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRl
-        ZF9jb3VudCI6IDAsICJpZCI6ICI1NmM0ZDFiZjVjYTAxMzE4ZjMwY2FmZDci
-        LCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJp
-        dGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
-        TklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90
-        YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBt
-        X2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
-        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGQxYmRk
-        YjAzYzJiYTdjOTFiMTNjIn0sICJpZCI6ICI1NmM0ZDFiZGRiMDNjMmJhN2M5
-        MWIxM2MifSwgeyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1
-        bHAuc2VydmVyLm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjog
-        Ii9wdWxwL2FwaS92Mi90YXNrcy85N2IwMzEzNi0zMjMzLTQyZjUtYTYwOS03
-        OWU1ZmQ4NTk0NWQvIiwgInRhc2tfaWQiOiAiOTdiMDMxMzYtMzIzMy00MmY1
-        LWE2MDktNzllNWZkODU5NDVkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0xN1QyMDowMjoyNFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDowMjoyM1oiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6
-        ICIvcHVscC9hcGkvdjIvdGFza3MvZDk2YjdkYzAtNzM5Zi00NTFiLTlkODgt
-        OWFmYjA1NWYwZWY4LyIsICJ0YXNrX2lkIjogImQ5NmI3ZGMwLTczOWYtNDUx
-        Yi05ZDg4LTlhZmIwNTVmMGVmOCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsi
-        eXVtX2ltcG9ydGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJw
-        bV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAw
-        LCAic2l6ZV9sZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNf
-        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
-        c2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5cy5yZWRoYXQu
-        Y29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0
-        ZXJfaWQiOiB7IiRvaWQiOiAiNTZjNGQxY2Y1Y2EwMTMxODRlMjhmYmE5In0s
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0xN1QyMDow
-        MjoyM1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDE2LTAyLTE3VDIwOjAyOjI0WiIsICJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
-        bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0s
-        ICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRh
-        dGVkX2NvdW50IjogMCwgImlkIjogIjU2YzRkMWQwNWNhMDEzMThmMzBjYWZm
-        NSIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwg
-        Iml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90
-        b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRy
-        cG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNf
-        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZDFj
-        ZmRiMDNjMmJhN2M5MWIxYTgifSwgImlkIjogIjU2YzRkMWNmZGIwM2MyYmE3
-        YzkxYjFhOCJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAi
-        cHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYi
-        OiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzEyNWE4MTU3LTU5N2ItNDI1OS04NjI5
-        LTM3NGJlYzdiYjEwMy8iLCAidGFza19pZCI6ICIxMjVhODE1Ny01OTdiLTQy
-        NTktODYyOS0zNzRiZWM3YmIxMDMiLCAidGFncyI6IFsicHVscDpyZXBvc2l0
-        b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hf
-        dGltZSI6ICIyMDE2LTAyLTE3VDIwOjAyOjI3WiIsICJfbnMiOiAidGFza19z
-        dGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjAyOjI2WiIs
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi90YXNrcy80MWFjYzE4Yi00MDkwLTQzZTItOTRl
-        My0zZDVjMjQyMmY1NDUvIiwgInRhc2tfaWQiOiAiNDFhY2MxOGItNDA5MC00
-        M2UyLTk0ZTMtM2Q1YzI0MjJmNTQ1In1dLCAicHJvZ3Jlc3NfcmVwb3J0Ijog
-        eyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQiOiB7Iml0ZW1zX3RvdGFsIjog
-        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJk
-        cnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAic2l6ZV90b3RhbCI6
-        IDAsICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifX19LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWJlZC51c2Vyc3lzLnJlZGhh
-        dC5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBv
-        cnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM0ZDFkMjVjYTAxMzE4NGUyOGZiYWUi
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRl
+        cl9pZCI6IHsiJG9pZCI6ICI1NmM2NWMzMGRlMDQwMzY4OTI5MjU3ZjQifSwg
+        ImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0
+        cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjA1
+        OjA0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMTlUMDA6MDU6MDRaIiwgImltcG9ydGVyX3R5cGVfaWQi
+        OiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3Vt
+        bWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNv
+        bXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRl
+        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwg
+        ImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0
+        ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjVjMzBkZTA0MDM2YTI3YzBiZmU4
+        IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAi
+        aXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3Rv
+        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
+        bV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
+        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY1YzMw
+        YmQ5YjcyZTQwYzM1MWEzNyJ9LCAiaWQiOiAiNTZjNjVjMzBiZDliNzJlNDBj
+        MzUxYTM3In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJw
+        dWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6
+        ICIvcHVscC9hcGkvdjIvdGFza3MvYmU3YmFjNzMtMTRmZS00ZjM2LWI4YmIt
+        OWZjZTBlMjhlNDkyLyIsICJ0YXNrX2lkIjogImJlN2JhYzczLTE0ZmUtNGYz
+        Ni1iOGJiLTlmY2UwZTI4ZTQ5MiIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRv
+        cnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90
+        aW1lIjogIjIwMTYtMDItMTlUMDA6MDU6MDhaIiwgIl9ucyI6ICJ0YXNrX3N0
+        YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDU6MDhaIiwg
+        InRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2E0YWE5OWMwLWMyYzQtNGUzNS04ZDU5
+        LWY3MmY5MzUwZmEzNS8iLCAidGFza19pZCI6ICJhNGFhOTljMC1jMmM0LTRl
+        MzUtOGQ1OS1mNzJmOTM1MGZhMzUifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
+        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjog
+        MCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBs
+        ZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBv
+        cnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NWMzM2RlMDQwMzY4OTM3Yzc5MGEi
         fSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE3VDIw
-        OjAyOjI2WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxl
-        dGVkIjogIjIwMTYtMDItMTdUMjA6MDI6MjdaIiwgImltcG9ydGVyX3R5cGVf
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAw
+        OjA1OjA4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxl
+        dGVkIjogIjIwMTYtMDItMTlUMDA6MDU6MDhaIiwgImltcG9ydGVyX3R5cGVf
         aWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAi
         c3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
         ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
@@ -5961,31 +6099,31 @@ http_interactions:
         IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAi
         RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
         fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVw
-        ZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNGQxZDM1Y2EwMTMxOGYzMGNh
-        ZmZhIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAw
+        ZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjVjMzRkZTA0MDM2YTI3YzBi
+        ZmVkIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAw
         LCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBt
         X3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAi
         ZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMi
         OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
         eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        c190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRl
         IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRk
-        MWQyZGIwM2MyYmE3YzkxYjFiYSJ9LCAiaWQiOiAiNTZjNGQxZDJkYjAzYzJi
-        YTdjOTFiMWJhIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6
+        RUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY1
+        YzM0YmQ5YjcyZTQwYzM1MWE0YSJ9LCAiaWQiOiAiNTZjNjVjMzRiZDliNzJl
+        NDBjMzUxYTRhIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6
         ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJl
-        ZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMjVjMGRjZTktN2QzMi00NWY2LWIw
-        YjMtZTA5YzdlODU2NTkwLyIsICJ0YXNrX2lkIjogIjI1YzBkY2U5LTdkMzIt
-        NDVmNi1iMGIzLWUwOWM3ZTg1NjU5MCIsICJ0YWdzIjogWyJwdWxwOnJlcG9z
+        ZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZDc0ZTUzNzgtYjMxZS00YmU2LTkx
+        NzgtYzJiZTE2NThiYTFhLyIsICJ0YXNrX2lkIjogImQ3NGU1Mzc4LWIzMWUt
+        NGJlNi05MTc4LWMyYmUxNjU4YmExYSIsICJ0YWdzIjogWyJwdWxwOnJlcG9z
         aXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlz
-        aF90aW1lIjogIjIwMTYtMDItMTdUMjA6MDI6MDNaIiwgIl9ucyI6ICJ0YXNr
-        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTdUMjA6MDI6MDJa
+        aF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDU6MTFaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDU6MTFa
         IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hy
-        ZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzY4NGZkNTA0LWM4ZjEtNDc2MC1h
-        M2FhLTg4YjZmZGEyOWI2Zi8iLCAidGFza19pZCI6ICI2ODRmZDUwNC1jOGYx
-        LTQ3NjAtYTNhYS04OGI2ZmRhMjliNmYifV0sICJwcm9ncmVzc19yZXBvcnQi
+        ZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzNjM2UzMTNiLTFkODktNGQ3MS04
+        NTAyLTRhNjhmZDRmYzc1Ni8iLCAidGFza19pZCI6ICIzYzNlMzEzYi0xZDg5
+        LTRkNzEtODUwMi00YTY4ZmQ0ZmM3NTYifV0sICJwcm9ncmVzc19yZXBvcnQi
         OiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwi
         OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
         LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
@@ -5993,79 +6131,179 @@ http_interactions:
         IjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21w
         cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMi
         OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
         dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3Rh
         dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
         U0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVk
-        aGF0LmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImlt
-        cG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YzRkMWI5NWNhMDEzMTg0ZGM4MTVh
-        OCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3
-        IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMTdU
-        MjA6MDI6MDJaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21w
-        bGV0ZWQiOiAiMjAxNi0wMi0xN1QyMDowMjowM1oiLCAiaW1wb3J0ZXJfdHlw
-        ZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGws
-        ICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In19LCAiYWRkZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmM0ZDFiYjVjYTAxMzE4ZjMw
-        Y2FmZDIiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3Rh
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJp
+        bXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NWMzN2RlMDQwMzY4OTI5MjU4
+        MDcifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8x
+        NyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5
+        VDAwOjA1OjExWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29t
+        cGxldGVkIjogIjIwMTYtMDItMTlUMDA6MDU6MTFaIiwgImltcG9ydGVyX3R5
+        cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxs
+        LCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
+        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwg
+        InVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjVjMzdkZTA0MDM2YTI3
+        YzBiZmYyIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwi
+        OiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsi
+        cnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAw
+        LCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29t
+        cHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJp
+        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2
+        YzY1YzM3YmQ5YjcyZTQwYzM1MWE1ZCJ9LCAiaWQiOiAiNTZjNjVjMzdiZDli
+        NzJlNDBjMzUxYTVkIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlw
+        ZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJf
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvOWY4MjcwNTktYWU3NS00MWI2
+        LWJlZGMtZDdjMzc3ZDk1OWEzLyIsICJ0YXNrX2lkIjogIjlmODI3MDU5LWFl
+        NzUtNDFiNi1iZWRjLWQ3YzM3N2Q5NTlhMyIsICJ0YWdzIjogWyJwdWxwOnJl
+        cG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZp
+        bmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDU6MTVaIiwgIl9ucyI6ICJ0
+        YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDU6
+        MTRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3si
+        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2FlNjI2MDBiLTdmZTQtNDE3
+        Ny04YzA1LTE0MmQ0MGE2MDNlMi8iLCAidGFza19pZCI6ICJhZTYyNjAwYi03
+        ZmU0LTQxNzctOGMwNS0xNDJkNDBhNjAzZTIifV0sICJwcm9ncmVzc19yZXBv
+        cnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3Rv
+        dGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJj
+        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
+        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NWMzYWRlMDQwMzY4OTEz
+        ZjFjODMifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9y
+        YV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAy
+        LTE5VDAwOjA1OjE0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAi
+        Y29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6MDU6MTVaIiwgImltcG9ydGVy
+        X3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBu
+        dWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3Rh
         dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZj
-        NGQxYmFkYjAzYzJiYTdjOTFiMTJhIn0sICJpZCI6ICI1NmM0ZDFiYWRiMDNj
-        MmJhN2M5MWIxMmEifSwgeyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBl
-        IjogInB1bHAuc2VydmVyLm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9o
-        cmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8yMTZlMzJjMS02N2U2LTRkYjMt
-        OThlZC00MjE5YTBhNWQ0MTMvIiwgInRhc2tfaWQiOiAiMjE2ZTMyYzEtNjdl
-        Ni00ZGIzLTk4ZWQtNDIxOWEwYTVkNDEzIiwgInRhZ3MiOiBbInB1bHA6cmVw
-        b3NpdG9yeTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmlu
-        aXNoX3RpbWUiOiAiMjAxNi0wMi0xN1QyMDowMTo1NloiLCAiX25zIjogInRh
-        c2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDowMTo1
-        M1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJf
-        aHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNzBkODljNmQtZTFmYS00ODEy
-        LWIwODgtYWQ5NDJiNTUxOGY1LyIsICJ0YXNrX2lkIjogIjcwZDg5YzZkLWUx
-        ZmEtNDgxMi1iMDg4LWFkOTQyYjU1MThmNSJ9XSwgInByb2dyZXNzX3JlcG9y
-        dCI6IHsieXVtX2ltcG9ydGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3Rh
-        bCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiA4LCAicnBtX2RvbmUiOiA4
-        LCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90
-        YWwiOiAxNzg3MiwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0s
+        U0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50Ijog
+        MCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjVjM2JkZTA0MDM2
+        YTI3YzBiZmY3IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90
+        YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAi
+        Y29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNh
+        dGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjog
+        eyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjog
+        IjU2YzY1YzNhYmQ5YjcyZTQwYzM1MWE3MCJ9LCAiaWQiOiAiNTZjNjVjM2Fi
+        ZDliNzJlNDBjMzUxYTcwIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tf
+        dHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIs
+        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvYjQ4Mzc0M2YtZDRiYi00
+        NzljLTk2OTgtZWU4YThmOTk3Yjc2LyIsICJ0YXNrX2lkIjogImI0ODM3NDNm
+        LWQ0YmItNDc5Yy05Njk4LWVlOGE4Zjk5N2I3NiIsICJ0YWdzIjogWyJwdWxw
+        OnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwg
+        ImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDU6MThaIiwgIl9ucyI6
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6
+        MDU6MThaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        W3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2ZmOWNhODc4LWM3ZjAt
+        NDM1MC05MGI4LTY1YzMzYjQxNGQxOS8iLCAidGFza19pZCI6ICJmZjljYTg3
+        OC1jN2YwLTQzNTAtOTBiOC02NWMzM2I0MTRkMTkifV0sICJwcm9ncmVzc19y
+        ZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNf
+        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
+        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXpl
+        X3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0s
         ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
         Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
         OiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
         cm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6
         IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
         ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBhYmVkLnVzZXJz
-        eXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YzRkMWIwNWNhMDEzMTg0
-        ZGM4MTVhMCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVk
-        b3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMTYt
-        MDItMTdUMjA6MDE6NTNaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0xN1QyMDowMTo1NloiLCAiaW1wb3J0
-        ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6
-        IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJn
-        ZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
-        YnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQi
-        OiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmM0ZDFiNDVjYTAx
-        MzE4ZjMwY2FmY2MiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90
-        b3RhbCI6IDE3ODcyLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
-        IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
-        YWlscyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1f
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlv
+        ZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2Vz
+        cyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NWMzZWRlMDQwMzY4
+        OTM3Yzc5MWIifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZl
+        ZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2
+        LTAyLTE5VDAwOjA1OjE4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMi
+        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6MDU6MThaIiwgImltcG9y
+        dGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2Ui
+        OiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVy
+        Z2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3Ry
+        aWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50
+        IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjVjM2VkZTA0
+        MDM2YTI3YzBiZmZjIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVf
+        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
+        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
+        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
+        IjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
+        IjogIjU2YzY1YzNlYmQ5YjcyZTQwYzM1MWE4MyJ9LCAiaWQiOiAiNTZjNjVj
+        M2ViZDliNzJlNDBjMzUxYTgzIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRh
+        c2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3lu
+        YyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNDQ4NzRlM2MtZDAz
+        Yy00MmUzLWI0N2UtNDc5MTM3NmNmY2UxLyIsICJ0YXNrX2lkIjogIjQ0ODc0
+        ZTNjLWQwM2MtNDJlMy1iNDdlLTQ3OTEzNzZjZmNlMSIsICJ0YWdzIjogWyJw
+        dWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMi
+        XSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDU6MjJaIiwgIl9u
+        cyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlU
+        MDA6MDU6MjFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        IjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzE1ODk0MDAyLTRk
+        OTktNDA1Ny1hNTBhLTQ0ZGMyODNkZmQ0ZC8iLCAidGFza19pZCI6ICIxNTg5
+        NDAwMi00ZDk5LTQwNTctYTUwYS00NGRjMjgzZGZkNGQifV0sICJwcm9ncmVz
+        c19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRl
+        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJz
+        aXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0Ijog
+        MH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1
+        cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRp
+        b24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NWM0MWRlMDQw
+        MzY4OTM3Yzc5MjYifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTE5VDAwOjA1OjIxWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6MDU6MjJaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjVjNDJk
+        ZTA0MDM2YTI3YzBjMDAxIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
         dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
         W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
         dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
@@ -6073,19 +6311,3774 @@ http_interactions:
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
         dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
         dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
-        b2lkIjogIjU2YzRkMWIwZGIwM2MyYmE3YzkxYjExNSJ9LCAiaWQiOiAiNTZj
-        NGQxYjBkYjAzYzJiYTdjOTFiMTE1In0sIHsiZXhjZXB0aW9uIjogbnVsbCwg
+        b2lkIjogIjU2YzY1YzQxYmQ5YjcyZTQwYzM1MWE5NiJ9LCAiaWQiOiAiNTZj
+        NjVjNDFiZDliNzJlNDBjMzUxYTk2In0sIHsiZXhjZXB0aW9uIjogbnVsbCwg
         InRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMu
-        c3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNGUzYTk5ODQt
-        ZWMwZC00MjVlLTg3M2EtMWRjNTQ4YmExOTdlLyIsICJ0YXNrX2lkIjogIjRl
-        M2E5OTg0LWVjMGQtNDI1ZS04NzNhLTFkYzU0OGJhMTk3ZSIsICJ0YWdzIjog
+        c3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNTQwMjBhYTkt
+        NzA0OC00OTQ4LTkwZTktMTY5NTM5MWM0MzRjLyIsICJ0YXNrX2lkIjogIjU0
+        MDIwYWE5LTcwNDgtNDk0OC05MGU5LTE2OTUzOTFjNDM0YyIsICJ0YWdzIjog
         WyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5
-        bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTdUMjA6MDI6MThaIiwg
+        bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDU6MzlaIiwg
         Il9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDIt
-        MTdUMjA6MDI6MTdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rh
-        c2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2JiYzIxMWVi
-        LWEyNzQtNGM3Ny1iNjAxLTY5MDVmZDUzMWI0NS8iLCAidGFza19pZCI6ICJi
-        YmMyMTFlYi1hMjc0LTRjNzctYjYwMS02OTA1ZmQ1MzFiNDUifV0sICJwcm9n
+        MTlUMDA6MDU6MzhaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rh
+        c2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2QwMzdlNzNk
+        LTAyOGYtNGI0ZC04ZmM0LWYxODkwNDMzZTBlYS8iLCAidGFza19pZCI6ICJk
+        MDM3ZTczZC0wMjhmLTRiNGQtOGZjNC1mMTg5MDQzM2UwZWEifV0sICJwcm9n
+        cmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsi
+        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJw
+        bV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0s
+        ICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0
+        IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdl
+        X2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
+        c3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NWM1MmRl
+        MDQwMzY4OTEzZjFjODkifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lk
+        IjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6
+        ICIyMDE2LTAyLTE5VDAwOjA1OjM4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jl
+        c3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6MDU6MzlaIiwg
+        ImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21l
+        c3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVk
+        X2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjVj
+        NTNkZTA0MDM2YTI3YzBjMDA2IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7
+        InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3Rh
+        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAi
+        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
+        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxz
+        IjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJn
+        ZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
+        YnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJl
+        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
+        eyIkb2lkIjogIjU2YzY1YzUyYmQ5YjcyZTQwYzM1MWFiMiJ9LCAiaWQiOiAi
+        NTZjNjVjNTJiZDliNzJlNDBjMzUxYWIyIn0sIHsiZXhjZXB0aW9uIjogbnVs
+        bCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5
+        bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZmU1ZTNl
+        ZTEtNDg4ZC00MjE1LWE1M2MtZDc4NGE4ZTNhMDE0LyIsICJ0YXNrX2lkIjog
+        ImZlNWUzZWUxLTQ4OGQtNDIxNS1hNTNjLWQ3ODRhOGUzYTAxNCIsICJ0YWdz
+        IjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9u
+        OnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDU6NDZa
+        IiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYt
+        MDItMTlUMDA6MDU6NDZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
+        X3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzRjZmNm
+        MzQwLWI1MmEtNDJiYy05MzJlLTc4ZTJkZTYyNzg2MC8iLCAidGFza19pZCI6
+        ICI0Y2ZjZjM0MC1iNTJhLTQyYmMtOTMyZS03OGUyZGU2Mjc4NjAifV0sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwg
+        InJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
+        MH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
+        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
+        cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
+        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NWM1
+        YWRlMDQwMzY4OTI5MjU4MmIifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
+        ZCI6ICIyMDE2LTAyLTE5VDAwOjA1OjQ2WiIsICJfbnMiOiAicmVwb19zeW5j
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6MDU6NDZa
+        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZj
+        NjVjNWFkZTA0MDM2YTI3YzBjMDEyIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
+        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
+        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
+        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
+        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
+        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
+        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
+        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjU2YzY1YzVhYmQ5YjcyZTQwYzM1MWFjNyJ9LCAiaWQi
+        OiAiNTZjNjVjNWFiZDliNzJlNDBjMzUxYWM3In0sIHsiZXhjZXB0aW9uIjog
+        bnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBv
+        LnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvM2Fk
+        ZTk0ZTQtOTE1Yi00NWYwLTg4ZjUtYzNlMDFmY2M4ZGRkLyIsICJ0YXNrX2lk
+        IjogIjNhZGU5NGU0LTkxNWItNDVmMC04OGY1LWMzZTAxZmNjOGRkZCIsICJ0
+        YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0
+        aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDU6
+        NTFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTYtMDItMTlUMDA6MDU6NTFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzc3
+        NTI0NDgyLTM1MmUtNGIyMi1iOGE5LTA0YWRkOGQ0ODYwMy8iLCAidGFza19p
+        ZCI6ICI3NzUyNDQ4Mi0zNTJlLTRiMjItYjhhOS0wNGFkZDhkNDg2MDMifV0s
+        ICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVu
+        dCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjog
+        MCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25l
+        IjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVt
+        c19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        InB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJk
+        aXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAw
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2
+        NWM1ZmRlMDQwMzY4OTEzZjFjOTIifSwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTAyLTE5VDAwOjA1OjUxWiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6MDU6
+        NTFaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZjNjVjNWZkZTA0MDM2YTI3YzBjMDFkIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU2YzY1YzVmYmQ5YjcyZTQwYzM1MWFkOSJ9LCAi
+        aWQiOiAiNTZjNjVjNWZiZDliNzJlNDBjMzUxYWQ5In0sIHsiZXhjZXB0aW9u
+        IjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5y
+        ZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3Mv
+        NWQxYjY0NmQtN2UyNi00NTVhLTkwM2UtNDE4NDc4NjIxZWZlLyIsICJ0YXNr
+        X2lkIjogIjVkMWI2NDZkLTdlMjYtNDU1YS05MDNlLTQxODQ3ODYyMWVmZSIs
+        ICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6
+        YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6
+        MDU6NTZaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
+        IjIwMTYtMDItMTlUMDA6MDU6NTZaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
+        cGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tz
+        LzNiOTA5ZjYwLTNmZWQtNGM3OS1hOGQwLWY3NWMwZjJlYWIzMS8iLCAidGFz
+        a19pZCI6ICIzYjkwOWY2MC0zZmVkLTRjNzktYThkMC1mNzVjMGYyZWFiMzEi
+        fV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29u
+        dGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
+        IjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9k
+        b25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJp
+        dGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5p
+        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJy
+        ZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1
+        NmM2NWM2NGRlMDQwMzY4OTM3Yzc5NDIifSwgImV4Y2VwdGlvbiI6IG51bGws
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAi
+        c3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjA1OjU2WiIsICJfbnMiOiAicmVw
+        b19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6
+        MDU6NTZaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwg
+        ImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUs
+        ICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQi
+        OiAiNTZjNjVjNjRkZTA0MDM2YTI3YzBjMDI4IiwgImRldGFpbHMiOiB7ImNv
+        bnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xl
+        ZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
+        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJv
+        cl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0
+        IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
+        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YzY1YzY0YmQ5YjcyZTQwYzM1MWFlYiJ9
+        LCAiaWQiOiAiNTZjNjVjNjRiZDliNzJlNDBjMzUxYWViIn0sIHsiZXhjZXB0
+        aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vy
+        cy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFz
+        a3MvMTdiZGFkZDctYWI1MC00NTBkLTkxMzEtNzNmODNhMjUxMmRkLyIsICJ0
+        YXNrX2lkIjogIjE3YmRhZGQ3LWFiNTAtNDUwZC05MTMxLTczZjgzYTI1MTJk
+        ZCIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1
+        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlU
+        MDA6MDY6MDFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
+        IjogIjIwMTYtMDItMTlUMDA6MDY6MDFaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2E1YzRhZmRkLWRmNWItNDY4YS1iZWQzLTA2MTk2YTdjODBiNy8iLCAi
+        dGFza19pZCI6ICJhNWM0YWZkZC1kZjViLTQ2OGEtYmVkMy0wNjE5NmE3Yzgw
+        YjcifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsi
+        Y29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3Rv
+        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
+        bV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAs
+        ICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xl
+        ZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
+        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJm
+        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
+        eyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6
+        ICI1NmM2NWM2OWRlMDQwMzY4OTM3Yzc5NDcifSwgImV4Y2VwdGlvbiI6IG51
+        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
+        LCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjA2OjAxWiIsICJfbnMiOiAi
+        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlU
+        MDA6MDY6MDFaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVu
+        dCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50Ijog
+        MTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAi
+        aWQiOiAiNTZjNjVjNjlkZTA0MDM2YTI3YzBjMDMzIiwgImRldGFpbHMiOiB7
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY1YzY5YmQ5YjcyZTQwYzM1MWFm
+        ZCJ9LCAiaWQiOiAiNTZjNjVjNjliZDliNzJlNDBjMzUxYWZkIn0sIHsiZXhj
+        ZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5h
+        Z2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIv
+        dGFza3MvMGUyZWY5NmMtZWVlYS00YWMxLThjODgtZjdhM2ZlOTM1MGU4LyIs
+        ICJ0YXNrX2lkIjogIjBlMmVmOTZjLWVlZWEtNGFjMS04Yzg4LWY3YTNmZTkz
+        NTBlOCIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3Iiwg
+        InB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDIt
+        MTlUMDA6MDY6MDZaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTYtMDItMTlUMDA6MDY6MDZaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L3Rhc2tzL2ZlM2JjOWE2LWQ4ZDEtNDBmNi04YzdhLWRkOTg3YWEwMTJhZi8i
+        LCAidGFza19pZCI6ICJmZTNiYzlhNi1kOGQxLTQwZjYtOGM3YS1kZDk4N2Fh
+        MDEyYWYifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6
+        IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklO
+        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBt
+        X3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAi
+        ZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6
+        IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0
+        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1z
+        X2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6
+        ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0
+        IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9p
+        ZCI6ICI1NmM2NWM2ZWRlMDQwMzY4OTEzZjFjOTkifSwgImV4Y2VwdGlvbiI6
+        IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjA2OjA2WiIsICJfbnMi
+        OiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDIt
+        MTlUMDA6MDY6MDZaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9y
+        dGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29u
+        dGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
+        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50
+        IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAw
+        LCAiaWQiOiAiNTZjNjVjNmVkZTA0MDM2YTI3YzBjMDNlIiwgImRldGFpbHMi
+        OiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6
+        IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJz
+        aXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJw
+        bV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0s
+        ICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVt
+        c19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3Ii
+        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY1YzZlYmQ5YjcyZTQwYzM1
+        MWIwZiJ9LCAiaWQiOiAiNTZjNjVjNmViZDliNzJlNDBjMzUxYjBmIn0sIHsi
+        ZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5t
+        YW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkv
+        djIvdGFza3MvMDVmMDVjYzQtZDNlMS00Y2NjLTk5NWQtOTkyNjQxY2NkZmI0
+        LyIsICJ0YXNrX2lkIjogIjA1ZjA1Y2M0LWQzZTEtNGNjYy05OTVkLTk5MjY0
+        MWNjZGZiNCIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3
+        IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYt
+        MDItMTlUMDA6MDY6MTFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFy
+        dF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDY6MTFaIiwgInRyYWNlYmFjayI6
+        IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBp
+        L3YyL3Rhc2tzL2U4YjJlNWIwLWRiZTItNDdjMS1hNzRjLTViMTQ5NjVlMGU5
+        OC8iLCAidGFza19pZCI6ICJlOGIyZTViMC1kYmUyLTQ3YzEtYTc0Yy01YjE0
+        OTY1ZTBlOTgifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRl
+        ciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsi
+        cnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAw
+        LCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVm
+        dCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0
+        ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0
+        ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsi
+        JG9pZCI6ICI1NmM2NWM3M2RlMDQwMzY4OTEzZjFjOWUifSwgImV4Y2VwdGlv
+        biI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2si
+        OiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjA2OjExWiIsICJf
+        bnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYt
+        MDItMTlUMDA6MDY6MTFaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2lt
+        cG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsi
+        Y29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2Nv
+        dW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQi
+        OiAwLCAiaWQiOiAiNTZjNjVjNzNkZTA0MDM2YTI3YzBjMDQ5IiwgImRldGFp
+        bHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVm
+        dCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwg
+        InJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
+        MH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
+        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY1YzczYmQ5YjcyZTQw
+        YzM1MWIyMSJ9LCAiaWQiOiAiNTZjNjVjNzNiZDliNzJlNDBjMzUxYjIxIn0s
+        IHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZl
+        ci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMDYzZTJhNDktYjQyMS00MjFjLThhNDgtMzhjZTZhYjI3
+        ZjYxLyIsICJ0YXNrX2lkIjogIjA2M2UyYTQ5LWI0MjEtNDIxYy04YTQ4LTM4
+        Y2U2YWIyN2Y2MSIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3Jh
+        XzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIw
+        MTYtMDItMTlUMDA6MDY6MTZaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
+        dGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDY6MTZaIiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAv
+        YXBpL3YyL3Rhc2tzL2ZjZmQ0MTM1LTllMDEtNGU2Ni1iMzdlLTJjY2Q4Nzcy
+        ZjcyYS8iLCAidGFza19pZCI6ICJmY2ZkNDEzNS05ZTAxLTRlNjYtYjM3ZS0y
+        Y2NkODc3MmY3MmEifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJz
+        dGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
+        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6
+        IHsiJG9pZCI6ICI1NmM2NWM3OGRlMDQwMzY4OTI5MjU4MzcifSwgImV4Y2Vw
+        dGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjA2OjE2WiIs
+        ICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
+        MTYtMDItMTlUMDA6MDY6MTZaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVt
+        X2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6
+        IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVk
+        X2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291
+        bnQiOiAwLCAiaWQiOiAiNTZjNjVjNzhkZTA0MDM2YTI3YzBjMDU0IiwgImRl
+        dGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNf
+        bGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjog
+        MCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25l
+        IjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY1Yzc4YmQ5Yjcy
+        ZTQwYzM1MWIzMyJ9LCAiaWQiOiAiNTZjNjVjNzhiZDliNzJlNDBjMzUxYjMz
+        In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNl
+        cnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVs
+        cC9hcGkvdjIvdGFza3MvN2Q5YzY0MjAtOWZjYS00MGY5LTg0YWUtZDllY2E3
+        N2FhYzMzLyIsICJ0YXNrX2lkIjogIjdkOWM2NDIwLTlmY2EtNDBmOS04NGFl
+        LWQ5ZWNhNzdhYWMzMyIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVk
+        b3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTYtMDItMTlUMDA6MDY6MjJaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDY6MjFaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzL2QyMTkzMmIwLTNlODYtNDIxNC04MTM5LTdkMWJi
+        MjM0MjY0MS8iLCAidGFza19pZCI6ICJkMjE5MzJiMC0zZTg2LTQyMTQtODEz
+        OS03ZDFiYjIzNDI2NDEifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
+        ZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9p
+        ZCI6IHsiJG9pZCI6ICI1NmM2NWM3ZGRlMDQwMzY4OTM3Yzc5NGQifSwgImV4
+        Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFj
+        ZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjA2OjIx
+        WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjog
+        IjIwMTYtMDItMTlUMDA6MDY6MjFaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFy
+        eSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFk
+        ZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRf
+        Y291bnQiOiAwLCAiaWQiOiAiNTZjNjVjN2VkZTA0MDM2YTI3YzBjMDVmIiwg
+        ImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRl
+        bXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
+        IjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9k
+        b25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
+        bCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY1YzdkYmQ5
+        YjcyZTQwYzM1MWI0NSJ9LCAiaWQiOiAiNTZjNjVjN2RiZDliNzJlNDBjMzUx
+        YjQ1In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxw
+        LnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIv
+        cHVscC9hcGkvdjIvdGFza3MvMDRjODk4NTMtYTA2MS00NDZlLTlmMjUtYmVh
+        Njc0YmEwMGU3LyIsICJ0YXNrX2lkIjogIjA0Yzg5ODUzLWEwNjEtNDQ2ZS05
+        ZjI1LWJlYTY3NGJhMDBlNyIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6
+        RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1l
+        IjogIjIwMTYtMDItMTlUMDA6MDY6MjdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1
+        cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDY6MjZaIiwgInRy
+        YWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAi
+        L3B1bHAvYXBpL3YyL3Rhc2tzLzUzY2VhNjFiLWZiYTktNGQ2OS04N2ZjLTdm
+        NGY0MGM0YjI4YS8iLCAidGFza19pZCI6ICI1M2NlYTYxYi1mYmE5LTRkNjkt
+        ODdmYy03ZjRmNDBjNGIyOGEifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1
+        bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwg
+        InNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRl
+        cl9pZCI6IHsiJG9pZCI6ICI1NmM2NWM4MmRlMDQwMzY4OTM3Yzc5NTIifSwg
+        ImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0
+        cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjA2
+        OjI2WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMTlUMDA6MDY6MjdaIiwgImltcG9ydGVyX3R5cGVfaWQi
+        OiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3Vt
+        bWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNv
+        bXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRl
+        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwg
+        ImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0
+        ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjVjODNkZTA0MDM2YTI3YzBjMDZh
+        IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAi
+        aXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3Rv
+        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
+        bV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
+        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY1Yzgy
+        YmQ5YjcyZTQwYzM1MWI1NyJ9LCAiaWQiOiAiNTZjNjVjODJiZDliNzJlNDBj
+        MzUxYjU3In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJw
+        dWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6
+        ICIvcHVscC9hcGkvdjIvdGFza3MvYjc3ODcyNzMtNWQwNC00NmY5LTkxMTQt
+        ZDA3Njc2OWIxMzAyLyIsICJ0YXNrX2lkIjogImI3Nzg3MjczLTVkMDQtNDZm
+        OS05MTE0LWQwNzY3NjliMTMwMiIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRv
+        cnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90
+        aW1lIjogIjIwMTYtMDItMTlUMDA6MDY6MzJaIiwgIl9ucyI6ICJ0YXNrX3N0
+        YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDY6MzFaIiwg
+        InRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzRhYjk0MjYyLTRlZWYtNDk2ZS1hMTZi
+        LWE0ZmYwMmIzN2EyYi8iLCAidGFza19pZCI6ICI0YWI5NDI2Mi00ZWVmLTQ5
+        NmUtYTE2Yi1hNGZmMDJiMzdhMmIifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
+        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjog
+        MCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBs
+        ZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBv
+        cnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NWM4N2RlMDQwMzY4OTEzZjFjYTQi
+        fSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAw
+        OjA2OjMxWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxl
+        dGVkIjogIjIwMTYtMDItMTlUMDA6MDY6MzJaIiwgImltcG9ydGVyX3R5cGVf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAi
+        c3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVw
+        ZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjVjODhkZTA0MDM2YTI3YzBj
+        MDc1IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAw
+        LCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBt
+        X3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAi
+        ZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVt
+        c190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY1
+        Yzg3YmQ5YjcyZTQwYzM1MWI2OSJ9LCAiaWQiOiAiNTZjNjVjODdiZDliNzJl
+        NDBjMzUxYjY5In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6
+        ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJl
+        ZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZGZjYTdiNWYtNmU5Ni00OTZjLWIz
+        NTEtMmI2ODQ5NjdkY2I1LyIsICJ0YXNrX2lkIjogImRmY2E3YjVmLTZlOTYt
+        NDk2Yy1iMzUxLTJiNjg0OTY3ZGNiNSIsICJ0YWdzIjogWyJwdWxwOnJlcG9z
+        aXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDY6MzdaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDY6Mzda
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hy
+        ZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzUxZGZjZjI2LWNlODctNDIyYy05
+        ZThjLTgzYjAzOWVmMGU3Yy8iLCAidGFza19pZCI6ICI1MWRmY2YyNi1jZTg3
+        LTQyMmMtOWU4Yy04M2IwMzllZjBlN2MifV0sICJwcm9ncmVzc19yZXBvcnQi
+        OiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
+        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFs
+        IjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21w
+        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0
+        ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJp
+        bXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NWM4Y2RlMDQwMzY4OTM3Yzc5
+        NWIifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8x
+        NyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5
+        VDAwOjA2OjM3WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29t
+        cGxldGVkIjogIjIwMTYtMDItMTlUMDA6MDY6MzdaIiwgImltcG9ydGVyX3R5
+        cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxs
+        LCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
+        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwg
+        InVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjVjOGRkZTA0MDM2YTI3
+        YzBjMDgwIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwi
+        OiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsi
+        cnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAw
+        LCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29t
+        cHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJp
+        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2
+        YzY1YzhkYmQ5YjcyZTQwYzM1MWI3YiJ9LCAiaWQiOiAiNTZjNjVjOGRiZDli
+        NzJlNDBjMzUxYjdiIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlw
+        ZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJf
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMTdmNzBiNWYtMGRhZi00NmFi
+        LTlhZmEtYmFkNTU0MjVlYTc5LyIsICJ0YXNrX2lkIjogIjE3ZjcwYjVmLTBk
+        YWYtNDZhYi05YWZhLWJhZDU1NDI1ZWE3OSIsICJ0YWdzIjogWyJwdWxwOnJl
+        cG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZp
+        bmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDY6NDJaIiwgIl9ucyI6ICJ0
+        YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDY6
+        NDJaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3si
+        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2NhZWQ4NjI4LTc1MWItNGUy
+        MS05YTc1LWRiYTkxZjg2NGUyNi8iLCAidGFza19pZCI6ICJjYWVkODYyOC03
+        NTFiLTRlMjEtOWE3NS1kYmE5MWY4NjRlMjYifV0sICJwcm9ncmVzc19yZXBv
+        cnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3Rv
+        dGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJj
+        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
+        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NWM5MmRlMDQwMzY4OTM3
+        Yzc5NjAifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9y
+        YV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAy
+        LTE5VDAwOjA2OjQyWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAi
+        Y29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6MDY6NDJaIiwgImltcG9ydGVy
+        X3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBu
+        dWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50Ijog
+        MCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjVjOTJkZTA0MDM2
+        YTI3YzBjMDhiIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90
+        YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAi
+        Y29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNh
+        dGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjog
+        eyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjog
+        IjU2YzY1YzkyYmQ5YjcyZTQwYzM1MWI4ZCJ9LCAiaWQiOiAiNTZjNjVjOTJi
+        ZDliNzJlNDBjMzUxYjhkIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tf
+        dHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIs
+        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMmVhOWRhZGItYTBjNC00
+        YjYyLTkwYmEtOGZlZTI4OWU4NjBjLyIsICJ0YXNrX2lkIjogIjJlYTlkYWRi
+        LWEwYzQtNGI2Mi05MGJhLThmZWUyODllODYwYyIsICJ0YWdzIjogWyJwdWxw
+        OnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwg
+        ImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDY6NDdaIiwgIl9ucyI6
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6
+        MDY6NDdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        W3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2Q0NzQ2ZDJiLWFkYTIt
+        NDM0ZS1hODViLWE0NTU1YzQzNWJkYS8iLCAidGFza19pZCI6ICJkNDc0NmQy
+        Yi1hZGEyLTQzNGUtYTg1Yi1hNDU1NWM0MzViZGEifV0sICJwcm9ncmVzc19y
+        ZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNf
+        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
+        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXpl
+        X3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlv
+        ZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2Vz
+        cyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NWM5N2RlMDQwMzY4
+        OTEzZjFjYTkifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZl
+        ZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2
+        LTAyLTE5VDAwOjA2OjQ3WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMi
+        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6MDY6NDdaIiwgImltcG9y
+        dGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2Ui
+        OiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVy
+        Z2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3Ry
+        aWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50
+        IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjVjOTdkZTA0
+        MDM2YTI3YzBjMDk2IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVf
+        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
+        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
+        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
+        IjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
+        IjogIjU2YzY1Yzk3YmQ5YjcyZTQwYzM1MWI5ZiJ9LCAiaWQiOiAiNTZjNjVj
+        OTdiZDliNzJlNDBjMzUxYjlmIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRh
+        c2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3lu
+        YyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvYmQ3ZDFhOTgtM2Ix
+        NS00OWM3LTkyZmUtNjM2NjJkZWNjYzU2LyIsICJ0YXNrX2lkIjogImJkN2Qx
+        YTk4LTNiMTUtNDljNy05MmZlLTYzNjYyZGVjY2M1NiIsICJ0YWdzIjogWyJw
+        dWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMi
+        XSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDY6NTJaIiwgIl9u
+        cyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlU
+        MDA6MDY6NTJaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        IjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzEwMWE2ODk4LWYz
+        MjctNDllMC04MTA5LTQzMjUyZTBjN2IzNS8iLCAidGFza19pZCI6ICIxMDFh
+        Njg5OC1mMzI3LTQ5ZTAtODEwOS00MzI1MmUwYzdiMzUifV0sICJwcm9ncmVz
+        c19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRl
+        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJz
+        aXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0Ijog
+        MH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1
+        cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRp
+        b24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NWM5Y2RlMDQw
+        MzY4OTEzZjFjYWUifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTE5VDAwOjA2OjUyWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6MDY6NTJaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjVjOWNk
+        ZTA0MDM2YTI3YzBjMGExIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2YzY1YzljYmQ5YjcyZTQwYzM1MWJiMSJ9LCAiaWQiOiAiNTZj
+        NjVjOWNiZDliNzJlNDBjMzUxYmIxIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwg
+        InRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMu
+        c3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMGYzZTQzYzgt
+        NGI0YS00ZDA4LTgwMjEtNzFiYjBkZWU0MmYzLyIsICJ0YXNrX2lkIjogIjBm
+        M2U0M2M4LTRiNGEtNGQwOC04MDIxLTcxYmIwZGVlNDJmMyIsICJ0YWdzIjog
+        WyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5
+        bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDY6NTdaIiwg
+        Il9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDIt
+        MTlUMDA6MDY6NTdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rh
+        c2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzg2NTAxZGI2
+        LWU5OWUtNGZhNC1hMjVjLTY5ZWU1ZTI5MjIxOS8iLCAidGFza19pZCI6ICI4
+        NjUwMWRiNi1lOTllLTRmYTQtYTI1Yy02OWVlNWUyOTIyMTkifV0sICJwcm9n
+        cmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsi
+        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJw
+        bV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0s
+        ICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0
+        IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdl
+        X2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
+        c3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NWNhMWRl
+        MDQwMzY4OTI5MjU4NDAifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lk
+        IjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6
+        ICIyMDE2LTAyLTE5VDAwOjA2OjU3WiIsICJfbnMiOiAicmVwb19zeW5jX3Jl
+        c3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6MDY6NTdaIiwg
+        ImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21l
+        c3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVk
+        X2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjVj
+        YTFkZTA0MDM2YTI3YzBjMGFjIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7
+        InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3Rh
+        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAi
+        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
+        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxz
+        IjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJn
+        ZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
+        YnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJl
+        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
+        eyIkb2lkIjogIjU2YzY1Y2ExYmQ5YjcyZTQwYzM1MWJjMyJ9LCAiaWQiOiAi
+        NTZjNjVjYTFiZDliNzJlNDBjMzUxYmMzIn0sIHsiZXhjZXB0aW9uIjogbnVs
+        bCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5
+        bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNjlkYTM1
+        MmQtZjQ1Zi00ZDRhLWFjYjMtOTc4YzY5MjYyMTI5LyIsICJ0YXNrX2lkIjog
+        IjY5ZGEzNTJkLWY0NWYtNGQ0YS1hY2IzLTk3OGM2OTI2MjEyOSIsICJ0YWdz
+        IjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9u
+        OnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDc6MDNa
+        IiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYt
+        MDItMTlUMDA6MDc6MDJaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
+        X3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzU2NDU1
+        YmEyLTgwMzgtNGQyNy04ZmQ3LWIxYTM1MDhkZGFlNC8iLCAidGFza19pZCI6
+        ICI1NjQ1NWJhMi04MDM4LTRkMjctOGZkNy1iMWEzNTA4ZGRhZTQifV0sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwg
+        InJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
+        MH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
+        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
+        cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
+        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NWNh
+        NmRlMDQwMzY4OTI5MjU4NDUifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
+        ZCI6ICIyMDE2LTAyLTE5VDAwOjA3OjAyWiIsICJfbnMiOiAicmVwb19zeW5j
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6MDc6MDNa
+        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZj
+        NjVjYTdkZTA0MDM2YTI3YzBjMGI3IiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
+        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
+        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
+        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
+        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
+        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
+        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
+        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjU2YzY1Y2E2YmQ5YjcyZTQwYzM1MWJkNSJ9LCAiaWQi
+        OiAiNTZjNjVjYTZiZDliNzJlNDBjMzUxYmQ1In0sIHsiZXhjZXB0aW9uIjog
+        bnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBv
+        LnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvYjIy
+        MzBiOTktZjFhNi00NGU4LTlhYTAtODk0ZDYwNWEzNjBlLyIsICJ0YXNrX2lk
+        IjogImIyMjMwYjk5LWYxYTYtNDRlOC05YWEwLTg5NGQ2MDVhMzYwZSIsICJ0
+        YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0
+        aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDc6
+        MDhaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTYtMDItMTlUMDA6MDc6MDdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzVh
+        ZjliMTRjLTgwN2UtNDExNC05YTgwLTk2ZTg3MDc3NWYyZS8iLCAidGFza19p
+        ZCI6ICI1YWY5YjE0Yy04MDdlLTQxMTQtOWE4MC05NmU4NzA3NzVmMmUifV0s
+        ICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVu
+        dCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjog
+        MCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25l
+        IjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVt
+        c19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        InB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJk
+        aXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAw
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2
+        NWNhYmRlMDQwMzY4OTEzZjFjYjMifSwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTAyLTE5VDAwOjA3OjA3WiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6MDc6
+        MDhaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZjNjVjYWNkZTA0MDM2YTI3YzBjMGMyIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU2YzY1Y2FiYmQ5YjcyZTQwYzM1MWJlNyJ9LCAi
+        aWQiOiAiNTZjNjVjYWJiZDliNzJlNDBjMzUxYmU3In0sIHsiZXhjZXB0aW9u
+        IjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5y
+        ZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3Mv
+        ZWFkMWE5NGYtODc5My00NzlhLWFmYWQtOTVhZmY4NTFjYTM5LyIsICJ0YXNr
+        X2lkIjogImVhZDFhOTRmLTg3OTMtNDc5YS1hZmFkLTk1YWZmODUxY2EzOSIs
+        ICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6
+        YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6
+        MDc6MTVaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
+        IjIwMTYtMDItMTlUMDA6MDc6MTRaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
+        cGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tz
+        Lzc4YTg4MTA1LTVlMWYtNDg1Yi1hZWFkLWQxYzAzYTk5NWNkOS8iLCAidGFz
+        a19pZCI6ICI3OGE4ODEwNS01ZTFmLTQ4NWItYWVhZC1kMWMwM2E5OTVjZDki
+        fV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29u
+        dGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
+        IjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9k
+        b25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJp
+        dGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5p
+        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJy
+        ZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1
+        NmM2NWNiMmRlMDQwMzY4OTI5MjU4NGIifSwgImV4Y2VwdGlvbiI6IG51bGws
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAi
+        c3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjA3OjE0WiIsICJfbnMiOiAicmVw
+        b19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6
+        MDc6MTVaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwg
+        ImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUs
+        ICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQi
+        OiAiNTZjNjVjYjNkZTA0MDM2YTI3YzBjMGQxIiwgImRldGFpbHMiOiB7ImNv
+        bnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xl
+        ZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
+        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJv
+        cl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0
+        IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
+        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YzY1Y2IyYmQ5YjcyZTQwYzM1MWMwYiJ9
+        LCAiaWQiOiAiNTZjNjVjYjJiZDliNzJlNDBjMzUxYzBiIn0sIHsiZXhjZXB0
+        aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vy
+        cy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFz
+        a3MvNDBmYzA4NmMtNmYwZS00NDllLWFjNjctMjI3ZTY0YTY4MDBiLyIsICJ0
+        YXNrX2lkIjogIjQwZmMwODZjLTZmMGUtNDQ5ZS1hYzY3LTIyN2U2NGE2ODAw
+        YiIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1
+        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlU
+        MDA6MDc6MTlaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
+        IjogIjIwMTYtMDItMTlUMDA6MDc6MThaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzcyYmM1NzFmLWY1ZmQtNDk5MC1hZDlkLTc0YTZhODZmZDljYy8iLCAi
+        dGFza19pZCI6ICI3MmJjNTcxZi1mNWZkLTQ5OTAtYWQ5ZC03NGE2YTg2ZmQ5
+        Y2MifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsi
+        Y29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3Rv
+        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
+        bV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAs
+        ICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xl
+        ZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
+        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJm
+        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
+        eyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6
+        ICI1NmM2NWNiNmRlMDQwMzY4OTEzZjFjYzAifSwgImV4Y2VwdGlvbiI6IG51
+        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
+        LCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjA3OjE4WiIsICJfbnMiOiAi
+        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlU
+        MDA6MDc6MTlaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVu
+        dCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50Ijog
+        MTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAi
+        aWQiOiAiNTZjNjVjYjdkZTA0MDM2YTI3YzBjMGQ2IiwgImRldGFpbHMiOiB7
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY1Y2I2YmQ5YjcyZTQwYzM1MWMx
+        ZCJ9LCAiaWQiOiAiNTZjNjVjYjZiZDliNzJlNDBjMzUxYzFkIn0sIHsiZXhj
+        ZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5h
+        Z2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIv
+        dGFza3MvZDVmYWIyMDUtMGZmMy00M2EzLTgyYWYtNjExNWVmNGU5ZDExLyIs
+        ICJ0YXNrX2lkIjogImQ1ZmFiMjA1LTBmZjMtNDNhMy04MmFmLTYxMTVlZjRl
+        OWQxMSIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3Iiwg
+        InB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDIt
+        MTlUMDA6MDc6MjJaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTYtMDItMTlUMDA6MDc6MjFaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L3Rhc2tzLzE4ZjM0NmYwLWQ2MTAtNDg5Yi05Yjg1LWY4ZGUwMzJjZDEzNy8i
+        LCAidGFza19pZCI6ICIxOGYzNDZmMC1kNjEwLTQ4OWItOWI4NS1mOGRlMDMy
+        Y2QxMzcifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6
+        IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklO
+        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBt
+        X3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAi
+        ZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6
+        IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0
+        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1z
+        X2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6
+        ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0
+        IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9p
+        ZCI6ICI1NmM2NWNiOWRlMDQwMzY4OTEzZjFjY2EifSwgImV4Y2VwdGlvbiI6
+        IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjA3OjIxWiIsICJfbnMi
+        OiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDIt
+        MTlUMDA6MDc6MjJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9y
+        dGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29u
+        dGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
+        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50
+        IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAw
+        LCAiaWQiOiAiNTZjNjVjYmFkZTA0MDM2YTI3YzBjMGRiIiwgImRldGFpbHMi
+        OiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6
+        IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJz
+        aXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJw
+        bV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0s
+        ICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVt
+        c19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3Ii
+        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY1Y2I5YmQ5YjcyZTQwYzM1
+        MWMyZiJ9LCAiaWQiOiAiNTZjNjVjYjliZDliNzJlNDBjMzUxYzJmIn0sIHsi
+        ZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5t
+        YW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkv
+        djIvdGFza3MvNzhjYzQ4ZjYtYTQ2MS00NTE4LTgyZjktYjY3ZDZlOTZhZGUy
+        LyIsICJ0YXNrX2lkIjogIjc4Y2M0OGY2LWE0NjEtNDUxOC04MmY5LWI2N2Q2
+        ZTk2YWRlMiIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3
+        IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYt
+        MDItMTlUMDA6MDc6MjVaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFy
+        dF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDc6MjRaIiwgInRyYWNlYmFjayI6
+        IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBp
+        L3YyL3Rhc2tzLzg1ZGU2ZTUyLTM1YTAtNDIzZS1iM2YzLTNjODliNjdjMDNm
+        NC8iLCAidGFza19pZCI6ICI4NWRlNmU1Mi0zNWEwLTQyM2UtYjNmMy0zYzg5
+        YjY3YzAzZjQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRl
+        ciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsi
+        cnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAw
+        LCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVm
+        dCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0
+        ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0
+        ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsi
+        JG9pZCI6ICI1NmM2NWNiY2RlMDQwMzY4OTI5MjU4NTcifSwgImV4Y2VwdGlv
+        biI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2si
+        OiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjA3OjI0WiIsICJf
+        bnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYt
+        MDItMTlUMDA6MDc6MjVaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2lt
+        cG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsi
+        Y29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2Nv
+        dW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQi
+        OiAwLCAiaWQiOiAiNTZjNjVjYmRkZTA0MDM2YTI3YzBjMGUwIiwgImRldGFp
+        bHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVm
+        dCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwg
+        InJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
+        MH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
+        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY1Y2JjYmQ5YjcyZTQw
+        YzM1MWM0MSJ9LCAiaWQiOiAiNTZjNjVjYmNiZDliNzJlNDBjMzUxYzQxIn0s
+        IHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZl
+        ci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvYjQ0NmFiMDItMmRkMi00MzI3LWFlODYtNzMxNjE3NDRh
+        ODYzLyIsICJ0YXNrX2lkIjogImI0NDZhYjAyLTJkZDItNDMyNy1hZTg2LTcz
+        MTYxNzQ0YTg2MyIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3Jh
+        XzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIw
+        MTYtMDItMTlUMDA6MDc6MjdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
+        dGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDc6MjdaIiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAv
+        YXBpL3YyL3Rhc2tzLzNjYjBmYzM4LTFjNDctNGEyOC05MDIyLWU3ZDYzZWJj
+        MTAwMS8iLCAidGFza19pZCI6ICIzY2IwZmMzOC0xYzQ3LTRhMjgtOTAyMi1l
+        N2Q2M2ViYzEwMDEifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJz
+        dGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
+        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6
+        IHsiJG9pZCI6ICI1NmM2NWNiZmRlMDQwMzY4OTEzZjFjZDQifSwgImV4Y2Vw
+        dGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjA3OjI3WiIs
+        ICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
+        MTYtMDItMTlUMDA6MDc6MjdaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVt
+        X2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6
+        IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVk
+        X2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291
+        bnQiOiAwLCAiaWQiOiAiNTZjNjVjYmZkZTA0MDM2YTI3YzBjMGU1IiwgImRl
+        dGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNf
+        bGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjog
+        MCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25l
+        IjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY1Y2JmYmQ5Yjcy
+        ZTQwYzM1MWM1MyJ9LCAiaWQiOiAiNTZjNjVjYmZiZDliNzJlNDBjMzUxYzUz
+        In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNl
+        cnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVs
+        cC9hcGkvdjIvdGFza3MvMjVmMmMxYmItMzJjMC00Y2E1LWFhZGUtNTkzYTAx
+        MWU5YmU4LyIsICJ0YXNrX2lkIjogIjI1ZjJjMWJiLTMyYzAtNGNhNS1hYWRl
+        LTU5M2EwMTFlOWJlOCIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVk
+        b3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTYtMDItMTlUMDA6MDc6MzBaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDc6MzBaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzLzViZTI5YmFmLTM3NTYtNDRmMy1hZDM0LTFlZjAz
+        OTZiNjQ3OC8iLCAidGFza19pZCI6ICI1YmUyOWJhZi0zNzU2LTQ0ZjMtYWQz
+        NC0xZWYwMzk2YjY0NzgifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
+        ZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9p
+        ZCI6IHsiJG9pZCI6ICI1NmM2NWNjMWRlMDQwMzY4OTM3Yzc5NjcifSwgImV4
+        Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFj
+        ZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjA3OjMw
+        WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjog
+        IjIwMTYtMDItMTlUMDA6MDc6MzBaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFy
+        eSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFk
+        ZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRf
+        Y291bnQiOiAwLCAiaWQiOiAiNTZjNjVjYzJkZTA0MDM2YTI3YzBjMGVhIiwg
+        ImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRl
+        bXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
+        IjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9k
+        b25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
+        bCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY1Y2MyYmQ5
+        YjcyZTQwYzM1MWM2NSJ9LCAiaWQiOiAiNTZjNjVjYzJiZDliNzJlNDBjMzUx
+        YzY1In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxw
+        LnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIv
+        cHVscC9hcGkvdjIvdGFza3MvZDE5NDI0ODItYzk1Yy00ZDM5LWFhM2ItZDA3
+        N2I2NzNlM2Q4LyIsICJ0YXNrX2lkIjogImQxOTQyNDgyLWM5NWMtNGQzOS1h
+        YTNiLWQwNzdiNjczZTNkOCIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6
+        RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1l
+        IjogIjIwMTYtMDItMTlUMDA6MDc6MzNaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1
+        cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDc6MzNaIiwgInRy
+        YWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAi
+        L3B1bHAvYXBpL3YyL3Rhc2tzL2VkZWY5ZWY4LTIzNWItNDUyYi04MzQ0LTFi
+        NTU3ODNmYjViOS8iLCAidGFza19pZCI6ICJlZGVmOWVmOC0yMzViLTQ1MmIt
+        ODM0NC0xYjU1NzgzZmI1YjkifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1
+        bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwg
+        InNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRl
+        cl9pZCI6IHsiJG9pZCI6ICI1NmM2NWNjNGRlMDQwMzY4OTEzZjFjZGIifSwg
+        ImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0
+        cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjA3
+        OjMzWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMTlUMDA6MDc6MzNaIiwgImltcG9ydGVyX3R5cGVfaWQi
+        OiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3Vt
+        bWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNv
+        bXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRl
+        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwg
+        ImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0
+        ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjVjYzVkZTA0MDM2YTI3YzBjMGVm
+        IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAi
+        aXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3Rv
+        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
+        bV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
+        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY1Y2M0
+        YmQ5YjcyZTQwYzM1MWM3NyJ9LCAiaWQiOiAiNTZjNjVjYzRiZDliNzJlNDBj
+        MzUxYzc3In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJw
+        dWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6
+        ICIvcHVscC9hcGkvdjIvdGFza3MvZjk2YTc0MzMtMzkyYS00ZWY4LThjNzUt
+        M2Y3ODk1ZmM1NTQ4LyIsICJ0YXNrX2lkIjogImY5NmE3NDMzLTM5MmEtNGVm
+        OC04Yzc1LTNmNzg5NWZjNTU0OCIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRv
+        cnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90
+        aW1lIjogIjIwMTYtMDItMTlUMDA6MDc6MzZaIiwgIl9ucyI6ICJ0YXNrX3N0
+        YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDc6MzVaIiwg
+        InRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2EwYmYyNjQ3LTRmMDItNDJhZC1iN2Y0
+        LTc5OGE2N2QwOWMyYy8iLCAidGFza19pZCI6ICJhMGJmMjY0Ny00ZjAyLTQy
+        YWQtYjdmNC03OThhNjdkMDljMmMifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
+        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjog
+        MCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBs
+        ZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBv
+        cnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NWNjN2RlMDQwMzY4OTEzZjFjZTAi
+        fSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAw
+        OjA3OjM1WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxl
+        dGVkIjogIjIwMTYtMDItMTlUMDA6MDc6MzZaIiwgImltcG9ydGVyX3R5cGVf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAi
+        c3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVw
+        ZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjVjYzhkZTA0MDM2YTI3YzBj
+        MGY0IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAw
+        LCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBt
+        X3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAi
+        ZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVt
+        c190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY1
+        Y2M3YmQ5YjcyZTQwYzM1MWM4OSJ9LCAiaWQiOiAiNTZjNjVjYzdiZDliNzJl
+        NDBjMzUxYzg5In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6
+        ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJl
+        ZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvYzI4YTJlZjQtMzEyMi00Nzc5LWI5
+        MzctMDM3NTI1MDNjYWVjLyIsICJ0YXNrX2lkIjogImMyOGEyZWY0LTMxMjIt
+        NDc3OS1iOTM3LTAzNzUyNTAzY2FlYyIsICJ0YWdzIjogWyJwdWxwOnJlcG9z
+        aXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDc6MzhaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDc6Mzha
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hy
+        ZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzBiZDNkZTZhLThkYzYtNDcwZS04
+        Y2Q3LTM5MjMwYzlhNmUzZC8iLCAidGFza19pZCI6ICIwYmQzZGU2YS04ZGM2
+        LTQ3MGUtOGNkNy0zOTIzMGM5YTZlM2QifV0sICJwcm9ncmVzc19yZXBvcnQi
+        OiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
+        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFs
+        IjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21w
+        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0
+        ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJp
+        bXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NWNjYWRlMDQwMzY4OTM3Yzc5
+        NmUifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8x
+        NyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5
+        VDAwOjA3OjM4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29t
+        cGxldGVkIjogIjIwMTYtMDItMTlUMDA6MDc6MzhaIiwgImltcG9ydGVyX3R5
+        cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxs
+        LCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
+        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwg
+        InVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjVjY2FkZTA0MDM2YTI3
+        YzBjMGY5IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwi
+        OiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsi
+        cnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAw
+        LCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29t
+        cHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJp
+        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2
+        YzY1Y2NhYmQ5YjcyZTQwYzM1MWM5YiJ9LCAiaWQiOiAiNTZjNjVjY2FiZDli
+        NzJlNDBjMzUxYzliIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlw
+        ZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJf
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNGIyY2U3MDQtN2QyOS00ZWM3
+        LWI4YmItNzE3YjNjY2E0M2ZkLyIsICJ0YXNrX2lkIjogIjRiMmNlNzA0LTdk
+        MjktNGVjNy1iOGJiLTcxN2IzY2NhNDNmZCIsICJ0YWdzIjogWyJwdWxwOnJl
+        cG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZp
+        bmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDc6NDFaIiwgIl9ucyI6ICJ0
+        YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6MDc6
+        NDFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3si
+        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzNiYjMwYzQwLWM5MWItNDhm
+        ZS1hYWUyLTc5MTM5NjI2Yjc2NC8iLCAidGFza19pZCI6ICIzYmIzMGM0MC1j
+        OTFiLTQ4ZmUtYWFlMi03OTEzOTYyNmI3NjQifV0sICJwcm9ncmVzc19yZXBv
+        cnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3Rv
+        dGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJj
+        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
+        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NWNjZGRlMDQwMzY4OTI5
+        MjU4NjQifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9y
+        YV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAy
+        LTE5VDAwOjA3OjQxWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAi
+        Y29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6MDc6NDFaIiwgImltcG9ydGVy
+        X3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBu
+        dWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50Ijog
+        MCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjVjY2RkZTA0MDM2
+        YTI3YzBjMGZlIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90
+        YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAi
+        Y29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNh
+        dGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjog
+        eyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjog
+        IjU2YzY1Y2NkYmQ5YjcyZTQwYzM1MWNhZCJ9LCAiaWQiOiAiNTZjNjVjY2Ri
+        ZDliNzJlNDBjMzUxY2FkIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tf
+        dHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIs
+        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvYTk1OWRlNzctMDQzNy00
+        Y2UxLTlmNWQtMGViMGM5ODRhNjFkLyIsICJ0YXNrX2lkIjogImE5NTlkZTc3
+        LTA0MzctNGNlMS05ZjVkLTBlYjBjOTg0YTYxZCIsICJ0YWdzIjogWyJwdWxw
+        OnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwg
+        ImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6MjU6MjBaIiwgIl9ucyI6
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6
+        MjU6MjBaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        W3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2IwN2E0OTIxLTBmZDQt
+        NDNlYS1hNmQ3LWU0M2E0YTY3MGFlZi8iLCAidGFza19pZCI6ICJiMDdhNDky
+        MS0wZmQ0LTQzZWEtYTZkNy1lNDNhNGE2NzBhZWYifV0sICJwcm9ncmVzc19y
+        ZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNf
+        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
+        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXpl
+        X3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlv
+        ZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2Vz
+        cyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NjBmMGRlMDQwMzY4
+        OTI5MjU4NmIifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZl
+        ZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2
+        LTAyLTE5VDAwOjI1OjIwWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMi
+        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6MjU6MjBaIiwgImltcG9y
+        dGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2Ui
+        OiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVy
+        Z2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3Ry
+        aWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50
+        IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjYwZjBkZTA0
+        MDM2YTI3YzBjMTAzIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVf
+        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
+        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
+        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
+        IjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
+        IjogIjU2YzY2MGYwYmQ5YjcyZTQwYzM1MWNjMSJ9LCAiaWQiOiAiNTZjNjYw
+        ZjBiZDliNzJlNDBjMzUxY2MxIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRh
+        c2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3lu
+        YyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvYzg5YWIwNWEtZmZi
+        MC00ZDI1LTlhNjgtZTk0YjRmZmFhZWQyLyIsICJ0YXNrX2lkIjogImM4OWFi
+        MDVhLWZmYjAtNGQyNS05YTY4LWU5NGI0ZmZhYWVkMiIsICJ0YWdzIjogWyJw
+        dWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMi
+        XSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6MjU6MzJaIiwgIl9u
+        cyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlU
+        MDA6MjU6MzFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        IjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzQzMmQ5ZDVlLTA5
+        YzctNDM3Zi04NDE5LWYzYjVmOGY1MGFmOC8iLCAidGFza19pZCI6ICI0MzJk
+        OWQ1ZS0wOWM3LTQzN2YtODQxOS1mM2I1ZjhmNTBhZjgifV0sICJwcm9ncmVz
+        c19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRl
+        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJz
+        aXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0Ijog
+        MH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1
+        cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRp
+        b24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NjBmYmRlMDQw
+        MzY4OTM3Yzc5ODcifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTE5VDAwOjI1OjMyWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6MjU6MzJaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjYwZmNk
+        ZTA0MDM2YTI3YzBjMTBkIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2YzY2MGZiYmQ5YjcyZTQwYzM1MWNlYiJ9LCAiaWQiOiAiNTZj
+        NjYwZmJiZDliNzJlNDBjMzUxY2ViIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwg
+        InRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMu
+        c3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMDNlMTZjM2Mt
+        ZjNjMS00NzgyLWFlYjUtNGM0ZWY4YzQ2ZDA2LyIsICJ0YXNrX2lkIjogIjAz
+        ZTE2YzNjLWYzYzEtNDc4Mi1hZWI1LTRjNGVmOGM0NmQwNiIsICJ0YWdzIjog
+        WyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5
+        bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6MjU6MzVaIiwg
+        Il9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDIt
+        MTlUMDA6MjU6MzVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rh
+        c2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzM3ZjA4MDUz
+        LWI0ZjYtNGMxNi05YzAxLWQ3NzY5NDk5Y2YwYS8iLCAidGFza19pZCI6ICIz
+        N2YwODA1My1iNGY2LTRjMTYtOWMwMS1kNzc2OTQ5OWNmMGEifV0sICJwcm9n
+        cmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsi
+        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJw
+        bV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0s
+        ICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0
+        IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdl
+        X2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
+        c3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NjBmZWRl
+        MDQwMzY4OTEzZjFkMDEifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lk
+        IjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6
+        ICIyMDE2LTAyLTE5VDAwOjI1OjM1WiIsICJfbnMiOiAicmVwb19zeW5jX3Jl
+        c3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6MjU6MzVaIiwg
+        ImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21l
+        c3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVk
+        X2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjYw
+        ZmZkZTA0MDM2YTI3YzBjMTEyIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7
+        InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3Rh
+        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAi
+        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
+        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxz
+        IjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJn
+        ZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
+        YnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJl
+        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
+        eyIkb2lkIjogIjU2YzY2MGZmYmQ5YjcyZTQwYzM1MWNmZSJ9LCAiaWQiOiAi
+        NTZjNjYwZmZiZDliNzJlNDBjMzUxY2ZlIn0sIHsiZXhjZXB0aW9uIjogbnVs
+        bCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5
+        bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZWZmZTRm
+        ZjEtNDlhZC00MzQ5LTk5MjEtZDc3MjBiYTJjYWMyLyIsICJ0YXNrX2lkIjog
+        ImVmZmU0ZmYxLTQ5YWQtNDM0OS05OTIxLWQ3NzIwYmEyY2FjMiIsICJ0YWdz
+        IjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9u
+        OnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6MjU6Mzha
+        IiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYt
+        MDItMTlUMDA6MjU6MzhaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
+        X3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzQyNDIx
+        NDZlLTE1Y2YtNDE2Mi1hZTIyLTVmNjNkNWE4NTczMS8iLCAidGFza19pZCI6
+        ICI0MjQyMTQ2ZS0xNWNmLTQxNjItYWUyMi01ZjYzZDVhODU3MzEifV0sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwg
+        InJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
+        MH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
+        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
+        cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
+        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NjEw
+        MWRlMDQwMzY4OTI5MjU4ODMifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
+        ZCI6ICIyMDE2LTAyLTE5VDAwOjI1OjM4WiIsICJfbnMiOiAicmVwb19zeW5j
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6MjU6Mzha
+        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZj
+        NjYxMDJkZTA0MDM2YTI3YzBjMTE3IiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
+        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
+        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
+        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
+        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
+        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
+        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
+        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjU2YzY2MTAyYmQ5YjcyZTQwYzM1MWQxMSJ9LCAiaWQi
+        OiAiNTZjNjYxMDJiZDliNzJlNDBjMzUxZDExIn0sIHsiZXhjZXB0aW9uIjog
+        bnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBv
+        LnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNTM0
+        ZTY0MWYtNzhmOS00MjZmLThkNDItMjdjN2M0NWY0MjIwLyIsICJ0YXNrX2lk
+        IjogIjUzNGU2NDFmLTc4ZjktNDI2Zi04ZDQyLTI3YzdjNDVmNDIyMCIsICJ0
+        YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0
+        aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6MjU6
+        NDFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTYtMDItMTlUMDA6MjU6NDFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzYw
+        ZWNlN2RmLWY5ZTItNGI0MS05MTMzLWM0YWMwZWVhNWNiMS8iLCAidGFza19p
+        ZCI6ICI2MGVjZTdkZi1mOWUyLTRiNDEtOTEzMy1jNGFjMGVlYTVjYjEifV0s
+        ICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVu
+        dCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjog
+        MCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25l
+        IjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVt
+        c19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        InB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJk
+        aXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAw
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2
+        NjEwNGRlMDQwMzY4OTEzZjFkMTQifSwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTAyLTE5VDAwOjI1OjQxWiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6MjU6
+        NDFaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZjNjYxMDVkZTA0MDM2YTI3YzBjMTFjIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU2YzY2MTA1YmQ5YjcyZTQwYzM1MWQyNCJ9LCAi
+        aWQiOiAiNTZjNjYxMDViZDliNzJlNDBjMzUxZDI0In0sIHsiZXhjZXB0aW9u
+        IjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5y
+        ZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3Mv
+        OGM3ZDhmYTctZDU1Ny00YjZjLTgyYzQtZWFmZGZiNTQzYWM3LyIsICJ0YXNr
+        X2lkIjogIjhjN2Q4ZmE3LWQ1NTctNGI2Yy04MmM0LWVhZmRmYjU0M2FjNyIs
+        ICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6
+        YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6
+        MjU6NDRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
+        IjIwMTYtMDItMTlUMDA6MjU6NDRaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
+        cGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tz
+        L2VlNTg3ODc4LTYwODQtNGU3NC05YjQ1LTA5MjM3NmUwNGIxMS8iLCAidGFz
+        a19pZCI6ICJlZTU4Nzg3OC02MDg0LTRlNzQtOWI0NS0wOTIzNzZlMDRiMTEi
+        fV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29u
+        dGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
+        IjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9k
+        b25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJp
+        dGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5p
+        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJy
+        ZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1
+        NmM2NjEwN2RlMDQwMzY4OTI5MjU4OGEifSwgImV4Y2VwdGlvbiI6IG51bGws
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAi
+        c3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjI1OjQ0WiIsICJfbnMiOiAicmVw
+        b19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6
+        MjU6NDRaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwg
+        ImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUs
+        ICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQi
+        OiAiNTZjNjYxMDhkZTA0MDM2YTI3YzBjMTIxIiwgImRldGFpbHMiOiB7ImNv
+        bnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xl
+        ZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
+        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJv
+        cl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0
+        IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
+        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YzY2MTA4YmQ5YjcyZTQwYzM1MWQzNyJ9
+        LCAiaWQiOiAiNTZjNjYxMDhiZDliNzJlNDBjMzUxZDM3In0sIHsiZXhjZXB0
+        aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vy
+        cy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFz
+        a3MvYWNjNTA4YzQtYzg5OC00YWU2LTgzYzMtODMwZGVjNmZkNTc4LyIsICJ0
+        YXNrX2lkIjogImFjYzUwOGM0LWM4OTgtNGFlNi04M2MzLTgzMGRlYzZmZDU3
+        OCIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1
+        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlU
+        MDA6MjU6NDdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
+        IjogIjIwMTYtMDItMTlUMDA6MjU6NDdaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzU5ZDIyNTEyLWI1YzMtNDRkNy1hMWFjLTJiOTc1NTI4Y2RkZS8iLCAi
+        dGFza19pZCI6ICI1OWQyMjUxMi1iNWMzLTQ0ZDctYTFhYy0yYjk3NTUyOGNk
+        ZGUifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsi
+        Y29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3Rv
+        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
+        bV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAs
+        ICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xl
+        ZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
+        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJm
+        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
+        eyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6
+        ICI1NmM2NjEwYWRlMDQwMzY4OTI5MjU4OTUifSwgImV4Y2VwdGlvbiI6IG51
+        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
+        LCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjI1OjQ3WiIsICJfbnMiOiAi
+        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlU
+        MDA6MjU6NDdaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVu
+        dCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50Ijog
+        MTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAi
+        aWQiOiAiNTZjNjYxMGJkZTA0MDM2YTI3YzBjMTI2IiwgImRldGFpbHMiOiB7
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY2MTBiYmQ5YjcyZTQwYzM1MWQ0
+        YSJ9LCAiaWQiOiAiNTZjNjYxMGJiZDliNzJlNDBjMzUxZDRhIn0sIHsiZXhj
+        ZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5h
+        Z2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIv
+        dGFza3MvMzBmOGVmZWQtYjYzZS00ZDJiLWJmZjUtNTA1Y2IyYzBlODQ5LyIs
+        ICJ0YXNrX2lkIjogIjMwZjhlZmVkLWI2M2UtNGQyYi1iZmY1LTUwNWNiMmMw
+        ZTg0OSIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3Iiwg
+        InB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDIt
+        MTlUMDA6MjU6NTBaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTYtMDItMTlUMDA6MjU6NTBaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L3Rhc2tzLzQyMmQ4YzlhLTZmYzktNGJhOC05NDcxLTcxOTYyMTcwNGViZi8i
+        LCAidGFza19pZCI6ICI0MjJkOGM5YS02ZmM5LTRiYTgtOTQ3MS03MTk2MjE3
+        MDRlYmYifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6
+        IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklO
+        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBt
+        X3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAi
+        ZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6
+        IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0
+        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1z
+        X2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6
+        ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0
+        IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9p
+        ZCI6ICI1NmM2NjEwZGRlMDQwMzY4OTI5MjU4OWQifSwgImV4Y2VwdGlvbiI6
+        IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjI1OjUwWiIsICJfbnMi
+        OiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDIt
+        MTlUMDA6MjU6NTBaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9y
+        dGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29u
+        dGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
+        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50
+        IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAw
+        LCAiaWQiOiAiNTZjNjYxMGVkZTA0MDM2YTI3YzBjMTJiIiwgImRldGFpbHMi
+        OiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6
+        IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJz
+        aXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJw
+        bV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0s
+        ICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVt
+        c19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3Ii
+        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY2MTBlYmQ5YjcyZTQwYzM1
+        MWQ1ZCJ9LCAiaWQiOiAiNTZjNjYxMGViZDliNzJlNDBjMzUxZDVkIn0sIHsi
+        ZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5t
+        YW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkv
+        djIvdGFza3MvYTBjYjQ1YTgtM2JmMC00MmYwLTg3YTEtN2M2M2YwNjYwZjU5
+        LyIsICJ0YXNrX2lkIjogImEwY2I0NWE4LTNiZjAtNDJmMC04N2ExLTdjNjNm
+        MDY2MGY1OSIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3
+        IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYt
+        MDItMTlUMDA6MjY6MDRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFy
+        dF90aW1lIjogIjIwMTYtMDItMTlUMDA6MjY6MDRaIiwgInRyYWNlYmFjayI6
+        IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBp
+        L3YyL3Rhc2tzL2JiZmUwZDE1LTRkMWUtNDRiMi04ZWZmLTU0MDI4ZjRjMzY1
+        Mi8iLCAidGFza19pZCI6ICJiYmZlMGQxNS00ZDFlLTQ0YjItOGVmZi01NDAy
+        OGY0YzM2NTIifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRl
+        ciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsi
+        cnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAw
+        LCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVm
+        dCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0
+        ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0
+        ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsi
+        JG9pZCI6ICI1NmM2NjExY2RlMDQwMzY4OTEzZjFkMzMifSwgImV4Y2VwdGlv
+        biI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2si
+        OiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjI2OjA0WiIsICJf
+        bnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYt
+        MDItMTlUMDA6MjY6MDRaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2lt
+        cG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsi
+        Y29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2Nv
+        dW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQi
+        OiAwLCAiaWQiOiAiNTZjNjYxMWNkZTA0MDM2YTI3YzBjMTMwIiwgImRldGFp
+        bHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVm
+        dCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwg
+        InJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
+        MH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
+        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY2MTFjYmQ5YjcyZTQw
+        YzM1MWQ3OSJ9LCAiaWQiOiAiNTZjNjYxMWNiZDliNzJlNDBjMzUxZDc5In0s
+        IHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZl
+        ci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMzI0YTQzOGQtZTQ1ZS00MzJjLWFmNjEtYzI3ODNhNTYz
+        ODk1LyIsICJ0YXNrX2lkIjogIjMyNGE0MzhkLWU0NWUtNDMyYy1hZjYxLWMy
+        NzgzYTU2Mzg5NSIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3Jh
+        XzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIw
+        MTYtMDItMTlUMDA6MjY6MTFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
+        dGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6MjY6MTFaIiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAv
+        YXBpL3YyL3Rhc2tzL2VlYmQzODYwLWU4ZmMtNDkzNS05N2QwLTE4ZDM5MmYx
+        MmQzYi8iLCAidGFza19pZCI6ICJlZWJkMzg2MC1lOGZjLTQ5MzUtOTdkMC0x
+        OGQzOTJmMTJkM2IifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJz
+        dGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
+        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6
+        IHsiJG9pZCI6ICI1NmM2NjEyM2RlMDQwMzY4OTI5MjU4YWYifSwgImV4Y2Vw
+        dGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjI2OjExWiIs
+        ICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
+        MTYtMDItMTlUMDA6MjY6MTFaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVt
+        X2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6
+        IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVk
+        X2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291
+        bnQiOiAwLCAiaWQiOiAiNTZjNjYxMjNkZTA0MDM2YTI3YzBjMTNjIiwgImRl
+        dGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNf
+        bGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjog
+        MCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25l
+        IjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY2MTIzYmQ5Yjcy
+        ZTQwYzM1MWQ4ZSJ9LCAiaWQiOiAiNTZjNjYxMjNiZDliNzJlNDBjMzUxZDhl
+        In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNl
+        cnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVs
+        cC9hcGkvdjIvdGFza3MvNDdmYTczODYtNmQ1Ny00MzVmLWFmODgtYzk3NThk
+        MTA2OGE4LyIsICJ0YXNrX2lkIjogIjQ3ZmE3Mzg2LTZkNTctNDM1Zi1hZjg4
+        LWM5NzU4ZDEwNjhhOCIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVk
+        b3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTYtMDItMTlUMDA6MjY6MTRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6MjY6MTRaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzLzA1MDUyY2NjLTAwNDUtNGVlYS05NDUwLTBiMmFk
+        MTgwYjIyYy8iLCAidGFza19pZCI6ICIwNTA1MmNjYy0wMDQ1LTRlZWEtOTQ1
+        MC0wYjJhZDE4MGIyMmMifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
+        ZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9p
+        ZCI6IHsiJG9pZCI6ICI1NmM2NjEyNmRlMDQwMzY4OTM3Yzc5YTQifSwgImV4
+        Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFj
+        ZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjI2OjE0
+        WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjog
+        IjIwMTYtMDItMTlUMDA6MjY6MTRaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFy
+        eSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFk
+        ZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRf
+        Y291bnQiOiAwLCAiaWQiOiAiNTZjNjYxMjZkZTA0MDM2YTI3YzBjMTQ3Iiwg
+        ImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRl
+        bXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
+        IjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9k
+        b25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
+        bCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY2MTI2YmQ5
+        YjcyZTQwYzM1MWRhMCJ9LCAiaWQiOiAiNTZjNjYxMjZiZDliNzJlNDBjMzUx
+        ZGEwIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxw
+        LnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIv
+        cHVscC9hcGkvdjIvdGFza3MvOGYxZjFhNTctZmJiNi00YTY3LTkzZWQtZjEy
+        NDNkZjlhMDlmLyIsICJ0YXNrX2lkIjogIjhmMWYxYTU3LWZiYjYtNGE2Ny05
+        M2VkLWYxMjQzZGY5YTA5ZiIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6
+        RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1l
+        IjogIjIwMTYtMDItMTlUMDA6MjY6MTdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1
+        cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6MjY6MTdaIiwgInRy
+        YWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAi
+        L3B1bHAvYXBpL3YyL3Rhc2tzL2I3NGQ1NmU2LTlhZGItNDBiNi04MGZiLTg2
+        ZTcxZTEzMzgwNi8iLCAidGFza19pZCI6ICJiNzRkNTZlNi05YWRiLTQwYjYt
+        ODBmYi04NmU3MWUxMzM4MDYifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1
+        bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwg
+        InNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRl
+        cl9pZCI6IHsiJG9pZCI6ICI1NmM2NjEyOWRlMDQwMzY4OTEzZjFkNDAifSwg
+        ImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0
+        cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjI2
+        OjE3WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMTlUMDA6MjY6MTdaIiwgImltcG9ydGVyX3R5cGVfaWQi
+        OiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3Vt
+        bWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNv
+        bXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRl
+        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwg
+        ImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0
+        ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjYxMjlkZTA0MDM2YTI3YzBjMTUy
+        IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAi
+        aXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3Rv
+        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
+        bV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
+        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY2MTI5
+        YmQ5YjcyZTQwYzM1MWRiMiJ9LCAiaWQiOiAiNTZjNjYxMjliZDliNzJlNDBj
+        MzUxZGIyIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJw
+        dWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6
+        ICIvcHVscC9hcGkvdjIvdGFza3MvODk4ZDFkNTQtYjAxOS00NzBiLWJlOTYt
+        NDNhNjc3NDdmZWE4LyIsICJ0YXNrX2lkIjogIjg5OGQxZDU0LWIwMTktNDcw
+        Yi1iZTk2LTQzYTY3NzQ3ZmVhOCIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRv
+        cnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90
+        aW1lIjogIjIwMTYtMDItMTlUMDA6MjY6MjBaIiwgIl9ucyI6ICJ0YXNrX3N0
+        YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6MjY6MjBaIiwg
+        InRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2U0NmRhOWVlLWQzNGUtNDZiOS05OTZm
+        LTYyZjZmZTA3ODUwNi8iLCAidGFza19pZCI6ICJlNDZkYTllZS1kMzRlLTQ2
+        YjktOTk2Zi02MmY2ZmUwNzg1MDYifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
+        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjog
+        MCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBs
+        ZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBv
+        cnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NjEyY2RlMDQwMzY4OTEzZjFkNDYi
+        fSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAw
+        OjI2OjIwWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxl
+        dGVkIjogIjIwMTYtMDItMTlUMDA6MjY6MjBaIiwgImltcG9ydGVyX3R5cGVf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAi
+        c3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVw
+        ZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjYxMmNkZTA0MDM2YTI3YzBj
+        MTVkIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAw
+        LCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBt
+        X3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAi
+        ZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVt
+        c190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY2
+        MTJjYmQ5YjcyZTQwYzM1MWRjNCJ9LCAiaWQiOiAiNTZjNjYxMmNiZDliNzJl
+        NDBjMzUxZGM0In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6
+        ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJl
+        ZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvOWFmZGM5ZDEtMmZmMC00NzhmLTk5
+        ZjItYTY5ODQxOGM4OTkxLyIsICJ0YXNrX2lkIjogIjlhZmRjOWQxLTJmZjAt
+        NDc4Zi05OWYyLWE2OTg0MThjODk5MSIsICJ0YWdzIjogWyJwdWxwOnJlcG9z
+        aXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTYtMDItMTlUMDA6MjY6MjNaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6MjY6MjNa
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hy
+        ZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzY5ZmE1MDNjLTAzYjItNDViYS1h
+        YmVjLTc4MDMzM2ZmMDk0Zi8iLCAidGFza19pZCI6ICI2OWZhNTAzYy0wM2Iy
+        LTQ1YmEtYWJlYy03ODAzMzNmZjA5NGYifV0sICJwcm9ncmVzc19yZXBvcnQi
+        OiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
+        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFs
+        IjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21w
+        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0
+        ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJp
+        bXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NjEyZmRlMDQwMzY4OTM3Yzc5
+        YTkifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8x
+        NyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5
+        VDAwOjI2OjIzWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29t
+        cGxldGVkIjogIjIwMTYtMDItMTlUMDA6MjY6MjNaIiwgImltcG9ydGVyX3R5
+        cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxs
+        LCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
+        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwg
+        InVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjYxMmZkZTA0MDM2YTI3
+        YzBjMTY4IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwi
+        OiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsi
+        cnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAw
+        LCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29t
+        cHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJp
+        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2
+        YzY2MTJmYmQ5YjcyZTQwYzM1MWRkNiJ9LCAiaWQiOiAiNTZjNjYxMmZiZDli
+        NzJlNDBjMzUxZGQ2In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlw
+        ZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJf
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMTBhNGY3M2ItNmQ5NS00N2Qy
+        LTliMGItYzU4ZGY1OTQxYjIyLyIsICJ0YXNrX2lkIjogIjEwYTRmNzNiLTZk
+        OTUtNDdkMi05YjBiLWM1OGRmNTk0MWIyMiIsICJ0YWdzIjogWyJwdWxwOnJl
+        cG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZp
+        bmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6MjY6MjZaIiwgIl9ucyI6ICJ0
+        YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6MjY6
+        MjZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3si
+        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzMxNTk4OTNmLWZkZDUtNGRh
+        NS1hYjdjLTU4OWQzMjllM2MwMC8iLCAidGFza19pZCI6ICIzMTU5ODkzZi1m
+        ZGQ1LTRkYTUtYWI3Yy01ODlkMzI5ZTNjMDAifV0sICJwcm9ncmVzc19yZXBv
+        cnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3Rv
+        dGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJj
+        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
+        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NjEzMmRlMDQwMzY4OTM3
+        Yzc5YWUifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9y
+        YV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAy
+        LTE5VDAwOjI2OjI2WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAi
+        Y29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6MjY6MjZaIiwgImltcG9ydGVy
+        X3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBu
+        dWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50Ijog
+        MCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjYxMzJkZTA0MDM2
+        YTI3YzBjMTczIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90
+        YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAi
+        Y29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNh
+        dGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjog
+        eyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjog
+        IjU2YzY2MTMyYmQ5YjcyZTQwYzM1MWRlOCJ9LCAiaWQiOiAiNTZjNjYxMzJi
+        ZDliNzJlNDBjMzUxZGU4In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tf
+        dHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIs
+        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZGQ0NGJhZmEtZTgzNS00
+        ZjdjLWE4NjctYjA5NzU1YmNjN2U3LyIsICJ0YXNrX2lkIjogImRkNDRiYWZh
+        LWU4MzUtNGY3Yy1hODY3LWIwOTc1NWJjYzdlNyIsICJ0YWdzIjogWyJwdWxw
+        OnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwg
+        ImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6MjY6MjlaIiwgIl9ucyI6
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6
+        MjY6MjlaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        W3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2YyZTgwNTZmLTdlYWQt
+        NDQxOC1iYTM2LWU2MzUxMGZhNTk5NS8iLCAidGFza19pZCI6ICJmMmU4MDU2
+        Zi03ZWFkLTQ0MTgtYmEzNi1lNjM1MTBmYTU5OTUifV0sICJwcm9ncmVzc19y
+        ZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNf
+        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
+        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXpl
+        X3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlv
+        ZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2Vz
+        cyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NjEzNWRlMDQwMzY4
+        OTM3Yzc5YjMifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZl
+        ZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2
+        LTAyLTE5VDAwOjI2OjI5WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMi
+        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6MjY6MjlaIiwgImltcG9y
+        dGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2Ui
+        OiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVy
+        Z2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3Ry
+        aWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50
+        IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjYxMzVkZTA0
+        MDM2YTI3YzBjMTdlIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVf
+        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
+        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
+        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
+        IjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
+        IjogIjU2YzY2MTM1YmQ5YjcyZTQwYzM1MWRmYSJ9LCAiaWQiOiAiNTZjNjYx
+        MzViZDliNzJlNDBjMzUxZGZhIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRh
+        c2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3lu
+        YyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvYWQ0OGY4ZTgtODAx
+        My00NmU5LWEzZDUtMTIzMWRhNjk2NmE2LyIsICJ0YXNrX2lkIjogImFkNDhm
+        OGU4LTgwMTMtNDZlOS1hM2Q1LTEyMzFkYTY5NjZhNiIsICJ0YWdzIjogWyJw
+        dWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMi
+        XSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6MjY6MzNaIiwgIl9u
+        cyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlU
+        MDA6MjY6MzJaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        IjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzRjZjc3NGIzLTJj
+        MTYtNDQwYi1hMDgzLTU1YmRhZWNkOWU0MS8iLCAidGFza19pZCI6ICI0Y2Y3
+        NzRiMy0yYzE2LTQ0MGItYTA4My01NWJkYWVjZDllNDEifV0sICJwcm9ncmVz
+        c19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRl
+        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJz
+        aXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0Ijog
+        MH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1
+        cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRp
+        b24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NjEzOGRlMDQw
+        MzY4OTM3Yzc5YjgifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTE5VDAwOjI2OjMyWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6MjY6MzNaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjYxMzlk
+        ZTA0MDM2YTI3YzBjMTg5IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2YzY2MTM4YmQ5YjcyZTQwYzM1MWUwYyJ9LCAiaWQiOiAiNTZj
+        NjYxMzhiZDliNzJlNDBjMzUxZTBjIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwg
+        InRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMu
+        c3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZDY2OGQyMzYt
+        MjkyNi00YjliLWE0YjMtNWZhNTg0Y2UzOWE0LyIsICJ0YXNrX2lkIjogImQ2
+        NjhkMjM2LTI5MjYtNGI5Yi1hNGIzLTVmYTU4NGNlMzlhNCIsICJ0YWdzIjog
+        WyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5
+        bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6MjY6MzZaIiwg
+        Il9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDIt
+        MTlUMDA6MjY6MzVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rh
+        c2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzBiNDllYmQ3
+        LTBlZGEtNDc5Ni1hZTg0LWUxMWVjZTdmYzQ0OC8iLCAidGFza19pZCI6ICIw
+        YjQ5ZWJkNy0wZWRhLTQ3OTYtYWU4NC1lMTFlY2U3ZmM0NDgifV0sICJwcm9n
+        cmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsi
+        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJw
+        bV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0s
+        ICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0
+        IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdl
+        X2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
+        c3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NjEzYmRl
+        MDQwMzY4OTEzZjFkNTYifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lk
+        IjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6
+        ICIyMDE2LTAyLTE5VDAwOjI2OjM1WiIsICJfbnMiOiAicmVwb19zeW5jX3Jl
+        c3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6MjY6MzZaIiwg
+        ImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21l
+        c3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVk
+        X2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjYx
+        M2NkZTA0MDM2YTI3YzBjMTk0IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7
+        InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3Rh
+        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAi
+        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
+        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxz
+        IjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJn
+        ZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
+        YnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJl
+        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
+        eyIkb2lkIjogIjU2YzY2MTNiYmQ5YjcyZTQwYzM1MWUxZSJ9LCAiaWQiOiAi
+        NTZjNjYxM2JiZDliNzJlNDBjMzUxZTFlIn0sIHsiZXhjZXB0aW9uIjogbnVs
+        bCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5
+        bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMWU5NTIz
+        MmMtODEyOS00OTc5LWExYWQtNTI3MzA1NTYwYWQ3LyIsICJ0YXNrX2lkIjog
+        IjFlOTUyMzJjLTgxMjktNDk3OS1hMWFkLTUyNzMwNTU2MGFkNyIsICJ0YWdz
+        IjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9u
+        OnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6MjY6Mzla
+        IiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYt
+        MDItMTlUMDA6MjY6MzhaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
+        X3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzQ1MDA2
+        NWUwLThkODEtNDc0My04MjhiLWNmZjRlOGFmZTEwNi8iLCAidGFza19pZCI6
+        ICI0NTAwNjVlMC04ZDgxLTQ3NDMtODI4Yi1jZmY0ZThhZmUxMDYifV0sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwg
+        InJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
+        MH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
+        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
+        cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
+        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NjEz
+        ZWRlMDQwMzY4OTI5MjU4YjYifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
+        ZCI6ICIyMDE2LTAyLTE5VDAwOjI2OjM4WiIsICJfbnMiOiAicmVwb19zeW5j
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6MjY6Mzla
+        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZj
+        NjYxM2ZkZTA0MDM2YTI3YzBjMTlmIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
+        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
+        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
+        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
+        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
+        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
+        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
+        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjU2YzY2MTNlYmQ5YjcyZTQwYzM1MWUzMCJ9LCAiaWQi
+        OiAiNTZjNjYxM2ViZDliNzJlNDBjMzUxZTMwIn0sIHsiZXhjZXB0aW9uIjog
+        bnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBv
+        LnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvYTdm
+        MDM3NGYtOWFkZi00M2M0LWFmMWQtZjI5NGY4YjI1ZTZjLyIsICJ0YXNrX2lk
+        IjogImE3ZjAzNzRmLTlhZGYtNDNjNC1hZjFkLWYyOTRmOGIyNWU2YyIsICJ0
+        YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0
+        aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6MjY6
+        NDJaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTYtMDItMTlUMDA6MjY6NDFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzM5
+        YmMzYWY2LThiYTktNDA0Yy1hOGNjLTMyYWU0Y2ZmN2M2My8iLCAidGFza19p
+        ZCI6ICIzOWJjM2FmNi04YmE5LTQwNGMtYThjYy0zMmFlNGNmZjdjNjMifV0s
+        ICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVu
+        dCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjog
+        MCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25l
+        IjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVt
+        c19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        InB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJk
+        aXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAw
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2
+        NjE0MWRlMDQwMzY4OTEzZjFkNWIifSwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTAyLTE5VDAwOjI2OjQxWiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6MjY6
+        NDJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZjNjYxNDJkZTA0MDM2YTI3YzBjMWFhIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU2YzY2MTQxYmQ5YjcyZTQwYzM1MWU0MiJ9LCAi
+        aWQiOiAiNTZjNjYxNDFiZDliNzJlNDBjMzUxZTQyIn0sIHsiZXhjZXB0aW9u
+        IjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5y
+        ZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3Mv
+        N2MxNWM0NmUtZmY4Ny00M2U3LTk3NjktMjgyZTI0NmMzNzlhLyIsICJ0YXNr
+        X2lkIjogIjdjMTVjNDZlLWZmODctNDNlNy05NzY5LTI4MmUyNDZjMzc5YSIs
+        ICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6
+        YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6
+        MjY6NDhaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
+        IjIwMTYtMDItMTlUMDA6MjY6NDhaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
+        cGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tz
+        L2FhMmQyY2FlLTIwYjUtNGZkNi05YjNmLTRmZGQ3OTY2YTUxZC8iLCAidGFz
+        a19pZCI6ICJhYTJkMmNhZS0yMGI1LTRmZDYtOWIzZi00ZmRkNzk2NmE1MWQi
+        fV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29u
+        dGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
+        IjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9k
+        b25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJp
+        dGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5p
+        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJy
+        ZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1
+        NmM2NjE0OGRlMDQwMzY4OTM3Yzc5YzIifSwgImV4Y2VwdGlvbiI6IG51bGws
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAi
+        c3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjI2OjQ4WiIsICJfbnMiOiAicmVw
+        b19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6
+        MjY6NDhaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwg
+        ImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUs
+        ICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQi
+        OiAiNTZjNjYxNDhkZTA0MDM2YTI3YzBjMWMwIiwgImRldGFpbHMiOiB7ImNv
+        bnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xl
+        ZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
+        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJv
+        cl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0
+        IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
+        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YzY2MTQ4YmQ5YjcyZTQwYzM1MWU2NiJ9
+        LCAiaWQiOiAiNTZjNjYxNDhiZDliNzJlNDBjMzUxZTY2In0sIHsiZXhjZXB0
+        aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vy
+        cy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFz
+        a3MvOGQwNjUwZjItYThiMy00MjNiLThmODMtNmIwYzU3ZmZkMDNhLyIsICJ0
+        YXNrX2lkIjogIjhkMDY1MGYyLWE4YjMtNDIzYi04ZjgzLTZiMGM1N2ZmZDAz
+        YSIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1
+        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlU
+        MDA6MjY6NTFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
+        IjogIjIwMTYtMDItMTlUMDA6MjY6NTFaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzI1NGVkMmEyLWYyYTctNDE5Mi05MWI2LTFhMThlZmNjNTU2Yy8iLCAi
+        dGFza19pZCI6ICIyNTRlZDJhMi1mMmE3LTQxOTItOTFiNi0xYTE4ZWZjYzU1
+        NmMifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsi
+        Y29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3Rv
+        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
+        bV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAs
+        ICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xl
+        ZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
+        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJm
+        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
+        eyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6
+        ICI1NmM2NjE0YmRlMDQwMzY4OTM3Yzc5YzcifSwgImV4Y2VwdGlvbiI6IG51
+        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
+        LCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjI2OjUxWiIsICJfbnMiOiAi
+        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlU
+        MDA6MjY6NTFaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVu
+        dCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50Ijog
+        MTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAi
+        aWQiOiAiNTZjNjYxNGJkZTA0MDM2YTI3YzBjMWNiIiwgImRldGFpbHMiOiB7
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY2MTRiYmQ5YjcyZTQwYzM1MWU3
+        OCJ9LCAiaWQiOiAiNTZjNjYxNGJiZDliNzJlNDBjMzUxZTc4In0sIHsiZXhj
+        ZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5h
+        Z2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIv
+        dGFza3MvZDg4ZjkwNjMtMzI2ZC00ODA4LWJjZTgtNjdjNjc2YTc5NzM1LyIs
+        ICJ0YXNrX2lkIjogImQ4OGY5MDYzLTMyNmQtNDgwOC1iY2U4LTY3YzY3NmE3
+        OTczNSIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3Iiwg
+        InB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDIt
+        MTlUMDA6MjY6NDVaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTYtMDItMTlUMDA6MjY6NDVaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L3Rhc2tzL2Q3OTQ5OWNjLTg2NzEtNDExYy1hYzk1LTMzM2RiMTVjNjVmYi8i
+        LCAidGFza19pZCI6ICJkNzk0OTljYy04NjcxLTQxMWMtYWM5NS0zMzNkYjE1
+        YzY1ZmIifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6
+        IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklO
+        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBt
+        X3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAi
+        ZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6
+        IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0
+        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1z
+        X2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6
+        ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0
+        IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9p
+        ZCI6ICI1NmM2NjE0NWRlMDQwMzY4OTM3Yzc5YmQifSwgImV4Y2VwdGlvbiI6
+        IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjI2OjQ1WiIsICJfbnMi
+        OiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDIt
+        MTlUMDA6MjY6NDVaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9y
+        dGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29u
+        dGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
+        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50
+        IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAw
+        LCAiaWQiOiAiNTZjNjYxNDVkZTA0MDM2YTI3YzBjMWI1IiwgImRldGFpbHMi
+        OiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6
+        IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJz
+        aXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJw
+        bV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0s
+        ICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVt
+        c19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3Ii
+        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY2MTQ1YmQ5YjcyZTQwYzM1
+        MWU1NCJ9LCAiaWQiOiAiNTZjNjYxNDViZDliNzJlNDBjMzUxZTU0In0sIHsi
+        ZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5t
+        YW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkv
+        djIvdGFza3MvMjBmYjQ3ZDktNTU4NS00NTYwLWFhZjgtNGRhMzI3MmFkZjgz
+        LyIsICJ0YXNrX2lkIjogIjIwZmI0N2Q5LTU1ODUtNDU2MC1hYWY4LTRkYTMy
+        NzJhZGY4MyIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3
+        IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYt
+        MDItMTlUMDA6MjY6NTRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFy
+        dF90aW1lIjogIjIwMTYtMDItMTlUMDA6MjY6NTRaIiwgInRyYWNlYmFjayI6
+        IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBp
+        L3YyL3Rhc2tzLzA0N2M2ZGIyLTY4OTktNDNmZS1iMjczLTdmNzFhYWZhYzg5
+        MS8iLCAidGFza19pZCI6ICIwNDdjNmRiMi02ODk5LTQzZmUtYjI3My03Zjcx
+        YWFmYWM4OTEifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRl
+        ciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsi
+        cnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAw
+        LCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVm
+        dCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0
+        ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0
+        ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsi
+        JG9pZCI6ICI1NmM2NjE0ZWRlMDQwMzY4OTM3Yzc5Y2MifSwgImV4Y2VwdGlv
+        biI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2si
+        OiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjI2OjU0WiIsICJf
+        bnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYt
+        MDItMTlUMDA6MjY6NTRaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2lt
+        cG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsi
+        Y29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2Nv
+        dW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQi
+        OiAwLCAiaWQiOiAiNTZjNjYxNGVkZTA0MDM2YTI3YzBjMWQ2IiwgImRldGFp
+        bHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVm
+        dCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwg
+        InJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
+        MH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
+        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY2MTRlYmQ5YjcyZTQw
+        YzM1MWU4YSJ9LCAiaWQiOiAiNTZjNjYxNGViZDliNzJlNDBjMzUxZThhIn0s
+        IHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZl
+        ci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMTQ2MDEwMmYtZjczNy00ODJlLWJjMDgtMDAwZjViYWI3
+        NTdlLyIsICJ0YXNrX2lkIjogIjE0NjAxMDJmLWY3MzctNDgyZS1iYzA4LTAw
+        MGY1YmFiNzU3ZSIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3Jh
+        XzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIw
+        MTYtMDItMTlUMDA6MjY6NTdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
+        dGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6MjY6NTdaIiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAv
+        YXBpL3YyL3Rhc2tzLzY1ZjE3OTRlLTRjOTMtNDc1MC04MjM4LWJmYTVhZmJj
+        NDEyZi8iLCAidGFza19pZCI6ICI2NWYxNzk0ZS00YzkzLTQ3NTAtODIzOC1i
+        ZmE1YWZiYzQxMmYifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJz
+        dGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
+        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6
+        IHsiJG9pZCI6ICI1NmM2NjE1MWRlMDQwMzY4OTEzZjFkNjAifSwgImV4Y2Vw
+        dGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjI2OjU3WiIs
+        ICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
+        MTYtMDItMTlUMDA6MjY6NTdaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVt
+        X2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6
+        IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVk
+        X2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291
+        bnQiOiAwLCAiaWQiOiAiNTZjNjYxNTFkZTA0MDM2YTI3YzBjMWUxIiwgImRl
+        dGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNf
+        bGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjog
+        MCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25l
+        IjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY2MTUxYmQ5Yjcy
+        ZTQwYzM1MWU5YyJ9LCAiaWQiOiAiNTZjNjYxNTFiZDliNzJlNDBjMzUxZTlj
+        In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNl
+        cnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVs
+        cC9hcGkvdjIvdGFza3MvNWM0MDU0OTMtOGMwYS00ZjlhLTk5ZGEtNmJlZGIz
+        YzcwNjEzLyIsICJ0YXNrX2lkIjogIjVjNDA1NDkzLThjMGEtNGY5YS05OWRh
+        LTZiZWRiM2M3MDYxMyIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVk
+        b3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTYtMDItMTlUMDA6Mjc6MDFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6Mjc6MDBaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzL2U5NWVjMzc4LTIwMjctNGVkNy1hYTdlLWZiZGM2
+        MDk3OWQxMC8iLCAidGFza19pZCI6ICJlOTVlYzM3OC0yMDI3LTRlZDctYWE3
+        ZS1mYmRjNjA5NzlkMTAifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
+        ZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9p
+        ZCI6IHsiJG9pZCI6ICI1NmM2NjE1NGRlMDQwMzY4OTM3Yzc5ZDEifSwgImV4
+        Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFj
+        ZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjI3OjAw
+        WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjog
+        IjIwMTYtMDItMTlUMDA6Mjc6MDFaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFy
+        eSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFk
+        ZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRf
+        Y291bnQiOiAwLCAiaWQiOiAiNTZjNjYxNTVkZTA0MDM2YTI3YzBjMWVjIiwg
+        ImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRl
+        bXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
+        IjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9k
+        b25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
+        bCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY2MTU0YmQ5
+        YjcyZTQwYzM1MWVhZSJ9LCAiaWQiOiAiNTZjNjYxNTRiZDliNzJlNDBjMzUx
+        ZWFlIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxw
+        LnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIv
+        cHVscC9hcGkvdjIvdGFza3MvZmI1ODFkNjMtMmQxNi00OTE0LWIwY2EtMDI3
+        NTdmM2ZjY2NhLyIsICJ0YXNrX2lkIjogImZiNTgxZDYzLTJkMTYtNDkxNC1i
+        MGNhLTAyNzU3ZjNmY2NjYSIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6
+        RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1l
+        IjogIjIwMTYtMDItMTlUMDA6Mjc6MDdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1
+        cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6Mjc6MDdaIiwgInRy
+        YWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAi
+        L3B1bHAvYXBpL3YyL3Rhc2tzLzI5ZWU0YmZjLTAwNzEtNDMyMy05ZTcxLTA1
+        NWY4ODdjNzdhOC8iLCAidGFza19pZCI6ICIyOWVlNGJmYy0wMDcxLTQzMjMt
+        OWU3MS0wNTVmODg3Yzc3YTgifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1
+        bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwg
+        InNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRl
+        cl9pZCI6IHsiJG9pZCI6ICI1NmM2NjE1YmRlMDQwMzY4OTI5MjU4YzYifSwg
+        ImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0
+        cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjI3
+        OjA3WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMTlUMDA6Mjc6MDdaIiwgImltcG9ydGVyX3R5cGVfaWQi
+        OiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3Vt
+        bWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNv
+        bXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRl
+        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwg
+        ImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0
+        ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjYxNWJkZTA0MDM2YTI3YzBjMWZi
+        IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAi
+        aXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3Rv
+        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
+        bV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
+        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY2MTVi
+        YmQ5YjcyZTQwYzM1MWVkMiJ9LCAiaWQiOiAiNTZjNjYxNWJiZDliNzJlNDBj
+        MzUxZWQyIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJw
+        dWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6
+        ICIvcHVscC9hcGkvdjIvdGFza3MvMzFiOTU2ZTQtYjE3NS00ZTY1LTgyZDgt
+        MjFlYzgzODE3YThjLyIsICJ0YXNrX2lkIjogIjMxYjk1NmU0LWIxNzUtNGU2
+        NS04MmQ4LTIxZWM4MzgxN2E4YyIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRv
+        cnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90
+        aW1lIjogIjIwMTYtMDItMTlUMDA6Mjc6MTFaIiwgIl9ucyI6ICJ0YXNrX3N0
+        YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6Mjc6MTBaIiwg
+        InRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzVmM2E0NDAyLTUzNTQtNGMwNy1hY2Iw
+        LTRjNmM1NDlmNThmNi8iLCAidGFza19pZCI6ICI1ZjNhNDQwMi01MzU0LTRj
+        MDctYWNiMC00YzZjNTQ5ZjU4ZjYifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
+        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjog
+        MCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBs
+        ZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBv
+        cnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NjE1ZWRlMDQwMzY4OTEzZjFkNjci
+        fSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAw
+        OjI3OjEwWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxl
+        dGVkIjogIjIwMTYtMDItMTlUMDA6Mjc6MTFaIiwgImltcG9ydGVyX3R5cGVf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAi
+        c3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVw
+        ZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjYxNWZkZTA0MDM2YTI3YzBj
+        MjAwIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAw
+        LCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBt
+        X3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAi
+        ZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVt
+        c190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzY2
+        MTVlYmQ5YjcyZTQwYzM1MWVlNCJ9LCAiaWQiOiAiNTZjNjYxNWViZDliNzJl
+        NDBjMzUxZWU0In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6
+        ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJl
+        ZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNjlmNDdkMDEtYTE4Mi00ZTkyLTg1
+        NGYtZjNiYWM5NGE5N2VkLyIsICJ0YXNrX2lkIjogIjY5ZjQ3ZDAxLWExODIt
+        NGU5Mi04NTRmLWYzYmFjOTRhOTdlZCIsICJ0YWdzIjogWyJwdWxwOnJlcG9z
+        aXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTYtMDItMTlUMDA6Mjc6MTNaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6Mjc6MTNa
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hy
+        ZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzlmYWE3NWE4LThmNTUtNGU1Ni05
+        ZDY1LTZkMDcyNDVjMjIzZS8iLCAidGFza19pZCI6ICI5ZmFhNzVhOC04ZjU1
+        LTRlNTYtOWQ2NS02ZDA3MjQ1YzIyM2UifV0sICJwcm9ncmVzc19yZXBvcnQi
+        OiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
+        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFs
+        IjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21w
+        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0
+        ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJp
+        bXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NjE2MWRlMDQwMzY4OTI5MjU4
+        Y2QifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8x
+        NyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE5
+        VDAwOjI3OjEzWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29t
+        cGxldGVkIjogIjIwMTYtMDItMTlUMDA6Mjc6MTNaIiwgImltcG9ydGVyX3R5
+        cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxs
+        LCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
+        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwg
+        InVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjYxNjFkZTA0MDM2YTI3
+        YzBjMjA1IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwi
+        OiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsi
+        cnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAw
+        LCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29t
+        cHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJp
+        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2
+        YzY2MTYxYmQ5YjcyZTQwYzM1MWVmNiJ9LCAiaWQiOiAiNTZjNjYxNjFiZDli
+        NzJlNDBjMzUxZWY2In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlw
+        ZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJf
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZTdjNmFmNmUtMzc0YS00Njhj
+        LWI2ZTUtMGI2NGMwYjllOWUwLyIsICJ0YXNrX2lkIjogImU3YzZhZjZlLTM3
+        NGEtNDY4Yy1iNmU1LTBiNjRjMGI5ZTllMCIsICJ0YWdzIjogWyJwdWxwOnJl
+        cG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZp
+        bmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6Mjc6MTZaIiwgIl9ucyI6ICJ0
+        YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6Mjc6
+        MTZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3si
+        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzg4NDBiNmI2LThiODYtNDNh
+        Zi05ZTRkLWI5YzIxZWJhMWQyNS8iLCAidGFza19pZCI6ICI4ODQwYjZiNi04
+        Yjg2LTQzYWYtOWU0ZC1iOWMyMWViYTFkMjUifV0sICJwcm9ncmVzc19yZXBv
+        cnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3Rv
+        dGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJj
+        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
+        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NjE2NGRlMDQwMzY4OTI5
+        MjU4ZDUifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9y
+        YV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAy
+        LTE5VDAwOjI3OjE2WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAi
+        Y29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6Mjc6MTZaIiwgImltcG9ydGVy
+        X3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBu
+        dWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50Ijog
+        MCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjYxNjRkZTA0MDM2
+        YTI3YzBjMjBhIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90
+        YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAi
+        Y29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNh
+        dGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjog
+        eyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjog
+        IjU2YzY2MTY0YmQ5YjcyZTQwYzM1MWYwOCJ9LCAiaWQiOiAiNTZjNjYxNjRi
+        ZDliNzJlNDBjMzUxZjA4In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tf
+        dHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIs
+        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvYTBhZTE1MDAtYzNiZS00
+        OTFlLTg3MDMtMzJiNjk5MzAwMWI5LyIsICJ0YXNrX2lkIjogImEwYWUxNTAw
+        LWMzYmUtNDkxZS04NzAzLTMyYjY5OTMwMDFiOSIsICJ0YWdzIjogWyJwdWxw
+        OnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwg
+        ImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6Mjc6MTlaIiwgIl9ucyI6
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlUMDA6
+        Mjc6MTlaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        W3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2JiOTY3MGYxLWY5N2Et
+        NGMxMy1iZGZkLWM3YTc2OWZlNGVlNC8iLCAidGFza19pZCI6ICJiYjk2NzBm
+        MS1mOTdhLTRjMTMtYmRmZC1jN2E3NjlmZTRlZTQifV0sICJwcm9ncmVzc19y
+        ZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNf
+        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
+        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXpl
+        X3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlv
+        ZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2Vz
+        cyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NjE2NmRlMDQwMzY4
+        OTEzZjFkNzIifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZl
+        ZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2
+        LTAyLTE5VDAwOjI3OjE5WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMi
+        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6Mjc6MTlaIiwgImltcG9y
+        dGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2Ui
+        OiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVy
+        Z2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3Ry
+        aWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50
+        IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjYxNjdkZTA0
+        MDM2YTI3YzBjMjBmIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVf
+        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
+        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
+        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
+        IjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
+        IjogIjU2YzY2MTY3YmQ5YjcyZTQwYzM1MWYxYSJ9LCAiaWQiOiAiNTZjNjYx
+        NjdiZDliNzJlNDBjMzUxZjFhIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRh
+        c2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3lu
+        YyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZWZiYmUzZGUtZjNh
+        Yi00ODVkLWJhNDEtY2MwMjgxNzA1NjQyLyIsICJ0YXNrX2lkIjogImVmYmJl
+        M2RlLWYzYWItNDg1ZC1iYTQxLWNjMDI4MTcwNTY0MiIsICJ0YWdzIjogWyJw
+        dWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMi
+        XSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6Mjc6MjFaIiwgIl9u
+        cyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTlU
+        MDA6Mjc6MjFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        IjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzcwOGFjNDEyLTFi
+        MjYtNDhkNC1iMjFiLTlkYzRmZWMyMmNjZC8iLCAidGFza19pZCI6ICI3MDhh
+        YzQxMi0xYjI2LTQ4ZDQtYjIxYi05ZGM0ZmVjMjJjY2QifV0sICJwcm9ncmVz
+        c19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRl
+        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJz
+        aXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0Ijog
+        MH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1
+        cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRp
+        b24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NjE2OWRlMDQw
+        MzY4OTI5MjU4ZTAifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTE5VDAwOjI3OjIxWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6Mjc6MjFaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjYxNjlk
+        ZTA0MDM2YTI3YzBjMjE0IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2YzY2MTY5YmQ5YjcyZTQwYzM1MWYyYyJ9LCAiaWQiOiAiNTZj
+        NjYxNjliZDliNzJlNDBjMzUxZjJjIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwg
+        InRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMu
+        c3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNzEzOTBjZWQt
+        Y2QyYS00MDA1LWEyZGQtOWZhNGM3ZGU3MzM1LyIsICJ0YXNrX2lkIjogIjcx
+        MzkwY2VkLWNkMmEtNDAwNS1hMmRkLTlmYTRjN2RlNzMzNSIsICJ0YWdzIjog
+        WyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5
+        bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6Mjc6MjVaIiwg
+        Il9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDIt
+        MTlUMDA6Mjc6MjRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rh
+        c2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzUzYzJhYjI4
+        LTdiMWMtNGJhOC05NWQzLTNiODczM2Y4ZmJlYi8iLCAidGFza19pZCI6ICI1
+        M2MyYWIyOC03YjFjLTRiYTgtOTVkMy0zYjg3MzNmOGZiZWIifV0sICJwcm9n
+        cmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsi
+        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJw
+        bV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0s
+        ICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0
+        IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdl
+        X2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
+        c3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NjE2Y2Rl
+        MDQwMzY4OTM3Yzc5ZGEifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lk
+        IjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6
+        ICIyMDE2LTAyLTE5VDAwOjI3OjI0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jl
+        c3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6Mjc6MjVaIiwg
+        ImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21l
+        c3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVk
+        X2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNjYx
+        NmRkZTA0MDM2YTI3YzBjMjE5IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7
+        InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3Rh
+        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAi
+        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
+        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxz
+        IjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJn
+        ZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
+        YnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJl
+        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
+        eyIkb2lkIjogIjU2YzY2MTZjYmQ5YjcyZTQwYzM1MWYzZSJ9LCAiaWQiOiAi
+        NTZjNjYxNmNiZDliNzJlNDBjMzUxZjNlIn0sIHsiZXhjZXB0aW9uIjogbnVs
+        bCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5
+        bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvYjM4NmMw
+        NjItZDEyMi00MjRkLWFkODMtOWY1MjMxODM1ZTYxLyIsICJ0YXNrX2lkIjog
+        ImIzODZjMDYyLWQxMjItNDI0ZC1hZDgzLTlmNTIzMTgzNWU2MSIsICJ0YWdz
+        IjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9u
+        OnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6Mjc6Mjda
+        IiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYt
+        MDItMTlUMDA6Mjc6MjdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
+        X3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzE1MDQw
+        NDMyLTM2YWEtNGU0Mi04OGMyLWYzMWRjN2E1NTBjZS8iLCAidGFza19pZCI6
+        ICIxNTA0MDQzMi0zNmFhLTRlNDItODhjMi1mMzFkYzdhNTUwY2UifV0sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwg
+        InJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
+        MH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
+        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
+        cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
+        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2NjE2
+        ZmRlMDQwMzY4OTEzZjFkN2MifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
+        ZCI6ICIyMDE2LTAyLTE5VDAwOjI3OjI3WiIsICJfbnMiOiAicmVwb19zeW5j
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6Mjc6Mjda
+        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZj
+        NjYxNmZkZTA0MDM2YTI3YzBjMjFlIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
+        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
+        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
+        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
+        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
+        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
+        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
+        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjU2YzY2MTZmYmQ5YjcyZTQwYzM1MWY1MCJ9LCAiaWQi
+        OiAiNTZjNjYxNmZiZDliNzJlNDBjMzUxZjUwIn0sIHsiZXhjZXB0aW9uIjog
+        bnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBv
+        LnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvYjMy
+        OWU0OWMtNDE2NS00YWM2LThjYzUtNjBiOGQ3NGZkODI1LyIsICJ0YXNrX2lk
+        IjogImIzMjllNDljLTQxNjUtNGFjNi04Y2M1LTYwYjhkNzRmZDgyNSIsICJ0
+        YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0
+        aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6Mjc6
+        MzFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTYtMDItMTlUMDA6Mjc6MzBaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzU0
+        MTRjNDU2LTdkYzItNDBjOC1hYzNkLTg5NjdmNjRhZjhiZi8iLCAidGFza19p
+        ZCI6ICI1NDE0YzQ1Ni03ZGMyLTQwYzgtYWMzZC04OTY3ZjY0YWY4YmYifV0s
+        ICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVu
+        dCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjog
+        MCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25l
+        IjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVt
+        c19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        InB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJk
+        aXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAw
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM2
+        NjE3MmRlMDQwMzY4OTM3Yzc5ZTIifSwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTAyLTE5VDAwOjI3OjMwWiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6Mjc6
+        MzFaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZjNjYxNzNkZTA0MDM2YTI3YzBjMjIzIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU2YzY2MTcyYmQ5YjcyZTQwYzM1MWY2MiJ9LCAi
+        aWQiOiAiNTZjNjYxNzJiZDliNzJlNDBjMzUxZjYyIn0sIHsiZXhjZXB0aW9u
+        IjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5y
+        ZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3Mv
+        ZmQ5MzBjMGQtM2ZjYy00NDI5LTllZmYtZmQ5Y2MyZDJmMzQ2LyIsICJ0YXNr
+        X2lkIjogImZkOTMwYzBkLTNmY2MtNDQyOS05ZWZmLWZkOWNjMmQyZjM0NiIs
+        ICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6
+        YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTlUMDA6
+        Mjc6MzRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
+        IjIwMTYtMDItMTlUMDA6Mjc6MzNaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
+        cGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tz
+        LzRhZjk3NWM1LWZmNDQtNDM3ZC05ZDNiLTk0MDQ1YzU4ZDEwYy8iLCAidGFz
+        a19pZCI6ICI0YWY5NzVjNS1mZjQ0LTQzN2QtOWQzYi05NDA0NWM1OGQxMGMi
+        fV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29u
+        dGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
+        IjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9k
+        b25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJp
+        dGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5p
+        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJy
+        ZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1
+        NmM2NjE3NWRlMDQwMzY4OTEzZjFkODIifSwgImV4Y2VwdGlvbiI6IG51bGws
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAi
+        c3RhcnRlZCI6ICIyMDE2LTAyLTE5VDAwOjI3OjMzWiIsICJfbnMiOiAicmVw
+        b19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTlUMDA6
+        Mjc6MzRaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwg
+        ImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUs
+        ICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQi
+        OiAiNTZjNjYxNzZkZTA0MDM2YTI3YzBjMjI4IiwgImRldGFpbHMiOiB7ImNv
+        bnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xl
+        ZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
+        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJv
+        cl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0
+        IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
+        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YzY2MTc1YmQ5YjcyZTQwYzM1MWY3NCJ9
+        LCAiaWQiOiAiNTZjNjYxNzViZDliNzJlNDBjMzUxZjc0In0sIHsiZXhjZXB0
+        aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vy
+        cy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFz
+        a3MvODgxOTI0M2UtOGYyMS00NDcxLWIyNDQtMjI4NjFmNDQxZTUwLyIsICJ0
+        YXNrX2lkIjogIjg4MTkyNDNlLThmMjEtNDQ3MS1iMjQ0LTIyODYxZjQ0MWU1
+        MCIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1
+        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNU
+        MTY6Mzc6MThaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
+        IjogIjIwMTYtMDItMjNUMTY6Mzc6MThaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2U5NjBiYjk5LTNlMTMtNGM5Mi1iNTBiLWU4ZDdkMjA0YzI2Ni8iLCAi
+        dGFza19pZCI6ICJlOTYwYmI5OS0zZTEzLTRjOTItYjUwYi1lOGQ3ZDIwNGMy
+        NjYifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsi
+        Y29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3Rv
+        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
+        bV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAs
+        ICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xl
+        ZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
+        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJm
+        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
+        eyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6
+        ICI1NmNjOGFiZGRlMDQwMzNmNDFkMmEzMzIifSwgImV4Y2VwdGlvbiI6IG51
+        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
+        LCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjM3OjE4WiIsICJfbnMiOiAi
+        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNU
+        MTY6Mzc6MThaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVu
+        dCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50Ijog
+        MTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAi
+        aWQiOiAiNTZjYzhhYmVkZTA0MDMwODk3NThhNzFkIiwgImRldGFpbHMiOiB7
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4YWJlOTg5MDU0ZmM0OGJhMmI1
+        ZiJ9LCAiaWQiOiAiNTZjYzhhYmU5ODkwNTRmYzQ4YmEyYjVmIn0sIHsiZXhj
+        ZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5h
+        Z2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIv
+        dGFza3MvMTE1NWE4NjctOGFhMy00YzkzLTk3OGQtY2M4ZjhkMTE5OWMyLyIs
+        ICJ0YXNrX2lkIjogIjExNTVhODY3LThhYTMtNGM5My05NzhkLWNjOGY4ZDEx
+        OTljMiIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3Iiwg
+        InB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDIt
+        MjNUMTY6Mzc6MzBaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTYtMDItMjNUMTY6Mzc6MzBaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L3Rhc2tzL2Y5NjYxMjk4LTFhMzUtNDI2MC1iMTQ0LTY0MTI0NWQ0Y2ZmOS8i
+        LCAidGFza19pZCI6ICJmOTY2MTI5OC0xYTM1LTQyNjAtYjE0NC02NDEyNDVk
+        NGNmZjkifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6
+        IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklO
+        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBt
+        X3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAi
+        ZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6
+        IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0
+        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1z
+        X2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6
+        ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0
+        IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9p
+        ZCI6ICI1NmNjOGFjYWRlMDQwMzNmNDI2MmNhMGUifSwgImV4Y2VwdGlvbiI6
+        IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjM3OjMwWiIsICJfbnMi
+        OiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDIt
+        MjNUMTY6Mzc6MzBaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9y
+        dGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29u
+        dGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
+        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50
+        IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAw
+        LCAiaWQiOiAiNTZjYzhhY2FkZTA0MDMwODk3NThhNzI3IiwgImRldGFpbHMi
+        OiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6
+        IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJz
+        aXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJw
+        bV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0s
+        ICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVt
+        c19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3Ii
+        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4YWNhOTg5MDU0ZmM0OGJh
+        MmI4OSJ9LCAiaWQiOiAiNTZjYzhhY2E5ODkwNTRmYzQ4YmEyYjg5In0sIHsi
+        ZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5t
+        YW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkv
+        djIvdGFza3MvYWJmZDVjNmUtNzU0NC00ZTBjLWI3MTAtOTY3YTA3N2JmMDg2
+        LyIsICJ0YXNrX2lkIjogImFiZmQ1YzZlLTc1NDQtNGUwYy1iNzEwLTk2N2Ew
+        NzdiZjA4NiIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3
+        IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYt
+        MDItMjNUMTY6Mzc6MzRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFy
+        dF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzc6MzNaIiwgInRyYWNlYmFjayI6
+        IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBp
+        L3YyL3Rhc2tzLzA4NjNlNDk2LTdjM2ItNGE2MS1hN2UyLWQ0NTQwZWExOTg4
+        ZS8iLCAidGFza19pZCI6ICIwODYzZTQ5Ni03YzNiLTRhNjEtYTdlMi1kNDU0
+        MGVhMTk4OGUifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRl
+        ciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsi
+        cnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAw
+        LCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVm
+        dCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0
+        ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0
+        ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsi
+        JG9pZCI6ICI1NmNjOGFjZGRlMDQwMzNmNDM1MTRlYmYifSwgImV4Y2VwdGlv
+        biI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2si
+        OiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjM3OjMzWiIsICJf
+        bnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYt
+        MDItMjNUMTY6Mzc6MzRaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2lt
+        cG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsi
+        Y29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2Nv
+        dW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQi
+        OiAwLCAiaWQiOiAiNTZjYzhhY2VkZTA0MDMwODk3NThhNzJjIiwgImRldGFp
+        bHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVm
+        dCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwg
+        InJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
+        MH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
+        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4YWNkOTg5MDU0ZmM0
+        OGJhMmI5YyJ9LCAiaWQiOiAiNTZjYzhhY2Q5ODkwNTRmYzQ4YmEyYjljIn0s
+        IHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZl
+        ci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNjE1YzM4ZWYtOTQ5NS00YmU4LWI5N2YtMmYzYmJlMThi
+        NzRiLyIsICJ0YXNrX2lkIjogIjYxNWMzOGVmLTk0OTUtNGJlOC1iOTdmLTJm
+        M2JiZTE4Yjc0YiIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3Jh
+        XzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIw
+        MTYtMDItMjNUMTY6Mzc6MzdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
+        dGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzc6MzdaIiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAv
+        YXBpL3YyL3Rhc2tzL2UzZDdmYTQ1LWI5Y2YtNGY2NC05ZjhhLWFkZTFiYTEz
+        OWRkZC8iLCAidGFza19pZCI6ICJlM2Q3ZmE0NS1iOWNmLTRmNjQtOWY4YS1h
+        ZGUxYmExMzlkZGQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJz
+        dGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
+        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6
+        IHsiJG9pZCI6ICI1NmNjOGFkMGRlMDQwMzNmNDFkMmEzNDYifSwgImV4Y2Vw
+        dGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjM3OjM3WiIs
+        ICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
+        MTYtMDItMjNUMTY6Mzc6MzdaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVt
+        X2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6
+        IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVk
+        X2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291
+        bnQiOiAwLCAiaWQiOiAiNTZjYzhhZDFkZTA0MDMwODk3NThhNzMxIiwgImRl
+        dGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNf
+        bGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjog
+        MCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25l
+        IjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4YWQxOTg5MDU0
+        ZmM0OGJhMmJhZiJ9LCAiaWQiOiAiNTZjYzhhZDE5ODkwNTRmYzQ4YmEyYmFm
+        In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNl
+        cnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVs
+        cC9hcGkvdjIvdGFza3MvODFlYTkzNGMtNjFlYS00MWRjLWJlMzAtYzFmMjIx
+        MDdiNDBjLyIsICJ0YXNrX2lkIjogIjgxZWE5MzRjLTYxZWEtNDFkYy1iZTMw
+        LWMxZjIyMTA3YjQwYyIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVk
+        b3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTYtMDItMjNUMTY6Mzc6NDBaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzc6NDBaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzLzE2ZmUyNzhkLTFjYmEtNDYxMS05MWU3LTkyNDNl
+        Y2EzZmQ2Ny8iLCAidGFza19pZCI6ICIxNmZlMjc4ZC0xY2JhLTQ2MTEtOTFl
+        Ny05MjQzZWNhM2ZkNjcifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
+        ZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9p
+        ZCI6IHsiJG9pZCI6ICI1NmNjOGFkNGRlMDQwMzNmNDM1MTRlY2EifSwgImV4
+        Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFj
+        ZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjM3OjQw
+        WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjog
+        IjIwMTYtMDItMjNUMTY6Mzc6NDBaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFy
+        eSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFk
+        ZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRf
+        Y291bnQiOiAwLCAiaWQiOiAiNTZjYzhhZDRkZTA0MDMwODk3NThhNzM2Iiwg
+        ImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRl
+        bXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
+        IjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9k
+        b25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
+        bCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4YWQ0OTg5
+        MDU0ZmM0OGJhMmJjMiJ9LCAiaWQiOiAiNTZjYzhhZDQ5ODkwNTRmYzQ4YmEy
+        YmMyIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxw
+        LnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIv
+        cHVscC9hcGkvdjIvdGFza3MvZWI2YjcwODktMzQzNC00Y2U1LWFmZmEtNDNm
+        NGVhNTk4MmIwLyIsICJ0YXNrX2lkIjogImViNmI3MDg5LTM0MzQtNGNlNS1h
+        ZmZhLTQzZjRlYTU5ODJiMCIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6
+        RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1l
+        IjogIjIwMTYtMDItMjNUMTY6Mzc6NDRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1
+        cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzc6NDNaIiwgInRy
+        YWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAi
+        L3B1bHAvYXBpL3YyL3Rhc2tzLzc0NGFiNjg4LTYxYmYtNDkzZS1iYjNiLWVj
+        N2Y1MTYzZTI3MC8iLCAidGFza19pZCI6ICI3NDRhYjY4OC02MWJmLTQ5M2Ut
+        YmIzYi1lYzdmNTE2M2UyNzAifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1
+        bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwg
+        InNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRl
+        cl9pZCI6IHsiJG9pZCI6ICI1NmNjOGFkN2RlMDQwMzNmNDI2MmNhMTcifSwg
+        ImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0
+        cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjM3
+        OjQzWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMjNUMTY6Mzc6NDRaIiwgImltcG9ydGVyX3R5cGVfaWQi
+        OiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3Vt
+        bWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNv
+        bXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRl
+        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwg
+        ImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0
+        ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhhZDhkZTA0MDMwODk3NThhNzNi
+        IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAi
+        aXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3Rv
+        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
+        bV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
+        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4YWQ3
+        OTg5MDU0ZmM0OGJhMmJkNSJ9LCAiaWQiOiAiNTZjYzhhZDc5ODkwNTRmYzQ4
+        YmEyYmQ1In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJw
+        dWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6
+        ICIvcHVscC9hcGkvdjIvdGFza3MvZTc5N2Y2ODktYzQ5OS00ZGIwLThkOWEt
+        ZTZiYTE0YjE4NmY0LyIsICJ0YXNrX2lkIjogImU3OTdmNjg5LWM0OTktNGRi
+        MC04ZDlhLWU2YmExNGIxODZmNCIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRv
+        cnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90
+        aW1lIjogIjIwMTYtMDItMjNUMTY6Mzc6NDdaIiwgIl9ucyI6ICJ0YXNrX3N0
+        YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzc6NDdaIiwg
+        InRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzE2MmM1NmM4LTI5ZjUtNDc3NS04Y2I2
+        LTEzZmYxNjVhM2M4MS8iLCAidGFza19pZCI6ICIxNjJjNTZjOC0yOWY1LTQ3
+        NzUtOGNiNi0xM2ZmMTY1YTNjODEifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
+        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjog
+        MCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBs
+        ZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBv
+        cnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGFkYmRlMDQwMzNmNDI2MmNhMWUi
+        fSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2
+        OjM3OjQ3WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxl
+        dGVkIjogIjIwMTYtMDItMjNUMTY6Mzc6NDdaIiwgImltcG9ydGVyX3R5cGVf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAi
+        c3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVw
+        ZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhhZGJkZTA0MDMwODk3NThh
+        NzQwIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAw
+        LCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBt
+        X3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAi
+        ZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVt
+        c190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4
+        YWRiOTg5MDU0ZmM0OGJhMmJlOCJ9LCAiaWQiOiAiNTZjYzhhZGI5ODkwNTRm
+        YzQ4YmEyYmU4In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6
+        ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJl
+        ZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvYzkwZGE1ZWItMDQ3MS00MzRmLWJk
+        NGUtM2QwZmNhY2I1YzM0LyIsICJ0YXNrX2lkIjogImM5MGRhNWViLTA0NzEt
+        NDM0Zi1iZDRlLTNkMGZjYWNiNWMzNCIsICJ0YWdzIjogWyJwdWxwOnJlcG9z
+        aXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzc6NTBaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzc6NTBa
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hy
+        ZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzk0NmM0MzRhLTRjYjYtNDA4MC04
+        NDBkLWE3MjliMmE4OWQ5ZC8iLCAidGFza19pZCI6ICI5NDZjNDM0YS00Y2I2
+        LTQwODAtODQwZC1hNzI5YjJhODlkOWQifV0sICJwcm9ncmVzc19yZXBvcnQi
+        OiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
+        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFs
+        IjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21w
+        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0
+        ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJp
+        bXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGFkZWRlMDQwMzNmNDM1MTRl
+        ZDcifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8x
+        NyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIz
+        VDE2OjM3OjUwWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29t
+        cGxldGVkIjogIjIwMTYtMDItMjNUMTY6Mzc6NTBaIiwgImltcG9ydGVyX3R5
+        cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxs
+        LCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
+        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwg
+        InVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhhZGVkZTA0MDMwODk3
+        NThhNzQ1IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwi
+        OiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsi
+        cnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAw
+        LCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29t
+        cHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJp
+        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2
+        Y2M4YWRlOTg5MDU0ZmM0OGJhMmJmYiJ9LCAiaWQiOiAiNTZjYzhhZGU5ODkw
+        NTRmYzQ4YmEyYmZiIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlw
+        ZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJf
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvYzc0YjQ4ZWYtNWQwMi00MGYx
+        LWFkNDQtMTk2ZTY5NzZmMWVmLyIsICJ0YXNrX2lkIjogImM3NGI0OGVmLTVk
+        MDItNDBmMS1hZDQ0LTE5NmU2OTc2ZjFlZiIsICJ0YWdzIjogWyJwdWxwOnJl
+        cG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZp
+        bmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzg6MDVaIiwgIl9ucyI6ICJ0
+        YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzg6
+        MDVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3si
+        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzc2Y2ZmZTYzLTZlNTEtNDkx
+        NC05Y2E3LTY4OWQxN2E3MDg0ZC8iLCAidGFza19pZCI6ICI3NmNmZmU2My02
+        ZTUxLTQ5MTQtOWNhNy02ODlkMTdhNzA4NGQifV0sICJwcm9ncmVzc19yZXBv
+        cnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3Rv
+        dGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJj
+        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
+        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGFlZGRlMDQwMzNmNDFk
+        MmEzNmQifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9y
+        YV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAy
+        LTIzVDE2OjM4OjA1WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAi
+        Y29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6Mzg6MDVaIiwgImltcG9ydGVy
+        X3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBu
+        dWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50Ijog
+        MCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhhZWRkZTA0MDMw
+        ODk3NThhNzRhIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90
+        YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAi
+        Y29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNh
+        dGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjog
+        eyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjog
+        IjU2Y2M4YWVkOTg5MDU0ZmM0OGJhMmMxNyJ9LCAiaWQiOiAiNTZjYzhhZWQ5
+        ODkwNTRmYzQ4YmEyYzE3In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tf
+        dHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIs
+        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMDk2ZTlmMWYtNjc0OS00
+        OTFmLThhZGEtNDQxOTJmOWZkY2EzLyIsICJ0YXNrX2lkIjogIjA5NmU5ZjFm
+        LTY3NDktNDkxZi04YWRhLTQ0MTkyZjlmZGNhMyIsICJ0YWdzIjogWyJwdWxw
+        OnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwg
+        ImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzg6MTJaIiwgIl9ucyI6
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6
+        Mzg6MTJaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        W3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2JiOGIwMmRiLTE1OTUt
+        NDJkMi05MjI1LTljNDY4ZGMyMDE5NS8iLCAidGFza19pZCI6ICJiYjhiMDJk
+        Yi0xNTk1LTQyZDItOTIyNS05YzQ2OGRjMjAxOTUifV0sICJwcm9ncmVzc19y
+        ZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNf
+        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
+        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXpl
+        X3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlv
+        ZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2Vz
+        cyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGFmNGRlMDQwMzNm
+        NDI2MmNhMzIifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZl
+        ZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2
+        LTAyLTIzVDE2OjM4OjEyWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMi
+        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6Mzg6MTJaIiwgImltcG9y
+        dGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2Ui
+        OiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVy
+        Z2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3Ry
+        aWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50
+        IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhhZjRkZTA0
+        MDMwODk3NThhNzU2IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVf
+        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
+        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
+        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
+        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
+        IjogIjU2Y2M4YWY0OTg5MDU0ZmM0OGJhMmMyYyJ9LCAiaWQiOiAiNTZjYzhh
+        ZjQ5ODkwNTRmYzQ4YmEyYzJjIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRh
+        c2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3lu
+        YyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMmFiYzQwOWQtMzZh
+        MC00Mzg2LWIwZWEtMTA5NTYyMWUxNDg1LyIsICJ0YXNrX2lkIjogIjJhYmM0
+        MDlkLTM2YTAtNDM4Ni1iMGVhLTEwOTU2MjFlMTQ4NSIsICJ0YWdzIjogWyJw
+        dWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMi
+        XSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzg6MTVaIiwgIl9u
+        cyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNU
+        MTY6Mzg6MTVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        IjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2U5ZTQ3YzVhLWM2
+        MWMtNGRmMC1hOTY2LTA2OTRkYTkwZjU0NC8iLCAidGFza19pZCI6ICJlOWU0
+        N2M1YS1jNjFjLTRkZjAtYTk2Ni0wNjk0ZGE5MGY1NDQifV0sICJwcm9ncmVz
+        c19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRl
+        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJz
+        aXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0Ijog
+        MH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1
+        cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRp
+        b24iOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGFmN2RlMDQw
+        MzNmNDI2MmNhMzcifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjM4OjE1WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6Mzg6MTVaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhhZjdk
+        ZTA0MDMwODk3NThhNzYxIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4YWY3OTg5MDU0ZmM0OGJhMmMzZSJ9LCAiaWQiOiAiNTZj
+        YzhhZjc5ODkwNTRmYzQ4YmEyYzNlIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwg
+        InRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMu
+        c3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMDU4ODQ0ZWMt
+        ZGE0NS00ZmMyLWE2ZDEtOWMyZGY0OTAzNzY3LyIsICJ0YXNrX2lkIjogIjA1
+        ODg0NGVjLWRhNDUtNGZjMi1hNmQxLTljMmRmNDkwMzc2NyIsICJ0YWdzIjog
+        WyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5
+        bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzg6MThaIiwg
+        Il9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDIt
+        MjNUMTY6Mzg6MThaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rh
+        c2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzNhNTU5NTk3
+        LTk5YzEtNDRlMi1hNGU1LWY4ZmFmOWI3MTdmMi8iLCAidGFza19pZCI6ICIz
+        YTU1OTU5Ny05OWMxLTQ0ZTItYTRlNS1mOGZhZjliNzE3ZjIifV0sICJwcm9n
         cmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsi
         aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
         ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJw
@@ -6097,113 +10090,63 @@ http_interactions:
         IiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVy
         cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
         dGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBhYmVk
-        LnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJz
-        dWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YzRkMWM5NWNh
-        MDEzMTg0ZjZkYjBlZSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQi
-        OiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjog
-        IjIwMTYtMDItMTdUMjA6MDI6MTdaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVz
-        dWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0xN1QyMDowMjoxOFoiLCAi
-        aW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJyb3JfbWVz
-        c2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAxNSwgInJlbW92ZWRf
-        Y291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmM0ZDFj
-        YTVjYTAxMzE4ZjMwY2FmZWIiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsi
-        c2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFs
-        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJk
-        ZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJw
-        bV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMi
-        OiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdl
-        X2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
-        dXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNTZjNGQxYzlkYjAzYzJiYTdjOTFiMTg0In0sICJpZCI6ICI1
-        NmM0ZDFjOWRiMDNjMmJhN2M5MWIxODQifSwgeyJleGNlcHRpb24iOiBudWxs
-        LCAidGFza190eXBlIjogInB1bHAuc2VydmVyLm1hbmFnZXJzLnJlcG8uc3lu
-        Yy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy80NGIyYjVi
-        ZC0wMzA5LTQ0ZGYtODQ1Zi00MzYzMGQ1NzAzNGYvIiwgInRhc2tfaWQiOiAi
-        NDRiMmI1YmQtMDMwOS00NGRmLTg0NWYtNDM2MzBkNTcwMzRmIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246
-        c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0xN1QyMDowMjoyMVoi
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0xN1QyMDowMjoyMFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZDJlYzk0
-        YjQtMGUxOS00Nzk3LWFiOTUtM2EyZmZjMmExMzI1LyIsICJ0YXNrX2lkIjog
-        ImQyZWM5NGI0LTBlMTktNDc5Ny1hYjk1LTNhMmZmYzJhMTMyNSJ9XSwgInBy
-        b2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVyIjogeyJjb250ZW50Ijog
-        eyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAi
-        cnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAw
-        fSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0IjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVy
-        Z2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3Ry
-        aWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFi
-        ZWQudXNlcnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0Ijog
-        InN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZjNGQxY2M1
-        Y2EwMTMxODRlMjhmYmEwIn0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQi
-        OiAiMjAxNi0wMi0xN1QyMDowMjoyMFoiLCAiX25zIjogInJlcG9fc3luY19y
-        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTE3VDIwOjAyOjIxWiIs
-        ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9t
-        ZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3Zl
-        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YzRk
-        MWNkNWNhMDEzMThmMzBjYWZmMCIsICJkZXRhaWxzIjogeyJjb250ZW50Ijog
-        eyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90
-        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwg
-        ImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJk
-        cnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWls
-        cyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVy
-        Z2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3Ry
-        aWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NmM0ZDFjY2RiMDNjMmJhN2M5MWIxOTYifSwgImlkIjog
-        IjU2YzRkMWNjZGIwM2MyYmE3YzkxYjE5NiJ9LCB7ImV4Y2VwdGlvbiI6IG51
-        bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5z
-        eW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzA0NjQz
-        YmU1LTJkOTYtNGE0My1iYjdmLTU4YzIxMGIyMWUzZi8iLCAidGFza19pZCI6
-        ICIwNDY0M2JlNS0yZDk2LTRhNDMtYmI3Zi01OGMyMTBiMjFlM2YiLCAidGFn
-        cyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlv
-        bjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjAyOjEy
-        WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
-        LTAyLTE3VDIwOjAyOjEyWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
-        ZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9jMmIx
-        YjRmNi00ODNlLTQ5NWYtOTBmNy02OTVhMTI1YmYwMmIvIiwgInRhc2tfaWQi
-        OiAiYzJiMWI0ZjYtNDgzZS00OTVmLTkwZjctNjk1YTEyNWJmMDJiIn1dLCAi
-        cHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQi
-        OiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRlbXNf
-        bGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAic3RhdGUiOiAiZmluaXNoZWQi
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
-        YWJlZC51c2Vyc3lzLnJlZGhhdC5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM0ZDFj
-        MzVjYTAxMzE4NGY2ZGIwZTkifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
+        c3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGFmYWRl
+        MDQwMzNmNDI2MmNhM2MifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lk
+        IjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6
+        ICIyMDE2LTAyLTIzVDE2OjM4OjE4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jl
+        c3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6Mzg6MThaIiwg
+        ImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21l
+        c3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVk
+        X2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhh
+        ZmFkZTA0MDMwODk3NThhNzZjIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7
+        InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3Rh
+        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAi
+        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
+        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxz
+        IjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJn
+        ZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
+        YnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJl
+        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
+        eyIkb2lkIjogIjU2Y2M4YWZhOTg5MDU0ZmM0OGJhMmM1MCJ9LCAiaWQiOiAi
+        NTZjYzhhZmE5ODkwNTRmYzQ4YmEyYzUwIn0sIHsiZXhjZXB0aW9uIjogbnVs
+        bCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5
+        bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZTM5NmJm
+        MzQtNzY2NC00MWJmLWFiN2ItNzM0ODIxMTYwY2ZlLyIsICJ0YXNrX2lkIjog
+        ImUzOTZiZjM0LTc2NjQtNDFiZi1hYjdiLTczNDgyMTE2MGNmZSIsICJ0YWdz
+        IjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9u
+        OnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzg6MjFa
+        IiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYt
+        MDItMjNUMTY6Mzg6MjFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
+        X3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzI3MThk
+        ZTUzLTE5MzMtNDNiMy1hYWQyLWVkNzVhYjdhNTgxOC8iLCAidGFza19pZCI6
+        ICIyNzE4ZGU1My0xOTMzLTQzYjMtYWFkMi1lZDc1YWI3YTU4MTgifV0sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwg
+        InJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
+        MH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
+        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
+        cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
+        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGFm
+        ZGRlMDQwMzNmNDI2MmNhNDEifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
         X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTE3VDIwOjAyOjEyWiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTdUMjA6MDI6MTJa
+        ZCI6ICIyMDE2LTAyLTIzVDE2OjM4OjIxWiIsICJfbnMiOiAicmVwb19zeW5j
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6Mzg6MjFa
         IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
         X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
         dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
@@ -6212,7 +10155,7 @@ http_interactions:
         cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
         dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
         dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZj
-        NGQxYzQ1Y2EwMTMxOGYzMGNhZmUxIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
+        YzhhZmRkZTA0MDMwODk3NThhNzc3IiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
         OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
         b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
         LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
@@ -6223,19 +10166,19 @@ http_interactions:
         U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
         ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
         IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YzRkMWMzZGIwM2MyYmE3YzkxYjE2MCJ9LCAiaWQi
-        OiAiNTZjNGQxYzNkYjAzYzJiYTdjOTFiMTYwIn0sIHsiZXhjZXB0aW9uIjog
+        IjogeyIkb2lkIjogIjU2Y2M4YWZkOTg5MDU0ZmM0OGJhMmM2MiJ9LCAiaWQi
+        OiAiNTZjYzhhZmQ5ODkwNTRmYzQ4YmEyYzYyIn0sIHsiZXhjZXB0aW9uIjog
         bnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBv
-        LnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMWU3
-        NWYxZDUtMjY3My00N2NlLThjMjItNDljNzZmMjA3ZWEzLyIsICJ0YXNrX2lk
-        IjogIjFlNzVmMWQ1LTI2NzMtNDdjZS04YzIyLTQ5Yzc2ZjIwN2VhMyIsICJ0
+        LnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvM2Nj
+        YWNhYmEtZDM1OS00NDBmLTk3OTMtODkzOTA2ZTVkNGI1LyIsICJ0YXNrX2lk
+        IjogIjNjY2FjYWJhLWQzNTktNDQwZi05NzkzLTg5MzkwNmU1ZDRiNSIsICJ0
         YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0
-        aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTdUMjA6MDI6
-        MTVaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTYtMDItMTdUMjA6MDI6MTRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
-        bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2Jj
-        YmRjYWRkLTRiMjQtNDdiYS1hYzdiLTUwMTZiYTQwMDcxMy8iLCAidGFza19p
-        ZCI6ICJiY2JkY2FkZC00YjI0LTQ3YmEtYWM3Yi01MDE2YmE0MDA3MTMifV0s
+        aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzg6
+        MjRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTYtMDItMjNUMTY6Mzg6MjRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2Y4
+        ODUyMTM5LWIxYTUtNGQwNy04NWIyLWRiMDI2OGE2MjNhNy8iLCAidGFza19p
+        ZCI6ICJmODg1MjEzOS1iMWE1LTRkMDctODViMi1kYjAyNjhhNjIzYTcifV0s
         ICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVu
         dCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjog
@@ -6248,964 +10191,13 @@ http_interactions:
         fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
         IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hl
         ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YzRk
-        MWM2NWNhMDEzMTg0ZGM4MTVhZSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMTdUMjA6MDI6MTRaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0xN1QyMDowMjox
-        NVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAxNSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        NmM0ZDFjNzVjYTAxMzE4ZjMwY2FmZTYiLCAiZGV0YWlscyI6IHsiY29udGVu
-        dCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1z
-        X3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6
-        IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAw
-        LCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2Rl
-        dGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        InB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJk
-        aXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
-        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAw
-        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJf
-        aWQiOiB7IiRvaWQiOiAiNTZjNGQxYzZkYjAzYzJiYTdjOTFiMTcyIn0sICJp
-        ZCI6ICI1NmM0ZDFjNmRiMDNjMmJhN2M5MWIxNzIifSwgeyJleGNlcHRpb24i
-        OiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVyLm1hbmFnZXJzLnJl
-        cG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy83
-        YmUyOWM3Mi00NjQxLTQ1OTktODVjMC00ZWQ1MTYyYjI5YzkvIiwgInRhc2tf
-        aWQiOiAiN2JlMjljNzItNDY0MS00NTk5LTg1YzAtNGVkNTE2MmIyOWM5Iiwg
-        InRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFfMTciLCAicHVscDph
-        Y3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0xN1QyMDow
-        MjozNloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAi
-        MjAxNi0wMi0xN1QyMDowMjozNloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNw
-        YXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3Mv
-        YmE5YTViM2UtOTFiNy00ZmJjLWEzMzMtZGE1ZjQwNTQ5NGE4LyIsICJ0YXNr
-        X2lkIjogImJhOWE1YjNlLTkxYjctNGZiYy1hMzMzLWRhNWY0MDU0OTRhOCJ9
-        XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVyIjogeyJjb250
-        ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJycG1fdG90YWwi
-        OiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2Rv
-        bmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0IjogMCwgIml0
-        ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        ImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6
-        IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IHsicmVz
-        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZj
-        NGQxZGM1Y2EwMTMxODRlMjhmYmJiIn0sICJleGNlcHRpb24iOiBudWxsLCAi
-        cmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0
-        YXJ0ZWQiOiAiMjAxNi0wMi0xN1QyMDowMjozNloiLCAiX25zIjogInJlcG9f
-        c3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTE3VDIwOjAy
-        OjM2WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJl
-        cnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAi
-        cmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjog
-        IjU2YzRkMWRjNWNhMDEzMThmMzBjYjAwOSIsICJkZXRhaWxzIjogeyJjb250
-        ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRl
-        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0
-        IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6
-        IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        ImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6
-        IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwg
-        Il9pZCI6IHsiJG9pZCI6ICI1NmM0ZDFkY2RiMDNjMmJhN2M5MWIxZjAifSwg
-        ImlkIjogIjU2YzRkMWRjZGIwM2MyYmE3YzkxYjFmMCJ9LCB7ImV4Y2VwdGlv
-        biI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMu
-        cmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tz
-        LzQ4NmQ1MTg3LWNkYzAtNDAwNC05NTJhLWMxODRlZWYwNzI0MC8iLCAidGFz
-        a19pZCI6ICI0ODZkNTE4Ny1jZGMwLTQwMDQtOTUyYS1jMTg0ZWVmMDcyNDAi
-        LCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxw
-        OmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTE3VDIw
-        OjAyOjQwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6
-        ICIyMDE2LTAyLTE3VDIwOjAyOjM5WiIsICJ0cmFjZWJhY2siOiBudWxsLCAi
-        c3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNr
-        cy9mMTEzMWE5OC0wYjY3LTRlMzEtOTU5Ni0xOWM2MGZjNzVjNmQvIiwgInRh
-        c2tfaWQiOiAiZjExMzFhOTgtMGI2Ny00ZTMxLTk1OTYtMTljNjBmYzc1YzZk
-        In1dLCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNv
-        bnRlbnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3Rh
-        bCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1f
-        ZG9uZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0
-        IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
-        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAic3RhdGUiOiAiZmlu
-        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTBAYWJlZC51c2Vyc3lzLnJlZGhhdC5jb20iLCAicmVzdWx0IjogeyJy
-        ZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1
-        NmM0ZDFkZjVjYTAxMzE4NGY2ZGIwZjQifSwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAi
-        c3RhcnRlZCI6ICIyMDE2LTAyLTE3VDIwOjAyOjM5WiIsICJfbnMiOiAicmVw
-        b19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTdUMjA6
-        MDI6NDBaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwg
-        ImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUs
-        ICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQi
-        OiAiNTZjNGQxZTA1Y2EwMTMxOGYzMGNiMDBlIiwgImRldGFpbHMiOiB7ImNv
-        bnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJp
-        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xl
-        ZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
-        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJv
-        cl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0
-        IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
-        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxs
-        LCAiX2lkIjogeyIkb2lkIjogIjU2YzRkMWRmZGIwM2MyYmE3YzkxYjIwMiJ9
-        LCAiaWQiOiAiNTZjNGQxZGZkYjAzYzJiYTdjOTFiMjAyIn0sIHsiZXhjZXB0
-        aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vy
-        cy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFz
-        a3MvYzJiMzE0OTEtYzcyMS00MzExLTg2NmItN2M0NDRkYzg3ZGMyLyIsICJ0
-        YXNrX2lkIjogImMyYjMxNDkxLWM3MjEtNDMxMS04NjZiLTdjNDQ0ZGM4N2Rj
-        MiIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1
-        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTdU
-        MjA6MDI6NDJaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
-        IjogIjIwMTYtMDItMTdUMjA6MDI6NDJaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzI5YTYzOTc1LWU3MTgtNGViMC04MWViLTk1MWVmODg3ZjMzMS8iLCAi
-        dGFza19pZCI6ICIyOWE2Mzk3NS1lNzE4LTRlYjAtODFlYi05NTFlZjg4N2Yz
-        MzEifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsi
-        Y29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3Rv
-        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
-        bV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAs
-        ICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xl
-        ZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
-        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJm
-        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
-        b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiB7
-        InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjog
-        IjU2YzRkMWUyNWNhMDEzMTg0ZGM4MTViYyJ9LCAiZXhjZXB0aW9uIjogbnVs
-        bCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGws
-        ICJzdGFydGVkIjogIjIwMTYtMDItMTdUMjA6MDI6NDJaIiwgIl9ucyI6ICJy
-        ZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0xN1Qy
-        MDowMjo0MloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIi
-        LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAx
-        NSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJp
-        ZCI6ICI1NmM0ZDFlMjVjYTAxMzE4ZjMwY2IwMTMiLCAiZGV0YWlscyI6IHsi
-        Y29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwg
-        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVf
-        bGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2Rv
-        bmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVy
-        cm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xl
-        ZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
-        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51
-        bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGQxZTJkYjAzYzJiYTdjOTFiMjE0
-        In0sICJpZCI6ICI1NmM0ZDFlMmRiMDNjMmJhN2M5MWIyMTQifSwgeyJleGNl
-        cHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVyLm1hbmFn
-        ZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90
-        YXNrcy8zZDU3NTgyZi05MTM2LTQzNTgtYTMzNi0zM2Y3ZDUyZWM5NzIvIiwg
-        InRhc2tfaWQiOiAiM2Q1NzU4MmYtOTEzNi00MzU4LWEzMzYtMzNmN2Q1MmVj
-        OTcyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFfMTciLCAi
-        cHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0x
-        N1QyMDowMjo0NloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3Rp
-        bWUiOiAiMjAxNi0wMi0xN1QyMDowMjo0NVoiLCAidHJhY2ViYWNrIjogbnVs
-        bCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIv
-        dGFza3MvYWI5ZjExY2MtODI3Zi00NjE3LTk3MWItMDM4ZjY2Mzk3MjhjLyIs
-        ICJ0YXNrX2lkIjogImFiOWYxMWNjLTgyN2YtNDYxNy05NzFiLTAzOGY2NjM5
-        NzI4YyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVyIjog
-        eyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJycG1f
-        dG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJk
-        cnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0Ijog
-        MCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNf
-        bGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjog
-        ImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
-        X3dvcmtlci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6
-        IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQi
-        OiAiNTZjNGQxZTU1Y2EwMTMxODRmNmRiMGY5In0sICJleGNlcHRpb24iOiBu
-        dWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVs
-        bCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0xN1QyMDowMjo0NVoiLCAiX25zIjog
-        InJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTE3
-        VDIwOjAyOjQ2WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRl
-        ciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRl
-        bnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
-        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6
-        IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwg
-        ImlkIjogIjU2YzRkMWU2NWNhMDEzMThmMzBjYjAxOCIsICJkZXRhaWxzIjog
-        eyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAw
-        LCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6
-        ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1f
-        ZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNf
-        bGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9yIjog
-        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZDFlNWRiMDNjMmJhN2M5MWIy
-        MjYifSwgImlkIjogIjU2YzRkMWU1ZGIwM2MyYmE3YzkxYjIyNiJ9LCB7ImV4
-        Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFu
-        YWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
-        L3Rhc2tzLzlhYTY0NDJmLThiNmQtNDQ0MS04M2MyLTdlY2QxMWQxZmE5ZC8i
-        LCAidGFza19pZCI6ICI5YWE2NDQyZi04YjZkLTQ0NDEtODNjMi03ZWNkMTFk
-        MWZhOWQiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIs
-        ICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAy
-        LTE3VDIwOjAyOjQ5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRf
-        dGltZSI6ICIyMDE2LTAyLTE3VDIwOjAyOjQ4WiIsICJ0cmFjZWJhY2siOiBu
-        dWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92
-        Mi90YXNrcy84OWRkZjFiNS01NGMyLTQ0MDAtOGMxMS05OTNkZDFhODRjZTMv
-        IiwgInRhc2tfaWQiOiAiODlkZGYxYjUtNTRjMi00NDAwLThjMTEtOTkzZGQx
-        YTg0Y2UzIn1dLCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIi
-        OiB7ImNvbnRlbnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
-        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJw
-        bV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwg
-        ImRycG1fZG9uZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQi
-        OiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVt
-        c19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAic3RhdGUi
-        OiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
-        Y2Vfd29ya2VyLTBAYWJlZC51c2Vyc3lzLnJlZGhhdC5jb20iLCAicmVzdWx0
-        IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9p
-        ZCI6ICI1NmM0ZDFlODVjYTAxMzE4NGRjODE1YzEifSwgImV4Y2VwdGlvbiI6
-        IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBu
-        dWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE3VDIwOjAyOjQ4WiIsICJfbnMi
-        OiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDIt
-        MTdUMjA6MDI6NDlaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9y
-        dGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29u
-        dGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
-        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50
-        IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAw
-        LCAiaWQiOiAiNTZjNGQxZTk1Y2EwMTMxOGYzMGNiMDFkIiwgImRldGFpbHMi
-        OiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6
-        IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJz
-        aXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJw
-        bV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0s
-        ICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVt
-        c19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3Ii
-        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkMWU4ZGIwM2MyYmE3Yzkx
-        YjIzOCJ9LCAiaWQiOiAiNTZjNGQxZThkYjAzYzJiYTdjOTFiMjM4In0sIHsi
-        ZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5t
-        YW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkv
-        djIvdGFza3MvMTU0NmRjYWItM2UwNy00NTFmLWFkOTItZGU4ZWViZWRlOTMz
-        LyIsICJ0YXNrX2lkIjogIjE1NDZkY2FiLTNlMDctNDUxZi1hZDkyLWRlOGVl
-        YmVkZTkzMyIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3
-        IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYt
-        MDItMTdUMjA6MDI6NTJaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFy
-        dF90aW1lIjogIjIwMTYtMDItMTdUMjA6MDI6NTFaIiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBp
-        L3YyL3Rhc2tzL2MzNWZmYjIxLWFkZmEtNDhhYS1hODY0LWM0OTA4ZTgxZTcz
-        Zi8iLCAidGFza19pZCI6ICJjMzVmZmIyMS1hZGZhLTQ4YWEtYTg2NC1jNDkw
-        OGU4MWU3M2YifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRl
-        ciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsi
-        cnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAw
-        LCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVm
-        dCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMCwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0
-        ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0
-        ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YzRkMWViNWNhMDEzMTg0ZGM4MTVjNiJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMTdUMjA6MDI6NTFaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0xN1QyMDowMjo1MloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
-        IDAsICJpZCI6ICI1NmM0ZDFlYzVjYTAxMzE4ZjMwY2IwMjIiLCAiZGV0YWls
-        cyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0
-        IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        InNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAi
-        cnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAw
-        fSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMCwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0
-        ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJv
-        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGQxZWJkYjAzYzJiYTdj
-        OTFiMjRhIn0sICJpZCI6ICI1NmM0ZDFlYmRiMDNjMmJhN2M5MWIyNGEifSwg
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84MWVlMGQxOS1kMGI5LTRiOWItYTkxZS04NWM0N2Y0ODQ2
-        OTkvIiwgInRhc2tfaWQiOiAiODFlZTBkMTktZDBiOS00YjliLWE5MWUtODVj
-        NDdmNDg0Njk5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xN1QyMDowMjo1OVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDowMjo1OFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZGY3NmE2NjgtNzhjYS00Y2Q1LWE3MDctZWNkODQwNTE3
-        ZmJkLyIsICJ0YXNrX2lkIjogImRmNzZhNjY4LTc4Y2EtNGNkNS1hNzA3LWVj
-        ZDg0MDUxN2ZiZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0
-        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
-        c291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwgInJl
-        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiB7
-        IiRvaWQiOiAiNTZjNGQxZjI1Y2EwMTMxODRmNmRiMGZmIn0sICJleGNlcHRp
-        b24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0xN1QyMDowMjo1OFoiLCAi
-        X25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2
-        LTAyLTE3VDIwOjAyOjU5WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9p
-        bXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7
-        ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YzRkMWYzNWNhMDEzMThmMzBjYjAyYiIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgImVy
-        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZDFmMmRiMDNjMmJh
-        N2M5MWIyNmUifSwgImlkIjogIjU2YzRkMWYyZGIwM2MyYmE3YzkxYjI2ZSJ9
-        LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2
-        ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAv
-        YXBpL3YyL3Rhc2tzLzg2MWE1YTNlLTk3ZjYtNDQ0Ni1hN2VlLTVjY2VkMDQ3
-        YmFkZS8iLCAidGFza19pZCI6ICI4NjFhNWEzZS05N2Y2LTQ0NDYtYTdlZS01
-        Y2NlZDA0N2JhZGUiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9y
-        YV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM4OjMzWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM4OjMyWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxw
-        L2FwaS92Mi90YXNrcy85ODU5ZTM2Mi1kMDRlLTQ0ZDYtOTc2Yi0wNTMxZTI3
-        ZDQzNDIvIiwgInRhc2tfaWQiOiAiOTg1OWUzNjItZDA0ZS00NGQ2LTk3NmIt
-        MDUzMWUyN2Q0MzQyIn1dLCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1w
-        b3J0ZXIiOiB7ImNvbnRlbnQiOiB7Iml0ZW1zX3RvdGFsIjogOCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiB7InJwbV90b3RhbCI6IDgsICJycG1fZG9uZSI6IDgsICJkcnBtX3RvdGFs
-        IjogMCwgImRycG1fZG9uZSI6IDB9LCAic2l6ZV90b3RhbCI6IDE3ODcyLCAi
-        c2l6ZV9sZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
-        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19
-        fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29t
-        IiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJf
-        aWQiOiB7IiRvaWQiOiAiNTZjNGRhNDg1Y2EwMTMxODRlMjhmYmU0In0sICJl
-        eGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJh
-        Y2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0xN1QyMDozODoz
-        MloiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6
-        ICIyMDE2LTAyLTE3VDIwOjM4OjMzWiIsICJpbXBvcnRlcl90eXBlX2lkIjog
-        Inl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1h
-        cnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJh
-        ZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVk
-        X2NvdW50IjogMCwgImlkIjogIjU2YzRkYTQ5NWNhMDEzMThmMzBjYjAzOCIs
-        ICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMTc4NzIs
-        ICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjog
-        IkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1f
-        dG90YWwiOiA4LCAicnBtX2RvbmUiOiA4LCAiZHJwbV90b3RhbCI6IDAsICJk
-        cnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
-        X3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRh
-        NDhkYjAzYzJiYTdjOTFiMjhhIn0sICJpZCI6ICI1NmM0ZGE0OGRiMDNjMmJh
-        N2M5MWIyOGEifSwgeyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjog
-        InB1bHAuc2VydmVyLm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi90YXNrcy84YWFhMjY5Ni1mMmRmLTRiMjktYmIz
-        Zi1hODRkODE0OGUyZDYvIiwgInRhc2tfaWQiOiAiOGFhYTI2OTYtZjJkZi00
-        YjI5LWJiM2YtYTg0ZDgxNDhlMmQ2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
-        dG9yeTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNo
-        X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDozODo0MVoiLCAiX25zIjogInRhc2tf
-        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDozODo0MFoi
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJl
-        ZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvODlmODY0OGQtMDYwNy00ZDM5LWEw
-        NTAtNDljYTVjMDMyMmUwLyIsICJ0YXNrX2lkIjogIjg5Zjg2NDhkLTA2MDct
-        NGQzOS1hMDUwLTQ5Y2E1YzAzMjJlMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6
-        IHsieXVtX2ltcG9ydGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6
-        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAi
-        ZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwi
-        OiAwLCAic2l6ZV9sZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBz
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRl
-        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5cy5yZWRo
-        YXQuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNTA1Y2EwMTMxODRlMjhmYmVl
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0xN1Qy
-        MDozODo0MFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM4OjQxWiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
-        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
-        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YzRkYTUxNWNhMDEzMThmMzBj
-        YjAzZSIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjog
-        MCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJw
-        bV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwg
-        ImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBz
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRl
-        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0
-        ZGE1MGRiMDNjMmJhN2M5MWIyOWYifSwgImlkIjogIjU2YzRkYTUwZGIwM2My
-        YmE3YzkxYjI5ZiJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUi
-        OiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hy
-        ZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzMyNmZiZTc4LWU0MDMtNDE0Yi1i
-        Y2Y0LTQ1N2EzMzU2NGRjYi8iLCAidGFza19pZCI6ICIzMjZmYmU3OC1lNDAz
-        LTQxNGItYmNmNC00NTdhMzM1NjRkY2IiLCAidGFncyI6IFsicHVscDpyZXBv
-        c2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM4OjQ0WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM4OjQz
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9o
-        cmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84YzU0MWFhZC03NTc2LTRkZDgt
-        YWUyZC00YzQ4YTliYmI3MjAvIiwgInRhc2tfaWQiOiAiOGM1NDFhYWQtNzU3
-        Ni00ZGQ4LWFlMmQtNGM0OGE5YmJiNzIwIn1dLCAicHJvZ3Jlc3NfcmVwb3J0
-        IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQiOiB7Iml0ZW1zX3RvdGFs
-        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAs
-        ICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAic2l6ZV90b3Rh
-        bCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29t
-        cHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVz
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJp
-        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifX19LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
-        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWJlZC51c2Vyc3lzLnJl
-        ZGhhdC5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJp
-        bXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE1MzVjYTAxMzE4NGRjODE1
-        ZDYifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8x
-        NyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTE3
-        VDIwOjM4OjQzWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29t
-        cGxldGVkIjogIjIwMTYtMDItMTdUMjA6Mzg6NDRaIiwgImltcG9ydGVyX3R5
-        cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxs
-        LCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
-        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwg
-        InVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNGRhNTQ1Y2EwMTMxOGYz
-        MGNiMDQzIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwi
-        OiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsi
-        cnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAw
-        LCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29t
-        cHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVz
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJp
-        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2
-        YzRkYTUzZGIwM2MyYmE3YzkxYjJiMSJ9LCAiaWQiOiAiNTZjNGRhNTNkYjAz
-        YzJiYTdjOTFiMmIxIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlw
-        ZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJf
-        aHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNzBiZDk4NmItOTVmZC00NWU4
-        LWI1YjgtOTUxMDE0M2Q0ZTMxLyIsICJ0YXNrX2lkIjogIjcwYmQ5ODZiLTk1
-        ZmQtNDVlOC1iNWI4LTk1MTAxNDNkNGUzMSIsICJ0YWdzIjogWyJwdWxwOnJl
-        cG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZp
-        bmlzaF90aW1lIjogIjIwMTYtMDItMTdUMjA6Mzg6NDdaIiwgIl9ucyI6ICJ0
-        YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTdUMjA6Mzg6
-        NDZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3si
-        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzVkMWJjZTE5LTBkODEtNDFj
-        ZS1iMTc4LTM4ZDFjZjkyMDZhZi8iLCAidGFza19pZCI6ICI1ZDFiY2UxOS0w
-        ZDgxLTQxY2UtYjE3OC0zOGQxY2Y5MjA2YWYifV0sICJwcm9ncmVzc19yZXBv
-        cnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90
-        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3Rv
-        dGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFt
-        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBhYmVkLnVzZXJzeXMu
-        cmVkaGF0LmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwg
-        ImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YzRkYTU2NWNhMDEzMTg0ZGM4
-        MTVkYyJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MTdUMjA6Mzg6NDZaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJj
-        b21wbGV0ZWQiOiAiMjAxNi0wMi0xN1QyMDozODo0N1oiLCAiaW1wb3J0ZXJf
-        dHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51
-        bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
-        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
-        aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn19LCAiYWRkZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAw
-        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmM0ZGE1NzVjYTAxMzE4
-        ZjMwY2IwNDgiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
-        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZjNGRhNTZkYjAzYzJiYTdjOTFiMmMzIn0sICJpZCI6ICI1NmM0ZGE1NmRi
-        MDNjMmJhN2M5MWIyYzMifSwgeyJleGNlcHRpb24iOiBudWxsLCAidGFza190
-        eXBlIjogInB1bHAuc2VydmVyLm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwg
-        Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9kMmFmODNlMy0zZGE5LTQ1
-        NDYtYmQzOS00YTFjMDA0M2I1YTMvIiwgInRhc2tfaWQiOiAiZDJhZjgzZTMt
-        M2RhOS00NTQ2LWJkMzktNGExYzAwNDNiNWEzIiwgInRhZ3MiOiBbInB1bHA6
-        cmVwb3NpdG9yeTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246c3luYyJdLCAi
-        ZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0xN1QyMDozODo1MFoiLCAiX25zIjog
-        InRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDoz
-        ODo0OVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBb
-        eyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZjlhZTBhNjktYTc3MS00
-        YmRkLTgwNzItYzk0YzY5YTJjOWM4LyIsICJ0YXNrX2lkIjogImY5YWUwYTY5
-        LWE3NzEtNGJkZC04MDcyLWM5NGM2OWEyYzljOCJ9XSwgInByb2dyZXNzX3Jl
-        cG9ydCI6IHsieXVtX2ltcG9ydGVyIjogeyJjb250ZW50IjogeyJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUi
-        OiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVf
-        dG90YWwiOiAwLCAic2l6ZV9sZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwg
-        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
-        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
-        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9u
-        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5
-        cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3Mi
-        LCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNTk1Y2EwMTMxODRl
-        MjhmYmY1In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0w
-        Mi0xN1QyMDozODo0OVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwg
-        ImNvbXBsZXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM4OjUwWiIsICJpbXBvcnRl
-        cl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjog
-        bnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdl
-        X2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
-        dXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6
-        IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YzRkYTVhNWNhMDEz
-        MThmMzBjYjA0ZCIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3Rv
-        dGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAi
-        c3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMi
-        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
-        IjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwg
-        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
-        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
-        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
-        ICI1NmM0ZGE1OWRiMDNjMmJhN2M5MWIyZDUifSwgImlkIjogIjU2YzRkYTU5
-        ZGIwM2MyYmE3YzkxYjJkNSJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNr
-        X3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMi
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2RlYWI0ZTc0LTU2MWYt
-        NGJkNi1iNDEzLTE0ZmVkNGM5NzMxMi8iLCAidGFza19pZCI6ICJkZWFiNGU3
-        NC01NjFmLTRiZDYtYjQxMy0xNGZlZDRjOTczMTIiLCAidGFncyI6IFsicHVs
-        cDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0s
-        ICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM4OjUzWiIsICJfbnMi
-        OiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIw
-        OjM4OjUyWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6
-        IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy83NTU5MzNlOC03ZTM0
-        LTRkZWEtOGQwYS00YzkyMjg0YzI5M2QvIiwgInRhc2tfaWQiOiAiNzU1OTMz
-        ZTgtN2UzNC00ZGVhLThkMGEtNGM5MjI4NGMyOTNkIn1dLCAicHJvZ3Jlc3Nf
-        cmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQiOiB7Iml0ZW1z
-        X3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9u
-        ZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAic2l6
-        ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2Vy
-        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWJlZC51c2Vy
-        c3lzLnJlZGhhdC5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2Vz
-        cyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE1YzVjYTAxMzE4
-        NGRjODE1ZTMifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZl
-        ZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2
-        LTAyLTE3VDIwOjM4OjUyWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMi
-        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMTdUMjA6Mzg6NTNaIiwgImltcG9y
-        dGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2Ui
-        OiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVy
-        Z2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3Ry
-        aWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50
-        IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNGRhNWQ1Y2Ew
-        MTMxOGYzMGNiMDUyIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjU2YzRkYTVjZGIwM2MyYmE3YzkxYjJlNyJ9LCAiaWQiOiAiNTZjNGRh
-        NWNkYjAzYzJiYTdjOTFiMmU3In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRh
-        c2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3lu
-        YyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZWJiM2MxZDUtMGUw
-        MS00MDZhLTliY2ItOWI5ZmUzZDgxMmM4LyIsICJ0YXNrX2lkIjogImViYjNj
-        MWQ1LTBlMDEtNDA2YS05YmNiLTliOWZlM2Q4MTJjOCIsICJ0YWdzIjogWyJw
-        dWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMi
-        XSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTdUMjA6Mzg6NTZaIiwgIl9u
-        cyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMTdU
-        MjA6Mzg6NTVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
-        IjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzgwOTIzYWU2LTY5
-        YWEtNGJhMS1iODU0LTAxNjQ0OGQ5NTNiZS8iLCAidGFza19pZCI6ICI4MDky
-        M2FlNi02OWFhLTRiYTEtYjg1NC0wMTY0NDhkOTUzYmUifV0sICJwcm9ncmVz
-        c19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRl
-        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
-        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJz
-        aXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0Ijog
-        MH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1
-        cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRp
-        b24iOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
-        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBhYmVkLnVz
-        ZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNj
-        ZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YzRkYTVmNWNhMDEz
-        MTg0ZTI4ZmJmYSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAi
-        RmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIw
-        MTYtMDItMTdUMjA6Mzg6NTVaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0
-        cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0xN1QyMDozODo1NloiLCAiaW1w
-        b3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2Fn
-        ZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291
-        bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmM0ZGE2MDVj
-        YTAxMzE4ZjMwY2IwNTciLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6
-        ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjog
-        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRh
-        aWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90
-        b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBb
-        XX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1
-        cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRp
-        b24iOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRv
-        aWQiOiAiNTZjNGRhNWZkYjAzYzJiYTdjOTFiMmY5In0sICJpZCI6ICI1NmM0
-        ZGE1ZmRiMDNjMmJhN2M5MWIyZjkifSwgeyJleGNlcHRpb24iOiBudWxsLCAi
-        dGFza190eXBlIjogInB1bHAuc2VydmVyLm1hbmFnZXJzLnJlcG8uc3luYy5z
-        eW5jIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9iMWJhNTU4ZS1h
-        ZGEyLTQ5MzUtODgwYy0yNWYwY2FlYTViZTYvIiwgInRhc2tfaWQiOiAiYjFi
-        YTU1OGUtYWRhMi00OTM1LTg4MGMtMjVmMGNhZWE1YmU2IiwgInRhZ3MiOiBb
-        InB1bHA6cmVwb3NpdG9yeTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246c3lu
-        YyJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0xN1QyMDozODo1OVoiLCAi
-        X25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0x
-        N1QyMDozODo1OFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFz
-        a3MiOiBbeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZWIzOTgxYjEt
-        YzNlNi00YWJiLWEyMDAtMzQ5MmQxNTdiZjZiLyIsICJ0YXNrX2lkIjogImVi
-        Mzk4MWIxLWMzZTYtNGFiYi1hMjAwLTM0OTJkMTU3YmY2YiJ9XSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVyIjogeyJjb250ZW50IjogeyJp
-        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBt
-        X2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwg
-        InNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0IjogMCwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
-        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
-        dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJy
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
-        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQu
-        dXNlcnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1
-        Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNjI1Y2Ew
-        MTMxODRkYzgxNWVkIn0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAi
-        MjAxNi0wMi0xN1QyMDozODo1OFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1
-        bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM4OjU5WiIsICJp
-        bXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNz
-        YWdlIjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        InB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJk
-        aXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9j
-        b3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YzRkYTYz
-        NWNhMDEzMThmMzBjYjA1YyIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJz
-        aXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwi
-        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRl
-        dGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBt
-        X3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6
-        IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
-        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
-        dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJy
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
-        JG9pZCI6ICI1NmM0ZGE2MmRiMDNjMmJhN2M5MWIzMGIifSwgImlkIjogIjU2
-        YzRkYTYyZGIwM2MyYmE3YzkxYjMwYiJ9LCB7ImV4Y2VwdGlvbiI6IG51bGws
-        ICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5j
-        LnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2M3MWQwMzVi
-        LTEzODItNDZkNS1hYWYzLWY4NjdjNGQwN2U3NS8iLCAidGFza19pZCI6ICJj
-        NzFkMDM1Yi0xMzgyLTQ2ZDUtYWFmMy1mODY3YzRkMDdlNzUiLCAidGFncyI6
-        IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpz
-        eW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM5OjAyWiIs
-        ICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAy
-        LTE3VDIwOjM5OjAxWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90
-        YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84NWQwNzcw
-        Mi0wYmMyLTRhY2EtODJhOC1lZjNkNTY5MDRiNTYvIiwgInRhc2tfaWQiOiAi
-        ODVkMDc3MDItMGJjMi00YWNhLTgyYTgtZWYzZDU2OTA0YjU2In1dLCAicHJv
-        Z3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQiOiB7
-        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJy
-        cG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9
-        LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVm
-        dCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJn
-        ZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
-        YnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJl
-        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifX19LCAic3RhdGUiOiAiZmluaXNoZWQiLCAi
-        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWJl
-        ZC51c2Vyc3lzLnJlZGhhdC5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
-        c3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE2NTVj
-        YTAxMzE4NGY2ZGIxMGUifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lk
-        IjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6
-        ICIyMDE2LTAyLTE3VDIwOjM5OjAxWiIsICJfbnMiOiAicmVwb19zeW5jX3Jl
-        c3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTdUMjA6Mzk6MDJaIiwg
-        ImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21l
-        c3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        ImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVk
-        X2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjNGRh
-        NjY1Y2EwMTMxOGYzMGNiMDYxIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7
-        InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3Rh
-        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAi
-        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
-        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxz
-        IjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJn
-        ZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
-        YnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJl
-        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjU2YzRkYTY1ZGIwM2MyYmE3YzkxYjMxZCJ9LCAiaWQiOiAi
-        NTZjNGRhNjVkYjAzYzJiYTdjOTFiMzFkIn0sIHsiZXhjZXB0aW9uIjogbnVs
-        bCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5
-        bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMmY5ZjY3
-        YWQtZjczNi00MGU4LWFlNTUtNmE5OWZiYWYyMTExLyIsICJ0YXNrX2lkIjog
-        IjJmOWY2N2FkLWY3MzYtNDBlOC1hZTU1LTZhOTlmYmFmMjExMSIsICJ0YWdz
-        IjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9u
-        OnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTdUMjA6Mzk6MDVa
-        IiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYt
-        MDItMTdUMjA6Mzk6MDRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
-        X3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzMxZTk4
-        NzRkLWIzNjgtNDUxNy1hZWJjLTllZWI1OGEyMGI1Ny8iLCAidGFza19pZCI6
-        ICIzMWU5ODc0ZC1iMzY4LTQ1MTctYWViYy05ZWViNThhMjBiNTcifV0sICJw
-        cm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6
-        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwg
-        InJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
-        MH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19s
-        ZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
-        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
-        cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwg
-        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBh
-        YmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6
-        ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YzRkYTY4
-        NWNhMDEzMTg0ZGM4MTVmMyJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9f
-        aWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFydGVk
-        IjogIjIwMTYtMDItMTdUMjA6Mzk6MDRaIiwgIl9ucyI6ICJyZXBvX3N5bmNf
-        cmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0xN1QyMDozOTowNVoi
-        LCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJyb3Jf
-        bWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJy
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAxNSwgInJlbW92
-        ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmM0
-        ZGE2OTVjYTAxMzE4ZjMwY2IwNjYiLCAiZGV0YWlscyI6IHsiY29udGVudCI6
-        IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3Rv
-        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAs
-        ICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAi
-        ZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFp
-        bHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
-        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
-        cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwg
-        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQi
-        OiB7IiRvaWQiOiAiNTZjNGRhNjhkYjAzYzJiYTdjOTFiMzJmIn0sICJpZCI6
-        ICI1NmM0ZGE2OGRiMDNjMmJhN2M5MWIzMmYifSwgeyJleGNlcHRpb24iOiBu
-        dWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVyLm1hbmFnZXJzLnJlcG8u
-        c3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82Mzhm
-        NDYzOC05Yzc2LTQzYjctOGYxYi0wNGIxOTI4YWExYWUvIiwgInRhc2tfaWQi
-        OiAiNjM4ZjQ2MzgtOWM3Ni00M2I3LThmMWItMDRiMTkyOGFhMWFlIiwgInRh
-        Z3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFfMTciLCAicHVscDphY3Rp
-        b246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0xN1QyMDozOTow
-        OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAx
-        Ni0wMi0xN1QyMDozOTowN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXdu
-        ZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvYmNj
-        YjdiNDctMGZkMS00MTRmLTlhZjgtODhkNGRjMDU4OTQxLyIsICJ0YXNrX2lk
-        IjogImJjY2I3YjQ3LTBmZDEtNDE0Zi05YWY4LTg4ZDRkYzA1ODk0MSJ9XSwg
-        InByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVyIjogeyJjb250ZW50
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
-        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
-        OiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0IjogMCwgIml0ZW1z
-        X2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
-        c3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklO
-        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9
-        LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVk
-        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0w
-        QGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0
-        IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZjNGRh
-        NmI1Y2EwMTMxODRlMjhmYzAwIn0sICJleGNlcHRpb24iOiBudWxsLCAicmVw
-        b19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0
-        ZWQiOiAiMjAxNi0wMi0xN1QyMDozOTowN1oiLCAiX25zIjogInJlcG9fc3lu
-        Y19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM5OjA4
-        WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJl
-        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVt
-        b3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2
-        YzRkYTZjNWNhMDEzMThmMzBjYjA2YiIsICJkZXRhaWxzIjogeyJjb250ZW50
-        IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNf
-        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0Ijog
-        MCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAs
-        ICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0
-        YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
-        c3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklO
-        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9
-        LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1NmM0ZGE2YmRiMDNjMmJhN2M5MWIzNDEifSwgImlk
-        IjogIjU2YzRkYTZiZGIwM2MyYmE3YzkxYjM0MSJ9LCB7ImV4Y2VwdGlvbiI6
-        IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVw
-        by5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2M1
-        ZjFlZmU1LWNkZWItNDVkNi04MGZhLTMwY2U0MGJkMGNiZS8iLCAidGFza19p
-        ZCI6ICJjNWYxZWZlNS1jZGViLTQ1ZDYtODBmYS0zMGNlNDBiZDBjYmUiLCAi
-        dGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFj
-        dGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM5
-        OjExWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM5OjEwWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bh
-        d25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82
-        YTFlNmU1ZS1lMDU2LTQwYWUtODU1NC1hNjg3M2Y2N2FjMjYvIiwgInRhc2tf
-        aWQiOiAiNmExZTZlNWUtZTA1Ni00MGFlLTg1NTQtYTY4NzNmNjdhYzI2In1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAic3RhdGUiOiAiZmluaXNo
-        ZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTBAYWJlZC51c2Vyc3lzLnJlZGhhdC5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmM0
-        ZGE2ZTVjYTAxMzE4NGY2ZGIxMTMifSwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNj
+        OGIwMGRlMDQwMzNmNDM1MTRlZWYifSwgImV4Y2VwdGlvbiI6IG51bGwsICJy
         ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
-        cnRlZCI6ICIyMDE2LTAyLTE3VDIwOjM5OjEwWiIsICJfbnMiOiAicmVwb19z
-        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTdUMjA6Mzk6
-        MTFaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cnRlZCI6ICIyMDE2LTAyLTIzVDE2OjM4OjI0WiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6Mzg6
+        MjRaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
         cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
         c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
         U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
@@ -7213,7 +10205,7 @@ http_interactions:
         ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
         eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
         ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZjNGRhNmY1Y2EwMTMxOGYzMGNiMDcwIiwgImRldGFpbHMiOiB7ImNvbnRl
+        NTZjYzhiMDBkZTA0MDMwODk3NThhNzgyIiwgImRldGFpbHMiOiB7ImNvbnRl
         bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
         c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
         OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
@@ -7224,19 +10216,19 @@ http_interactions:
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
         MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
         YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjU2YzRkYTZlZGIwM2MyYmE3YzkxYjM1MyJ9LCAi
-        aWQiOiAiNTZjNGRhNmVkYjAzYzJiYTdjOTFiMzUzIn0sIHsiZXhjZXB0aW9u
+        X2lkIjogeyIkb2lkIjogIjU2Y2M4YjAwOTg5MDU0ZmM0OGJhMmM3NCJ9LCAi
+        aWQiOiAiNTZjYzhiMDA5ODkwNTRmYzQ4YmEyYzc0In0sIHsiZXhjZXB0aW9u
         IjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5y
         ZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3Mv
-        NWIwODZmYmUtNWVmNS00ZDg1LThjNzUtZGJjZTg2ZGYyOTViLyIsICJ0YXNr
-        X2lkIjogIjViMDg2ZmJlLTVlZjUtNGQ4NS04Yzc1LWRiY2U4NmRmMjk1YiIs
+        OWNkOTNhYzMtZmUyYy00N2U4LTk5MWMtNzFmM2EyNzExMzY1LyIsICJ0YXNr
+        X2lkIjogIjljZDkzYWMzLWZlMmMtNDdlOC05OTFjLTcxZjNhMjcxMTM2NSIs
         ICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6
-        YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMTdUMjA6
-        Mzk6MTVaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
-        IjIwMTYtMDItMTdUMjA6Mzk6MTRaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
+        YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6
+        Mzg6MjhaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
+        IjIwMTYtMDItMjNUMTY6Mzg6MjdaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
         cGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tz
-        L2YzMWQ5Zjg1LWIyOTEtNDg1My1iNDFmLTU4ZDgyNjc3ZmVmNS8iLCAidGFz
-        a19pZCI6ICJmMzFkOWY4NS1iMjkxLTQ4NTMtYjQxZi01OGQ4MjY3N2ZlZjUi
+        L2RhNDE3NmFkLWJiYjEtNDcwNi04ZDQ3LTA5OTg2NjczYzliOS8iLCAidGFz
+        a19pZCI6ICJkYTQxNzZhZC1iYmIxLTQ3MDYtOGQ0Ny0wOTk4NjY3M2M5Yjki
         fV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29u
         dGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
         LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
@@ -7249,113 +10241,63 @@ http_interactions:
         OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5p
         c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiB7InJl
-        c3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2
-        YzRkYTcxNWNhMDEzMTg0ZGM4MTVmYyJ9LCAiZXhjZXB0aW9uIjogbnVsbCwg
-        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJz
-        dGFydGVkIjogIjIwMTYtMDItMTdUMjA6Mzk6MTRaIiwgIl9ucyI6ICJyZXBv
-        X3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0xN1QyMDoz
-        OToxNVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
-        ZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50Ijog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAxNSwg
-        InJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6
-        ICI1NmM0ZGE3MzVjYTAxMzE4ZjMwY2IwNzUiLCAiZGV0YWlscyI6IHsiY29u
-        dGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVm
-        dCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUi
-        OiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9y
-        X2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNzJkYjAzYzJiYTdjOTFiMzY1In0s
-        ICJpZCI6ICI1NmM0ZGE3MmRiMDNjMmJhN2M5MWIzNjUifSwgeyJleGNlcHRp
-        b24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVyLm1hbmFnZXJz
-        LnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNr
-        cy82NmYzNGMxZS0wYjI0LTRlYTktYmZjMC1jNDNmYzJmNGEyYTcvIiwgInRh
-        c2tfaWQiOiAiNjZmMzRjMWUtMGIyNC00ZWE5LWJmYzAtYzQzZmMyZjRhMmE3
-        IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFfMTciLCAicHVs
-        cDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0xN1Qy
-        MDozOToxN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0xN1QyMDozOToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFz
-        a3MvNGU3MzlmY2UtOGYxOC00ODAwLTk1ZmEtZGI4MGNiMzcxMDY1LyIsICJ0
-        YXNrX2lkIjogIjRlNzM5ZmNlLThmMTgtNDgwMC05NWZhLWRiODBjYjM3MTA2
-        NSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVyIjogeyJj
-        b250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJycG1fdG90
-        YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBt
-        X2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0IjogMCwg
-        Iml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVm
-        dCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0
-        YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZp
-        bmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
-        cmtlci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IHsi
-        cmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAi
-        NTZjNGRhNzU1Y2EwMTMxODRmNmRiMTE4In0sICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InN0YXJ0ZWQiOiAiMjAxNi0wMi0xN1QyMDozOToxN1oiLCAiX25zIjogInJl
-        cG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTE3VDIw
-        OjM5OjE3WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDE1
-        LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlk
-        IjogIjU2YzRkYTc1NWNhMDEzMThmMzBjYjA3YSIsICJkZXRhaWxzIjogeyJj
-        b250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAi
-        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9s
-        ZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9u
-        ZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJy
-        b3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVm
-        dCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0
-        YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVs
-        bCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE3NWRiMDNjMmJhN2M5MWIzNzci
-        fSwgImlkIjogIjU2YzRkYTc1ZGIwM2MyYmE3YzkxYjM3NyJ9LCB7ImV4Y2Vw
-        dGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdl
-        cnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzY2ZDRjMjE0LTlkYjAtNDM2YS1iMDI4LWY1OTcyYTU0Y2FlMy8iLCAi
-        dGFza19pZCI6ICI2NmQ0YzIxNC05ZGIwLTQzNmEtYjAyOC1mNTk3MmE1NGNh
-        ZTMiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJw
-        dWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTE3
-        VDIwOjM5OjIwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGlt
-        ZSI6ICIyMDE2LTAyLTE3VDIwOjM5OjIwWiIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90
-        YXNrcy84YmY5N2MwZC1jMDBjLTRjZDItOTJkOS00ZWZiYzE0ODgyZGIvIiwg
-        InRhc2tfaWQiOiAiOGJmOTdjMGQtYzAwYy00Y2QyLTkyZDktNGVmYmMxNDg4
-        MmRiIn1dLCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7
-        ImNvbnRlbnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90
-        b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRy
-        cG1fZG9uZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAw
-        LCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
-        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAYWJlZC51c2Vyc3lzLnJlZGhhdC5jb20iLCAicmVzdWx0Ijog
+        ZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJy
+        ZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1
+        NmNjOGIwM2RlMDQwMzNmNDM1MTRlZjQifSwgImV4Y2VwdGlvbiI6IG51bGws
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAi
+        c3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjM4OjI3WiIsICJfbnMiOiAicmVw
+        b19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6
+        Mzg6MjhaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwg
+        ImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUs
+        ICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQi
+        OiAiNTZjYzhiMDRkZTA0MDMwODk3NThhNzhkIiwgImRldGFpbHMiOiB7ImNv
+        bnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xl
+        ZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
+        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJv
+        cl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0
+        IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
+        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4YjAzOTg5MDU0ZmM0OGJhMmM4NiJ9
+        LCAiaWQiOiAiNTZjYzhiMDM5ODkwNTRmYzQ4YmEyYzg2In0sIHsiZXhjZXB0
+        aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vy
+        cy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFz
+        a3MvYTBlMmYyOWUtZjZkNy00YTkxLWE2MTEtOGExNDJmNGViMzFiLyIsICJ0
+        YXNrX2lkIjogImEwZTJmMjllLWY2ZDctNGE5MS1hNjExLThhMTQyZjRlYjMx
+        YiIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1
+        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNU
+        MTY6Mzg6MzFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
+        IjogIjIwMTYtMDItMjNUMTY6Mzg6MzBaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzM2ZDAzYjM2LTFiZDctNDkwZi04ODY0LWE5MmI0NmUyMmM1OC8iLCAi
+        dGFza19pZCI6ICIzNmQwM2IzNi0xYmQ3LTQ5MGYtODg2NC1hOTJiNDZlMjJj
+        NTgifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsi
+        Y29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3Rv
+        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
+        bV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAs
+        ICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xl
+        ZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
+        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJm
+        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
         eyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6
-        ICI1NmM0ZGE3ODVjYTAxMzE4NGY2ZGIxMWQifSwgImV4Y2VwdGlvbiI6IG51
+        ICI1NmNjOGIwNmRlMDQwMzNmNDI2MmNhNGEifSwgImV4Y2VwdGlvbiI6IG51
         bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDE2LTAyLTE3VDIwOjM5OjIwWiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTdU
-        MjA6Mzk6MjBaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
+        LCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjM4OjMwWiIsICJfbnMiOiAi
+        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNU
+        MTY6Mzg6MzFaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
         IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVu
         dCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6
         ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
@@ -7363,7 +10305,7 @@ http_interactions:
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50Ijog
         MTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAi
-        aWQiOiAiNTZjNGRhNzg1Y2EwMTMxOGYzMGNiMDdmIiwgImRldGFpbHMiOiB7
+        aWQiOiAiNTZjYzhiMDdkZTA0MDMwODk3NThhNzk4IiwgImRldGFpbHMiOiB7
         ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
         X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
@@ -7374,20 +10316,20 @@ http_interactions:
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
         ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
         ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTc4ZGIwM2MyYmE3YzkxYjM4
-        OSJ9LCAiaWQiOiAiNTZjNGRhNzhkYjAzYzJiYTdjOTFiMzg5In0sIHsiZXhj
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4YjA2OTg5MDU0ZmM0OGJhMmM5
+        OCJ9LCAiaWQiOiAiNTZjYzhiMDY5ODkwNTRmYzQ4YmEyYzk4In0sIHsiZXhj
         ZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5h
         Z2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIv
-        dGFza3MvZjJjMzMxMzMtNGUwNy00ZWU0LWI3Y2ItMDEzMDkzYjM1MmQ2LyIs
-        ICJ0YXNrX2lkIjogImYyYzMzMTMzLTRlMDctNGVlNC1iN2NiLTAxMzA5M2Iz
-        NTJkNiIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3Iiwg
+        dGFza3MvMmU4MDk0YjktZTViYy00ODQxLWJjZTMtYTY2NDM0ZWMyZDJlLyIs
+        ICJ0YXNrX2lkIjogIjJlODA5NGI5LWU1YmMtNDg0MS1iY2UzLWE2NjQzNGVj
+        MmQyZSIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3Iiwg
         InB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDIt
-        MTdUMjA6Mzk6MjNaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTYtMDItMTdUMjA6Mzk6MjNaIiwgInRyYWNlYmFjayI6IG51
+        MjNUMTY6Mzg6MzRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTYtMDItMjNUMTY6Mzg6MzRaIiwgInRyYWNlYmFjayI6IG51
         bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
-        L3Rhc2tzLzBkNzIzYmJhLTczMDctNGZlYS05MmFkLTlhNTQ0MWU1YjgyMy8i
-        LCAidGFza19pZCI6ICIwZDcyM2JiYS03MzA3LTRmZWEtOTJhZC05YTU0NDFl
-        NWI4MjMifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6
+        L3Rhc2tzLzI2MTg3MDYxLTRhZGEtNDgwOS04ZTc1LTQwZTg2ZDg4MDUxMy8i
+        LCAidGFza19pZCI6ICIyNjE4NzA2MS00YWRhLTQ4MDktOGU3NS00MGU4NmQ4
+        ODA1MTMifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6
         IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklO
         SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBt
         X3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAi
@@ -7399,88 +10341,2241 @@ http_interactions:
         X2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
         Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6
         ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQi
-        OiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lk
-        IjogIjU2YzRkYTdiNWNhMDEzMTg0ZGM4MTYwMSJ9LCAiZXhjZXB0aW9uIjog
-        bnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzdGFydGVkIjogIjIwMTYtMDItMTdUMjA6Mzk6MjNaIiwgIl9ucyI6
-        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0x
-        N1QyMDozOToyM1oiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
-        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250
-        ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRl
+        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0
+        IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9p
+        ZCI6ICI1NmNjOGIwYWRlMDQwMzNmNDFkMmEzODAifSwgImV4Y2VwdGlvbiI6
+        IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjM4OjM0WiIsICJfbnMi
+        OiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDIt
+        MjNUMTY6Mzg6MzRaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9y
+        dGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29u
+        dGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
+        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50
+        IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAw
+        LCAiaWQiOiAiNTZjYzhiMGFkZTA0MDMwODk3NThhN2EzIiwgImRldGFpbHMi
+        OiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6
+        IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJz
+        aXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJw
+        bV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0s
+        ICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVt
+        c19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3Ii
+        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4YjBhOTg5MDU0ZmM0OGJh
+        MmNhYSJ9LCAiaWQiOiAiNTZjYzhiMGE5ODkwNTRmYzQ4YmEyY2FhIn0sIHsi
+        ZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5t
+        YW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkv
+        djIvdGFza3MvNDM0ZTYzNWMtMTM4Mi00ZGFmLWJhZDMtOWI0NDMxNTU0MjAx
+        LyIsICJ0YXNrX2lkIjogIjQzNGU2MzVjLTEzODItNGRhZi1iYWQzLTliNDQz
+        MTU1NDIwMSIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3
+        IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYt
+        MDItMjNUMTY6Mzg6MzdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFy
+        dF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzg6MzdaIiwgInRyYWNlYmFjayI6
+        IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBp
+        L3YyL3Rhc2tzL2Y0MTZlODk0LThlM2QtNDM3YS1iZjQ5LTJmMWY2MzJjNWZm
+        Zi8iLCAidGFza19pZCI6ICJmNDE2ZTg5NC04ZTNkLTQzN2EtYmY0OS0yZjFm
+        NjMyYzVmZmYifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRl
+        ciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsi
+        cnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAw
+        LCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVm
+        dCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0
+        ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0
+        ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsi
+        JG9pZCI6ICI1NmNjOGIwZGRlMDQwMzNmNDM1MTRlZmMifSwgImV4Y2VwdGlv
+        biI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2si
+        OiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjM4OjM3WiIsICJf
+        bnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYt
+        MDItMjNUMTY6Mzg6MzdaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2lt
+        cG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsi
+        Y29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2Nv
+        dW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQi
+        OiAwLCAiaWQiOiAiNTZjYzhiMGRkZTA0MDMwODk3NThhN2FlIiwgImRldGFp
+        bHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVm
+        dCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwg
+        InJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
+        MH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
+        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4YjBkOTg5MDU0ZmM0
+        OGJhMmNiYyJ9LCAiaWQiOiAiNTZjYzhiMGQ5ODkwNTRmYzQ4YmEyY2JjIn0s
+        IHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZl
+        ci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvY2E2MWNiZTYtNjI2MS00Y2QxLTg2NDYtZWQzN2E3YTAw
+        MGYxLyIsICJ0YXNrX2lkIjogImNhNjFjYmU2LTYyNjEtNGNkMS04NjQ2LWVk
+        MzdhN2EwMDBmMSIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3Jh
+        XzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIw
+        MTYtMDItMjNUMTY6Mzg6NDBaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
+        dGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzg6NDBaIiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAv
+        YXBpL3YyL3Rhc2tzLzAzNzEzYmY1LTZmNmEtNGZkZi05YjVhLTI5YzcyMzlm
+        YmY3OS8iLCAidGFza19pZCI6ICIwMzcxM2JmNS02ZjZhLTRmZGYtOWI1YS0y
+        OWM3MjM5ZmJmNzkifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJz
+        dGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
+        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6
+        IHsiJG9pZCI6ICI1NmNjOGIxMGRlMDQwMzNmNDFkMmEzODUifSwgImV4Y2Vw
+        dGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjM4OjQwWiIs
+        ICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
+        MTYtMDItMjNUMTY6Mzg6NDBaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVt
+        X2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6
+        IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVk
+        X2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291
+        bnQiOiAwLCAiaWQiOiAiNTZjYzhiMTBkZTA0MDMwODk3NThhN2I5IiwgImRl
+        dGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNf
+        bGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjog
+        MCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25l
+        IjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRl
         IjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0
-        YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQi
-        OiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAs
-        ICJpZCI6ICI1NmM0ZGE3YjVjYTAxMzE4ZjMwY2IwODQiLCAiZGV0YWlscyI6
-        IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0Ijog
-        MCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNp
-        emVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBt
-        X2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwg
-        ImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklO
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4YjEwOTg5MDU0
+        ZmM0OGJhMmNjZSJ9LCAiaWQiOiAiNTZjYzhiMTA5ODkwNTRmYzQ4YmEyY2Nl
+        In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNl
+        cnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVs
+        cC9hcGkvdjIvdGFza3MvMDg5N2EzNGItODhhNi00MDY3LTgyMWMtZTc5M2Q4
+        Y2JkMTgwLyIsICJ0YXNrX2lkIjogIjA4OTdhMzRiLTg4YTYtNDA2Ny04MjFj
+        LWU3OTNkOGNiZDE4MCIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVk
+        b3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTYtMDItMjNUMTY6Mzg6NDNaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzg6NDNaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzL2YwY2NkZDM1LWJmMTQtNDhiMi04YWMxLTQyMTU4
+        YzdhYzFlZi8iLCAidGFza19pZCI6ICJmMGNjZGQzNS1iZjE0LTQ4YjItOGFj
+        MS00MjE1OGM3YWMxZWYifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
+        ZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9p
+        ZCI6IHsiJG9pZCI6ICI1NmNjOGIxM2RlMDQwMzNmNDM1MTRmMDIifSwgImV4
+        Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFj
+        ZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjM4OjQz
+        WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjog
+        IjIwMTYtMDItMjNUMTY6Mzg6NDNaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFy
+        eSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFk
+        ZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRf
+        Y291bnQiOiAwLCAiaWQiOiAiNTZjYzhiMTNkZTA0MDMwODk3NThhN2M0Iiwg
+        ImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRl
+        bXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
+        IjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9k
+        b25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
+        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4YjEzOTg5
+        MDU0ZmM0OGJhMmNlMCJ9LCAiaWQiOiAiNTZjYzhiMTM5ODkwNTRmYzQ4YmEy
+        Y2UwIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxw
+        LnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIv
+        cHVscC9hcGkvdjIvdGFza3MvMDk4MGY0MjAtMTRjZS00M2Q0LTlhM2QtZTli
+        YmVkNTc4OGVkLyIsICJ0YXNrX2lkIjogIjA5ODBmNDIwLTE0Y2UtNDNkNC05
+        YTNkLWU5YmJlZDU3ODhlZCIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6
+        RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1l
+        IjogIjIwMTYtMDItMjNUMTY6Mzg6NDdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1
+        cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzg6NDZaIiwgInRy
+        YWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAi
+        L3B1bHAvYXBpL3YyL3Rhc2tzL2IyOTRkMGEyLWE3NjItNDQwMi1hZDQ2LTc0
+        ZWZmZTkzYTYzNC8iLCAidGFza19pZCI6ICJiMjk0ZDBhMi1hNzYyLTQ0MDIt
+        YWQ0Ni03NGVmZmU5M2E2MzQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1
+        bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwg
+        InNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRl
+        cl9pZCI6IHsiJG9pZCI6ICI1NmNjOGIxNmRlMDQwMzNmNDFkMmEzOGEifSwg
+        ImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0
+        cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjM4
+        OjQ2WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMjNUMTY6Mzg6NDdaIiwgImltcG9ydGVyX3R5cGVfaWQi
+        OiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3Vt
+        bWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNv
+        bXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRl
+        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwg
+        ImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0
+        ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhiMTdkZTA0MDMwODk3NThhN2Nm
+        IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAi
+        aXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3Rv
+        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
+        bV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
+        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4YjE2
+        OTg5MDU0ZmM0OGJhMmNmMiJ9LCAiaWQiOiAiNTZjYzhiMTY5ODkwNTRmYzQ4
+        YmEyY2YyIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJw
+        dWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6
+        ICIvcHVscC9hcGkvdjIvdGFza3MvNzc2ZjBkODYtNWE1YS00MmU4LTk3YWMt
+        ODIzMGRkMTAyMDA3LyIsICJ0YXNrX2lkIjogIjc3NmYwZDg2LTVhNWEtNDJl
+        OC05N2FjLTgyMzBkZDEwMjAwNyIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRv
+        cnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90
+        aW1lIjogIjIwMTYtMDItMjNUMTY6Mzg6NTBaIiwgIl9ucyI6ICJ0YXNrX3N0
+        YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzg6NTBaIiwg
+        InRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzczOTRlNzUxLWVhMTgtNGU4ZC1hMWE3
+        LWYyNWEwYWJiNjU3OS8iLCAidGFza19pZCI6ICI3Mzk0ZTc1MS1lYTE4LTRl
+        OGQtYTFhNy1mMjVhMGFiYjY1NzkifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
+        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjog
+        MCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBs
+        ZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBv
+        cnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGIxYWRlMDQwMzNmNDM1MTRmMDci
+        fSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2
+        OjM4OjUwWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxl
+        dGVkIjogIjIwMTYtMDItMjNUMTY6Mzg6NTBaIiwgImltcG9ydGVyX3R5cGVf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAi
+        c3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVw
+        ZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhiMWFkZTA0MDMwODk3NThh
+        N2RhIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAw
+        LCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBt
+        X3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAi
+        ZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4
+        YjFhOTg5MDU0ZmM0OGJhMmQwNCJ9LCAiaWQiOiAiNTZjYzhiMWE5ODkwNTRm
+        YzQ4YmEyZDA0In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6
+        ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJl
+        ZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvYWRjOTBhNGYtNDYzOS00NmZiLWFk
+        NGUtY2U4OWZjMTAzMjVkLyIsICJ0YXNrX2lkIjogImFkYzkwYTRmLTQ2Mzkt
+        NDZmYi1hZDRlLWNlODlmYzEwMzI1ZCIsICJ0YWdzIjogWyJwdWxwOnJlcG9z
+        aXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzg6NTNaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzg6NTNa
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hy
+        ZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzc2NmU5NmZhLWFhNWMtNGY2MS05
+        NGU0LTkyM2ZhMjBlNWE1MS8iLCAidGFza19pZCI6ICI3NjZlOTZmYS1hYTVj
+        LTRmNjEtOTRlNC05MjNmYTIwZTVhNTEifV0sICJwcm9ncmVzc19yZXBvcnQi
+        OiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
+        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFs
+        IjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21w
+        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJp
+        bXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGIxZGRlMDQwMzNmNDI2MmNh
+        NTMifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8x
+        NyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIz
+        VDE2OjM4OjUzWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29t
+        cGxldGVkIjogIjIwMTYtMDItMjNUMTY6Mzg6NTNaIiwgImltcG9ydGVyX3R5
+        cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxs
+        LCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
+        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwg
+        InVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhiMWRkZTA0MDMwODk3
+        NThhN2U1IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwi
+        OiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsi
+        cnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAw
+        LCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29t
+        cHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2
+        Y2M4YjFkOTg5MDU0ZmM0OGJhMmQxNiJ9LCAiaWQiOiAiNTZjYzhiMWQ5ODkw
+        NTRmYzQ4YmEyZDE2In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlw
+        ZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJf
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNzc2ODRiNzItNTg0OC00ZTU5
+        LTlkM2MtMzNjZWQxOWMwODhhLyIsICJ0YXNrX2lkIjogIjc3Njg0YjcyLTU4
+        NDgtNGU1OS05ZDNjLTMzY2VkMTljMDg4YSIsICJ0YWdzIjogWyJwdWxwOnJl
+        cG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZp
+        bmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzg6NTZaIiwgIl9ucyI6ICJ0
+        YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzg6
+        NTZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3si
+        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzE3M2Y2NmU3LWM3ODUtNDk0
+        YS1iOTYyLTFjZGMwNDVhZmM5YS8iLCAidGFza19pZCI6ICIxNzNmNjZlNy1j
+        Nzg1LTQ5NGEtYjk2Mi0xY2RjMDQ1YWZjOWEifV0sICJwcm9ncmVzc19yZXBv
+        cnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3Rv
+        dGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJj
+        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
+        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
+        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGIyMGRlMDQwMzNmNDM1
+        MTRmMGMifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9y
+        YV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAy
+        LTIzVDE2OjM4OjU2WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAi
+        Y29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6Mzg6NTZaIiwgImltcG9ydGVy
+        X3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBu
+        dWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50Ijog
+        MCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhiMjBkZTA0MDMw
+        ODk3NThhN2YwIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90
+        YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAi
+        Y29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNh
+        dGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjog
+        eyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjog
+        IjU2Y2M4YjIwOTg5MDU0ZmM0OGJhMmQyOCJ9LCAiaWQiOiAiNTZjYzhiMjA5
+        ODkwNTRmYzQ4YmEyZDI4In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tf
+        dHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIs
+        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZmFiNDYzYmMtNTM5Yi00
+        OGM4LWE3NzItOTIzODNkZmFmYjc1LyIsICJ0YXNrX2lkIjogImZhYjQ2M2Jj
+        LTUzOWItNDhjOC1hNzcyLTkyMzgzZGZhZmI3NSIsICJ0YWdzIjogWyJwdWxw
+        OnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwg
+        ImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzk6MDBaIiwgIl9ucyI6
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6
+        Mzg6NTlaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        W3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzVjYTVkNTQzLTkzMzQt
+        NDgyOS05MGUyLWRlNmU4ZDBiY2I1Ny8iLCAidGFza19pZCI6ICI1Y2E1ZDU0
+        My05MzM0LTQ4MjktOTBlMi1kZTZlOGQwYmNiNTcifV0sICJwcm9ncmVzc19y
+        ZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNf
+        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
+        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXpl
+        X3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlv
+        ZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2Vz
+        cyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGIyM2RlMDQwMzNm
+        NDM1MTRmMTEifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZl
+        ZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2
+        LTAyLTIzVDE2OjM4OjU5WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMi
+        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6Mzk6MDBaIiwgImltcG9y
+        dGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2Ui
+        OiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVy
+        Z2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3Ry
+        aWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50
+        IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhiMjRkZTA0
+        MDMwODk3NThhN2ZiIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVf
+        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
+        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
+        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
+        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
+        IjogIjU2Y2M4YjIzOTg5MDU0ZmM0OGJhMmQzYSJ9LCAiaWQiOiAiNTZjYzhi
+        MjM5ODkwNTRmYzQ4YmEyZDNhIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRh
+        c2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3lu
+        YyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNGVhYWZlN2UtYTBh
+        My00ZmZlLWJmZmYtZDMxYTk0OTEyZDNkLyIsICJ0YXNrX2lkIjogIjRlYWFm
+        ZTdlLWEwYTMtNGZmZS1iZmZmLWQzMWE5NDkxMmQzZCIsICJ0YWdzIjogWyJw
+        dWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMi
+        XSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzk6MDNaIiwgIl9u
+        cyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNU
+        MTY6Mzk6MDNaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        IjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzc5N2FiMTk1LTA3
+        MTEtNDhhOS05NzZlLWFkMDU2YTQzOWIyMy8iLCAidGFza19pZCI6ICI3OTdh
+        YjE5NS0wNzExLTQ4YTktOTc2ZS1hZDA1NmE0MzliMjMifV0sICJwcm9ncmVz
+        c19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRl
+        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJz
+        aXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0Ijog
+        MH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1
+        cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRp
+        b24iOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGIyN2RlMDQw
+        MzNmNDM1MTRmMTYifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjM5OjAzWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6Mzk6MDNaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhiMjdk
+        ZTA0MDMwODk3NThhODA2IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4YjI3OTg5MDU0ZmM0OGJhMmQ0YyJ9LCAiaWQiOiAiNTZj
+        YzhiMjc5ODkwNTRmYzQ4YmEyZDRjIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwg
+        InRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMu
+        c3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvY2Y3NDJlOTYt
+        ZjJiYy00MGE0LWIxMTgtYTUyNTRlZGEyMWYwLyIsICJ0YXNrX2lkIjogImNm
+        NzQyZTk2LWYyYmMtNDBhNC1iMTE4LWE1MjU0ZWRhMjFmMCIsICJ0YWdzIjog
+        WyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5
+        bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzk6MDlaIiwg
+        Il9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDIt
+        MjNUMTY6Mzk6MDlaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rh
+        c2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzJhMTczNjlh
+        LThlYjQtNDE0NS04NzBjLTY5ZjhhMmU5N2E5Ni8iLCAidGFza19pZCI6ICIy
+        YTE3MzY5YS04ZWI0LTQxNDUtODcwYy02OWY4YTJlOTdhOTYifV0sICJwcm9n
+        cmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsi
+        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJw
+        bV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0s
+        ICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0
+        IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdl
+        X2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
+        c3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGIyZGRl
+        MDQwMzNmNDFkMmEzOTYifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lk
+        IjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6
+        ICIyMDE2LTAyLTIzVDE2OjM5OjA5WiIsICJfbnMiOiAicmVwb19zeW5jX3Jl
+        c3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6Mzk6MDlaIiwg
+        ImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21l
+        c3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVk
+        X2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhi
+        MmRkZTA0MDMwODk3NThhODE1IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7
+        InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3Rh
+        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAi
+        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
+        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxz
+        IjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJn
+        ZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
+        YnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJl
+        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
+        eyIkb2lkIjogIjU2Y2M4YjJkOTg5MDU0ZmM0OGJhMmQ3MCJ9LCAiaWQiOiAi
+        NTZjYzhiMmQ5ODkwNTRmYzQ4YmEyZDcwIn0sIHsiZXhjZXB0aW9uIjogbnVs
+        bCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5
+        bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZThlMzEx
+        ZTQtODFiYi00ODg3LTllYTAtZjE0ODBkZjcwOGE3LyIsICJ0YXNrX2lkIjog
+        ImU4ZTMxMWU0LTgxYmItNDg4Ny05ZWEwLWYxNDgwZGY3MDhhNyIsICJ0YWdz
+        IjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9u
+        OnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzk6MTNa
+        IiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYt
+        MDItMjNUMTY6Mzk6MTJaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
+        X3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2Y1YTg1
+        NWI0LTBiNWItNDA0My05ZDdmLTNhNTU4Y2I0Nzg4Yi8iLCAidGFza19pZCI6
+        ICJmNWE4NTViNC0wYjViLTQwNDMtOWQ3Zi0zYTU1OGNiNDc4OGIifV0sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwg
+        InJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
+        MH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
+        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
+        cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
+        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGIz
+        MGRlMDQwMzNmNDI2MmNhNTkifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
+        ZCI6ICIyMDE2LTAyLTIzVDE2OjM5OjEyWiIsICJfbnMiOiAicmVwb19zeW5j
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6Mzk6MTNa
+        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZj
+        YzhiMzFkZTA0MDMwODk3NThhODFhIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
+        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
+        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
+        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
+        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
+        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
+        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
+        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjU2Y2M4YjMwOTg5MDU0ZmM0OGJhMmQ4MiJ9LCAiaWQi
+        OiAiNTZjYzhiMzA5ODkwNTRmYzQ4YmEyZDgyIn0sIHsiZXhjZXB0aW9uIjog
+        bnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBv
+        LnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNDAx
+        ZDcwNzUtZGQwOC00YmEyLTkwOTctN2M2ODcyMDI0ODRlLyIsICJ0YXNrX2lk
+        IjogIjQwMWQ3MDc1LWRkMDgtNGJhMi05MDk3LTdjNjg3MjAyNDg0ZSIsICJ0
+        YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0
+        aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzk6
+        MTVaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTYtMDItMjNUMTY6Mzk6MTVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzVi
+        OTJkN2Q4LWIwYWUtNDZhOS1hYzZmLWYwYTJkMDU4NDBhOC8iLCAidGFza19p
+        ZCI6ICI1YjkyZDdkOC1iMGFlLTQ2YTktYWM2Zi1mMGEyZDA1ODQwYTgifV0s
+        ICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVu
+        dCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjog
+        MCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25l
+        IjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVt
+        c19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        InB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJk
+        aXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAw
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNj
+        OGIzM2RlMDQwMzNmNDFkMmEzOWMifSwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTAyLTIzVDE2OjM5OjE1WiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6Mzk6
+        MTVaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZjYzhiMzNkZTA0MDMwODk3NThhODFmIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU2Y2M4YjMzOTg5MDU0ZmM0OGJhMmQ5NCJ9LCAi
+        aWQiOiAiNTZjYzhiMzM5ODkwNTRmYzQ4YmEyZDk0In0sIHsiZXhjZXB0aW9u
+        IjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5y
+        ZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3Mv
+        OTZkMTJmYmYtNmU2Mi00MDY2LWE2NDMtMWFiYzM3YzY2MDMwLyIsICJ0YXNr
+        X2lkIjogIjk2ZDEyZmJmLTZlNjItNDA2Ni1hNjQzLTFhYmMzN2M2NjAzMCIs
+        ICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6
+        YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6
+        Mzk6MThaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
+        IjIwMTYtMDItMjNUMTY6Mzk6MThaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
+        cGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tz
+        LzE0Y2VmOThjLWIwOTItNGVjYi1hNGY5LTcxNjQ5MmFiOTE4YS8iLCAidGFz
+        a19pZCI6ICIxNGNlZjk4Yy1iMDkyLTRlY2ItYTRmOS03MTY0OTJhYjkxOGEi
+        fV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29u
+        dGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
+        IjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9k
+        b25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJp
+        dGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5p
+        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJy
+        ZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1
+        NmNjOGIzNmRlMDQwMzNmNDM1MTRmMWMifSwgImV4Y2VwdGlvbiI6IG51bGws
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAi
+        c3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjM5OjE4WiIsICJfbnMiOiAicmVw
+        b19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6
+        Mzk6MThaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwg
+        ImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUs
+        ICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQi
+        OiAiNTZjYzhiMzZkZTA0MDMwODk3NThhODI0IiwgImRldGFpbHMiOiB7ImNv
+        bnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xl
+        ZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
+        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJv
+        cl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0
+        IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
+        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4YjM2OTg5MDU0ZmM0OGJhMmRhNiJ9
+        LCAiaWQiOiAiNTZjYzhiMzY5ODkwNTRmYzQ4YmEyZGE2In0sIHsiZXhjZXB0
+        aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vy
+        cy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFz
+        a3MvYTBmNjJlOWItYTVhYS00YTdiLWE0MTEtNWIzNmQ1ZjAxNWFmLyIsICJ0
+        YXNrX2lkIjogImEwZjYyZTliLWE1YWEtNGE3Yi1hNDExLTViMzZkNWYwMTVh
+        ZiIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1
+        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNU
+        MTY6Mzk6MjFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
+        IjogIjIwMTYtMDItMjNUMTY6Mzk6MjFaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2QxYzMwMjc1LTYyOGEtNGQyYy05YmU2LTIxODJkZDkxNjRjOC8iLCAi
+        dGFza19pZCI6ICJkMWMzMDI3NS02MjhhLTRkMmMtOWJlNi0yMTgyZGQ5MTY0
+        YzgifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsi
+        Y29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3Rv
+        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
+        bV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAs
+        ICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xl
+        ZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
+        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJm
+        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
+        eyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6
+        ICI1NmNjOGIzOGRlMDQwMzNmNDM1MTRmMjEifSwgImV4Y2VwdGlvbiI6IG51
+        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
+        LCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjM5OjIxWiIsICJfbnMiOiAi
+        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNU
+        MTY6Mzk6MjFaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVu
+        dCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50Ijog
+        MTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAi
+        aWQiOiAiNTZjYzhiMzlkZTA0MDMwODk3NThhODI5IiwgImRldGFpbHMiOiB7
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4YjM5OTg5MDU0ZmM0OGJhMmRi
+        OCJ9LCAiaWQiOiAiNTZjYzhiMzk5ODkwNTRmYzQ4YmEyZGI4In0sIHsiZXhj
+        ZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5h
+        Z2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIv
+        dGFza3MvM2Q5ODJkMmYtZGUxOS00NDVmLTg2MjctNzM0YjMyMDIzMmVmLyIs
+        ICJ0YXNrX2lkIjogIjNkOTgyZDJmLWRlMTktNDQ1Zi04NjI3LTczNGIzMjAy
+        MzJlZiIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3Iiwg
+        InB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDIt
+        MjNUMTY6Mzk6MjRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTYtMDItMjNUMTY6Mzk6MjNaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L3Rhc2tzLzhmY2QxOTJkLTk5ZmMtNGFmMC1iZmI0LWI0ODU2ZWM0M2YwMC8i
+        LCAidGFza19pZCI6ICI4ZmNkMTkyZC05OWZjLTRhZjAtYmZiNC1iNDg1NmVj
+        NDNmMDAifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6
+        IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklO
+        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBt
+        X3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAi
+        ZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6
+        IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0
+        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1z
+        X2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6
+        ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0
+        IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9p
+        ZCI6ICI1NmNjOGIzYmRlMDQwMzNmNDM1MTRmMjYifSwgImV4Y2VwdGlvbiI6
+        IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjM5OjIzWiIsICJfbnMi
+        OiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDIt
+        MjNUMTY6Mzk6MjRaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9y
+        dGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29u
+        dGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
+        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50
+        IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAw
+        LCAiaWQiOiAiNTZjYzhiM2NkZTA0MDMwODk3NThhODJlIiwgImRldGFpbHMi
+        OiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6
+        IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJz
+        aXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJw
+        bV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0s
+        ICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVt
+        c19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3Ii
+        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4YjNiOTg5MDU0ZmM0OGJh
+        MmRjYSJ9LCAiaWQiOiAiNTZjYzhiM2I5ODkwNTRmYzQ4YmEyZGNhIn0sIHsi
+        ZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5t
+        YW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkv
+        djIvdGFza3MvN2MxNzEwMmEtY2E3ZC00YmFiLTk3NGUtY2NlNmY0ZGUxYTM0
+        LyIsICJ0YXNrX2lkIjogIjdjMTcxMDJhLWNhN2QtNGJhYi05NzRlLWNjZTZm
+        NGRlMWEzNCIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3
+        IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYt
+        MDItMjNUMTY6Mzk6MjZaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFy
+        dF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzk6MjZaIiwgInRyYWNlYmFjayI6
+        IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBp
+        L3YyL3Rhc2tzLzI3ODdlNmE1LTRkZDktNDMwYi05MDY3LWI1YjM1YzkwOGM2
+        Ny8iLCAidGFza19pZCI6ICIyNzg3ZTZhNS00ZGQ5LTQzMGItOTA2Ny1iNWIz
+        NWM5MDhjNjcifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRl
+        ciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsi
+        cnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAw
+        LCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVm
+        dCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0
+        ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0
+        ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsi
+        JG9pZCI6ICI1NmNjOGIzZWRlMDQwMzNmNDFkMmEzYTYifSwgImV4Y2VwdGlv
+        biI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2si
+        OiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjM5OjI2WiIsICJf
+        bnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYt
+        MDItMjNUMTY6Mzk6MjZaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2lt
+        cG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsi
+        Y29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2Nv
+        dW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQi
+        OiAwLCAiaWQiOiAiNTZjYzhiM2VkZTA0MDMwODk3NThhODMzIiwgImRldGFp
+        bHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVm
+        dCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwg
+        InJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
+        MH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
+        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4YjNlOTg5MDU0ZmM0
+        OGJhMmRkYyJ9LCAiaWQiOiAiNTZjYzhiM2U5ODkwNTRmYzQ4YmEyZGRjIn0s
+        IHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZl
+        ci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvY2M4YzUwNjctYmUyMi00MjUxLThkMGYtODFiNDQxNWJl
+        Y2I4LyIsICJ0YXNrX2lkIjogImNjOGM1MDY3LWJlMjItNDI1MS04ZDBmLTgx
+        YjQ0MTViZWNiOCIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3Jh
+        XzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIw
+        MTYtMDItMjNUMTY6Mzk6MjlaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
+        dGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzk6MjlaIiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAv
+        YXBpL3YyL3Rhc2tzL2Y3ZjIwMzY3LTYxNTMtNDg1OC05Zjc4LWE5ZDZmYTAz
+        MmJhMS8iLCAidGFza19pZCI6ICJmN2YyMDM2Ny02MTUzLTQ4NTgtOWY3OC1h
+        OWQ2ZmEwMzJiYTEifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJz
+        dGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
+        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6
+        IHsiJG9pZCI6ICI1NmNjOGI0MGRlMDQwMzNmNDI2MmNhNmYifSwgImV4Y2Vw
+        dGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjM5OjI5WiIs
+        ICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
+        MTYtMDItMjNUMTY6Mzk6MjlaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVt
+        X2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6
+        IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVk
+        X2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291
+        bnQiOiAwLCAiaWQiOiAiNTZjYzhiNDFkZTA0MDMwODk3NThhODM4IiwgImRl
+        dGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNf
+        bGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjog
+        MCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25l
+        IjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4YjQxOTg5MDU0
+        ZmM0OGJhMmRlZSJ9LCAiaWQiOiAiNTZjYzhiNDE5ODkwNTRmYzQ4YmEyZGVl
+        In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNl
+        cnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVs
+        cC9hcGkvdjIvdGFza3MvNGY2M2UxMWMtNzExZS00MjE4LThiYjYtNTMzNDZl
+        NWNiYTAzLyIsICJ0YXNrX2lkIjogIjRmNjNlMTFjLTcxMWUtNDIxOC04YmI2
+        LTUzMzQ2ZTVjYmEwMyIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVk
+        b3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTYtMDItMjNUMTY6Mzk6MzJaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzk6MzJaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzL2JlOWZjZWQ5LWE0ZmYtNGZmMC05MmYzLTA3NDNi
+        ZmYzMjBlOC8iLCAidGFza19pZCI6ICJiZTlmY2VkOS1hNGZmLTRmZjAtOTJm
+        My0wNzQzYmZmMzIwZTgifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
+        ZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9p
+        ZCI6IHsiJG9pZCI6ICI1NmNjOGI0M2RlMDQwMzNmNDFkMmEzYWIifSwgImV4
+        Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFj
+        ZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjM5OjMy
+        WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjog
+        IjIwMTYtMDItMjNUMTY6Mzk6MzJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFy
+        eSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFk
+        ZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRf
+        Y291bnQiOiAwLCAiaWQiOiAiNTZjYzhiNDRkZTA0MDMwODk3NThhODNkIiwg
+        ImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRl
+        bXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
+        IjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9k
+        b25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
+        bCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4YjQ0OTg5
+        MDU0ZmM0OGJhMmUwMCJ9LCAiaWQiOiAiNTZjYzhiNDQ5ODkwNTRmYzQ4YmEy
+        ZTAwIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxw
+        LnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIv
+        cHVscC9hcGkvdjIvdGFza3MvYzMyZDY0OTEtNWJjNy00NWYzLTkxMzItNzZk
+        YThmZWIxYmFiLyIsICJ0YXNrX2lkIjogImMzMmQ2NDkxLTViYzctNDVmMy05
+        MTMyLTc2ZGE4ZmViMWJhYiIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6
+        RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1l
+        IjogIjIwMTYtMDItMjNUMTY6Mzk6MzVaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1
+        cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6Mzk6MzRaIiwgInRy
+        YWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAi
+        L3B1bHAvYXBpL3YyL3Rhc2tzL2U2OWQ4OTgxLWY3ODktNDA2ZS04MGY5LTFk
+        MDdjYjc5MzdkZC8iLCAidGFza19pZCI6ICJlNjlkODk4MS1mNzg5LTQwNmUt
+        ODBmOS0xZDA3Y2I3OTM3ZGQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1
+        bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwg
+        InNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRl
+        cl9pZCI6IHsiJG9pZCI6ICI1NmNjOGI0NmRlMDQwMzNmNDI2MmNhNzkifSwg
+        ImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0
+        cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjM5
+        OjM0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMjNUMTY6Mzk6MzVaIiwgImltcG9ydGVyX3R5cGVfaWQi
+        OiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3Vt
+        bWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNv
+        bXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRl
+        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwg
+        ImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0
+        ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhiNDdkZTA0MDMwODk3NThhODQy
+        IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAi
+        aXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3Rv
+        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
+        bV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
+        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4YjQ2
+        OTg5MDU0ZmM0OGJhMmUxMiJ9LCAiaWQiOiAiNTZjYzhiNDY5ODkwNTRmYzQ4
+        YmEyZTEyIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJw
+        dWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6
+        ICIvcHVscC9hcGkvdjIvdGFza3MvNzZiZGFjNmUtY2MzNi00ODhhLTg3Zjkt
+        NzgyZTk0ZmUxODVhLyIsICJ0YXNrX2lkIjogIjc2YmRhYzZlLWNjMzYtNDg4
+        YS04N2Y5LTc4MmU5NGZlMTg1YSIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRv
+        cnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90
+        aW1lIjogIjIwMTYtMDItMjNUMTY6NDc6MDVaIiwgIl9ucyI6ICJ0YXNrX3N0
+        YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDc6MDVaIiwg
+        InRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2FmNmU0MjY4LWQ3MTAtNGNhYi05MjZl
+        LTJhNWY3NTY1Nzk1MS8iLCAidGFza19pZCI6ICJhZjZlNDI2OC1kNzEwLTRj
+        YWItOTI2ZS0yYTVmNzU2NTc5NTEifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
+        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjog
+        MCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBs
+        ZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBv
+        cnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQwOGRlMDQwMzNmNDM1MTRmM2Yi
+        fSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2
+        OjQ3OjA1WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxl
+        dGVkIjogIjIwMTYtMDItMjNUMTY6NDc6MDVaIiwgImltcG9ydGVyX3R5cGVf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAi
+        c3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVw
+        ZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkMDlkZTA0MDMwODk3NThh
+        ODQ3IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAw
+        LCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBt
+        X3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAi
+        ZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVt
+        c190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4
+        ZDA5OTg5MDU0ZmM0OGJhMmUyNSJ9LCAiaWQiOiAiNTZjYzhkMDk5ODkwNTRm
+        YzQ4YmEyZTI1In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6
+        ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJl
+        ZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMzBjNzU3NTAtMWYxZi00MWQ4LTgy
+        MjgtMDhhNzUxOWU0MGU3LyIsICJ0YXNrX2lkIjogIjMwYzc1NzUwLTFmMWYt
+        NDFkOC04MjI4LTA4YTc1MTllNDBlNyIsICJ0YWdzIjogWyJwdWxwOnJlcG9z
+        aXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDc6MTZaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDc6MTZa
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hy
+        ZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzcwNDlhOWI1LTM4MjgtNDhlYy1i
+        Y2MwLTVlNDkxZGYzZGEyMC8iLCAidGFza19pZCI6ICI3MDQ5YTliNS0zODI4
+        LTQ4ZWMtYmNjMC01ZTQ5MWRmM2RhMjAifV0sICJwcm9ncmVzc19yZXBvcnQi
+        OiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
+        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFs
+        IjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21w
+        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0
+        ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJp
+        bXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQxM2RlMDQwMzNmNDFkMmEz
+        Y2YifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8x
+        NyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIz
+        VDE2OjQ3OjE2WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29t
+        cGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDc6MTZaIiwgImltcG9ydGVyX3R5
+        cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxs
+        LCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
+        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwg
+        InVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkMTRkZTA0MDMwODk3
+        NThhODUxIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwi
+        OiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsi
+        cnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAw
+        LCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29t
+        cHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJp
+        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2
+        Y2M4ZDE0OTg5MDU0ZmM0OGJhMmU0ZiJ9LCAiaWQiOiAiNTZjYzhkMTQ5ODkw
+        NTRmYzQ4YmEyZTRmIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlw
+        ZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJf
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMDZkZTM5ZDItYTFmNC00ZWZm
+        LWE3MmYtYzUxNjMwMjgxNDYxLyIsICJ0YXNrX2lkIjogIjA2ZGUzOWQyLWEx
+        ZjQtNGVmZi1hNzJmLWM1MTYzMDI4MTQ2MSIsICJ0YWdzIjogWyJwdWxwOnJl
+        cG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZp
+        bmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDc6MTlaIiwgIl9ucyI6ICJ0
+        YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDc6
+        MTlaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3si
+        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2Q0MDE5ZGZmLTYzYWItNDI1
+        Zi1hM2EyLWQ1NjdmMTNjZDU3NC8iLCAidGFza19pZCI6ICJkNDAxOWRmZi02
+        M2FiLTQyNWYtYTNhMi1kNTY3ZjEzY2Q1NzQifV0sICJwcm9ncmVzc19yZXBv
+        cnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3Rv
+        dGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJj
+        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
+        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQxNmRlMDQwMzNmNDM1
+        MTRmNTEifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9y
+        YV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAy
+        LTIzVDE2OjQ3OjE5WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAi
+        Y29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDc6MTlaIiwgImltcG9ydGVy
+        X3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBu
+        dWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50Ijog
+        MCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkMTdkZTA0MDMw
+        ODk3NThhODU2IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90
+        YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAi
+        Y29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNh
+        dGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjog
+        eyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjog
+        IjU2Y2M4ZDE3OTg5MDU0ZmM0OGJhMmU2MiJ9LCAiaWQiOiAiNTZjYzhkMTc5
+        ODkwNTRmYzQ4YmEyZTYyIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tf
+        dHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIs
+        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMGIxN2JkNWMtZTk2OC00
+        YjM5LWE2MDYtMDM5ZGUzZjhiNDJmLyIsICJ0YXNrX2lkIjogIjBiMTdiZDVj
+        LWU5NjgtNGIzOS1hNjA2LTAzOWRlM2Y4YjQyZiIsICJ0YWdzIjogWyJwdWxw
+        OnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwg
+        ImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDc6MjJaIiwgIl9ucyI6
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6
+        NDc6MjJaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        W3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzBhYTZhODIwLWYxYjQt
+        NDBmZC1iZDBjLWUzZGQ0YzFiZThjMi8iLCAidGFza19pZCI6ICIwYWE2YTgy
+        MC1mMWI0LTQwZmQtYmQwYy1lM2RkNGMxYmU4YzIifV0sICJwcm9ncmVzc19y
+        ZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNf
+        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
+        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXpl
+        X3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlv
+        ZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2Vz
+        cyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQxOWRlMDQwMzNm
+        NDI2MmNhODQifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZl
+        ZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2
+        LTAyLTIzVDE2OjQ3OjIyWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMi
+        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDc6MjJaIiwgImltcG9y
+        dGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2Ui
+        OiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVy
+        Z2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3Ry
+        aWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50
+        IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkMWFkZTA0
+        MDMwODk3NThhODViIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVf
+        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
+        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
+        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
+        IjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
+        IjogIjU2Y2M4ZDFhOTg5MDU0ZmM0OGJhMmU3NSJ9LCAiaWQiOiAiNTZjYzhk
+        MWE5ODkwNTRmYzQ4YmEyZTc1In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRh
+        c2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3lu
+        YyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMWQ1NDNhZGEtMzI5
+        OC00NTYxLThhODMtMTI5MWQ3NGZiMTgwLyIsICJ0YXNrX2lkIjogIjFkNTQz
+        YWRhLTMyOTgtNDU2MS04YTgzLTEyOTFkNzRmYjE4MCIsICJ0YWdzIjogWyJw
+        dWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMi
+        XSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDc6MjVaIiwgIl9u
+        cyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNU
+        MTY6NDc6MjVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        IjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzY3M2M0NDc4LTFk
+        ZjQtNDFhZS04ZWNlLTk2YjJhMDNmY2JjNS8iLCAidGFza19pZCI6ICI2NzNj
+        NDQ3OC0xZGY0LTQxYWUtOGVjZS05NmIyYTAzZmNiYzUifV0sICJwcm9ncmVz
+        c19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRl
+        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJz
+        aXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0Ijog
+        MH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1
+        cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRp
+        b24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQxY2RlMDQw
+        MzNmNDFkMmEzZGMifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ3OjI1WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDc6MjVaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkMWRk
+        ZTA0MDMwODk3NThhODYwIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDFkOTg5MDU0ZmM0OGJhMmU4OCJ9LCAiaWQiOiAiNTZj
+        YzhkMWQ5ODkwNTRmYzQ4YmEyZTg4In0sIHsiZXhjZXB0aW9uIjogbnVsbCwg
+        InRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMu
+        c3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNGM1MzkwNDkt
+        YzcwMi00ZWVhLTliMTUtNGQ3NDJiYTViOTcxLyIsICJ0YXNrX2lkIjogIjRj
+        NTM5MDQ5LWM3MDItNGVlYS05YjE1LTRkNzQyYmE1Yjk3MSIsICJ0YWdzIjog
+        WyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5
+        bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDc6MjhaIiwg
+        Il9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDIt
+        MjNUMTY6NDc6MjhaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rh
+        c2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzdkYjcxYzI0
+        LTllNjUtNDQ3ZC1hNmM3LWQ0OTk2YWQ2OWU1NS8iLCAidGFza19pZCI6ICI3
+        ZGI3MWMyNC05ZTY1LTQ0N2QtYTZjNy1kNDk5NmFkNjllNTUifV0sICJwcm9n
+        cmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsi
+        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJw
+        bV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0s
+        ICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0
+        IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdl
+        X2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
+        c3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQxZmRl
+        MDQwMzNmNDI2MmNhOTEifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lk
+        IjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6
+        ICIyMDE2LTAyLTIzVDE2OjQ3OjI4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jl
+        c3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDc6MjhaIiwg
+        ImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21l
+        c3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVk
+        X2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhk
+        MjBkZTA0MDMwODk3NThhODY1IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7
+        InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3Rh
+        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAi
+        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
+        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxz
+        IjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJn
+        ZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
+        YnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJl
+        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
+        eyIkb2lkIjogIjU2Y2M4ZDIwOTg5MDU0ZmM0OGJhMmU5YiJ9LCAiaWQiOiAi
+        NTZjYzhkMjA5ODkwNTRmYzQ4YmEyZTliIn0sIHsiZXhjZXB0aW9uIjogbnVs
+        bCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5
+        bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZGI4MWU4
+        MTctZjJiNi00N2NlLWE0MzQtZWVlZTAzM2NlOGI1LyIsICJ0YXNrX2lkIjog
+        ImRiODFlODE3LWYyYjYtNDdjZS1hNDM0LWVlZWUwMzNjZThiNSIsICJ0YWdz
+        IjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9u
+        OnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDc6MzFa
+        IiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYt
+        MDItMjNUMTY6NDc6MzFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
+        X3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzk2ZDcz
+        N2E5LTE3NDgtNGI2My05MTZiLTM5OTI1ODZhMzJkYy8iLCAidGFza19pZCI6
+        ICI5NmQ3MzdhOS0xNzQ4LTRiNjMtOTE2Yi0zOTkyNTg2YTMyZGMifV0sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwg
+        InJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
+        MH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
+        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
+        cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
+        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQy
+        MmRlMDQwMzNmNDFkMmEzZTcifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
+        ZCI6ICIyMDE2LTAyLTIzVDE2OjQ3OjMxWiIsICJfbnMiOiAicmVwb19zeW5j
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDc6MzFa
+        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZj
+        YzhkMjNkZTA0MDMwODk3NThhODZhIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
+        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
+        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
+        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
+        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
+        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
+        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
+        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjU2Y2M4ZDIzOTg5MDU0ZmM0OGJhMmVhZSJ9LCAiaWQi
+        OiAiNTZjYzhkMjM5ODkwNTRmYzQ4YmEyZWFlIn0sIHsiZXhjZXB0aW9uIjog
+        bnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBv
+        LnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZDg3
+        ODQwN2UtMDA1Mi00M2UzLTljYjMtNWU5ZTZmZGU5NmU1LyIsICJ0YXNrX2lk
+        IjogImQ4Nzg0MDdlLTAwNTItNDNlMy05Y2IzLTVlOWU2ZmRlOTZlNSIsICJ0
+        YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0
+        aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDc6
+        MzRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTYtMDItMjNUMTY6NDc6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2U5
+        MmI4YzkxLWU3MmYtNDk3Mi05MjgwLTFkM2M3MmI1NGY5Yy8iLCAidGFza19p
+        ZCI6ICJlOTJiOGM5MS1lNzJmLTQ5NzItOTI4MC0xZDNjNzJiNTRmOWMifV0s
+        ICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVu
+        dCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjog
+        MCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25l
+        IjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVt
+        c19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        InB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJk
+        aXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAw
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNj
+        OGQyNWRlMDQwMzNmNDM1MTRmNjEifSwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ3OjM0WiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDc6
+        MzRaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZjYzhkMjZkZTA0MDMwODk3NThhODZmIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU2Y2M4ZDI2OTg5MDU0ZmM0OGJhMmVjMSJ9LCAi
+        aWQiOiAiNTZjYzhkMjY5ODkwNTRmYzQ4YmEyZWMxIn0sIHsiZXhjZXB0aW9u
+        IjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5y
+        ZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3Mv
+        ZmY0MDYzMGQtZmRhNy00ZjUzLTg3NDMtZmI5MDE4N2EwZDY3LyIsICJ0YXNr
+        X2lkIjogImZmNDA2MzBkLWZkYTctNGY1My04NzQzLWZiOTAxODdhMGQ2NyIs
+        ICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6
+        YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6
+        NDc6NDhaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
+        IjIwMTYtMDItMjNUMTY6NDc6NDhaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
+        cGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tz
+        L2U5YTZmOWFkLWEyMzctNDI0ZC04ZDA3LTliY2JiNzQ4ZjUzMy8iLCAidGFz
+        a19pZCI6ICJlOWE2ZjlhZC1hMjM3LTQyNGQtOGQwNy05YmNiYjc0OGY1MzMi
+        fV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29u
+        dGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
+        IjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9k
+        b25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJp
+        dGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5p
+        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJy
+        ZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1
+        NmNjOGQzNGRlMDQwMzNmNDI2MmNhYWMifSwgImV4Y2VwdGlvbiI6IG51bGws
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAi
+        c3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ3OjQ4WiIsICJfbnMiOiAicmVw
+        b19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6
+        NDc6NDhaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwg
+        ImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUs
+        ICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQi
+        OiAiNTZjYzhkMzRkZTA0MDMwODk3NThhODc0IiwgImRldGFpbHMiOiB7ImNv
+        bnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xl
+        ZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
+        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJv
+        cl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0
+        IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
+        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDM0OTg5MDU0ZmM0OGJhMmVkZCJ9
+        LCAiaWQiOiAiNTZjYzhkMzQ5ODkwNTRmYzQ4YmEyZWRkIn0sIHsiZXhjZXB0
+        aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vy
+        cy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFz
+        a3MvMmRmOTM2NDctNGQwOS00ODFkLWI0NmEtOWQ0N2M5YzViNzNjLyIsICJ0
+        YXNrX2lkIjogIjJkZjkzNjQ3LTRkMDktNDgxZC1iNDZhLTlkNDdjOWM1Yjcz
+        YyIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1
+        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNU
+        MTY6NDc6NTVaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
+        IjogIjIwMTYtMDItMjNUMTY6NDc6NTVaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzg1OWFhMjkyLTZhNTctNDMzNC1hNWViLTQ0NWNlZmQyOTdiZS8iLCAi
+        dGFza19pZCI6ICI4NTlhYTI5Mi02YTU3LTQzMzQtYTVlYi00NDVjZWZkMjk3
+        YmUifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsi
+        Y29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3Rv
+        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
+        bV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAs
+        ICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xl
+        ZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
+        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJm
+        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
+        eyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6
+        ICI1NmNjOGQzYmRlMDQwMzNmNDI2MmNhYjEifSwgImV4Y2VwdGlvbiI6IG51
+        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
+        LCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ3OjU1WiIsICJfbnMiOiAi
+        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNU
+        MTY6NDc6NTVaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVu
+        dCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50Ijog
+        MTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAi
+        aWQiOiAiNTZjYzhkM2JkZTA0MDMwODk3NThhODgwIiwgImRldGFpbHMiOiB7
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDNiOTg5MDU0ZmM0OGJhMmVm
+        MiJ9LCAiaWQiOiAiNTZjYzhkM2I5ODkwNTRmYzQ4YmEyZWYyIn0sIHsiZXhj
+        ZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5h
+        Z2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIv
+        dGFza3MvZmFkYjdmOWEtMWZiYS00YjAwLTgzZGItZmI2ZTYxZGU2ZWQyLyIs
+        ICJ0YXNrX2lkIjogImZhZGI3ZjlhLTFmYmEtNGIwMC04M2RiLWZiNmU2MWRl
+        NmVkMiIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3Iiwg
+        InB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDIt
+        MjNUMTY6NDc6NThaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTYtMDItMjNUMTY6NDc6NTdaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L3Rhc2tzLzc5YjgwMjg3LTM4YTItNGFkYS04YzgxLWFiYzVjYmYwZmJiNy8i
+        LCAidGFza19pZCI6ICI3OWI4MDI4Ny0zOGEyLTRhZGEtOGM4MS1hYmM1Y2Jm
+        MGZiYjcifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6
+        IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklO
+        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBt
+        X3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAi
+        ZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6
+        IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklO
         SVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklT
         SEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0
         YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1z
         X2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhN2JkYjAzYzJiYTdjOTFi
-        MzliIn0sICJpZCI6ICI1NmM0ZGE3YmRiMDNjMmJhN2M5MWIzOWIifSwgeyJl
-        eGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVyLm1h
-        bmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92
-        Mi90YXNrcy83MmY2YjEyOC0yMzkyLTQxYmEtYTZjZS0xYWIxODA3NmU2YzYv
-        IiwgInRhc2tfaWQiOiAiNzJmNmIxMjgtMjM5Mi00MWJhLWE2Y2UtMWFiMTgw
-        NzZlNmM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFfMTci
-        LCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0w
-        Mi0xN1QyMDozOToyN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0
-        X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDozOToyNloiLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9hcGkv
-        djIvdGFza3MvY2ZiNDAzODEtZjFiMy00ZGE3LTk0ZWQtZjliMTQwY2M0YjEx
-        LyIsICJ0YXNrX2lkIjogImNmYjQwMzgxLWYxYjMtNGRhNy05NGVkLWY5YjE0
-        MGNjNGIxMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAwLCAi
-        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwgInJlc3Vs
-        dCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRv
-        aWQiOiAiNTZjNGRhN2U1Y2EwMTMxODRlMjhmYzA1In0sICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0xN1QyMDozOToyNloiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAy
-        LTE3VDIwOjM5OjI3WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7ImNv
-        bnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3Rh
+        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6
+        ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0
+        IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9p
+        ZCI6ICI1NmNjOGQzZGRlMDQwMzNmNDI2MmNhYjYifSwgImV4Y2VwdGlvbiI6
+        IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ3OjU3WiIsICJfbnMi
+        OiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDIt
+        MjNUMTY6NDc6NThaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9y
+        dGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29u
+        dGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
+        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50
+        IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAw
+        LCAiaWQiOiAiNTZjYzhkM2VkZTA0MDMwODk3NThhODhiIiwgImRldGFpbHMi
+        OiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6
+        IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJz
+        aXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJw
+        bV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0s
+        ICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVt
+        c19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3Ii
+        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDNkOTg5MDU0ZmM0OGJh
+        MmYwNCJ9LCAiaWQiOiAiNTZjYzhkM2Q5ODkwNTRmYzQ4YmEyZjA0In0sIHsi
+        ZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5t
+        YW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkv
+        djIvdGFza3MvYTA5ZWU2YWQtMzFkMS00M2VkLWE4MTYtODMwMzljZGZhMWEz
+        LyIsICJ0YXNrX2lkIjogImEwOWVlNmFkLTMxZDEtNDNlZC1hODE2LTgzMDM5
+        Y2RmYTFhMyIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3
+        IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYt
+        MDItMjNUMTY6NDg6MDFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFy
+        dF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDg6MDBaIiwgInRyYWNlYmFjayI6
+        IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBp
+        L3YyL3Rhc2tzLzAyZDZkYjdhLTJiNmQtNDM0Zi05MDRiLTQwZWJhNDFhYzk2
+        My8iLCAidGFza19pZCI6ICIwMmQ2ZGI3YS0yYjZkLTQzNGYtOTA0Yi00MGVi
+        YTQxYWM5NjMifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRl
+        ciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsi
+        cnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAw
+        LCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVm
+        dCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0
+        ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0
+        ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsi
+        JG9pZCI6ICI1NmNjOGQ0MGRlMDQwMzNmNDM1MTRmODAifSwgImV4Y2VwdGlv
+        biI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2si
+        OiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ4OjAwWiIsICJf
+        bnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYt
+        MDItMjNUMTY6NDg6MDFaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2lt
+        cG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsi
+        Y29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2Nv
+        dW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQi
+        OiAwLCAiaWQiOiAiNTZjYzhkNDFkZTA0MDMwODk3NThhODk2IiwgImRldGFp
+        bHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVm
+        dCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwg
+        InJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
+        MH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
+        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDQwOTg5MDU0ZmM0
+        OGJhMmYxNiJ9LCAiaWQiOiAiNTZjYzhkNDA5ODkwNTRmYzQ4YmEyZjE2In0s
+        IHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZl
+        ci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvODdhZThiYmUtNzQwMS00OTVjLTk4ZjUtMTdkNjY1ZDU4
+        MjFmLyIsICJ0YXNrX2lkIjogIjg3YWU4YmJlLTc0MDEtNDk1Yy05OGY1LTE3
+        ZDY2NWQ1ODIxZiIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3Jh
+        XzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIw
+        MTYtMDItMjNUMTY6NDg6MDRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
+        dGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDg6MDNaIiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAv
+        YXBpL3YyL3Rhc2tzL2U5N2QzYWY5LWYwYzQtNDk4Mi04MGQxLWQ1NDdhZmRi
+        MWMwMi8iLCAidGFza19pZCI6ICJlOTdkM2FmOS1mMGM0LTQ5ODItODBkMS1k
+        NTQ3YWZkYjFjMDIifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJz
+        dGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
+        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6
+        IHsiJG9pZCI6ICI1NmNjOGQ0M2RlMDQwMzNmNDFkMmE0MDAifSwgImV4Y2Vw
+        dGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ4OjAzWiIs
+        ICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
+        MTYtMDItMjNUMTY6NDg6MDRaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVt
+        X2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6
+        IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVk
+        X2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291
+        bnQiOiAwLCAiaWQiOiAiNTZjYzhkNDRkZTA0MDMwODk3NThhOGExIiwgImRl
+        dGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNf
+        bGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjog
+        MCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25l
+        IjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDQzOTg5MDU0
+        ZmM0OGJhMmYyOCJ9LCAiaWQiOiAiNTZjYzhkNDM5ODkwNTRmYzQ4YmEyZjI4
+        In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNl
+        cnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVs
+        cC9hcGkvdjIvdGFza3MvMThiZjEwMzMtNzUzMi00ZjJjLWI3NGUtYTI3MDJh
+        MWEzNzk3LyIsICJ0YXNrX2lkIjogIjE4YmYxMDMzLTc1MzItNGYyYy1iNzRl
+        LWEyNzAyYTFhMzc5NyIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVk
+        b3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTYtMDItMjNUMTY6NDg6MDdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDg6MDZaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzLzg1ZDFjZGI4LWUxNDgtNGE2Mi04YzZiLTcwNzkx
+        OWZkOThjNy8iLCAidGFza19pZCI6ICI4NWQxY2RiOC1lMTQ4LTRhNjItOGM2
+        Yi03MDc5MTlmZDk4YzcifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
         dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3Vu
-        dCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50Ijog
-        MCwgImlkIjogIjU2YzRkYTdmNWNhMDEzMThmMzBjYjA4OSIsICJkZXRhaWxz
-        IjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQi
-        OiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        c2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJy
-        cG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
+        ZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9p
+        ZCI6IHsiJG9pZCI6ICI1NmNjOGQ0NmRlMDQwMzNmNDM1MTRmODUifSwgImV4
+        Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFj
+        ZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ4OjA2
+        WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjog
+        IjIwMTYtMDItMjNUMTY6NDg6MDdaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFy
+        eSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFk
+        ZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRf
+        Y291bnQiOiAwLCAiaWQiOiAiNTZjYzhkNDdkZTA0MDMwODk3NThhOGFjIiwg
+        ImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRl
+        bXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
+        IjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9k
+        b25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
+        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDQ2OTg5
+        MDU0ZmM0OGJhMmYzYSJ9LCAiaWQiOiAiNTZjYzhkNDY5ODkwNTRmYzQ4YmEy
+        ZjNhIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxw
+        LnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIv
+        cHVscC9hcGkvdjIvdGFza3MvMDQwOThjZWMtODYxMy00MDQ2LTgxZWEtMDlk
+        NzI4MmU4N2NhLyIsICJ0YXNrX2lkIjogIjA0MDk4Y2VjLTg2MTMtNDA0Ni04
+        MWVhLTA5ZDcyODJlODdjYSIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6
+        RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1l
+        IjogIjIwMTYtMDItMjNUMTY6NDg6MDlaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1
+        cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDg6MDlaIiwgInRy
+        YWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAi
+        L3B1bHAvYXBpL3YyL3Rhc2tzLzgwMzg5OTQ3LTAxMDktNDYyMy1iNTRkLTBk
+        OTRiZTFmNWY2MC8iLCAidGFza19pZCI6ICI4MDM4OTk0Ny0wMTA5LTQ2MjMt
+        YjU0ZC0wZDk0YmUxZjVmNjAifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1
+        bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwg
+        InNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRl
+        cl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ0OWRlMDQwMzNmNDFkMmE0MDYifSwg
+        ImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0
+        cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ4
+        OjA5WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMjNUMTY6NDg6MDlaIiwgImltcG9ydGVyX3R5cGVfaWQi
+        OiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3Vt
+        bWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNv
+        bXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRl
+        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwg
+        ImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0
+        ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkNDlkZTA0MDMwODk3NThhOGI3
+        IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAi
+        aXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3Rv
+        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
+        bV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
+        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDQ5
+        OTg5MDU0ZmM0OGJhMmY0YyJ9LCAiaWQiOiAiNTZjYzhkNDk5ODkwNTRmYzQ4
+        YmEyZjRjIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJw
+        dWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6
+        ICIvcHVscC9hcGkvdjIvdGFza3MvOGUxODgxNzktY2FiOC00Y2JiLWI5MmYt
+        ZTFmMjc2YWM0NzA0LyIsICJ0YXNrX2lkIjogIjhlMTg4MTc5LWNhYjgtNGNi
+        Yi1iOTJmLWUxZjI3NmFjNDcwNCIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRv
+        cnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90
+        aW1lIjogIjIwMTYtMDItMjNUMTY6NDg6MTNaIiwgIl9ucyI6ICJ0YXNrX3N0
+        YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDg6MTJaIiwg
+        InRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzJlOTY3MzU3LWEzNGQtNGYyNi1iYzg1
+        LWVlYjc4OWRmYjhlNy8iLCAidGFza19pZCI6ICIyZTk2NzM1Ny1hMzRkLTRm
+        MjYtYmM4NS1lZWI3ODlkZmI4ZTcifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
+        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjog
+        MCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBs
+        ZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBv
+        cnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ0Y2RlMDQwMzNmNDFkMmE0MGIi
+        fSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2
+        OjQ4OjEyWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxl
+        dGVkIjogIjIwMTYtMDItMjNUMTY6NDg6MTNaIiwgImltcG9ydGVyX3R5cGVf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAi
+        c3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVw
+        ZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkNGRkZTA0MDMwODk3NThh
+        OGMyIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAw
+        LCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBt
+        X3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAi
+        ZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4
+        ZDRjOTg5MDU0ZmM0OGJhMmY1ZSJ9LCAiaWQiOiAiNTZjYzhkNGM5ODkwNTRm
+        YzQ4YmEyZjVlIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6
+        ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJl
+        ZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvOWIwYzhlYTItNTEzNC00MTBmLWIx
+        MWItNjU4YzJhMGNiMTM2LyIsICJ0YXNrX2lkIjogIjliMGM4ZWEyLTUxMzQt
+        NDEwZi1iMTFiLTY1OGMyYTBjYjEzNiIsICJ0YWdzIjogWyJwdWxwOnJlcG9z
+        aXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDg6MTZaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDg6MTVa
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hy
+        ZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2M3MjYwMTQ0LTVjODQtNDdjMi04
+        OWZhLTYwMWM3OWFiYjE3ZS8iLCAidGFza19pZCI6ICJjNzI2MDE0NC01Yzg0
+        LTQ3YzItODlmYS02MDFjNzlhYmIxN2UifV0sICJwcm9ncmVzc19yZXBvcnQi
+        OiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
+        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFs
+        IjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21w
+        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJp
+        bXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ0ZmRlMDQwMzNmNDM1MTRm
+        OGUifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8x
+        NyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIz
+        VDE2OjQ4OjE2WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29t
+        cGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6MTZaIiwgImltcG9ydGVyX3R5
+        cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxs
+        LCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
+        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwg
+        InVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkNTBkZTA0MDMwODk3
+        NThhOGNkIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwi
+        OiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsi
+        cnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAw
+        LCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29t
+        cHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2
+        Y2M4ZDRmOTg5MDU0ZmM0OGJhMmY3MCJ9LCAiaWQiOiAiNTZjYzhkNGY5ODkw
+        NTRmYzQ4YmEyZjcwIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlw
+        ZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJf
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNGE2YWJjM2QtMDU2Yy00NmRm
+        LWEzZTMtNTFhYmZjYjMzYTcwLyIsICJ0YXNrX2lkIjogIjRhNmFiYzNkLTA1
+        NmMtNDZkZi1hM2UzLTUxYWJmY2IzM2E3MCIsICJ0YWdzIjogWyJwdWxwOnJl
+        cG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZp
+        bmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDg6MTlaIiwgIl9ucyI6ICJ0
+        YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDg6
+        MTlaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3si
+        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzFjNjgyN2RkLTkyZGEtNDk2
+        Ny1hOTcxLWI3ZGI3ZDEwY2JiNS8iLCAidGFza19pZCI6ICIxYzY4MjdkZC05
+        MmRhLTQ5NjctYTk3MS1iN2RiN2QxMGNiYjUifV0sICJwcm9ncmVzc19yZXBv
+        cnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3Rv
+        dGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJj
+        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0
+        ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
+        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ1MmRlMDQwMzNmNDM1
+        MTRmOTQifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9y
+        YV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAy
+        LTIzVDE2OjQ4OjE5WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAi
+        Y29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6MTlaIiwgImltcG9ydGVy
+        X3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBu
+        dWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50Ijog
+        MCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkNTNkZTA0MDMw
+        ODk3NThhOGQ4IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90
+        YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAi
+        Y29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNh
+        dGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjog
+        eyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjog
+        IjU2Y2M4ZDUyOTg5MDU0ZmM0OGJhMmY4MiJ9LCAiaWQiOiAiNTZjYzhkNTI5
+        ODkwNTRmYzQ4YmEyZjgyIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tf
+        dHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIs
+        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZjk0NDViOTMtNWY0ZS00
+        NDE1LTk0YjctMmU0NjlmZTg2MjE5LyIsICJ0YXNrX2lkIjogImY5NDQ1Yjkz
+        LTVmNGUtNDQxNS05NGI3LTJlNDY5ZmU4NjIxOSIsICJ0YWdzIjogWyJwdWxw
+        OnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwg
+        ImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDg6MjJaIiwgIl9ucyI6
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6
+        NDg6MjFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        W3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzNiOTQ3ZjdkLWE1NmUt
+        NDQ1Ni1hYTlmLWQ0NTc2YzU4ODNkOC8iLCAidGFza19pZCI6ICIzYjk0N2Y3
+        ZC1hNTZlLTQ0NTYtYWE5Zi1kNDU3NmM1ODgzZDgifV0sICJwcm9ncmVzc19y
+        ZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNf
+        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
+        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXpl
+        X3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxp
+        Y2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlv
+        ZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2Vz
+        cyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ1NWRlMDQwMzNm
+        NDFkMmE0MTAifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZl
+        ZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2
+        LTAyLTIzVDE2OjQ4OjIxWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMi
+        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6MjJaIiwgImltcG9y
+        dGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2Ui
+        OiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVy
+        Z2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3Ry
+        aWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50
+        IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkNTZkZTA0
+        MDMwODk3NThhOGUzIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVf
+        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
+        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
+        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
+        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
+        IjogIjU2Y2M4ZDU1OTg5MDU0ZmM0OGJhMmY5NCJ9LCAiaWQiOiAiNTZjYzhk
+        NTU5ODkwNTRmYzQ4YmEyZjk0In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRh
+        c2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3lu
+        YyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZjNlNWE5Y2YtMTI5
+        Yi00NTE3LThmM2QtMjdhN2JkYTQ1ODQwLyIsICJ0YXNrX2lkIjogImYzZTVh
+        OWNmLTEyOWItNDUxNy04ZjNkLTI3YTdiZGE0NTg0MCIsICJ0YWdzIjogWyJw
+        dWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMi
+        XSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDg6MjVaIiwgIl9u
+        cyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMjNU
+        MTY6NDg6MjVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        IjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2JiNzZhZDk3LWM3
+        NzMtNDBjNS05NmE1LTgyMDI4YTBmNzZiZi8iLCAidGFza19pZCI6ICJiYjc2
+        YWQ5Ny1jNzczLTQwYzUtOTZhNS04MjAyOGEwZjc2YmYifV0sICJwcm9ncmVz
+        c19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRl
+        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJz
+        aXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0Ijog
+        MH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1
+        cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRp
+        b24iOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ1OWRlMDQw
+        MzNmNDFkMmE0MTUifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjI1WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6MjVaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkNTlk
+        ZTA0MDMwODk3NThhOGVlIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDU5OTg5MDU0ZmM0OGJhMmZhNiJ9LCAiaWQiOiAiNTZj
+        YzhkNTk5ODkwNTRmYzQ4YmEyZmE2In0sIHsiZXhjZXB0aW9uIjogbnVsbCwg
+        InRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMu
+        c3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvN2ZkOGFlZTUt
+        Mzc3Yi00ODQ2LWI5ODEtMzg1M2MzYjRiODczLyIsICJ0YXNrX2lkIjogIjdm
+        ZDhhZWU1LTM3N2ItNDg0Ni1iOTgxLTM4NTNjM2I0Yjg3MyIsICJ0YWdzIjog
+        WyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5
+        bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDg6MjhaIiwg
+        Il9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDIt
+        MjNUMTY6NDg6MjhaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rh
+        c2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzdkYWFkOWU0
+        LWFkOGItNDA1My04ZTU1LTllODBjNjcxMGE2Mi8iLCAidGFza19pZCI6ICI3
+        ZGFhZDllNC1hZDhiLTQwNTMtOGU1NS05ZTgwYzY3MTBhNjIifV0sICJwcm9n
+        cmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsi
+        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJw
+        bV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0s
+        ICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0
+        IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdl
+        X2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
+        c3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ1Y2Rl
+        MDQwMzNmNDM1MTRmOTkifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lk
+        IjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6
+        ICIyMDE2LTAyLTIzVDE2OjQ4OjI4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jl
+        c3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6MjhaIiwg
+        ImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21l
+        c3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVk
+        X2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhk
+        NWNkZTA0MDMwODk3NThhOGY5IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7
+        InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3Rh
+        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAi
+        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
+        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxz
+        IjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJn
+        ZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
+        YnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJl
+        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
+        eyIkb2lkIjogIjU2Y2M4ZDVjOTg5MDU0ZmM0OGJhMmZiOCJ9LCAiaWQiOiAi
+        NTZjYzhkNWM5ODkwNTRmYzQ4YmEyZmI4In0sIHsiZXhjZXB0aW9uIjogbnVs
+        bCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5
+        bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNzZmZTEw
+        MGYtZjk2Zi00N2I2LTg0OTItZDA3MmNiM2IyMmU5LyIsICJ0YXNrX2lkIjog
+        Ijc2ZmUxMDBmLWY5NmYtNDdiNi04NDkyLWQwNzJjYjNiMjJlOSIsICJ0YWdz
+        IjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9u
+        OnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDg6MzFa
+        IiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYt
+        MDItMjNUMTY6NDg6MzFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
+        X3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2FmOGM4
+        MTM1LWUwNTEtNDZjYy05ODYxLTVlNzdhMmM5YmNkMC8iLCAidGFza19pZCI6
+        ICJhZjhjODEzNS1lMDUxLTQ2Y2MtOTg2MS01ZTc3YTJjOWJjZDAifV0sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwg
+        InJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
+        MH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19s
+        ZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
+        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
+        cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
+        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ1
+        ZmRlMDQwMzNmNDM1MTRmOWUifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
+        ZCI6ICIyMDE2LTAyLTIzVDE2OjQ4OjMxWiIsICJfbnMiOiAicmVwb19zeW5j
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6MzFa
+        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZj
+        YzhkNWZkZTA0MDMwODk3NThhOTA0IiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
+        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
+        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
+        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
+        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
+        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
+        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
+        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjU2Y2M4ZDVmOTg5MDU0ZmM0OGJhMmZjYSJ9LCAiaWQi
+        OiAiNTZjYzhkNWY5ODkwNTRmYzQ4YmEyZmNhIn0sIHsiZXhjZXB0aW9uIjog
+        bnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBv
+        LnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMzAy
+        MzI3NjktNTJmZi00OTg3LWFkNTItZjIwNzgwMDI5NTRiLyIsICJ0YXNrX2lk
+        IjogIjMwMjMyNzY5LTUyZmYtNDk4Ny1hZDUyLWYyMDc4MDAyOTU0YiIsICJ0
+        YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0
+        aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDg6
+        MzRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTYtMDItMjNUMTY6NDg6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2E3
+        ZGU5M2U2LTYxMjAtNDVmNC1iNGZlLTkzNTExMDgzMzI5NS8iLCAidGFza19p
+        ZCI6ICJhN2RlOTNlNi02MTIwLTQ1ZjQtYjRmZS05MzUxMTA4MzMyOTUifV0s
+        ICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVu
+        dCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjog
+        MCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25l
+        IjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVt
+        c19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        InB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJk
+        aXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAw
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNj
+        OGQ2MmRlMDQwMzNmNDFkMmE0MWEifSwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ4OjM0WiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6
+        MzRaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZjYzhkNjJkZTA0MDMwODk3NThhOTBmIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU2Y2M4ZDYyOTg5MDU0ZmM0OGJhMmZkYyJ9LCAi
+        aWQiOiAiNTZjYzhkNjI5ODkwNTRmYzQ4YmEyZmRjIn0sIHsiZXhjZXB0aW9u
+        IjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5y
+        ZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3Mv
+        YjE0ZjE3YmItYzQwYy00OWE1LWFiZGUtODg5YWIwMzQ1OTA0LyIsICJ0YXNr
+        X2lkIjogImIxNGYxN2JiLWM0MGMtNDlhNS1hYmRlLTg4OWFiMDM0NTkwNCIs
+        ICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6
+        YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNUMTY6
+        NDg6MzhaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
+        IjIwMTYtMDItMjNUMTY6NDg6MzdaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
+        cGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tz
+        L2FhYzgwY2VmLTYxNzktNDQ4NC1hY2NjLWJlMWYwOWE3Mjg4OS8iLCAidGFz
+        a19pZCI6ICJhYWM4MGNlZi02MTc5LTQ0ODQtYWNjYy1iZTFmMDlhNzI4ODki
+        fV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29u
+        dGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
+        IjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9k
+        b25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJp
+        dGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5p
+        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJy
+        ZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1
+        NmNjOGQ2NWRlMDQwMzNmNDFkMmE0MWYifSwgImV4Y2VwdGlvbiI6IG51bGws
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAi
+        c3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ4OjM3WiIsICJfbnMiOiAicmVw
+        b19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6
+        NDg6MzhaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwg
+        ImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
         SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAwLCAi
-        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9y
-        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE3ZWRiMDNjMmJhN2M5
-        MWIzYWQifSwgImlkIjogIjU2YzRkYTdlZGIwM2MyYmE3YzkxYjNhZCJ9XQ==
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUs
+        ICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQi
+        OiAiNTZjYzhkNjZkZTA0MDMwODk3NThhOTFhIiwgImRldGFpbHMiOiB7ImNv
+        bnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xl
+        ZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
+        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJv
+        cl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0
+        IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
+        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDY1OTg5MDU0ZmM0OGJhMmZlZSJ9
+        LCAiaWQiOiAiNTZjYzhkNjU5ODkwNTRmYzQ4YmEyZmVlIn0sIHsiZXhjZXB0
+        aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vy
+        cy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFz
+        a3MvY2M3OGRmNTctYjAzYS00NDIwLTk0YmItYTA1MWFhOGQ4ZTA3LyIsICJ0
+        YXNrX2lkIjogImNjNzhkZjU3LWIwM2EtNDQyMC05NGJiLWEwNTFhYThkOGUw
+        NyIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1
+        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMjNU
+        MTY6NDg6NDFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
+        IjogIjIwMTYtMDItMjNUMTY6NDg6NDFaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzUzMGJiZTAyLTM5ZDItNDM5ZC1iNGZmLWU1MmViMzI0MTE4NS8iLCAi
+        dGFza19pZCI6ICI1MzBiYmUwMi0zOWQyLTQzOWQtYjRmZi1lNTJlYjMyNDEx
+        ODUifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsi
+        Y29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3Rv
+        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
+        bV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAs
+        ICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xl
+        ZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
+        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJm
+        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
+        eyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6
+        ICI1NmNjOGQ2OGRlMDQwMzNmNDFkMmE0MjQifSwgImV4Y2VwdGlvbiI6IG51
+        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
+        LCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ4OjQxWiIsICJfbnMiOiAi
+        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNU
+        MTY6NDg6NDFaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVu
+        dCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50Ijog
+        MTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAi
+        aWQiOiAiNTZjYzhkNjlkZTA0MDMwODk3NThhOTI1IiwgImRldGFpbHMiOiB7
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDY5OTg5MDU0ZmM0OGJhMzAw
+        MCJ9LCAiaWQiOiAiNTZjYzhkNjk5ODkwNTRmYzQ4YmEzMDAwIn1d
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:28 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:42 GMT
 - request:
     method: delete
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -7499,7 +12594,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:28 GMT
+      - Tue, 23 Feb 2016 16:48:43 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -7512,14 +12607,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzhhNTE5Yzc0LWFiMzYtNGUyNS1iOWM2LTU2NWVlYjZhMzNiYi8iLCAi
-        dGFza19pZCI6ICI4YTUxOWM3NC1hYjM2LTRlMjUtYjljNi01NjVlZWI2YTMz
-        YmIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2Q4NDQ0OTVkLTk5ZTItNGZhNi04NzM0LTI2YmQxYTRjMWRjMi8iLCAi
+        dGFza19pZCI6ICJkODQ0NDk1ZC05OWUyLTRmYTYtODczNC0yNmJkMWE0YzFk
+        YzIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:28 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:43 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/8a519c74-ab36-4e25-b9c6-565eeb6a33bb/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/d844495d-99e2-4fa6-8734-26bd1a4c1dc2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -7538,13 +12633,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:28 GMT
+      - Tue, 23 Feb 2016 16:48:43 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '567'
       Connection:
       - close
       Content-Type:
@@ -7554,22 +12649,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84YTUxOWM3NC1hYjM2LTRlMjUtYjljNi01NjVlZWI2YTMz
-        YmIvIiwgInRhc2tfaWQiOiAiOGE1MTljNzQtYWIzNi00ZTI1LWI5YzYtNTY1
-        ZWViNmEzM2JiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kODQ0NDk1ZC05OWUyLTRmYTYtODczNC0yNmJkMWE0YzFk
+        YzIvIiwgInRhc2tfaWQiOiAiZDg0NDQ5NWQtOTllMi00ZmE2LTg3MzQtMjZi
+        ZDFhNGMxZGMyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE4
-        MGRiMDNjMmJhN2M5MWIzYmUifSwgImlkIjogIjU2YzRkYTgwZGIwM2MyYmE3
-        YzkxYjNiZSJ9
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ4OjQzWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJOb25lLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiBudWxsLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6
+        IHsiJG9pZCI6ICI1NmNjOGQ2Yjk4OTA1NGZjNDhiYTMwMTEifSwgImlkIjog
+        IjU2Y2M4ZDZiOTg5MDU0ZmM0OGJhMzAxMSJ9
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:28 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:43 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/8a519c74-ab36-4e25-b9c6-565eeb6a33bb/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/d844495d-99e2-4fa6-8734-26bd1a4c1dc2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -7588,13 +12683,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:28 GMT
+      - Tue, 23 Feb 2016 16:48:43 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '680'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -7604,20 +12699,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84YTUxOWM3NC1hYjM2LTRlMjUtYjljNi01NjVlZWI2YTMz
-        YmIvIiwgInRhc2tfaWQiOiAiOGE1MTljNzQtYWIzNi00ZTI1LWI5YzYtNTY1
-        ZWViNmEzM2JiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kODQ0NDk1ZC05OWUyLTRmYTYtODczNC0yNmJkMWE0YzFk
+        YzIvIiwgInRhc2tfaWQiOiAiZDg0NDQ5NWQtOTllMi00ZmE2LTg3MzQtMjZi
+        ZDFhNGMxZGMyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM5OjI4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM5OjI4WiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ4OjQzWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjQzWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTgwZGIw
-        M2MyYmE3YzkxYjNiZSJ9LCAiaWQiOiAiNTZjNGRhODBkYjAzYzJiYTdjOTFi
-        M2JlIn0=
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNmI5
+        ODkwNTRmYzQ4YmEzMDExIn0sICJpZCI6ICI1NmNjOGQ2Yjk4OTA1NGZjNDhi
+        YTMwMTEifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:28 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:43 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/pulp/repository/create.yml
+++ b/test/fixtures/vcr_cassettes/pulp/repository/create.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -11,20 +11,20 @@ http_interactions:
         b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
         ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6ImZvbyIsInNzbF9jbGllbnRfY2Vy
         dCI6ImZvbyIsInNzbF9jbGllbnRfa2V5IjoiZm9vIiwiZG93bmxvYWRfcG9s
-        aWN5IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0s
-        ImRpc3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9k
-        aXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91
-        cmwiOiJ0ZXN0X3BhdGgvIiwiaHR0cCI6ZmFsc2UsImh0dHBzIjp0cnVlLCJw
-        cm90ZWN0ZWQiOnRydWV9LCJhdXRvX3B1Ymxpc2giOnRydWUsImRpc3RyaWJ1
-        dG9yX2lkIjoiRmVkb3JhXzE3In0seyJkaXN0cmlidXRvcl90eXBlX2lkIjoi
-        eXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7
-        ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjoiRmVkb3JhXzE3In0sImF1
-        dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiRmVkb3JhXzE3
-        X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBlX2lkIjoiZXhwb3J0X2Rpc3Ry
-        aWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7Imh0dHAiOmZhbHNlLCJo
-        dHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6InRlc3RfcGF0aC8ifSwiYXV0
-        b19wdWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJleHBvcnRfZGlz
-        dHJpYnV0b3IifV19
+        aWN5IjpudWxsLCJyZW1vdmVfbWlzc2luZyI6bnVsbH0sIm5vdGVzIjp7Il9y
+        ZXBvLXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3Ry
+        aWJ1dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRv
+        cl9jb25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoLyIsImh0dHAi
+        OmZhbHNlLCJodHRwcyI6dHJ1ZSwicHJvdGVjdGVkIjp0cnVlfSwiYXV0b19w
+        dWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9pZCI6IkZlZG9yYV8xNyJ9LHsi
+        ZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9jbG9uZV9kaXN0cmlidXRvciIs
+        ImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRv
+        cl9pZCI6IkZlZG9yYV8xNyJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0
+        cmlidXRvcl9pZCI6IkZlZG9yYV8xN19jbG9uZSJ9LHsiZGlzdHJpYnV0b3Jf
+        dHlwZV9pZCI6ImV4cG9ydF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2Nv
+        bmZpZyI6eyJodHRwIjpmYWxzZSwiaHR0cHMiOmZhbHNlLCJyZWxhdGl2ZV91
+        cmwiOiJ0ZXN0X3BhdGgvIn0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3Ry
+        aWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
     headers:
       Accept:
       - application/json
@@ -33,7 +33,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '822'
+      - '844'
       User-Agent:
       - Ruby
   response:
@@ -42,13 +42,13 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:08 GMT
+      - Tue, 23 Feb 2016 16:47:37 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
       - '320'
       Location:
-      - https://abed.usersys.redhat.com/pulp/api/v2/repositories/Fedora_17/
+      - https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/
       Connection:
       - close
       Content-Type:
@@ -61,14 +61,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZjNGRhMzA1Y2EwMTMxODRlMjhmYmM1In0sICJpZCI6ICJGZWRvcmFfMTci
+        NTZjYzhkMjlkZTA0MDMzZjQzNTE0ZjY5In0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:08 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:37 GMT
 - request:
     method: delete
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -87,7 +87,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:08 GMT
+      - Tue, 23 Feb 2016 16:47:37 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -100,14 +100,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzY1ZmQ0MmZhLWRkOWQtNDYxMC04MzVlLTExOTRjZjZmZjJiNC8iLCAi
-        dGFza19pZCI6ICI2NWZkNDJmYS1kZDlkLTQ2MTAtODM1ZS0xMTk0Y2Y2ZmYy
-        YjQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2UwZWFiZjU1LWU2OGYtNDg2ZC1iNTI5LWE4OTJhZGQ1ZjUzNi8iLCAi
+        dGFza19pZCI6ICJlMGVhYmY1NS1lNjhmLTQ4NmQtYjUyOS1hODkyYWRkNWY1
+        MzYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:08 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:37 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/65fd42fa-dd9d-4610-835e-1194cf6ff2b4/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/e0eabf55-e68f-486d-b529-a892add5f536/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -126,13 +126,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:08 GMT
+      - Tue, 23 Feb 2016 16:47:37 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '645'
       Connection:
       - close
       Content-Type:
@@ -142,22 +142,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NWZkNDJmYS1kZDlkLTQ2MTAtODM1ZS0xMTk0Y2Y2ZmYy
-        YjQvIiwgInRhc2tfaWQiOiAiNjVmZDQyZmEtZGQ5ZC00NjEwLTgzNWUtMTE5
-        NGNmNmZmMmI0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9lMGVhYmY1NS1lNjhmLTQ4NmQtYjUyOS1hODkyYWRkNWY1
+        MzYvIiwgInRhc2tfaWQiOiAiZTBlYWJmNTUtZTY4Zi00ODZkLWI1MjktYTg5
+        MmFkZDVmNTM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
         bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
         ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGEz
-        MGRiMDNjMmJhN2M5MWIyODEifSwgImlkIjogIjU2YzRkYTMwZGIwM2MyYmE3
-        YzkxYjI4MSJ9
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3Rh
+        dGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        NmNjOGQyOTk4OTA1NGZjNDhiYTJlZDQifSwgImlkIjogIjU2Y2M4ZDI5OTg5
+        MDU0ZmM0OGJhMmVkNCJ9
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:08 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:37 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/65fd42fa-dd9d-4610-835e-1194cf6ff2b4/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/e0eabf55-e68f-486d-b529-a892add5f536/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -176,13 +178,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:08 GMT
+      - Tue, 23 Feb 2016 16:47:37 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '680'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -192,20 +194,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NWZkNDJmYS1kZDlkLTQ2MTAtODM1ZS0xMTk0Y2Y2ZmYy
-        YjQvIiwgInRhc2tfaWQiOiAiNjVmZDQyZmEtZGQ5ZC00NjEwLTgzNWUtMTE5
-        NGNmNmZmMmI0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9lMGVhYmY1NS1lNjhmLTQ4NmQtYjUyOS1hODkyYWRkNWY1
+        MzYvIiwgInRhc2tfaWQiOiAiZTBlYWJmNTUtZTY4Zi00ODZkLWI1MjktYTg5
+        MmFkZDVmNTM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM4OjA4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM4OjA4WiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ3OjM3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ3OjM3WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTMwZGIw
-        M2MyYmE3YzkxYjI4MSJ9LCAiaWQiOiAiNTZjNGRhMzBkYjAzYzJiYTdjOTFi
-        MjgxIn0=
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMjk5
+        ODkwNTRmYzQ4YmEyZWQ0In0sICJpZCI6ICI1NmNjOGQyOTk4OTA1NGZjNDhi
+        YTJlZDQifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:08 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:37 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/pulp/repository/operations.yml
+++ b/test/fixtures/vcr_cassettes/pulp/repository/operations.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/221aef97-84ca-41af-90f4-6627e1514b5d/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/5cdb1331-73a8-4215-b866-bcbb4d9878b1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -21,13 +21,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:29 GMT
+      - Tue, 23 Feb 2016 16:48:44 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '565'
       Connection:
       - close
       Content-Type:
@@ -37,22 +37,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yMjFhZWY5Ny04NGNhLTQxYWYtOTBmNC02NjI3ZTE1MTRi
-        NWQvIiwgInRhc2tfaWQiOiAiMjIxYWVmOTctODRjYS00MWFmLTkwZjQtNjYy
-        N2UxNTE0YjVkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy81Y2RiMTMzMS03M2E4LTQyMTUtYjg2Ni1iY2JiNGQ5ODc4
+        YjEvIiwgInRhc2tfaWQiOiAiNWNkYjEzMzEtNzNhOC00MjE1LWI4NjYtYmNi
+        YjRkOTg3OGIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhODFk
-        YjAzYzJiYTdjOTFiM2JmIn0sICJpZCI6ICI1NmM0ZGE4MWRiMDNjMmJhN2M5
-        MWIzYmYifQ==
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0ODo0NFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        Tm9uZS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjog
+        bnVsbCwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNTZjYzhkNmM5ODkwNTRmYzQ4YmEzMDEyIn0sICJpZCI6ICI1
+        NmNjOGQ2Yzk4OTA1NGZjNDhiYTMwMTIifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:29 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:44 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/221aef97-84ca-41af-90f4-6627e1514b5d/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/5cdb1331-73a8-4215-b866-bcbb4d9878b1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -71,13 +71,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:29 GMT
+      - Tue, 23 Feb 2016 16:48:44 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '1133'
       Connection:
       - close
       Content-Type:
@@ -87,22 +87,35 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yMjFhZWY5Ny04NGNhLTQxYWYtOTBmNC02NjI3ZTE1MTRi
-        NWQvIiwgInRhc2tfaWQiOiAiMjIxYWVmOTctODRjYS00MWFmLTkwZjQtNjYy
-        N2UxNTE0YjVkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy81Y2RiMTMzMS03M2E4LTQyMTUtYjg2Ni1iY2JiNGQ5ODc4
+        YjEvIiwgInRhc2tfaWQiOiAiNWNkYjEzMzEtNzNhOC00MjE1LWI4NjYtYmNi
+        YjRkOTg3OGIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhODFk
-        YjAzYzJiYTdjOTFiM2JmIn0sICJpZCI6ICI1NmM0ZGE4MWRiMDNjMmJhN2M5
-        MWIzYmYifQ==
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0ODo0NFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
+        T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDZj
+        OTg5MDU0ZmM0OGJhMzAxMiJ9LCAiaWQiOiAiNTZjYzhkNmM5ODkwNTRmYzQ4
+        YmEzMDEyIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:29 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:44 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/221aef97-84ca-41af-90f4-6627e1514b5d/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/5cdb1331-73a8-4215-b866-bcbb4d9878b1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -121,13 +134,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:30 GMT
+      - Tue, 23 Feb 2016 16:48:45 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2316'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -137,16 +150,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yMjFhZWY5Ny04NGNhLTQxYWYtOTBmNC02NjI3ZTE1MTRi
-        NWQvIiwgInRhc2tfaWQiOiAiMjIxYWVmOTctODRjYS00MWFmLTkwZjQtNjYy
-        N2UxNTE0YjVkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy81Y2RiMTMzMS03M2E4LTQyMTUtYjg2Ni1iY2JiNGQ5ODc4
+        YjEvIiwgInRhc2tfaWQiOiAiNWNkYjEzMzEtNzNhOC00MjE1LWI4NjYtYmNi
+        YjRkOTg3OGIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xN1QyMDozOTozMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDozOToyOVoiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0ODo0NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0ODo0NFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvOWQ2ZDIyMTctNDE4YS00YWE5LWIxYWMtMWM1NTY0Yjcz
-        ZTVlLyIsICJ0YXNrX2lkIjogIjlkNmQyMjE3LTQxOGEtNGFhOS1iMWFjLTFj
-        NTU2NGI3M2U1ZSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvZmFlZTYwN2ItZjlkZC00YjBlLTk1ZGUtMTM5ZmUwZjI2
+        OGYxLyIsICJ0YXNrX2lkIjogImZhZWU2MDdiLWY5ZGQtNGIwZS05NWRlLTEz
+        OWZlMGYyNjhmMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -157,41 +170,41 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5
-        cy5yZWRoYXQuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNl
-        cnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhODE1Y2EwMTMx
-        ODRkYzgxNjA2In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAx
-        Ni0wMi0xN1QyMDozOToyOVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRz
-        IiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM5OjMwWiIsICJpbXBv
-        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdl
-        IjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
-        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
-        cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3Vu
-        dCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YzRkYTgyNWNh
-        MDEzMThmMzBjYjA4ZSIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXpl
-        X3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
-        bHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3Rv
-        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
-        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
-        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmM0ZGE4MWRiMDNjMmJhN2M5MWIzYmYifSwgImlkIjogIjU2YzRk
-        YTgxZGIwM2MyYmE3YzkxYjNiZiJ9
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ2Y2RlMDQw
+        MzNmNDM1MTRmYTMifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjQ0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6NDRaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkNmNk
+        ZTA0MDMwODk3NThhOTMwIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDZjOTg5MDU0ZmM0OGJhMzAxMiJ9LCAiaWQiOiAiNTZj
+        YzhkNmM5ODkwNTRmYzQ4YmEzMDEyIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:30 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:45 GMT
 - request:
     method: post
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -229,13 +242,13 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:31 GMT
+      - Tue, 23 Feb 2016 16:48:45 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
       - '308'
       Location:
-      - https://abed.usersys.redhat.com/pulp/api/v2/repositories/2/
+      - https://katello-yoda.example.com/pulp/api/v2/repositories/2/
       Connection:
       - close
       Content-Type:
@@ -248,13 +261,13 @@ http_interactions:
         X2FkZGVkIjogbnVsbCwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
         ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3Vu
         aXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lkIjogeyIkb2lk
-        IjogIjU2YzRkYTgzNWNhMDEzMTg0ZGM4MTYwYSJ9LCAiaWQiOiAiMiIsICJf
+        IjogIjU2Y2M4ZDZkZGUwNDAzM2Y0MWQyYTQyOCJ9LCAiaWQiOiAiMiIsICJf
         aHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzLzIvIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:31 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:45 GMT
 - request:
     method: post
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/2/actions/associate/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/2/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -279,7 +292,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:31 GMT
+      - Tue, 23 Feb 2016 16:48:45 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -292,14 +305,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzA2ODU3MWFlLTI0NzEtNDg3NC04N2ZmLWVlNzI2NGIxY2RmNi8iLCAi
-        dGFza19pZCI6ICIwNjg1NzFhZS0yNDcxLTQ4NzQtODdmZi1lZTcyNjRiMWNk
-        ZjYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzVjMzBmMmFmLWEyMjctNGRkZi05MzU3LWYxYThhODk0ZjkzZC8iLCAi
+        dGFza19pZCI6ICI1YzMwZjJhZi1hMjI3LTRkZGYtOTM1Ny1mMWE4YTg5NGY5
+        M2QifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:31 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:46 GMT
 - request:
     method: post
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/2/actions/associate/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/2/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -322,7 +335,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:31 GMT
+      - Tue, 23 Feb 2016 16:48:46 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -335,14 +348,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzQ3YjBlYzNkLTg0ZjktNGVmOS04ZWQ4LWI1YWM0MWQ4MDI1YS8iLCAi
-        dGFza19pZCI6ICI0N2IwZWMzZC04NGY5LTRlZjktOGVkOC1iNWFjNDFkODAy
-        NWEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzAwMTc0NThlLTNmY2QtNDIyMC1iMGNkLTBmYjFiYjdhNGEyMi8iLCAi
+        dGFza19pZCI6ICIwMDE3NDU4ZS0zZmNkLTQyMjAtYjBjZC0wZmIxYmI3YTRh
+        MjIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:31 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:46 GMT
 - request:
     method: post
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/2/actions/associate/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/2/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -365,7 +378,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:31 GMT
+      - Tue, 23 Feb 2016 16:48:46 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -378,14 +391,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzZjODk5NTdmLTdjYzYtNGY1OC04YTE5LWM4YTFjYzA0ZDI4OC8iLCAi
-        dGFza19pZCI6ICI2Yzg5OTU3Zi03Y2M2LTRmNTgtOGExOS1jOGExY2MwNGQy
-        ODgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzJlZWZiOGQzLWEzZGYtNGQ1Yy04NGQ5LThkYmQ1OTNiZGUwYi8iLCAi
+        dGFza19pZCI6ICIyZWVmYjhkMy1hM2RmLTRkNWMtODRkOS04ZGJkNTkzYmRl
+        MGIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:31 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:46 GMT
 - request:
     method: post
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/2/actions/associate/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/2/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -409,7 +422,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:31 GMT
+      - Tue, 23 Feb 2016 16:48:46 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -422,14 +435,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzk2ZWM3Y2NhLWNhOGEtNDAwMC1iYmM1LWFhNGFhYzk1NTc3OS8iLCAi
-        dGFza19pZCI6ICI5NmVjN2NjYS1jYThhLTQwMDAtYmJjNS1hYTRhYWM5NTU3
-        NzkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzBhNTQ5MmI1LTJkZmUtNDU0Ni05ODhhLWMzZjBhZTExMmI1Zi8iLCAi
+        dGFza19pZCI6ICIwYTU0OTJiNS0yZGZlLTQ1NDYtOTg4YS1jM2YwYWUxMTJi
+        NWYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:31 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:46 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/068571ae-2471-4874-87ff-ee7264b1cdf6/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/5c30f2af-a227-4ddf-9357-f1a8a894f93d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -448,13 +461,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:31 GMT
+      - Tue, 23 Feb 2016 16:48:46 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '694'
+      - '2564'
       Connection:
       - close
       Content-Type:
@@ -464,278 +477,66 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8wNjg1NzFh
-        ZS0yNDcxLTQ4NzQtODdmZi1lZTcyNjRiMWNkZjYvIiwgInRhc2tfaWQiOiAi
-        MDY4NTcxYWUtMjQ3MS00ODc0LTg3ZmYtZWU3MjY0YjFjZGY2IiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81YzMwZjJh
+        Zi1hMjI3LTRkZGYtOTM1Ny1mMWE4YTg5NGY5M2QvIiwgInRhc2tfaWQiOiAi
+        NWMzMGYyYWYtYTIyNy00ZGRmLTkzNTctZjFhOGE4OTRmOTNkIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1bHA6cmVwb3NpdG9yeTpGZWRv
         cmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5pc2hfdGlt
-        ZSI6IG51bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6
-        IG51bGwsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtd
-        LCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9y
-        ZXNvdXJjZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIs
-        ICJzdGF0ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVk
-        X3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwg
-        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNTZjNGRhODNkYjAzYzJiYTdjOTFiM2QwIn0sICJpZCI6ICI1NmM0ZGE4
-        M2RiMDNjMmJhN2M5MWIzZDAifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:31 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/47b0ec3d-84f9-4ef9-8ed8-b5ac41d8025a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:31 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '694'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy80N2IwZWMz
-        ZC04NGY5LTRlZjktOGVkOC1iNWFjNDFkODAyNWEvIiwgInRhc2tfaWQiOiAi
-        NDdiMGVjM2QtODRmOS00ZWY5LThlZDgtYjVhYzQxZDgwMjVhIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1bHA6cmVwb3NpdG9yeTpGZWRv
-        cmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5pc2hfdGlt
-        ZSI6IG51bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6
-        IG51bGwsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtd
-        LCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9y
-        ZXNvdXJjZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIs
-        ICJzdGF0ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVk
-        X3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwg
-        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNTZjNGRhODNkYjAzYzJiYTdjOTFiM2QxIn0sICJpZCI6ICI1NmM0ZGE4
-        M2RiMDNjMmJhN2M5MWIzZDEifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:31 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/6c89957f-7cc6-4f58-8a19-c8a1cc04d288/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:31 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '694'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82Yzg5OTU3
-        Zi03Y2M2LTRmNTgtOGExOS1jOGExY2MwNGQyODgvIiwgInRhc2tfaWQiOiAi
-        NmM4OTk1N2YtN2NjNi00ZjU4LThhMTktYzhhMWNjMDRkMjg4IiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1bHA6cmVwb3NpdG9yeTpGZWRv
-        cmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5pc2hfdGlt
-        ZSI6IG51bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6
-        IG51bGwsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtd
-        LCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9y
-        ZXNvdXJjZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIs
-        ICJzdGF0ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVk
-        X3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwg
-        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNTZjNGRhODNkYjAzYzJiYTdjOTFiM2QyIn0sICJpZCI6ICI1NmM0ZGE4
-        M2RiMDNjMmJhN2M5MWIzZDIifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:31 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/96ec7cca-ca8a-4000-bbc5-aa4aac955779/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:32 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '694'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy85NmVjN2Nj
-        YS1jYThhLTQwMDAtYmJjNS1hYTRhYWM5NTU3NzkvIiwgInRhc2tfaWQiOiAi
-        OTZlYzdjY2EtY2E4YS00MDAwLWJiYzUtYWE0YWFjOTU1Nzc5IiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1bHA6cmVwb3NpdG9yeTpGZWRv
-        cmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5pc2hfdGlt
-        ZSI6IG51bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6
-        IG51bGwsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtd
-        LCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9y
-        ZXNvdXJjZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIs
-        ICJzdGF0ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVk
-        X3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwg
-        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNTZjNGRhODNkYjAzYzJiYTdjOTFiM2QzIn0sICJpZCI6ICI1NmM0ZGE4
-        M2RiMDNjMmJhN2M5MWIzZDMifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:32 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/068571ae-2471-4874-87ff-ee7264b1cdf6/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:39:32 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2562'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8wNjg1NzFh
-        ZS0yNDcxLTQ4NzQtODdmZi1lZTcyNjRiMWNkZjYvIiwgInRhc2tfaWQiOiAi
-        MDY4NTcxYWUtMjQ3MS00ODc0LTg3ZmYtZWU3MjY0YjFjZGY2IiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1bHA6cmVwb3NpdG9yeTpGZWRv
-        cmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5pc2hfdGlt
-        ZSI6ICIyMDE2LTAyLTE3VDIwOjM5OjMxWiIsICJfbnMiOiAidGFza19zdGF0
-        dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM5OjMxWiIsICJ0
+        ZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjQ2WiIsICJfbnMiOiAidGFza19zdGF0
+        dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjQ2WiIsICJ0
         cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jl
         c3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
-        b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6
-        ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQi
-        OiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJ1bml0X2tleSI6IHsibmFtZSI6
-        ICJlbGVwaGFudCIsICJjaGVja3N1bSI6ICIzZTFjNzBjZDFiNDIxMzI4YWNh
-        ZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3MmEwYTcwMWYz
+        b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUi
+        OiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJuYW1l
+        IjogImxpb24iLCAiY2hlY2tzdW0iOiAiMTI0MDBkYzk1YzIzYTRjMTYwNzI1
+        YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2MmVmYTNlNGFlNCIs
+        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAi
+        MC44IiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEy
+        NTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsidW5pdF9rZXkiOiB7Im5hbWUi
+        OiAiY2hlZXRhaCIsICJjaGVja3N1bSI6ICI0MjJkMGJhYTBjZDlkNzcxM2Fl
+        Nzk2ZTg4NmEyM2UxN2Y1NzhmOTI0Zjc0ODgwZGViZGJiN2Q2NWZiMzY4ZGFl
         IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6
         ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNo
         YTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJ1bml0X2tleSI6IHsibmFt
-        ZSI6ICJsaW9uIiwgImNoZWNrc3VtIjogIjEyNDAwZGM5NWMyM2E0YzE2MDcy
-        NWE5MDg3MTZjZDNmY2RkN2E4OTgxNTg1NDM3YWI2NGNkNjJlZmEzZTRhZTQi
-        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjog
-        IjAuOCIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hh
-        MjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InVuaXRfa2V5IjogeyJuYW1l
-        IjogInBlbmd1aW4iLCAiY2hlY2tzdW0iOiAiM2ZjYjJjOTI3ZGU5ZTEzYmY2
-        ODQ2OTAzMmEyOGIxMzlkM2U1YWQyZTU4NTY0ZmMyMTBmZDZlNDg2MzViZTY5
-        NCIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2Ui
-        OiAiMC44IiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJz
-        aGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsidW5pdF9rZXkiOiB7Im5h
-        bWUiOiAibW9ua2V5IiwgImNoZWNrc3VtIjogIjBlOGZhNTBkMDEyOGZiYWJj
-        N2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1MDFk
-        YjEiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNl
-        IjogIjAuOCIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAi
-        c2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InVuaXRfa2V5IjogeyJu
-        YW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6ICI2ZThkNmRjMDU3ZTNlMmM5
-        ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFhNDYx
-        ZGZkIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFz
+        ZSI6ICJlbGVwaGFudCIsICJjaGVja3N1bSI6ICIzZTFjNzBjZDFiNDIxMzI4
+        YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3MmEwYTcw
+        MWYzIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFz
         ZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjog
         InNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJ1bml0X2tleSI6IHsi
-        bmFtZSI6ICJnaXJhZmZlIiwgImNoZWNrc3VtIjogImYyNWQ2N2QxZDlkYTA0
-        ZjEyZTU3Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5
-        ZjlmMTQiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxl
-        YXNlIjogIjAuOCIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUi
-        OiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InVuaXRfa2V5Ijog
-        eyJuYW1lIjogImNoZWV0YWgiLCAiY2hlY2tzdW0iOiAiNDIyZDBiYWEwY2Q5
-        ZDc3MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVm
-        YjM2OGRhZSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJl
+        bmFtZSI6ICJtb25rZXkiLCAiY2hlY2tzdW0iOiAiMGU4ZmE1MGQwMTI4ZmJh
+        YmM3Y2NjNTYzMmUzZmEyNWQzOWIwMjgwMTY5ZjYxNjZjYjhlMmM4NGRlODUw
+        MWRiMSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVh
+        c2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6
+        ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsidW5pdF9rZXkiOiB7
+        Im5hbWUiOiAicGVuZ3VpbiIsICJjaGVja3N1bSI6ICIzZmNiMmM5MjdkZTll
+        MTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZkNmU0ODYz
+        NWJlNjk0IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVs
+        ZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBl
+        IjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJ1bml0X2tleSI6
+        IHsibmFtZSI6ICJ3YWxydXMiLCAiY2hlY2tzdW0iOiAiNmU4ZDZkYzA1N2Uz
+        ZTJjOTgxOWYwZGM3ZTZjN2I3Zjg2YmYyZTg1NzFiYmE0MTRhZGVjN2ZiNjIx
+        YTQ2MWRmZCIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJl
         bGVhc2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlw
         ZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsidW5pdF9rZXki
-        OiB7Im5hbWUiOiAic3F1aXJyZWwiLCAiY2hlY2tzdW0iOiAiMjUxNzY4YmRk
-        MTVmMTNkNzg0ODdjMjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMw
-        YWU4NzhhMTdkMiIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwg
-        InJlbGVhc2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3Vt
-        dHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn1dfSwgImVycm9y
-        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE4M2RiMDNjMmJhN2M5
-        MWIzZDAifSwgImlkIjogIjU2YzRkYTgzZGIwM2MyYmE3YzkxYjNkMCJ9
+        OiB7Im5hbWUiOiAiZ2lyYWZmZSIsICJjaGVja3N1bSI6ICJmMjVkNjdkMWQ5
+        ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTViODJkZTZkMTky
+        MjAwOWY5ZjE0IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAi
+        cmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10
+        eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJ1bml0X2tl
+        eSI6IHsibmFtZSI6ICJzcXVpcnJlbCIsICJjaGVja3N1bSI6ICIyNTE3Njhi
+        ZGQxNWYxM2Q3ODQ4N2MyNzYzOGFhNmFlY2QwMTU1MWUyNTM3NTYwOTNjZGUx
+        YzBhZTg3OGExN2QyIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMi
+        LCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tz
+        dW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDZlOTg5MDU0ZmM0
+        OGJhMzAyMyJ9LCAiaWQiOiAiNTZjYzhkNmU5ODkwNTRmYzQ4YmEzMDIzIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:32 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:46 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/47b0ec3d-84f9-4ef9-8ed8-b5ac41d8025a/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/0017458e-3fcd-4220-b0cd-0fb1bb7a4a22/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -754,13 +555,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:32 GMT
+      - Tue, 23 Feb 2016 16:48:46 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '935'
+      - '937'
       Connection:
       - close
       Content-Type:
@@ -770,30 +571,30 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy80N2IwZWMz
-        ZC04NGY5LTRlZjktOGVkOC1iNWFjNDFkODAyNWEvIiwgInRhc2tfaWQiOiAi
-        NDdiMGVjM2QtODRmOS00ZWY5LThlZDgtYjVhYzQxZDgwMjVhIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8wMDE3NDU4
+        ZS0zZmNkLTQyMjAtYjBjZC0wZmIxYmI3YTRhMjIvIiwgInRhc2tfaWQiOiAi
+        MDAxNzQ1OGUtM2ZjZC00MjIwLWIwY2QtMGZiMWJiN2E0YTIyIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1bHA6cmVwb3NpdG9yeTpGZWRv
         cmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5pc2hfdGlt
-        ZSI6ICIyMDE2LTAyLTE3VDIwOjM5OjMyWiIsICJfbnMiOiAidGFza19zdGF0
-        dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM5OjMyWiIsICJ0
+        ZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjQ2WiIsICJfbnMiOiAidGFza19zdGF0
+        dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjQ2WiIsICJ0
         cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jl
         c3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
-        b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6
-        ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQi
-        OiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJ1bml0X2tleSI6IHsiaWQiOiAi
-        UkhFQS0yMDEwOjAwMDIifSwgInR5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7InVu
-        aXRfa2V5IjogeyJpZCI6ICJSSFNBLTIwMTA6MDg1OCJ9LCAidHlwZV9pZCI6
-        ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7ImlkIjogIlJIRUEtMjAxMDow
-        MDAxIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifV19LCAiZXJyb3IiOiBudWxs
-        LCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTgzZGIwM2MyYmE3YzkxYjNkMSJ9
-        LCAiaWQiOiAiNTZjNGRhODNkYjAzYzJiYTdjOTFiM2QxIn0=
+        b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUi
+        OiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJpZCI6
+        ICJSSEVBLTIwMTA6MDAwMiJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsi
+        dW5pdF9rZXkiOiB7ImlkIjogIlJIRUEtMjAxMDowMDAxIn0sICJ0eXBlX2lk
+        IjogImVycmF0dW0ifSwgeyJ1bml0X2tleSI6IHsiaWQiOiAiUkhTQS0yMDEw
+        OjA4NTgifSwgInR5cGVfaWQiOiAiZXJyYXR1bSJ9XX0sICJlcnJvciI6IG51
+        bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNmU5ODkwNTRmYzQ4YmEzMDJj
+        In0sICJpZCI6ICI1NmNjOGQ2ZTk4OTA1NGZjNDhiYTMwMmMifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:32 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:46 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/6c89957f-7cc6-4f58-8a19-c8a1cc04d288/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/2eefb8d3-a3df-4d5c-84d9-8dbd593bde0b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -812,13 +613,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:33 GMT
+      - Tue, 23 Feb 2016 16:48:46 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '899'
+      - '901'
       Connection:
       - close
       Content-Type:
@@ -828,29 +629,30 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82Yzg5OTU3
-        Zi03Y2M2LTRmNTgtOGExOS1jOGExY2MwNGQyODgvIiwgInRhc2tfaWQiOiAi
-        NmM4OTk1N2YtN2NjNi00ZjU4LThhMTktYzhhMWNjMDRkMjg4IiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8yZWVmYjhk
+        My1hM2RmLTRkNWMtODRkOS04ZGJkNTkzYmRlMGIvIiwgInRhc2tfaWQiOiAi
+        MmVlZmI4ZDMtYTNkZi00ZDVjLTg0ZDktOGRiZDU5M2JkZTBiIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1bHA6cmVwb3NpdG9yeTpGZWRv
         cmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5pc2hfdGlt
-        ZSI6ICIyMDE2LTAyLTE3VDIwOjM5OjMyWiIsICJfbnMiOiAidGFza19zdGF0
-        dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM5OjMyWiIsICJ0
+        ZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjQ2WiIsICJfbnMiOiAidGFza19zdGF0
+        dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjQ2WiIsICJ0
         cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jl
         c3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
-        b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6
-        ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQi
-        OiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJ1bml0X2tleSI6IHsicmVwb19p
-        ZCI6ICIyIiwgImlkIjogImJpcmQifSwgInR5cGVfaWQiOiAicGFja2FnZV9n
-        cm91cCJ9LCB7InVuaXRfa2V5IjogeyJyZXBvX2lkIjogIjIiLCAiaWQiOiAi
-        bWFtbWFsIn0sICJ0eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAifV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTgzZGIwM2MyYmE3
-        YzkxYjNkMiJ9LCAiaWQiOiAiNTZjNGRhODNkYjAzYzJiYTdjOTFiM2QyIn0=
+        b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUi
+        OiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBv
+        X2lkIjogIjIiLCAiaWQiOiAibWFtbWFsIn0sICJ0eXBlX2lkIjogInBhY2th
+        Z2VfZ3JvdXAifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIyIiwgImlk
+        IjogImJpcmQifSwgInR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9XX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNmU5ODkwNTRm
+        YzQ4YmEzMDMwIn0sICJpZCI6ICI1NmNjOGQ2ZTk4OTA1NGZjNDhiYTMwMzAi
+        fQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:33 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:46 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/96ec7cca-ca8a-4000-bbc5-aa4aac955779/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/0a5492b5-2dfe-4546-988a-c3f0ae112b5f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -869,13 +671,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:33 GMT
+      - Tue, 23 Feb 2016 16:48:46 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '751'
+      - '753'
       Connection:
       - close
       Content-Type:
@@ -885,26 +687,290 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy85NmVjN2Nj
-        YS1jYThhLTQwMDAtYmJjNS1hYTRhYWM5NTU3NzkvIiwgInRhc2tfaWQiOiAi
-        OTZlYzdjY2EtY2E4YS00MDAwLWJiYzUtYWE0YWFjOTU1Nzc5IiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8wYTU0OTJi
+        NS0yZGZlLTQ1NDYtOTg4YS1jM2YwYWUxMTJiNWYvIiwgInRhc2tfaWQiOiAi
+        MGE1NDkyYjUtMmRmZS00NTQ2LTk4OGEtYzNmMGFlMTEyYjVmIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1bHA6cmVwb3NpdG9yeTpGZWRv
         cmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5pc2hfdGlt
-        ZSI6ICIyMDE2LTAyLTE3VDIwOjM5OjMyWiIsICJfbnMiOiAidGFza19zdGF0
-        dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM5OjMyWiIsICJ0
+        ZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjQ2WiIsICJfbnMiOiAidGFza19zdGF0
+        dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjQ2WiIsICJ0
         cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jl
         c3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
-        b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6
-        ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQi
-        OiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbXX0sICJlcnJvciI6IG51bGwsICJf
-        aWQiOiB7IiRvaWQiOiAiNTZjNGRhODNkYjAzYzJiYTdjOTFiM2QzIn0sICJp
-        ZCI6ICI1NmM0ZGE4M2RiMDNjMmJhN2M5MWIzZDMifQ==
+        b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUi
+        OiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFtdfSwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ2ZTk4OTA1NGZjNDhiYTMwMzEifSwg
+        ImlkIjogIjU2Y2M4ZDZlOTg5MDU0ZmM0OGJhMzAzMSJ9
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:33 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:46 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/5c30f2af-a227-4ddf-9357-f1a8a894f93d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:46 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2564'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81YzMwZjJh
+        Zi1hMjI3LTRkZGYtOTM1Ny1mMWE4YTg5NGY5M2QvIiwgInRhc2tfaWQiOiAi
+        NWMzMGYyYWYtYTIyNy00ZGRmLTkzNTctZjFhOGE4OTRmOTNkIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1bHA6cmVwb3NpdG9yeTpGZWRv
+        cmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5pc2hfdGlt
+        ZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjQ2WiIsICJfbnMiOiAidGFza19zdGF0
+        dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjQ2WiIsICJ0
+        cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jl
+        c3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUi
+        OiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJuYW1l
+        IjogImxpb24iLCAiY2hlY2tzdW0iOiAiMTI0MDBkYzk1YzIzYTRjMTYwNzI1
+        YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2MmVmYTNlNGFlNCIs
+        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAi
+        MC44IiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEy
+        NTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsidW5pdF9rZXkiOiB7Im5hbWUi
+        OiAiY2hlZXRhaCIsICJjaGVja3N1bSI6ICI0MjJkMGJhYTBjZDlkNzcxM2Fl
+        Nzk2ZTg4NmEyM2UxN2Y1NzhmOTI0Zjc0ODgwZGViZGJiN2Q2NWZiMzY4ZGFl
+        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6
+        ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNo
+        YTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJ1bml0X2tleSI6IHsibmFt
+        ZSI6ICJlbGVwaGFudCIsICJjaGVja3N1bSI6ICIzZTFjNzBjZDFiNDIxMzI4
+        YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3MmEwYTcw
+        MWYzIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFz
+        ZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjog
+        InNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJ1bml0X2tleSI6IHsi
+        bmFtZSI6ICJtb25rZXkiLCAiY2hlY2tzdW0iOiAiMGU4ZmE1MGQwMTI4ZmJh
+        YmM3Y2NjNTYzMmUzZmEyNWQzOWIwMjgwMTY5ZjYxNjZjYjhlMmM4NGRlODUw
+        MWRiMSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVh
+        c2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6
+        ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsidW5pdF9rZXkiOiB7
+        Im5hbWUiOiAicGVuZ3VpbiIsICJjaGVja3N1bSI6ICIzZmNiMmM5MjdkZTll
+        MTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZkNmU0ODYz
+        NWJlNjk0IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVs
+        ZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBl
+        IjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJ1bml0X2tleSI6
+        IHsibmFtZSI6ICJ3YWxydXMiLCAiY2hlY2tzdW0iOiAiNmU4ZDZkYzA1N2Uz
+        ZTJjOTgxOWYwZGM3ZTZjN2I3Zjg2YmYyZTg1NzFiYmE0MTRhZGVjN2ZiNjIx
+        YTQ2MWRmZCIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJl
+        bGVhc2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlw
+        ZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsidW5pdF9rZXki
+        OiB7Im5hbWUiOiAiZ2lyYWZmZSIsICJjaGVja3N1bSI6ICJmMjVkNjdkMWQ5
+        ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTViODJkZTZkMTky
+        MjAwOWY5ZjE0IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAi
+        cmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10
+        eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJ1bml0X2tl
+        eSI6IHsibmFtZSI6ICJzcXVpcnJlbCIsICJjaGVja3N1bSI6ICIyNTE3Njhi
+        ZGQxNWYxM2Q3ODQ4N2MyNzYzOGFhNmFlY2QwMTU1MWUyNTM3NTYwOTNjZGUx
+        YzBhZTg3OGExN2QyIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMi
+        LCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tz
+        dW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDZlOTg5MDU0ZmM0
+        OGJhMzAyMyJ9LCAiaWQiOiAiNTZjYzhkNmU5ODkwNTRmYzQ4YmEzMDIzIn0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:46 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/0017458e-3fcd-4220-b0cd-0fb1bb7a4a22/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:46 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '937'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8wMDE3NDU4
+        ZS0zZmNkLTQyMjAtYjBjZC0wZmIxYmI3YTRhMjIvIiwgInRhc2tfaWQiOiAi
+        MDAxNzQ1OGUtM2ZjZC00MjIwLWIwY2QtMGZiMWJiN2E0YTIyIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1bHA6cmVwb3NpdG9yeTpGZWRv
+        cmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5pc2hfdGlt
+        ZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjQ2WiIsICJfbnMiOiAidGFza19zdGF0
+        dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjQ2WiIsICJ0
+        cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jl
+        c3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUi
+        OiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJpZCI6
+        ICJSSEVBLTIwMTA6MDAwMiJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsi
+        dW5pdF9rZXkiOiB7ImlkIjogIlJIRUEtMjAxMDowMDAxIn0sICJ0eXBlX2lk
+        IjogImVycmF0dW0ifSwgeyJ1bml0X2tleSI6IHsiaWQiOiAiUkhTQS0yMDEw
+        OjA4NTgifSwgInR5cGVfaWQiOiAiZXJyYXR1bSJ9XX0sICJlcnJvciI6IG51
+        bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNmU5ODkwNTRmYzQ4YmEzMDJj
+        In0sICJpZCI6ICI1NmNjOGQ2ZTk4OTA1NGZjNDhiYTMwMmMifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:46 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/2eefb8d3-a3df-4d5c-84d9-8dbd593bde0b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '901'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8yZWVmYjhk
+        My1hM2RmLTRkNWMtODRkOS04ZGJkNTkzYmRlMGIvIiwgInRhc2tfaWQiOiAi
+        MmVlZmI4ZDMtYTNkZi00ZDVjLTg0ZDktOGRiZDU5M2JkZTBiIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1bHA6cmVwb3NpdG9yeTpGZWRv
+        cmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5pc2hfdGlt
+        ZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjQ2WiIsICJfbnMiOiAidGFza19zdGF0
+        dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjQ2WiIsICJ0
+        cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jl
+        c3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUi
+        OiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBv
+        X2lkIjogIjIiLCAiaWQiOiAibWFtbWFsIn0sICJ0eXBlX2lkIjogInBhY2th
+        Z2VfZ3JvdXAifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICIyIiwgImlk
+        IjogImJpcmQifSwgInR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9XX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNmU5ODkwNTRm
+        YzQ4YmEzMDMwIn0sICJpZCI6ICI1NmNjOGQ2ZTk4OTA1NGZjNDhiYTMwMzAi
+        fQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:47 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/0a5492b5-2dfe-4546-988a-c3f0ae112b5f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:48:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '753'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8wYTU0OTJi
+        NS0yZGZlLTQ1NDYtOTg4YS1jM2YwYWUxMTJiNWYvIiwgInRhc2tfaWQiOiAi
+        MGE1NDkyYjUtMmRmZS00NTQ2LTk4OGEtYzNmMGFlMTEyYjVmIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1bHA6cmVwb3NpdG9yeTpGZWRv
+        cmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5pc2hfdGlt
+        ZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjQ2WiIsICJfbnMiOiAidGFza19zdGF0
+        dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjQ2WiIsICJ0
+        cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jl
+        c3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUi
+        OiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFtdfSwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ2ZTk4OTA1NGZjNDhiYTMwMzEifSwg
+        ImlkIjogIjU2Y2M4ZDZlOTg5MDU0ZmM0OGJhMzAzMSJ9
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:47 GMT
 - request:
     method: delete
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/2/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -923,7 +989,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:34 GMT
+      - Tue, 23 Feb 2016 16:48:48 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -936,14 +1002,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzVjNTk1ZGMxLWMxZGItNGRlNy1iNGVkLTU4MGEzMGRhNTQyYS8iLCAi
-        dGFza19pZCI6ICI1YzU5NWRjMS1jMWRiLTRkZTctYjRlZC01ODBhMzBkYTU0
-        MmEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzk3NGQ3YTIwLWI4NmUtNDIzOC1iOGU3LTY2ZjFiYmU3YmZiNi8iLCAi
+        dGFza19pZCI6ICI5NzRkN2EyMC1iODZlLTQyMzgtYjhlNy02NmYxYmJlN2Jm
+        YjYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:34 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:48 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/5c595dc1-c1db-4de7-b4ed-580a30da542a/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/974d7a20-b86e-4238-b8e7-66f1bbe7bfb6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -962,13 +1028,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:34 GMT
+      - Tue, 23 Feb 2016 16:48:48 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '635'
+      - '559'
       Connection:
       - close
       Content-Type:
@@ -978,24 +1044,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81YzU5NWRjMS1jMWRiLTRkZTctYjRlZC01ODBhMzBkYTU0
-        MmEvIiwgInRhc2tfaWQiOiAiNWM1OTVkYzEtYzFkYi00ZGU3LWI0ZWQtNTgw
-        YTMwZGE1NDJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1
+        aS92Mi90YXNrcy85NzRkN2EyMC1iODZlLTQyMzgtYjhlNy02NmYxYmJlN2Jm
+        YjYvIiwgInRhc2tfaWQiOiAiOTc0ZDdhMjAtYjg2ZS00MjM4LWI4ZTctNjZm
+        MWJiZTdiZmI2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1
         bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiBudWxsLCAiX25z
-        IjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3Jl
-        cG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTBAYWJlZC51c2Vyc3lzLnJlZGhhdC5jb20uZHEiLCAic3RhdGUiOiAid2Fp
-        dGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTg2ZGIw
-        M2MyYmE3YzkxYjNlMSJ9LCAiaWQiOiAiNTZjNGRhODZkYjAzYzJiYTdjOTFi
-        M2UxIn0=
+        IjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1Qx
+        Njo0ODo0OFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3Mi
+        OiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5k
+        cSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwg
+        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNTZjYzhkNzA5ODkwNTRmYzQ4YmEzMDM0In0sICJpZCI6ICI1NmNjOGQ3
+        MDk4OTA1NGZjNDhiYTMwMzQifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:34 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:48 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/5c595dc1-c1db-4de7-b4ed-580a30da542a/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/974d7a20-b86e-4238-b8e7-66f1bbe7bfb6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1014,13 +1078,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:34 GMT
+      - Tue, 23 Feb 2016 16:48:49 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '672'
+      - '674'
       Connection:
       - close
       Content-Type:
@@ -1030,24 +1094,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81YzU5NWRjMS1jMWRiLTRkZTctYjRlZC01ODBhMzBkYTU0
-        MmEvIiwgInRhc2tfaWQiOiAiNWM1OTVkYzEtYzFkYi00ZGU3LWI0ZWQtNTgw
-        YTMwZGE1NDJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1
-        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0x
-        N1QyMDozOTozNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3Rp
-        bWUiOiAiMjAxNi0wMi0xN1QyMDozOTozNFoiLCAidHJhY2ViYWNrIjogbnVs
+        aS92Mi90YXNrcy85NzRkN2EyMC1iODZlLTQyMzgtYjhlNy02NmYxYmJlN2Jm
+        YjYvIiwgInRhc2tfaWQiOiAiOTc0ZDdhMjAtYjg2ZS00MjM4LWI4ZTctNjZm
+        MWJiZTdiZmI2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1
+        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0y
+        M1QxNjo0ODo0OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3Rp
+        bWUiOiAiMjAxNi0wMi0yM1QxNjo0ODo0OFoiLCAidHJhY2ViYWNrIjogbnVs
         bCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9
-        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWJlZC51
-        c2Vyc3lzLnJlZGhhdC5jb20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAi
-        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWJl
-        ZC51c2Vyc3lzLnJlZGhhdC5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9y
-        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE4NmRiMDNjMmJhN2M5
-        MWIzZTEifSwgImlkIjogIjU2YzRkYTg2ZGIwM2MyYmE3YzkxYjNlMSJ9
+        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
+        by15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDcwOTg5MDU0ZmM0
+        OGJhMzAzNCJ9LCAiaWQiOiAiNTZjYzhkNzA5ODkwNTRmYzQ4YmEzMDM0In0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:34 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:49 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/5eabb0f9-2a68-4d5d-8f49-24d506e3865a/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/8a6e53ca-bbeb-43dc-947a-08e96960340a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1066,13 +1130,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:35 GMT
+      - Tue, 23 Feb 2016 16:48:49 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '661'
+      - '549'
       Connection:
       - close
       Content-Type:
@@ -1082,24 +1146,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81ZWFiYjBmOS0yYTY4LTRkNWQtOGY0OS0yNGQ1MDZlMzg2
-        NWEvIiwgInRhc2tfaWQiOiAiNWVhYmIwZjktMmE2OC00ZDVkLThmNDktMjRk
-        NTA2ZTM4NjVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy84YTZlNTNjYS1iYmViLTQzZGMtOTQ3YS0wOGU5Njk2MDM0
+        MGEvIiwgInRhc2tfaWQiOiAiOGE2ZTUzY2EtYmJlYi00M2RjLTk0N2EtMDhl
+        OTY5NjAzNDBhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
-        LTAyLTE3VDIwOjM5OjM1WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
-        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVk
-        aGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5cy5y
-        ZWRoYXQuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
-        aWQiOiB7IiRvaWQiOiAiNTZjNGRhODdkYjAzYzJiYTdjOTFiM2UyIn0sICJp
-        ZCI6ICI1NmM0ZGE4N2RiMDNjMmJhN2M5MWIzZTIifQ==
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ3
+        MTk4OTA1NGZjNDhiYTMwMzUifSwgImlkIjogIjU2Y2M4ZDcxOTg5MDU0ZmM0
+        OGJhMzAzNSJ9
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:35 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:49 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/5eabb0f9-2a68-4d5d-8f49-24d506e3865a/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/8a6e53ca-bbeb-43dc-947a-08e96960340a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1118,13 +1180,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:35 GMT
+      - Tue, 23 Feb 2016 16:48:49 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '680'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -1134,25 +1196,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81ZWFiYjBmOS0yYTY4LTRkNWQtOGY0OS0yNGQ1MDZlMzg2
-        NWEvIiwgInRhc2tfaWQiOiAiNWVhYmIwZjktMmE2OC00ZDVkLThmNDktMjRk
-        NTA2ZTM4NjVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy84YTZlNTNjYS1iYmViLTQzZGMtOTQ3YS0wOGU5Njk2MDM0
+        MGEvIiwgInRhc2tfaWQiOiAiOGE2ZTUzY2EtYmJlYi00M2RjLTk0N2EtMDhl
+        OTY5NjAzNDBhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM5OjM1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM5OjM1WiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ4OjQ5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjQ5WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTg3ZGIw
-        M2MyYmE3YzkxYjNlMiJ9LCAiaWQiOiAiNTZjNGRhODdkYjAzYzJiYTdjOTFi
-        M2UyIn0=
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNzE5
+        ODkwNTRmYzQ4YmEzMDM1In0sICJpZCI6ICI1NmNjOGQ3MTk4OTA1NGZjNDhi
+        YTMwMzUifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:35 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:49 GMT
 - request:
     method: post
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1160,21 +1222,21 @@ http_interactions:
         ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
         b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
         ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJkb3dubG9hZF9wb2xpY3kiOiJvbl9kZW1hbmQifSwibm90ZXMi
-        OnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRpc3RyaWJ1dG9ycyI6W3si
-        ZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0cmlidXRvciIsImRpc3Ry
-        aWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwiOiJ0ZXN0X3BhdGgvIiwi
-        aHR0cCI6ZmFsc2UsImh0dHBzIjp0cnVlLCJwcm90ZWN0ZWQiOnRydWUsImNo
-        ZWNrc3VtX3R5cGUiOm51bGx9LCJhdXRvX3B1Ymxpc2giOnRydWUsImRpc3Ry
-        aWJ1dG9yX2lkIjoiRmVkb3JhXzE3In0seyJkaXN0cmlidXRvcl90eXBlX2lk
-        IjoieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmln
-        Ijp7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjoiRmVkb3JhXzE3In0s
-        ImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiRmVkb3Jh
-        XzE3X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBlX2lkIjoiZXhwb3J0X2Rp
-        c3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7Imh0dHAiOmZhbHNl
-        LCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6InRlc3RfcGF0aC8ifSwi
-        YXV0b19wdWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJleHBvcnRf
-        ZGlzdHJpYnV0b3IifV19
+        IjpudWxsLCJkb3dubG9hZF9wb2xpY3kiOiJvbl9kZW1hbmQiLCJyZW1vdmVf
+        bWlzc2luZyI6dHJ1ZX0sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJycG0tcmVw
+        byJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5
+        dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsicmVsYXRp
+        dmVfdXJsIjoidGVzdF9wYXRoLyIsImh0dHAiOmZhbHNlLCJodHRwcyI6dHJ1
+        ZSwicHJvdGVjdGVkIjp0cnVlLCJjaGVja3N1bV90eXBlIjpudWxsfSwiYXV0
+        b19wdWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9pZCI6IkZlZG9yYV8xNyJ9
+        LHsiZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9jbG9uZV9kaXN0cmlidXRv
+        ciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJkZXN0aW5hdGlvbl9kaXN0cmli
+        dXRvcl9pZCI6IkZlZG9yYV8xNyJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJk
+        aXN0cmlidXRvcl9pZCI6IkZlZG9yYV8xN19jbG9uZSJ9LHsiZGlzdHJpYnV0
+        b3JfdHlwZV9pZCI6ImV4cG9ydF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9y
+        X2NvbmZpZyI6eyJodHRwIjpmYWxzZSwiaHR0cHMiOmZhbHNlLCJyZWxhdGl2
+        ZV91cmwiOiJ0ZXN0X3BhdGgvIn0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRp
+        c3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
     headers:
       Accept:
       - application/json
@@ -1183,7 +1245,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '825'
+      - '847'
       User-Agent:
       - Ruby
   response:
@@ -1192,13 +1254,13 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:36 GMT
+      - Tue, 23 Feb 2016 16:48:50 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
       - '320'
       Location:
-      - https://abed.usersys.redhat.com/pulp/api/v2/repositories/Fedora_17/
+      - https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/
       Connection:
       - close
       Content-Type:
@@ -1211,14 +1273,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZjNGRhODg1Y2EwMTMxODRmNmRiMTIzIn0sICJpZCI6ICJGZWRvcmFfMTci
+        NTZjYzhkNzJkZTA0MDMzZjQxZDJhNDJlIn0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:36 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:50 GMT
 - request:
     method: post
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1240,7 +1302,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:36 GMT
+      - Tue, 23 Feb 2016 16:48:50 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -1253,14 +1315,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzRkMTZkYjI5LWNjMzQtNDIyYS05NjJiLTM2NDJmNjI1ZGQ3Mi8iLCAi
-        dGFza19pZCI6ICI0ZDE2ZGIyOS1jYzM0LTQyMmEtOTYyYi0zNjQyZjYyNWRk
-        NzIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzBiMGM4ZTY5LTYyMDktNDgzYi05MzM2LWJiMjdhMWQ3Y2VhMC8iLCAi
+        dGFza19pZCI6ICIwYjBjOGU2OS02MjA5LTQ4M2ItOTMzNi1iYjI3YTFkN2Nl
+        YTAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:36 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:50 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/4d16db29-cc34-422a-962b-3642f625dd72/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/0b0c8e69-6209-483b-9336-bb27a1d7cea0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1279,13 +1341,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:36 GMT
+      - Tue, 23 Feb 2016 16:48:50 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '661'
       Connection:
       - close
       Content-Type:
@@ -1295,22 +1357,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80ZDE2ZGIyOS1jYzM0LTQyMmEtOTYyYi0zNjQyZjYyNWRk
-        NzIvIiwgInRhc2tfaWQiOiAiNGQxNmRiMjktY2MzNC00MjJhLTk2MmItMzY0
-        MmY2MjVkZDcyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8wYjBjOGU2OS02MjA5LTQ4M2ItOTMzNi1iYjI3YTFkN2Nl
+        YTAvIiwgInRhc2tfaWQiOiAiMGIwYzhlNjktNjIwOS00ODNiLTkzMzYtYmIy
+        N2ExZDdjZWEwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhODhk
-        YjAzYzJiYTdjOTFiM2UzIn0sICJpZCI6ICI1NmM0ZGE4OGRiMDNjMmJhN2M5
-        MWIzZTMifQ==
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0ODo1MFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4
+        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNTZjYzhkNzI5ODkwNTRmYzQ4YmEzMDM2In0sICJp
+        ZCI6ICI1NmNjOGQ3Mjk4OTA1NGZjNDhiYTMwMzYifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:36 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:50 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/4d16db29-cc34-422a-962b-3642f625dd72/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/0b0c8e69-6209-483b-9336-bb27a1d7cea0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1329,13 +1393,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:36 GMT
+      - Tue, 23 Feb 2016 16:48:50 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '641'
+      - '1133'
       Connection:
       - close
       Content-Type:
@@ -1345,24 +1409,35 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80ZDE2ZGIyOS1jYzM0LTQyMmEtOTYyYi0zNjQyZjYyNWRk
-        NzIvIiwgInRhc2tfaWQiOiAiNGQxNmRiMjktY2MzNC00MjJhLTk2MmItMzY0
-        MmY2MjVkZDcyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8wYjBjOGU2OS02MjA5LTQ4M2ItOTMzNi1iYjI3YTFkN2Nl
+        YTAvIiwgInRhc2tfaWQiOiAiMGIwYzhlNjktNjIwOS00ODNiLTkzMzYtYmIy
+        N2ExZDdjZWEwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAYWJlZC51c2Vyc3lzLnJlZGhhdC5jb20uZHEiLCAic3RhdGUi
-        OiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQi
-        OiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRk
-        YTg4ZGIwM2MyYmE3YzkxYjNlMyJ9LCAiaWQiOiAiNTZjNGRhODhkYjAzYzJi
-        YTdjOTFiM2UzIn0=
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0ODo1MFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
+        T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDcy
+        OTg5MDU0ZmM0OGJhMzAzNiJ9LCAiaWQiOiAiNTZjYzhkNzI5ODkwNTRmYzQ4
+        YmEzMDM2In0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:36 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:50 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/4d16db29-cc34-422a-962b-3642f625dd72/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/0b0c8e69-6209-483b-9336-bb27a1d7cea0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1381,13 +1456,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:37 GMT
+      - Tue, 23 Feb 2016 16:48:51 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2316'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -1397,16 +1472,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80ZDE2ZGIyOS1jYzM0LTQyMmEtOTYyYi0zNjQyZjYyNWRk
-        NzIvIiwgInRhc2tfaWQiOiAiNGQxNmRiMjktY2MzNC00MjJhLTk2MmItMzY0
-        MmY2MjVkZDcyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8wYjBjOGU2OS02MjA5LTQ4M2ItOTMzNi1iYjI3YTFkN2Nl
+        YTAvIiwgInRhc2tfaWQiOiAiMGIwYzhlNjktNjIwOS00ODNiLTkzMzYtYmIy
+        N2ExZDdjZWEwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xN1QyMDozOTozNloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDozOTozNloiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0ODo1MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0ODo1MFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZjJiYTAxMWItODRjNS00OGJkLWI0N2UtOTYyOTBmODkw
-        YjY0LyIsICJ0YXNrX2lkIjogImYyYmEwMTFiLTg0YzUtNDhiZC1iNDdlLTk2
-        MjkwZjg5MGI2NCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvZWQ3OWQyNmEtOTMyMS00ODNmLThiNWMtMTUzYzMxMTRh
+        MWU2LyIsICJ0YXNrX2lkIjogImVkNzlkMjZhLTkzMjEtNDgzZi04YjVjLTE1
+        M2MzMTE0YTFlNiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -1417,41 +1492,41 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5
-        cy5yZWRoYXQuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNl
-        cnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhODg1Y2EwMTMx
-        ODRmNmRiMTI0In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAx
-        Ni0wMi0xN1QyMDozOTozNloiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRz
-        IiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTE3VDIwOjM5OjM2WiIsICJpbXBv
-        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdl
-        IjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1
-        cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
-        cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3Vu
-        dCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YzRkYTg4NWNh
-        MDEzMThmMzBjYjA5NyIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXpl
-        X3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
-        bHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3Rv
-        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
-        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
-        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmM0ZGE4OGRiMDNjMmJhN2M5MWIzZTMifSwgImlkIjogIjU2YzRk
-        YTg4ZGIwM2MyYmE3YzkxYjNlMyJ9
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ3MmRlMDQw
+        MzNmNDFkMmE0MmYifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjUwWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6NTBaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkNzJk
+        ZTA0MDMwODk3NThhOTNmIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDcyOTg5MDU0ZmM0OGJhMzAzNiJ9LCAiaWQiOiAiNTZj
+        YzhkNzI5ODkwNTRmYzQ4YmEzMDM2In0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:37 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:51 GMT
 - request:
     method: delete
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1470,7 +1545,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:38 GMT
+      - Tue, 23 Feb 2016 16:48:52 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -1483,14 +1558,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2RlMWU2MWEyLTNlNDUtNGFiNC1hMDM2LWQ4NTVjY2U0MjU0Mi8iLCAi
-        dGFza19pZCI6ICJkZTFlNjFhMi0zZTQ1LTRhYjQtYTAzNi1kODU1Y2NlNDI1
-        NDIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzY2Mjg3OGNkLWIyYjktNDc0Zi05N2IzLThkMzYxMGJhM2JiMS8iLCAi
+        dGFza19pZCI6ICI2NjI4NzhjZC1iMmI5LTQ3NGYtOTdiMy04ZDM2MTBiYTNi
+        YjEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:38 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:52 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/de1e61a2-3e45-4ab4-a036-d855cce42542/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/662878cd-b2b9-474f-97b3-8d3610ba3bb1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1509,7 +1584,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:38 GMT
+      - Tue, 23 Feb 2016 16:48:52 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -1525,22 +1600,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kZTFlNjFhMi0zZTQ1LTRhYjQtYTAzNi1kODU1Y2NlNDI1
-        NDIvIiwgInRhc2tfaWQiOiAiZGUxZTYxYTItM2U0NS00YWI0LWEwMzYtZDg1
-        NWNjZTQyNTQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy82NjI4NzhjZC1iMmI5LTQ3NGYtOTdiMy04ZDM2MTBiYTNi
+        YjEvIiwgInRhc2tfaWQiOiAiNjYyODc4Y2QtYjJiOS00NzRmLTk3YjMtOGQz
+        NjEwYmEzYmIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
         bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
         ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
         Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
         IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE4
-        YWRiMDNjMmJhN2M5MWIzZjQifSwgImlkIjogIjU2YzRkYThhZGIwM2MyYmE3
-        YzkxYjNmNCJ9
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ3
+        NDk4OTA1NGZjNDhiYTMwNDcifSwgImlkIjogIjU2Y2M4ZDc0OTg5MDU0ZmM0
+        OGJhMzA0NyJ9
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:38 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:52 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/de1e61a2-3e45-4ab4-a036-d855cce42542/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/662878cd-b2b9-474f-97b3-8d3610ba3bb1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1559,13 +1634,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:39:38 GMT
+      - Tue, 23 Feb 2016 16:48:52 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '680'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -1575,20 +1650,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kZTFlNjFhMi0zZTQ1LTRhYjQtYTAzNi1kODU1Y2NlNDI1
-        NDIvIiwgInRhc2tfaWQiOiAiZGUxZTYxYTItM2U0NS00YWI0LWEwMzYtZDg1
-        NWNjZTQyNTQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy82NjI4NzhjZC1iMmI5LTQ3NGYtOTdiMy04ZDM2MTBiYTNi
+        YjEvIiwgInRhc2tfaWQiOiAiNjYyODc4Y2QtYjJiOS00NzRmLTk3YjMtOGQz
+        NjEwYmEzYmIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM5OjM4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM5OjM4WiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ4OjUyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjUyWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYThhZGIw
-        M2MyYmE3YzkxYjNmNCJ9LCAiaWQiOiAiNTZjNGRhOGFkYjAzYzJiYTdjOTFi
-        M2Y0In0=
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNzQ5
+        ODkwNTRmYzQ4YmEzMDQ3In0sICJpZCI6ICI1NmNjOGQ3NDk4OTA1NGZjNDhi
+        YTMwNDcifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:39:38 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:52 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/pulp/repository/puppet.yml
+++ b/test/fixtures/vcr_cassettes/pulp/repository/puppet.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -38,13 +38,13 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:37 GMT
+      - Tue, 23 Feb 2016 16:47:52 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
       - '298'
       Location:
-      - https://abed.usersys.redhat.com/pulp/api/v2/repositories/4/
+      - https://katello-yoda.example.com/pulp/api/v2/repositories/4/
       Connection:
       - close
       Content-Type:
@@ -56,14 +56,14 @@ http_interactions:
         ICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRkZWQiOiBudWxs
         LCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicHVwcGV0LXJlcG8ifSwgImxh
         c3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3VudHMi
-        OiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRh
-        NGQ1Y2EwMTMxODRkYzgxNWQxIn0sICJpZCI6ICI0IiwgIl9ocmVmIjogIi9w
+        OiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhk
+        MzhkZTA0MDMzZjQxZDJhM2Y3In0sICJpZCI6ICI0IiwgIl9ocmVmIjogIi9w
         dWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvNC8ifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:37 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:52 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/4/?details=true
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/4/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -82,7 +82,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:38 GMT
+      - Tue, 23 Feb 2016 16:47:53 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -103,14 +103,14 @@ http_interactions:
         dHJpYnV0b3JzIiwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRv
         cl90eXBlX2lkIjogInB1cHBldF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxp
         c2giOiB0cnVlLCAic2NyYXRjaHBhZCI6IHt9LCAiX2lkIjogeyIkb2lkIjog
-        IjU2YzRkYTRkNWNhMDEzMTg0ZGM4MTVkNCJ9LCAiY29uZmlnIjogeyJzZXJ2
+        IjU2Y2M4ZDM4ZGUwNDAzM2Y0MWQyYTNmYSJ9LCAiY29uZmlnIjogeyJzZXJ2
         ZV9odHRwcyI6IHRydWUsICJzZXJ2ZV9odHRwIjogZmFsc2V9LCAiaWQiOiAi
         NF9wdXBwZXQifSwgeyJyZXBvX2lkIjogIjQiLCAiX2hyZWYiOiAiL3B1bHAv
         YXBpL3YyL3JlcG9zaXRvcmllcy80L2Rpc3RyaWJ1dG9ycy80LyIsICJfbnMi
         OiAicmVwb19kaXN0cmlidXRvcnMiLCAibGFzdF9wdWJsaXNoIjogbnVsbCwg
         ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAicHVwcGV0X2luc3RhbGxfZGlzdHJp
         YnV0b3IiLCAiYXV0b19wdWJsaXNoIjogdHJ1ZSwgInNjcmF0Y2hwYWQiOiB7
-        fSwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE0ZDVjYTAxMzE4NGRjODE1ZDMi
+        fSwgIl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQzOGRlMDQwMzNmNDFkMmEzZjki
         fSwgImNvbmZpZyI6IHsiaW5zdGFsbF9wYXRoIjogIi92YXIvbGliL3B1bHAv
         cHVibGlzaGVkL3B1cHBldF9rYXRlbGxvX3Rlc3QiLCAiYXV0b19wdWJsaXNo
         IjogdHJ1ZX0sICJpZCI6ICI0In1dLCAibGFzdF91bml0X2FkZGVkIjogbnVs
@@ -121,20 +121,20 @@ http_interactions:
         aWVzLzQvaW1wb3J0ZXJzL3B1cHBldF9pbXBvcnRlci8iLCAiX25zIjogInJl
         cG9faW1wb3J0ZXJzIiwgImltcG9ydGVyX3R5cGVfaWQiOiAicHVwcGV0X2lt
         cG9ydGVyIiwgImxhc3Rfc3luYyI6IG51bGwsICJyZXBvX2lkIjogIjQiLCAi
-        X2lkIjogeyIkb2lkIjogIjU2YzRkYTRkNWNhMDEzMTg0ZGM4MTVkMiJ9LCAi
+        X2lkIjogeyIkb2lkIjogIjU2Y2M4ZDM4ZGUwNDAzM2Y0MWQyYTNmOCJ9LCAi
         Y29uZmlnIjogeyJmZWVkIjogImh0dHA6Ly9kYXZpZGQuZmVkb3JhcGVvcGxl
         Lm9yZy9yZXBvcy9yYW5kb21fcHVwcGV0LyIsICJzc2xfY2FfY2VydCI6ICJm
         b28iLCAic3NsX2NsaWVudF9jZXJ0IjogImZvbyIsICJzc2xfY2xpZW50X2tl
         eSI6ICJmb28ifSwgImlkIjogInB1cHBldF9pbXBvcnRlciJ9XSwgImxvY2Fs
-        bHlfc3RvcmVkX3VuaXRzIjogMCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE0
-        ZDVjYTAxMzE4NGRjODE1ZDEifSwgInRvdGFsX3JlcG9zaXRvcnlfdW5pdHMi
+        bHlfc3RvcmVkX3VuaXRzIjogMCwgIl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQz
+        OGRlMDQwMzNmNDFkMmEzZjcifSwgInRvdGFsX3JlcG9zaXRvcnlfdW5pdHMi
         OiAwLCAiaWQiOiAiNCIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3Np
         dG9yaWVzLzQvIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:38 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:53 GMT
 - request:
     method: post
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/4/actions/publish/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/4/actions/publish/
     body:
       encoding: UTF-8
       base64_string: |
@@ -156,7 +156,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:38 GMT
+      - Tue, 23 Feb 2016 16:47:53 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -169,14 +169,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2I1ZDJhNGUzLWQ1NTEtNDQ0OS1hMDFiLTQ4MmI3NjcwMWY2MS8iLCAi
-        dGFza19pZCI6ICJiNWQyYTRlMy1kNTUxLTQ0NDktYTAxYi00ODJiNzY3MDFm
-        NjEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2NlZGUzZDkzLWJiZmQtNDYwYS1iZGMyLTNlNWY2ZTMyN2ZkMy8iLCAi
+        dGFza19pZCI6ICJjZWRlM2Q5My1iYmZkLTQ2MGEtYmRjMi0zZTVmNmUzMjdm
+        ZDMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:38 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:53 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/b5d2a4e3-d551-4449-a01b-482b76701f61/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/cede3d93-bbfd-460a-bdc2-3e5f6e327fd3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -195,13 +195,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:38 GMT
+      - Tue, 23 Feb 2016 16:47:53 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '548'
+      - '644'
       Connection:
       - close
       Content-Type:
@@ -211,22 +211,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9iNWQyYTRlMy1kNTUxLTQ0NDktYTAxYi00ODJi
-        NzY3MDFmNjEvIiwgInRhc2tfaWQiOiAiYjVkMmE0ZTMtZDU1MS00NDQ5LWEw
-        MWItNDgyYjc2NzAxZjYxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0
+        dWxwL2FwaS92Mi90YXNrcy9jZWRlM2Q5My1iYmZkLTQ2MGEtYmRjMi0zZTVm
+        NmUzMjdmZDMvIiwgInRhc2tfaWQiOiAiY2VkZTNkOTMtYmJmZC00NjBhLWJk
+        YzItM2U1ZjZlMzI3ZmQzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0
         IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogbnVs
         bCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogbnVsbCwg
         InRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9n
-        cmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIk5vbmUuZHEiLCAic3RhdGUi
-        OiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6IG51bGwsICJyZXN1bHQiOiBu
-        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTRl
-        ZGIwM2MyYmE3YzkxYjI5ZCJ9LCAiaWQiOiAiNTZjNGRhNGVkYjAzYzJiYTdj
-        OTFiMjlkIn0=
+        cmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNl
+        X3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0
+        ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
+        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
+        bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2
+        Y2M4ZDM5OTg5MDU0ZmM0OGJhMmVmMCJ9LCAiaWQiOiAiNTZjYzhkMzk5ODkw
+        NTRmYzQ4YmEyZWYwIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:38 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:53 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/b5d2a4e3-d551-4449-a01b-482b76701f61/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/cede3d93-bbfd-460a-bdc2-3e5f6e327fd3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -245,13 +247,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:38 GMT
+      - Tue, 23 Feb 2016 16:47:53 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1060'
+      - '1062'
       Connection:
       - close
       Content-Type:
@@ -261,33 +263,33 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9iNWQyYTRlMy1kNTUxLTQ0NDktYTAxYi00ODJi
-        NzY3MDFmNjEvIiwgInRhc2tfaWQiOiAiYjVkMmE0ZTMtZDU1MS00NDQ5LWEw
-        MWItNDgyYjc2NzAxZjYxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0
+        dWxwL2FwaS92Mi90YXNrcy9jZWRlM2Q5My1iYmZkLTQ2MGEtYmRjMi0zZTVm
+        NmUzMjdmZDMvIiwgInRhc2tfaWQiOiAiY2VkZTNkOTMtYmJmZC00NjBhLWJk
+        YzItM2U1ZjZlMzI3ZmQzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0
         IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogIjIw
-        MTYtMDItMTdUMjA6Mzg6MzhaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
-        dGFydF90aW1lIjogIjIwMTYtMDItMTdUMjA6Mzg6MzhaIiwgInRyYWNlYmFj
+        MTYtMDItMjNUMTY6NDc6NTNaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
+        dGFydF90aW1lIjogIjIwMTYtMDItMjNUMTY6NDc6NTNaIiwgInRyYWNlYmFj
         ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBv
-        cnQiOiB7fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0w
-        QGFiZWQudXNlcnN5cy5yZWRoYXQuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IHsicmVz
-        dWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQi
-        OiAiNCIsICJzdGFydGVkIjogIjIwMTYtMDItMTdUMjA6Mzg6MzhaIiwgIl9u
-        cyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAx
-        Ni0wMi0xN1QyMDozODozOFoiLCAidHJhY2ViYWNrIjogbnVsbCwgImRpc3Ry
-        aWJ1dG9yX3R5cGVfaWQiOiAicHVwcGV0X2luc3RhbGxfZGlzdHJpYnV0b3Ii
-        LCAic3VtbWFyeSI6ICJzdWNjZXNzIiwgImVycm9yX21lc3NhZ2UiOiBudWxs
-        LCAiZGlzdHJpYnV0b3JfaWQiOiAiNCIsICJpZCI6ICI1NmM0ZGE0ZTVjYTAx
-        MzE4ZjMwY2IwM2EiLCAiZGV0YWlscyI6IHsiZXJyb3JzIjogW10sICJzdWNj
-        ZXNzX3VuaXRfa2V5cyI6IFtdfX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNTZjNGRhNGVkYjAzYzJiYTdjOTFiMjlkIn0sICJpZCI6ICI1
-        NmM0ZGE0ZWRiMDNjMmJhN2M5MWIyOWQifQ==
+        cnQiOiB7fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
+        QGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
+        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJy
+        ZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19p
+        ZCI6ICI0IiwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0yM1QxNjo0Nzo1M1oiLCAi
+        X25zIjogInJlcG9fcHVibGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ3OjUzWiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlz
+        dHJpYnV0b3JfdHlwZV9pZCI6ICJwdXBwZXRfaW5zdGFsbF9kaXN0cmlidXRv
+        ciIsICJzdW1tYXJ5IjogInN1Y2Nlc3MiLCAiZXJyb3JfbWVzc2FnZSI6IG51
+        bGwsICJkaXN0cmlidXRvcl9pZCI6ICI0IiwgImlkIjogIjU2Y2M4ZDM5ZGUw
+        NDAzMDg5NzU4YTg3NiIsICJkZXRhaWxzIjogeyJlcnJvcnMiOiBbXSwgInN1
+        Y2Nlc3NfdW5pdF9rZXlzIjogW119fSwgImVycm9yIjogbnVsbCwgIl9pZCI6
+        IHsiJG9pZCI6ICI1NmNjOGQzOTk4OTA1NGZjNDhiYTJlZjAifSwgImlkIjog
+        IjU2Y2M4ZDM5OTg5MDU0ZmM0OGJhMmVmMCJ9
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:38 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:53 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/4/?details=true
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/4/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -306,7 +308,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:38 GMT
+      - Tue, 23 Feb 2016 16:47:53 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -327,15 +329,15 @@ http_interactions:
         dHJpYnV0b3JzIiwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRv
         cl90eXBlX2lkIjogInB1cHBldF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxp
         c2giOiB0cnVlLCAic2NyYXRjaHBhZCI6IHt9LCAiX2lkIjogeyIkb2lkIjog
-        IjU2YzRkYTRkNWNhMDEzMTg0ZGM4MTVkNCJ9LCAiY29uZmlnIjogeyJzZXJ2
+        IjU2Y2M4ZDM4ZGUwNDAzM2Y0MWQyYTNmYSJ9LCAiY29uZmlnIjogeyJzZXJ2
         ZV9odHRwcyI6IHRydWUsICJzZXJ2ZV9odHRwIjogZmFsc2V9LCAiaWQiOiAi
         NF9wdXBwZXQifSwgeyJyZXBvX2lkIjogIjQiLCAiX2hyZWYiOiAiL3B1bHAv
         YXBpL3YyL3JlcG9zaXRvcmllcy80L2Rpc3RyaWJ1dG9ycy80LyIsICJfbnMi
         OiAicmVwb19kaXN0cmlidXRvcnMiLCAibGFzdF9wdWJsaXNoIjogIjIwMTYt
-        MDItMTdUMjA6Mzg6MzhaIiwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAicHVw
+        MDItMjNUMTY6NDc6NTNaIiwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAicHVw
         cGV0X2luc3RhbGxfZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogdHJ1
-        ZSwgInNjcmF0Y2hwYWQiOiB7fSwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE0
-        ZDVjYTAxMzE4NGRjODE1ZDMifSwgImNvbmZpZyI6IHsiaW5zdGFsbF9wYXRo
+        ZSwgInNjcmF0Y2hwYWQiOiB7fSwgIl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQz
+        OGRlMDQwMzNmNDFkMmEzZjkifSwgImNvbmZpZyI6IHsiaW5zdGFsbF9wYXRo
         IjogIi92YXIvbGliL3B1bHAvcHVibGlzaGVkL3B1cHBldF9rYXRlbGxvX3Rl
         c3QiLCAiYXV0b19wdWJsaXNoIjogdHJ1ZX0sICJpZCI6ICI0In1dLCAibGFz
         dF91bml0X2FkZGVkIjogbnVsbCwgIm5vdGVzIjogeyJfcmVwby10eXBlIjog
@@ -345,20 +347,20 @@ http_interactions:
         cC9hcGkvdjIvcmVwb3NpdG9yaWVzLzQvaW1wb3J0ZXJzL3B1cHBldF9pbXBv
         cnRlci8iLCAiX25zIjogInJlcG9faW1wb3J0ZXJzIiwgImltcG9ydGVyX3R5
         cGVfaWQiOiAicHVwcGV0X2ltcG9ydGVyIiwgImxhc3Rfc3luYyI6IG51bGws
-        ICJyZXBvX2lkIjogIjQiLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTRkNWNh
-        MDEzMTg0ZGM4MTVkMiJ9LCAiY29uZmlnIjogeyJmZWVkIjogImh0dHA6Ly9k
+        ICJyZXBvX2lkIjogIjQiLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDM4ZGUw
+        NDAzM2Y0MWQyYTNmOCJ9LCAiY29uZmlnIjogeyJmZWVkIjogImh0dHA6Ly9k
         YXZpZGQuZmVkb3JhcGVvcGxlLm9yZy9yZXBvcy9yYW5kb21fcHVwcGV0LyIs
         ICJzc2xfY2FfY2VydCI6ICJmb28iLCAic3NsX2NsaWVudF9jZXJ0IjogImZv
         byIsICJzc2xfY2xpZW50X2tleSI6ICJmb28ifSwgImlkIjogInB1cHBldF9p
         bXBvcnRlciJ9XSwgImxvY2FsbHlfc3RvcmVkX3VuaXRzIjogMCwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NmM0ZGE0ZDVjYTAxMzE4NGRjODE1ZDEifSwgInRvdGFs
+        IHsiJG9pZCI6ICI1NmNjOGQzOGRlMDQwMzNmNDFkMmEzZjcifSwgInRvdGFs
         X3JlcG9zaXRvcnlfdW5pdHMiOiAwLCAiaWQiOiAiNCIsICJfaHJlZiI6ICIv
         cHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzLzQvIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:38 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:53 GMT
 - request:
     method: delete
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/4/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -377,7 +379,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:39 GMT
+      - Tue, 23 Feb 2016 16:47:54 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -390,14 +392,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzNmNTBhYzEzLTEyOTAtNDdmNC1iYTE0LWE5M2YzY2M4NmZkZi8iLCAi
-        dGFza19pZCI6ICIzZjUwYWMxMy0xMjkwLTQ3ZjQtYmExNC1hOTNmM2NjODZm
-        ZGYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2U1MmVmODI4LWQ0NTQtNGJhMS04MWI2LTNkMWRiMWIzZjIyOS8iLCAi
+        dGFza19pZCI6ICJlNTJlZjgyOC1kNDU0LTRiYTEtODFiNi0zZDFkYjFiM2Yy
+        MjkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:39 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:54 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/3f50ac13-1290-47f4-ba14-a93f3cc86fdf/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/e52ef828-d454-4ba1-81b6-3d1db1b3f229/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -416,13 +418,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:39 GMT
+      - Tue, 23 Feb 2016 16:47:54 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '635'
+      - '655'
       Connection:
       - close
       Content-Type:
@@ -432,24 +434,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zZjUwYWMxMy0xMjkwLTQ3ZjQtYmExNC1hOTNmM2NjODZm
-        ZGYvIiwgInRhc2tfaWQiOiAiM2Y1MGFjMTMtMTI5MC00N2Y0LWJhMTQtYTkz
-        ZjNjYzg2ZmRmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        aS92Mi90YXNrcy9lNTJlZjgyOC1kNDU0LTRiYTEtODFiNi0zZDFkYjFiM2Yy
+        MjkvIiwgInRhc2tfaWQiOiAiZTUyZWY4MjgtZDQ1NC00YmExLTgxYjYtM2Qx
+        ZGIxYjNmMjI5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
         bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiBudWxsLCAiX25z
-        IjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3Jl
-        cG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTBAYWJlZC51c2Vyc3lzLnJlZGhhdC5jb20uZHEiLCAic3RhdGUiOiAid2Fp
-        dGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTRmZGIw
-        M2MyYmE3YzkxYjI5ZSJ9LCAiaWQiOiAiNTZjNGRhNGZkYjAzYzJiYTdjOTFi
-        MjllIn0=
+        IjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1Qx
+        Njo0Nzo1NFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3Mi
+        OiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVz
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNTZjYzhkM2E5ODkwNTRmYzQ4YmEyZWYxIn0sICJpZCI6ICI1
+        NmNjOGQzYTk4OTA1NGZjNDhiYTJlZjEifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:39 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:54 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/3f50ac13-1290-47f4-ba14-a93f3cc86fdf/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/e52ef828-d454-4ba1-81b6-3d1db1b3f229/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -468,13 +470,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:39 GMT
+      - Tue, 23 Feb 2016 16:47:54 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '672'
+      - '674'
       Connection:
       - close
       Content-Type:
@@ -484,19 +486,19 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zZjUwYWMxMy0xMjkwLTQ3ZjQtYmExNC1hOTNmM2NjODZm
-        ZGYvIiwgInRhc2tfaWQiOiAiM2Y1MGFjMTMtMTI5MC00N2Y0LWJhMTQtYTkz
-        ZjNjYzg2ZmRmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
-        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0x
-        N1QyMDozODozOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3Rp
-        bWUiOiAiMjAxNi0wMi0xN1QyMDozODozOVoiLCAidHJhY2ViYWNrIjogbnVs
+        aS92Mi90YXNrcy9lNTJlZjgyOC1kNDU0LTRiYTEtODFiNi0zZDFkYjFiM2Yy
+        MjkvIiwgInRhc2tfaWQiOiAiZTUyZWY4MjgtZDQ1NC00YmExLTgxYjYtM2Qx
+        ZGIxYjNmMjI5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0y
+        M1QxNjo0Nzo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3Rp
+        bWUiOiAiMjAxNi0wMi0yM1QxNjo0Nzo1NFoiLCAidHJhY2ViYWNrIjogbnVs
         bCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9
-        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWJlZC51
-        c2Vyc3lzLnJlZGhhdC5jb20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAi
-        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWJl
-        ZC51c2Vyc3lzLnJlZGhhdC5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9y
-        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE0ZmRiMDNjMmJhN2M5
-        MWIyOWUifSwgImlkIjogIjU2YzRkYTRmZGIwM2MyYmE3YzkxYjI5ZSJ9
+        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
+        by15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDNhOTg5MDU0ZmM0
+        OGJhMmVmMSJ9LCAiaWQiOiAiNTZjYzhkM2E5ODkwNTRmYzQ4YmEyZWYxIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:39 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:54 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/pulp/repository/repository.yml
+++ b/test/fixtures/vcr_cassettes/pulp/repository/repository.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/7e758c14-7c15-4ebd-a059-11ec8334f6b9/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/f704cab2-e5e7-4287-91ba-d9da2fcc70bf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -21,13 +21,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:10 GMT
+      - Tue, 23 Feb 2016 16:47:38 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '645'
       Connection:
       - close
       Content-Type:
@@ -37,22 +37,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83ZTc1OGMxNC03YzE1LTRlYmQtYTA1OS0xMWVjODMzNGY2
-        YjkvIiwgInRhc2tfaWQiOiAiN2U3NThjMTQtN2MxNS00ZWJkLWEwNTktMTFl
-        YzgzMzRmNmI5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9mNzA0Y2FiMi1lNWU3LTQyODctOTFiYS1kOWRhMmZjYzcw
+        YmYvIiwgInRhc2tfaWQiOiAiZjcwNGNhYjItZTVlNy00Mjg3LTkxYmEtZDlk
+        YTJmY2M3MGJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
         bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
         ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGEz
-        MmRiMDNjMmJhN2M5MWIyODIifSwgImlkIjogIjU2YzRkYTMyZGIwM2MyYmE3
-        YzkxYjI4MiJ9
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3Rh
+        dGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        NmNjOGQyYTk4OTA1NGZjNDhiYTJlZDUifSwgImlkIjogIjU2Y2M4ZDJhOTg5
+        MDU0ZmM0OGJhMmVkNSJ9
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:10 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:38 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/7e758c14-7c15-4ebd-a059-11ec8334f6b9/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/f704cab2-e5e7-4287-91ba-d9da2fcc70bf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -71,13 +73,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:10 GMT
+      - Tue, 23 Feb 2016 16:47:39 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '680'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -87,25 +89,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83ZTc1OGMxNC03YzE1LTRlYmQtYTA1OS0xMWVjODMzNGY2
-        YjkvIiwgInRhc2tfaWQiOiAiN2U3NThjMTQtN2MxNS00ZWJkLWEwNTktMTFl
-        YzgzMzRmNmI5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9mNzA0Y2FiMi1lNWU3LTQyODctOTFiYS1kOWRhMmZjYzcw
+        YmYvIiwgInRhc2tfaWQiOiAiZjcwNGNhYjItZTVlNy00Mjg3LTkxYmEtZDlk
+        YTJmY2M3MGJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM4OjEwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM4OjEwWiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ3OjM4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ3OjM4WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTMyZGIw
-        M2MyYmE3YzkxYjI4MiJ9LCAiaWQiOiAiNTZjNGRhMzJkYjAzYzJiYTdjOTFi
-        MjgyIn0=
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMmE5
+        ODkwNTRmYzQ4YmEyZWQ1In0sICJpZCI6ICI1NmNjOGQyYTk4OTA1NGZjNDhi
+        YTJlZDUifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:10 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:39 GMT
 - request:
     method: delete
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/content/orphans/
+    uri: https://katello-yoda.example.com/pulp/api/v2/content/orphans/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -124,7 +126,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:11 GMT
+      - Tue, 23 Feb 2016 16:47:39 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -137,14 +139,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2FiM2Y0MzE2LWRkMDEtNGViYS1hODU4LTMxODRlNDc3YWQ4Mi8iLCAi
-        dGFza19pZCI6ICJhYjNmNDMxNi1kZDAxLTRlYmEtYTg1OC0zMTg0ZTQ3N2Fk
-        ODIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzE3ZDVkNjMxLTQ3NmItNDc4ZC1iOGEyLTMyNDM0YjA4YzVhMS8iLCAi
+        dGFza19pZCI6ICIxN2Q1ZDYzMS00NzZiLTQ3OGQtYjhhMi0zMjQzNGIwOGM1
+        YTEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:11 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:39 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/097fa0ff-bc3d-4176-bb84-1a6ba20de182/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/89e8dca9-94c3-46ce-b846-6dd98f046fc4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -163,13 +165,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:11 GMT
+      - Tue, 23 Feb 2016 16:47:40 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '645'
       Connection:
       - close
       Content-Type:
@@ -179,74 +181,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wOTdmYTBmZi1iYzNkLTQxNzYtYmI4NC0xYTZiYTIwZGUx
-        ODIvIiwgInRhc2tfaWQiOiAiMDk3ZmEwZmYtYmMzZC00MTc2LWJiODQtMWE2
-        YmEyMGRlMTgyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGEz
-        M2RiMDNjMmJhN2M5MWIyODQifSwgImlkIjogIjU2YzRkYTMzZGIwM2MyYmE3
-        YzkxYjI4NCJ9
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:11 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/097fa0ff-bc3d-4176-bb84-1a6ba20de182/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:11 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '643'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wOTdmYTBmZi1iYzNkLTQxNzYtYmI4NC0xYTZiYTIwZGUx
-        ODIvIiwgInRhc2tfaWQiOiAiMDk3ZmEwZmYtYmMzZC00MTc2LWJiODQtMWE2
-        YmEyMGRlMTgyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy84OWU4ZGNhOS05NGMzLTQ2Y2UtYjg0Ni02ZGQ5OGYwNDZm
+        YzQvIiwgInRhc2tfaWQiOiAiODllOGRjYTktOTRjMy00NmNlLWI4NDYtNmRk
+        OThmMDQ2ZmM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
         bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
         ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
         Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0
-        ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZj
-        NGRhMzNkYjAzYzJiYTdjOTFiMjg0In0sICJpZCI6ICI1NmM0ZGEzM2RiMDNj
-        MmJhN2M5MWIyODQifQ==
+        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3Rh
+        dGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        NmNjOGQyYzk4OTA1NGZjNDhiYTJlZDcifSwgImlkIjogIjU2Y2M4ZDJjOTg5
+        MDU0ZmM0OGJhMmVkNyJ9
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:11 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:40 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/097fa0ff-bc3d-4176-bb84-1a6ba20de182/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/89e8dca9-94c3-46ce-b846-6dd98f046fc4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -265,13 +217,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:12 GMT
+      - Tue, 23 Feb 2016 16:47:40 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '643'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -281,597 +233,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wOTdmYTBmZi1iYzNkLTQxNzYtYmI4NC0xYTZiYTIwZGUx
-        ODIvIiwgInRhc2tfaWQiOiAiMDk3ZmEwZmYtYmMzZC00MTc2LWJiODQtMWE2
-        YmEyMGRlMTgyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0
-        ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZj
-        NGRhMzNkYjAzYzJiYTdjOTFiMjg0In0sICJpZCI6ICI1NmM0ZGEzM2RiMDNj
-        MmJhN2M5MWIyODQifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:12 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/097fa0ff-bc3d-4176-bb84-1a6ba20de182/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:13 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '643'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wOTdmYTBmZi1iYzNkLTQxNzYtYmI4NC0xYTZiYTIwZGUx
-        ODIvIiwgInRhc2tfaWQiOiAiMDk3ZmEwZmYtYmMzZC00MTc2LWJiODQtMWE2
-        YmEyMGRlMTgyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0
-        ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZj
-        NGRhMzNkYjAzYzJiYTdjOTFiMjg0In0sICJpZCI6ICI1NmM0ZGEzM2RiMDNj
-        MmJhN2M5MWIyODQifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:13 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/097fa0ff-bc3d-4176-bb84-1a6ba20de182/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:13 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '643'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wOTdmYTBmZi1iYzNkLTQxNzYtYmI4NC0xYTZiYTIwZGUx
-        ODIvIiwgInRhc2tfaWQiOiAiMDk3ZmEwZmYtYmMzZC00MTc2LWJiODQtMWE2
-        YmEyMGRlMTgyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0
-        ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZj
-        NGRhMzNkYjAzYzJiYTdjOTFiMjg0In0sICJpZCI6ICI1NmM0ZGEzM2RiMDNj
-        MmJhN2M5MWIyODQifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:13 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/097fa0ff-bc3d-4176-bb84-1a6ba20de182/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:14 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '643'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wOTdmYTBmZi1iYzNkLTQxNzYtYmI4NC0xYTZiYTIwZGUx
-        ODIvIiwgInRhc2tfaWQiOiAiMDk3ZmEwZmYtYmMzZC00MTc2LWJiODQtMWE2
-        YmEyMGRlMTgyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0
-        ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZj
-        NGRhMzNkYjAzYzJiYTdjOTFiMjg0In0sICJpZCI6ICI1NmM0ZGEzM2RiMDNj
-        MmJhN2M5MWIyODQifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:14 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/097fa0ff-bc3d-4176-bb84-1a6ba20de182/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '643'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wOTdmYTBmZi1iYzNkLTQxNzYtYmI4NC0xYTZiYTIwZGUx
-        ODIvIiwgInRhc2tfaWQiOiAiMDk3ZmEwZmYtYmMzZC00MTc2LWJiODQtMWE2
-        YmEyMGRlMTgyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0
-        ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZj
-        NGRhMzNkYjAzYzJiYTdjOTFiMjg0In0sICJpZCI6ICI1NmM0ZGEzM2RiMDNj
-        MmJhN2M5MWIyODQifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:15 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/097fa0ff-bc3d-4176-bb84-1a6ba20de182/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:16 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '643'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wOTdmYTBmZi1iYzNkLTQxNzYtYmI4NC0xYTZiYTIwZGUx
-        ODIvIiwgInRhc2tfaWQiOiAiMDk3ZmEwZmYtYmMzZC00MTc2LWJiODQtMWE2
-        YmEyMGRlMTgyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0
-        ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZj
-        NGRhMzNkYjAzYzJiYTdjOTFiMjg0In0sICJpZCI6ICI1NmM0ZGEzM2RiMDNj
-        MmJhN2M5MWIyODQifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:16 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/097fa0ff-bc3d-4176-bb84-1a6ba20de182/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:17 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '643'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wOTdmYTBmZi1iYzNkLTQxNzYtYmI4NC0xYTZiYTIwZGUx
-        ODIvIiwgInRhc2tfaWQiOiAiMDk3ZmEwZmYtYmMzZC00MTc2LWJiODQtMWE2
-        YmEyMGRlMTgyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0
-        ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZj
-        NGRhMzNkYjAzYzJiYTdjOTFiMjg0In0sICJpZCI6ICI1NmM0ZGEzM2RiMDNj
-        MmJhN2M5MWIyODQifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:17 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/097fa0ff-bc3d-4176-bb84-1a6ba20de182/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:18 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '643'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wOTdmYTBmZi1iYzNkLTQxNzYtYmI4NC0xYTZiYTIwZGUx
-        ODIvIiwgInRhc2tfaWQiOiAiMDk3ZmEwZmYtYmMzZC00MTc2LWJiODQtMWE2
-        YmEyMGRlMTgyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0
-        ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZj
-        NGRhMzNkYjAzYzJiYTdjOTFiMjg0In0sICJpZCI6ICI1NmM0ZGEzM2RiMDNj
-        MmJhN2M5MWIyODQifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:18 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/097fa0ff-bc3d-4176-bb84-1a6ba20de182/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:19 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '643'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wOTdmYTBmZi1iYzNkLTQxNzYtYmI4NC0xYTZiYTIwZGUx
-        ODIvIiwgInRhc2tfaWQiOiAiMDk3ZmEwZmYtYmMzZC00MTc2LWJiODQtMWE2
-        YmEyMGRlMTgyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0
-        ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZj
-        NGRhMzNkYjAzYzJiYTdjOTFiMjg0In0sICJpZCI6ICI1NmM0ZGEzM2RiMDNj
-        MmJhN2M5MWIyODQifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:19 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/097fa0ff-bc3d-4176-bb84-1a6ba20de182/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:21 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '643'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wOTdmYTBmZi1iYzNkLTQxNzYtYmI4NC0xYTZiYTIwZGUx
-        ODIvIiwgInRhc2tfaWQiOiAiMDk3ZmEwZmYtYmMzZC00MTc2LWJiODQtMWE2
-        YmEyMGRlMTgyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0
-        ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZj
-        NGRhMzNkYjAzYzJiYTdjOTFiMjg0In0sICJpZCI6ICI1NmM0ZGEzM2RiMDNj
-        MmJhN2M5MWIyODQifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:21 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/097fa0ff-bc3d-4176-bb84-1a6ba20de182/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:23 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '643'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wOTdmYTBmZi1iYzNkLTQxNzYtYmI4NC0xYTZiYTIwZGUx
-        ODIvIiwgInRhc2tfaWQiOiAiMDk3ZmEwZmYtYmMzZC00MTc2LWJiODQtMWE2
-        YmEyMGRlMTgyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0
-        ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZj
-        NGRhMzNkYjAzYzJiYTdjOTFiMjg0In0sICJpZCI6ICI1NmM0ZGEzM2RiMDNj
-        MmJhN2M5MWIyODQifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:23 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/097fa0ff-bc3d-4176-bb84-1a6ba20de182/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:25 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '680'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wOTdmYTBmZi1iYzNkLTQxNzYtYmI4NC0xYTZiYTIwZGUx
-        ODIvIiwgInRhc2tfaWQiOiAiMDk3ZmEwZmYtYmMzZC00MTc2LWJiODQtMWE2
-        YmEyMGRlMTgyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy84OWU4ZGNhOS05NGMzLTQ2Y2UtYjg0Ni02ZGQ5OGYwNDZm
+        YzQvIiwgInRhc2tfaWQiOiAiODllOGRjYTktOTRjMy00NmNlLWI4NDYtNmRk
+        OThmMDQ2ZmM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM4OjI0WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM4OjI0WiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ3OjQwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ3OjQwWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTMzZGIw
-        M2MyYmE3YzkxYjI4NCJ9LCAiaWQiOiAiNTZjNGRhMzNkYjAzYzJiYTdjOTFi
-        Mjg0In0=
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMmM5
+        ODkwNTRmYzQ4YmEyZWQ3In0sICJpZCI6ICI1NmNjOGQyYzk4OTA1NGZjNDhi
+        YTJlZDcifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:25 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:40 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/eabe6116-26a1-4034-9c9b-1d78896234c5/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/a417bcd0-0164-4e74-8389-c5330f13b929/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -890,13 +270,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:26 GMT
+      - Tue, 23 Feb 2016 16:47:41 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '663'
       Connection:
       - close
       Content-Type:
@@ -906,22 +286,442 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lYWJlNjExNi0yNmExLTQwMzQtOWM5Yi0xZDc4ODk2MjM0
-        YzUvIiwgInRhc2tfaWQiOiAiZWFiZTYxMTYtMjZhMS00MDM0LTljOWItMWQ3
-        ODg5NjIzNGM1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hNDE3YmNkMC0wMTY0LTRlNzQtODM4OS1jNTMzMGYxM2I5
+        MjkvIiwgInRhc2tfaWQiOiAiYTQxN2JjZDAtMDE2NC00ZTc0LTgzODktYzUz
+        MzBmMTNiOTI5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ3OjQxWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQyZDk4OTA1NGZjNDhiYTJlZDgifSwg
+        ImlkIjogIjU2Y2M4ZDJkOTg5MDU0ZmM0OGJhMmVkOCJ9
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:41 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/a417bcd0-0164-4e74-8389-c5330f13b929/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:47:42 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '682'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hNDE3YmNkMC0wMTY0LTRlNzQtODM4OS1jNTMzMGYxM2I5
+        MjkvIiwgInRhc2tfaWQiOiAiYTQxN2JjZDAtMDE2NC00ZTc0LTgzODktYzUz
+        MzBmMTNiOTI5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTIzVDE2OjQ3OjQxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ3OjQxWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMmQ5
+        ODkwNTRmYzQ4YmEyZWQ4In0sICJpZCI6ICI1NmNjOGQyZDk4OTA1NGZjNDhi
+        YTJlZDgifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:42 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/5ce40f5f-20ab-4913-8083-1da10bd3d6f7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:47:42 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '567'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81Y2U0MGY1Zi0yMGFiLTQ5MTMtODA4My0xZGExMGJkM2Q2
+        ZjcvIiwgInRhc2tfaWQiOiAiNWNlNDBmNWYtMjBhYi00OTEzLTgwODMtMWRh
+        MTBiZDNkNmY3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ3OjQyWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJOb25lLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiBudWxsLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6
+        IHsiJG9pZCI6ICI1NmNjOGQyZTk4OTA1NGZjNDhiYTJlZDkifSwgImlkIjog
+        IjU2Y2M4ZDJlOTg5MDU0ZmM0OGJhMmVkOSJ9
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:42 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/5ce40f5f-20ab-4913-8083-1da10bd3d6f7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:47:43 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '682'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81Y2U0MGY1Zi0yMGFiLTQ5MTMtODA4My0xZGExMGJkM2Q2
+        ZjcvIiwgInRhc2tfaWQiOiAiNWNlNDBmNWYtMjBhYi00OTEzLTgwODMtMWRh
+        MTBiZDNkNmY3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTIzVDE2OjQ3OjQzWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ3OjQzWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMmU5
+        ODkwNTRmYzQ4YmEyZWQ5In0sICJpZCI6ICI1NmNjOGQyZTk4OTA1NGZjNDhi
+        YTJlZDkifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:43 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/35e62005-f318-45cc-b229-19d28c275821/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:47:44 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '663'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNWU2MjAwNS1mMzE4LTQ1Y2MtYjIyOS0xOWQyOGMyNzU4
+        MjEvIiwgInRhc2tfaWQiOiAiMzVlNjIwMDUtZjMxOC00NWNjLWIyMjktMTlk
+        MjhjMjc1ODIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ3OjQ0WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQzMDk4OTA1NGZjNDhiYTJlZGEifSwg
+        ImlkIjogIjU2Y2M4ZDMwOTg5MDU0ZmM0OGJhMmVkYSJ9
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:44 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/35e62005-f318-45cc-b229-19d28c275821/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:47:45 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '682'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNWU2MjAwNS1mMzE4LTQ1Y2MtYjIyOS0xOWQyOGMyNzU4
+        MjEvIiwgInRhc2tfaWQiOiAiMzVlNjIwMDUtZjMxOC00NWNjLWIyMjktMTlk
+        MjhjMjc1ODIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTIzVDE2OjQ3OjQ0WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ3OjQ0WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMzA5
+        ODkwNTRmYzQ4YmEyZWRhIn0sICJpZCI6ICI1NmNjOGQzMDk4OTA1NGZjNDhi
+        YTJlZGEifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:45 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/5d0f547c-16e2-4f7e-a9c0-fc83d3ae0a78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:47:45 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '663'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81ZDBmNTQ3Yy0xNmUyLTRmN2UtYTljMC1mYzgzZDNhZTBh
+        NzgvIiwgInRhc2tfaWQiOiAiNWQwZjU0N2MtMTZlMi00ZjdlLWE5YzAtZmM4
+        M2QzYWUwYTc4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ3OjQ1WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQzMTk4OTA1NGZjNDhiYTJlZGIifSwg
+        ImlkIjogIjU2Y2M4ZDMxOTg5MDU0ZmM0OGJhMmVkYiJ9
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:45 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/5d0f547c-16e2-4f7e-a9c0-fc83d3ae0a78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:47:46 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '682'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81ZDBmNTQ3Yy0xNmUyLTRmN2UtYTljMC1mYzgzZDNhZTBh
+        NzgvIiwgInRhc2tfaWQiOiAiNWQwZjU0N2MtMTZlMi00ZjdlLWE5YzAtZmM4
+        M2QzYWUwYTc4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTIzVDE2OjQ3OjQ1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ3OjQ1WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMzE5
+        ODkwNTRmYzQ4YmEyZWRiIn0sICJpZCI6ICI1NmNjOGQzMTk4OTA1NGZjNDhi
+        YTJlZGIifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:47:46 GMT
+- request:
+    method: get
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/217657a3-4346-43dd-9749-a0c99dbc838f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Feb 2016 16:47:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '645'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yMTc2NTdhMy00MzQ2LTQzZGQtOTc0OS1hMGM5OWRiYzgz
+        OGYvIiwgInRhc2tfaWQiOiAiMjE3NjU3YTMtNDM0Ni00M2RkLTk3NDktYTBj
+        OTlkYmM4MzhmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
         bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
         ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE0
-        MmRiMDNjMmJhN2M5MWIyODUifSwgImlkIjogIjU2YzRkYTQyZGIwM2MyYmE3
-        YzkxYjI4NSJ9
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3Rh
+        dGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        NmNjOGQzMzk4OTA1NGZjNDhiYTJlZGMifSwgImlkIjogIjU2Y2M4ZDMzOTg5
+        MDU0ZmM0OGJhMmVkYyJ9
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:26 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:47 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/eabe6116-26a1-4034-9c9b-1d78896234c5/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/217657a3-4346-43dd-9749-a0c99dbc838f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -940,13 +740,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:26 GMT
+      - Tue, 23 Feb 2016 16:47:47 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '680'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -956,437 +756,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lYWJlNjExNi0yNmExLTQwMzQtOWM5Yi0xZDc4ODk2MjM0
-        YzUvIiwgInRhc2tfaWQiOiAiZWFiZTYxMTYtMjZhMS00MDM0LTljOWItMWQ3
-        ODg5NjIzNGM1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8yMTc2NTdhMy00MzQ2LTQzZGQtOTc0OS1hMGM5OWRiYzgz
+        OGYvIiwgInRhc2tfaWQiOiAiMjE3NjU3YTMtNDM0Ni00M2RkLTk3NDktYTBj
+        OTlkYmM4MzhmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM4OjI2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM4OjI2WiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ3OjQ3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ3OjQ3WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTQyZGIw
-        M2MyYmE3YzkxYjI4NSJ9LCAiaWQiOiAiNTZjNGRhNDJkYjAzYzJiYTdjOTFi
-        Mjg1In0=
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMzM5
+        ODkwNTRmYzQ4YmEyZWRjIn0sICJpZCI6ICI1NmNjOGQzMzk4OTA1NGZjNDhi
+        YTJlZGMifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:26 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/0a84a38a-74cb-42cf-91ee-e0dd8f2bbf6c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:27 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wYTg0YTM4YS03NGNiLTQyY2YtOTFlZS1lMGRkOGYyYmJm
-        NmMvIiwgInRhc2tfaWQiOiAiMGE4NGEzOGEtNzRjYi00MmNmLTkxZWUtZTBk
-        ZDhmMmJiZjZjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE0
-        M2RiMDNjMmJhN2M5MWIyODYifSwgImlkIjogIjU2YzRkYTQzZGIwM2MyYmE3
-        YzkxYjI4NiJ9
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:27 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/0a84a38a-74cb-42cf-91ee-e0dd8f2bbf6c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:28 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '680'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wYTg0YTM4YS03NGNiLTQyY2YtOTFlZS1lMGRkOGYyYmJm
-        NmMvIiwgInRhc2tfaWQiOiAiMGE4NGEzOGEtNzRjYi00MmNmLTkxZWUtZTBk
-        ZDhmMmJiZjZjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM4OjI3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM4OjI3WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTQzZGIw
-        M2MyYmE3YzkxYjI4NiJ9LCAiaWQiOiAiNTZjNGRhNDNkYjAzYzJiYTdjOTFi
-        Mjg2In0=
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:28 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/d733ac4e-c409-4b43-958a-d4c65e5d3583/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:28 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kNzMzYWM0ZS1jNDA5LTRiNDMtOTU4YS1kNGM2NWU1ZDM1
-        ODMvIiwgInRhc2tfaWQiOiAiZDczM2FjNGUtYzQwOS00YjQzLTk1OGEtZDRj
-        NjVlNWQzNTgzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE0
-        NGRiMDNjMmJhN2M5MWIyODcifSwgImlkIjogIjU2YzRkYTQ0ZGIwM2MyYmE3
-        YzkxYjI4NyJ9
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:28 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/d733ac4e-c409-4b43-958a-d4c65e5d3583/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:29 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '680'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kNzMzYWM0ZS1jNDA5LTRiNDMtOTU4YS1kNGM2NWU1ZDM1
-        ODMvIiwgInRhc2tfaWQiOiAiZDczM2FjNGUtYzQwOS00YjQzLTk1OGEtZDRj
-        NjVlNWQzNTgzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM4OjI4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM4OjI4WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTQ0ZGIw
-        M2MyYmE3YzkxYjI4NyJ9LCAiaWQiOiAiNTZjNGRhNDRkYjAzYzJiYTdjOTFi
-        Mjg3In0=
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:29 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/1fc900eb-b457-4d78-8075-67c06e7043c7/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:30 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xZmM5MDBlYi1iNDU3LTRkNzgtODA3NS02N2MwNmU3MDQz
-        YzcvIiwgInRhc2tfaWQiOiAiMWZjOTAwZWItYjQ1Ny00ZDc4LTgwNzUtNjdj
-        MDZlNzA0M2M3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE0
-        NWRiMDNjMmJhN2M5MWIyODgifSwgImlkIjogIjU2YzRkYTQ1ZGIwM2MyYmE3
-        YzkxYjI4OCJ9
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:30 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/1fc900eb-b457-4d78-8075-67c06e7043c7/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:30 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '680'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xZmM5MDBlYi1iNDU3LTRkNzgtODA3NS02N2MwNmU3MDQz
-        YzcvIiwgInRhc2tfaWQiOiAiMWZjOTAwZWItYjQ1Ny00ZDc4LTgwNzUtNjdj
-        MDZlNzA0M2M3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM4OjMwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM4OjMwWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTQ1ZGIw
-        M2MyYmE3YzkxYjI4OCJ9LCAiaWQiOiAiNTZjNGRhNDVkYjAzYzJiYTdjOTFi
-        Mjg4In0=
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:30 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/83408b65-3b86-4dcb-af35-ee1d42680363/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:31 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84MzQwOGI2NS0zYjg2LTRkY2ItYWYzNS1lZTFkNDI2ODAz
-        NjMvIiwgInRhc2tfaWQiOiAiODM0MDhiNjUtM2I4Ni00ZGNiLWFmMzUtZWUx
-        ZDQyNjgwMzYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE0
-        N2RiMDNjMmJhN2M5MWIyODkifSwgImlkIjogIjU2YzRkYTQ3ZGIwM2MyYmE3
-        YzkxYjI4OSJ9
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:31 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/83408b65-3b86-4dcb-af35-ee1d42680363/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:31 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '680'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84MzQwOGI2NS0zYjg2LTRkY2ItYWYzNS1lZTFkNDI2ODAz
-        NjMvIiwgInRhc2tfaWQiOiAiODM0MDhiNjUtM2I4Ni00ZGNiLWFmMzUtZWUx
-        ZDQyNjgwMzYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM4OjMxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM4OjMxWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTQ3ZGIw
-        M2MyYmE3YzkxYjI4OSJ9LCAiaWQiOiAiNTZjNGRhNDdkYjAzYzJiYTdjOTFi
-        Mjg5In0=
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:31 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:47 GMT
 - request:
     method: post
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1408,7 +796,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:32 GMT
+      - Tue, 23 Feb 2016 16:47:48 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -1421,14 +809,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzg2MWE1YTNlLTk3ZjYtNDQ0Ni1hN2VlLTVjY2VkMDQ3YmFkZS8iLCAi
-        dGFza19pZCI6ICI4NjFhNWEzZS05N2Y2LTQ0NDYtYTdlZS01Y2NlZDA0N2Jh
-        ZGUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2ZmNDA2MzBkLWZkYTctNGY1My04NzQzLWZiOTAxODdhMGQ2Ny8iLCAi
+        dGFza19pZCI6ICJmZjQwNjMwZC1mZGE3LTRmNTMtODc0My1mYjkwMTg3YTBk
+        NjcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:32 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:48 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/861a5a3e-97f6-4446-a7ee-5cced047bade/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/ff40630d-fda7-4f53-8743-fb90187a0d67/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1447,13 +835,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:32 GMT
+      - Tue, 23 Feb 2016 16:47:48 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1131'
+      - '1133'
       Connection:
       - close
       Content-Type:
@@ -1463,12 +851,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84NjFhNWEzZS05N2Y2LTQ0NDYtYTdlZS01Y2NlZDA0N2Jh
-        ZGUvIiwgInRhc2tfaWQiOiAiODYxYTVhM2UtOTdmNi00NDQ2LWE3ZWUtNWNj
-        ZWQwNDdiYWRlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9mZjQwNjMwZC1mZGE3LTRmNTMtODc0My1mYjkwMTg3YTBk
+        NjcvIiwgInRhc2tfaWQiOiAiZmY0MDYzMGQtZmRhNy00ZjUzLTg3NDMtZmI5
+        MDE4N2EwZDY3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0xN1QyMDozODozMloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        Mi0yM1QxNjo0Nzo0OFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
         dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
         IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
         T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
@@ -1479,19 +867,19 @@ http_interactions:
         OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
         YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
         cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIk5PVF9T
-        VEFSVEVEIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0wQGFiZWQudXNlcnN5cy5yZWRoYXQuY29tLmRxIiwgInN0YXRlIjogInJ1
-        bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTBAYWJlZC51c2Vyc3lzLnJlZGhhdC5jb20iLCAicmVzdWx0IjogbnVs
-        bCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE0OGRi
-        MDNjMmJhN2M5MWIyOGEifSwgImlkIjogIjU2YzRkYTQ4ZGIwM2MyYmE3Yzkx
-        YjI4YSJ9
+        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
+        T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDM0
+        OTg5MDU0ZmM0OGJhMmVkZCJ9LCAiaWQiOiAiNTZjYzhkMzQ5ODkwNTRmYzQ4
+        YmEyZWRkIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:32 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:48 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/861a5a3e-97f6-4446-a7ee-5cced047bade/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/ff40630d-fda7-4f53-8743-fb90187a0d67/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1510,13 +898,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:32 GMT
+      - Tue, 23 Feb 2016 16:47:48 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1128'
+      - '1133'
       Connection:
       - close
       Content-Type:
@@ -1526,12 +914,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84NjFhNWEzZS05N2Y2LTQ0NDYtYTdlZS01Y2NlZDA0N2Jh
-        ZGUvIiwgInRhc2tfaWQiOiAiODYxYTVhM2UtOTdmNi00NDQ2LWE3ZWUtNWNj
-        ZWQwNDdiYWRlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9mZjQwNjMwZC1mZGE3LTRmNTMtODc0My1mYjkwMTg3YTBk
+        NjcvIiwgInRhc2tfaWQiOiAiZmY0MDYzMGQtZmRhNy00ZjUzLTg3NDMtZmI5
+        MDE4N2EwZDY3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0xN1QyMDozODozMloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        Mi0yM1QxNjo0Nzo0OFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
         dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
         IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
         T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
@@ -1542,19 +930,19 @@ http_interactions:
         OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
         YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
         cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0w
-        QGFiZWQudXNlcnN5cy5yZWRoYXQuY29tLmRxIiwgInN0YXRlIjogInJ1bm5p
-        bmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTBAYWJlZC51c2Vyc3lzLnJlZGhhdC5jb20iLCAicmVzdWx0IjogbnVsbCwg
-        ImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE0OGRiMDNj
-        MmJhN2M5MWIyOGEifSwgImlkIjogIjU2YzRkYTQ4ZGIwM2MyYmE3YzkxYjI4
-        YSJ9
+        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
+        T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDM0
+        OTg5MDU0ZmM0OGJhMmVkZCJ9LCAiaWQiOiAiNTZjYzhkMzQ5ODkwNTRmYzQ4
+        YmEyZWRkIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:32 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:48 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/861a5a3e-97f6-4446-a7ee-5cced047bade/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/ff40630d-fda7-4f53-8743-fb90187a0d67/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1573,13 +961,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:33 GMT
+      - Tue, 23 Feb 2016 16:47:49 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1117'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -1589,123 +977,61 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84NjFhNWEzZS05N2Y2LTQ0NDYtYTdlZS01Y2NlZDA0N2Jh
-        ZGUvIiwgInRhc2tfaWQiOiAiODYxYTVhM2UtOTdmNi00NDQ2LWE3ZWUtNWNj
-        ZWQwNDdiYWRlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0xN1QyMDozODozMloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiA4LCAicnBtX2RvbmUiOiA4LCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAxNzg3MiwgInNpemVf
-        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
-        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJx
-        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBhYmVkLnVzZXJz
-        eXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFiZWQudXNl
-        cnN5cy5yZWRoYXQuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51
-        bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjNGRhNDhkYjAzYzJiYTdjOTFiMjhh
-        In0sICJpZCI6ICI1NmM0ZGE0OGRiMDNjMmJhN2M5MWIyOGEifQ==
-    http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:33 GMT
-- request:
-    method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/861a5a3e-97f6-4446-a7ee-5cced047bade/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 17 Feb 2016 20:38:34 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2324'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84NjFhNWEzZS05N2Y2LTQ0NDYtYTdlZS01Y2NlZDA0N2Jh
-        ZGUvIiwgInRhc2tfaWQiOiAiODYxYTVhM2UtOTdmNi00NDQ2LWE3ZWUtNWNj
-        ZWQwNDdiYWRlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9mZjQwNjMwZC1mZGE3LTRmNTMtODc0My1mYjkwMTg3YTBk
+        NjcvIiwgInRhc2tfaWQiOiAiZmY0MDYzMGQtZmRhNy00ZjUzLTg3NDMtZmI5
+        MDE4N2EwZDY3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xN1QyMDozODozM1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xN1QyMDozODozMloiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0Nzo0OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0Nzo0OFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvOTg1OWUzNjItZDA0ZS00NGQ2LTk3NmItMDUzMWUyN2Q0
-        MzQyLyIsICJ0YXNrX2lkIjogIjk4NTllMzYyLWQwNGUtNDRkNi05NzZiLTA1
-        MzFlMjdkNDM0MiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6
+        cGkvdjIvdGFza3MvZTlhNmY5YWQtYTIzNy00MjRkLThkMDctOWJjYmI3NDhm
+        NTMzLyIsICJ0YXNrX2lkIjogImU5YTZmOWFkLWEyMzctNDI0ZC04ZDA3LTli
+        Y2JiNzQ4ZjUzMyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiA4LCAicnBtX2RvbmUiOiA4LCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAxNzg3MiwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
-        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBhYmVkLnVz
-        ZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBhYmVk
-        LnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJz
-        dWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YzRkYTQ4NWNh
-        MDEzMTg0ZTI4ZmJlNCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQi
-        OiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjog
-        IjIwMTYtMDItMTdUMjA6Mzg6MzJaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVz
-        dWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0xN1QyMDozODozM1oiLCAi
-        aW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJyb3JfbWVz
-        c2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAxNSwgInJlbW92ZWRf
-        Y291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmM0ZGE0
-        OTVjYTAxMzE4ZjMwY2IwMzgiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsi
-        c2l6ZV90b3RhbCI6IDE3ODcyLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YzRkYTQ4ZGIwM2MyYmE3YzkxYjI4YSJ9LCAiaWQi
-        OiAiNTZjNGRhNDhkYjAzYzJiYTdjOTFiMjhhIn0=
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQzNGRlMDQw
+        MzNmNDI2MmNhYWMifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ3OjQ4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDc6NDhaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkMzRk
+        ZTA0MDMwODk3NThhODc0IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDM0OTg5MDU0ZmM0OGJhMmVkZCJ9LCAiaWQiOiAiNTZj
+        YzhkMzQ5ODkwNTRmYzQ4YmEyZWRkIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:34 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:49 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/d309e760-2bf1-4b00-9995-06011b75eda2/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/b6524207-2270-4e31-82b7-3f1675c37a92/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1724,13 +1050,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:35 GMT
+      - Tue, 23 Feb 2016 16:47:50 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '663'
       Connection:
       - close
       Content-Type:
@@ -1740,22 +1066,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kMzA5ZTc2MC0yYmYxLTRiMDAtOTk5NS0wNjAxMWI3NWVk
-        YTIvIiwgInRhc2tfaWQiOiAiZDMwOWU3NjAtMmJmMS00YjAwLTk5OTUtMDYw
-        MTFiNzVlZGEyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9iNjUyNDIwNy0yMjcwLTRlMzEtODJiNy0zZjE2NzVjMzdh
+        OTIvIiwgInRhc2tfaWQiOiAiYjY1MjQyMDctMjI3MC00ZTMxLTgyYjctM2Yx
+        Njc1YzM3YTkyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE0
-        YmRiMDNjMmJhN2M5MWIyOWIifSwgImlkIjogIjU2YzRkYTRiZGIwM2MyYmE3
-        YzkxYjI5YiJ9
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ3OjUwWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQzNjk4OTA1NGZjNDhiYTJlZWUifSwg
+        ImlkIjogIjU2Y2M4ZDM2OTg5MDU0ZmM0OGJhMmVlZSJ9
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:35 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:50 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/d309e760-2bf1-4b00-9995-06011b75eda2/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/b6524207-2270-4e31-82b7-3f1675c37a92/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1774,13 +1102,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:36 GMT
+      - Tue, 23 Feb 2016 16:47:50 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '680'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -1790,25 +1118,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kMzA5ZTc2MC0yYmYxLTRiMDAtOTk5NS0wNjAxMWI3NWVk
-        YTIvIiwgInRhc2tfaWQiOiAiZDMwOWU3NjAtMmJmMS00YjAwLTk5OTUtMDYw
-        MTFiNzVlZGEyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9iNjUyNDIwNy0yMjcwLTRlMzEtODJiNy0zZjE2NzVjMzdh
+        OTIvIiwgInRhc2tfaWQiOiAiYjY1MjQyMDctMjI3MC00ZTMxLTgyYjctM2Yx
+        Njc1YzM3YTkyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM4OjM1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM4OjM1WiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ3OjUwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ3OjUwWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTRiZGIw
-        M2MyYmE3YzkxYjI5YiJ9LCAiaWQiOiAiNTZjNGRhNGJkYjAzYzJiYTdjOTFi
-        MjliIn0=
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMzY5
+        ODkwNTRmYzQ4YmEyZWVlIn0sICJpZCI6ICI1NmNjOGQzNjk4OTA1NGZjNDhi
+        YTJlZWUifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:36 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:50 GMT
 - request:
     method: post
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1817,20 +1145,20 @@ http_interactions:
         b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
         ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6ImZvbyIsInNzbF9jbGllbnRfY2Vy
         dCI6ImZvbyIsInNzbF9jbGllbnRfa2V5IjoiZm9vIiwiZG93bmxvYWRfcG9s
-        aWN5IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0s
-        ImRpc3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9k
-        aXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91
-        cmwiOiJ0ZXN0X3BhdGgvIiwiaHR0cCI6ZmFsc2UsImh0dHBzIjp0cnVlLCJw
-        cm90ZWN0ZWQiOnRydWV9LCJhdXRvX3B1Ymxpc2giOnRydWUsImRpc3RyaWJ1
-        dG9yX2lkIjoiRmVkb3JhXzE3In0seyJkaXN0cmlidXRvcl90eXBlX2lkIjoi
-        eXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7
-        ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjoiRmVkb3JhXzE3In0sImF1
-        dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiRmVkb3JhXzE3
-        X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBlX2lkIjoiZXhwb3J0X2Rpc3Ry
-        aWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7Imh0dHAiOmZhbHNlLCJo
-        dHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6InRlc3RfcGF0aC8ifSwiYXV0
-        b19wdWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJleHBvcnRfZGlz
-        dHJpYnV0b3IifV19
+        aWN5IjpudWxsLCJyZW1vdmVfbWlzc2luZyI6bnVsbH0sIm5vdGVzIjp7Il9y
+        ZXBvLXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3Ry
+        aWJ1dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRv
+        cl9jb25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoLyIsImh0dHAi
+        OmZhbHNlLCJodHRwcyI6dHJ1ZSwicHJvdGVjdGVkIjp0cnVlfSwiYXV0b19w
+        dWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9pZCI6IkZlZG9yYV8xNyJ9LHsi
+        ZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9jbG9uZV9kaXN0cmlidXRvciIs
+        ImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRv
+        cl9pZCI6IkZlZG9yYV8xNyJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0
+        cmlidXRvcl9pZCI6IkZlZG9yYV8xN19jbG9uZSJ9LHsiZGlzdHJpYnV0b3Jf
+        dHlwZV9pZCI6ImV4cG9ydF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2Nv
+        bmZpZyI6eyJodHRwIjpmYWxzZSwiaHR0cHMiOmZhbHNlLCJyZWxhdGl2ZV91
+        cmwiOiJ0ZXN0X3BhdGgvIn0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3Ry
+        aWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
     headers:
       Accept:
       - application/json
@@ -1839,7 +1167,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '822'
+      - '844'
       User-Agent:
       - Ruby
   response:
@@ -1848,13 +1176,13 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:36 GMT
+      - Tue, 23 Feb 2016 16:47:51 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
       - '320'
       Location:
-      - https://abed.usersys.redhat.com/pulp/api/v2/repositories/Fedora_17/
+      - https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/
       Connection:
       - close
       Content-Type:
@@ -1867,14 +1195,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZjNGRhNGM1Y2EwMTMxODRlMjhmYmU4In0sICJpZCI6ICJGZWRvcmFfMTci
+        NTZjYzhkMzdkZTA0MDMzZjQzNTE0Zjc4In0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:36 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:51 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1893,7 +1221,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:36 GMT
+      - Tue, 23 Feb 2016 16:47:51 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -1907,10 +1235,10 @@ http_interactions:
       base64_string: |
         W10=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:36 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:51 GMT
 - request:
     method: post
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1932,13 +1260,13 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:36 GMT
+      - Tue, 23 Feb 2016 16:47:51 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
       - '671'
       Location:
-      - https://abed.usersys.redhat.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56c4da4c5ca013184f6db109/
+      - https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56cc8d37de04033f43514f7e/
       Connection:
       - close
       Content-Type:
@@ -1946,26 +1274,26 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJuZXh0X3J1biI6ICIyMDE2LTAyLTE3VDIwOjM4OjM2WiIsICJyZW1haW5p
-        bmdfcnVucyI6IG51bGwsICJsYXN0X3VwZGF0ZWQiOiAxNDU1NzQxNTE2LjY1
-        MzEyNCwgImZpcnN0X3J1biI6ICIyMDEzLTA4LTAxVDAwOjAwOjAwLTA0OjAw
+        eyJuZXh0X3J1biI6ICIyMDE2LTAyLTIzVDE2OjQ3OjUxWiIsICJyZW1haW5p
+        bmdfcnVucyI6IG51bGwsICJsYXN0X3VwZGF0ZWQiOiAxNDU2MjQ2MDcxLjYz
+        MDQ0NiwgImZpcnN0X3J1biI6ICIyMDEzLTA4LTAxVDAwOjAwOjAwLTA0OjAw
         IiwgInRvdGFsX3J1bl9jb3VudCI6IDAsICJzY2hlZHVsZSI6ICIyMDEzLTA4
         LTAxVDAwOjAwOjAwLTA0OjAwL1AxRCIsICJrd2FyZ3MiOiB7Im92ZXJyaWRl
-        cyI6IHt9LCAic2NoZWR1bGVkX2NhbGxfaWQiOiAiNTZjNGRhNGM1Y2EwMTMx
-        ODRmNmRiMTA5In0sICJhcmdzIjogWyJGZWRvcmFfMTciXSwgImVuYWJsZWQi
+        cyI6IHt9LCAic2NoZWR1bGVkX2NhbGxfaWQiOiAiNTZjYzhkMzdkZTA0MDMz
+        ZjQzNTE0ZjdlIn0sICJhcmdzIjogWyJGZWRvcmFfMTciXSwgImVuYWJsZWQi
         OiB0cnVlLCAibGFzdF9ydW5fYXQiOiBudWxsLCAidGFzayI6ICJwdWxwLnNl
         cnZlci5jb250cm9sbGVycy5yZXBvc2l0b3J5LnF1ZXVlX3N5bmNfd2l0aF9h
         dXRvX3B1Ymxpc2giLCAiZmFpbHVyZV90aHJlc2hvbGQiOiBudWxsLCAicmVz
         b3VyY2UiOiAicHVscDppbXBvcnRlcjpGZWRvcmFfMTc6eXVtX2ltcG9ydGVy
-        IiwgIl9pZCI6ICI1NmM0ZGE0YzVjYTAxMzE4NGY2ZGIxMDkiLCAiY29uc2Vj
+        IiwgIl9pZCI6ICI1NmNjOGQzN2RlMDQwMzNmNDM1MTRmN2UiLCAiY29uc2Vj
         dXRpdmVfZmFpbHVyZXMiOiAwLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Jl
         cG9zaXRvcmllcy9GZWRvcmFfMTcvaW1wb3J0ZXJzL3l1bV9pbXBvcnRlci9z
-        Y2hlZHVsZXMvc3luYy81NmM0ZGE0YzVjYTAxMzE4NGY2ZGIxMDkvIn0=
+        Y2hlZHVsZXMvc3luYy81NmNjOGQzN2RlMDQwMzNmNDM1MTRmN2UvIn0=
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:36 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:51 GMT
 - request:
     method: delete
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1984,7 +1312,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:36 GMT
+      - Tue, 23 Feb 2016 16:47:51 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -1997,14 +1325,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzdhNmQxZmQ1LTEwY2YtNDI5Ni1hYmVkLTcwZTk5OGVjZjQ3OS8iLCAi
-        dGFza19pZCI6ICI3YTZkMWZkNS0xMGNmLTQyOTYtYWJlZC03MGU5OThlY2Y0
-        NzkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzExMzc4ZTdkLTdkMzctNGY0Yi1hOTU3LWY2MDFiZGE0MTFkNS8iLCAi
+        dGFza19pZCI6ICIxMTM3OGU3ZC03ZDM3LTRmNGItYTk1Ny1mNjAxYmRhNDEx
+        ZDUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:36 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:51 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/7a6d1fd5-10cf-4296-abed-70e998ecf479/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/11378e7d-7d37-4f4b-a957-f601bda411d5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2023,13 +1351,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:36 GMT
+      - Tue, 23 Feb 2016 16:47:51 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '663'
       Connection:
       - close
       Content-Type:
@@ -2039,22 +1367,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83YTZkMWZkNS0xMGNmLTQyOTYtYWJlZC03MGU5OThlY2Y0
-        NzkvIiwgInRhc2tfaWQiOiAiN2E2ZDFmZDUtMTBjZi00Mjk2LWFiZWQtNzBl
-        OTk4ZWNmNDc5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xMTM3OGU3ZC03ZDM3LTRmNGItYTk1Ny1mNjAxYmRhNDEx
+        ZDUvIiwgInRhc2tfaWQiOiAiMTEzNzhlN2QtN2QzNy00ZjRiLWE5NTctZjYw
+        MWJkYTQxMWQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmM0ZGE0
-        Y2RiMDNjMmJhN2M5MWIyOWMifSwgImlkIjogIjU2YzRkYTRjZGIwM2MyYmE3
-        YzkxYjI5YyJ9
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ3OjUxWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQzNzk4OTA1NGZjNDhiYTJlZWYifSwg
+        ImlkIjogIjU2Y2M4ZDM3OTg5MDU0ZmM0OGJhMmVlZiJ9
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:36 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:51 GMT
 - request:
     method: get
-    uri: https://abed.usersys.redhat.com/pulp/api/v2/tasks/7a6d1fd5-10cf-4296-abed-70e998ecf479/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/11378e7d-7d37-4f4b-a957-f601bda411d5/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2073,13 +1403,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 17 Feb 2016 20:38:37 GMT
+      - Tue, 23 Feb 2016 16:47:52 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '680'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -2089,20 +1419,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83YTZkMWZkNS0xMGNmLTQyOTYtYWJlZC03MGU5OThlY2Y0
-        NzkvIiwgInRhc2tfaWQiOiAiN2E2ZDFmZDUtMTBjZi00Mjk2LWFiZWQtNzBl
-        OTk4ZWNmNDc5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xMTM3OGU3ZC03ZDM3LTRmNGItYTk1Ny1mNjAxYmRhNDEx
+        ZDUvIiwgInRhc2tfaWQiOiAiMTEzNzhlN2QtN2QzNy00ZjRiLWE5NTctZjYw
+        MWJkYTQxMWQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTE3VDIwOjM4OjM2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTE3VDIwOjM4OjM2WiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ3OjUxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ3OjUxWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBhYmVkLnVzZXJzeXMucmVkaGF0LmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YzRkYTRjZGIw
-        M2MyYmE3YzkxYjI5YyJ9LCAiaWQiOiAiNTZjNGRhNGNkYjAzYzJiYTdjOTFi
-        MjljIn0=
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkMzc5
+        ODkwNTRmYzQ4YmEyZWVmIn0sICJpZCI6ICI1NmNjOGQzNzk4OTA1NGZjNDhi
+        YTJlZWYifQ==
     http_version: 
-  recorded_at: Wed, 17 Feb 2016 20:38:37 GMT
+  recorded_at: Tue, 23 Feb 2016 16:47:52 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/services/pulp/erratum.yml
+++ b/test/fixtures/vcr_cassettes/services/pulp/erratum.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/9ea582ae-e6f7-4109-836a-39d2f1f04d2c/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/f8d8bd32-7ac9-4e7b-b098-12350fa107ca/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -13,12 +13,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="WFVQ9wqOPdFIIzkPOAiOuEN5hiPomagMAzkbZdyXFo",
-        oauth_signature="LDWtfsChnbOm%2FEefyDos%2FCS7e7k%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292096", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -27,750 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:01:36 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85ZWE1ODJhZS1lNmY3LTQxMDktODM2YS0zOWQyZjFmMDRk
-        MmMvIiwgInRhc2tfaWQiOiAiOWVhNTgyYWUtZTZmNy00MTA5LTgzNmEtMzlk
-        MmYxZjA0ZDJjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjODBl
-        NTQ5NzVmNzFhNmE2NjVlIn0sICJpZCI6ICI1NmFlYmM4MGU1NDk3NWY3MWE2
-        YTY2NWUifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:36 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/9ea582ae-e6f7-4109-836a-39d2f1f04d2c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="mEv6fxV6DDH2326XATf79WNdDOauQTzet9QrEbQlX4",
-        oauth_signature="LpB90UHCclywqVkSQs%2BiY6qltT8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292097", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2310'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85ZWE1ODJhZS1lNmY3LTQxMDktODM2YS0zOWQyZjFmMDRk
-        MmMvIiwgInRhc2tfaWQiOiAiOWVhNTgyYWUtZTZmNy00MTA5LTgzNmEtMzlk
-        MmYxZjA0ZDJjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMjowMTozN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTozN1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNmUwNWU0Y2MtNmUwZC00MjEyLWE0NDAtYWUxZWVjZmNl
-        ODkzLyIsICJ0YXNrX2lkIjogIjZlMDVlNGNjLTZlMGQtNDIxMi1hNDQwLWFl
-        MWVlY2ZjZTg5MyJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84
-        NTA4YjYxOC1hMDBmLTRiZGMtYmEyOC1iNjdmZTY0YWRkNDIvIiwgInRhc2tf
-        aWQiOiAiODUwOGI2MTgtYTAwZi00YmRjLWJhMjgtYjY3ZmU2NGFkZDQyIn1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjODBkZTA0MDMzNDZiZmRhZDY4
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MjowMTozN1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAyOjAxOjM3WiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmM4MWRlMDQwMzRjZDky
-        ZGM1YjYiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmM4MGU1NDk3NWY3MWE2YTY2NWUifSwgImlkIjogIjU2YWViYzgwZTU0
-        OTc1ZjcxYTZhNjY1ZSJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:37 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/6e05e4cc-6e0d-4212-a440-ae1eecfce893/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="9wmxk5oqgatb0QGRghQWnlXN6bgz9OlXYd3MFhk6I",
-        oauth_signature="NTfQkDnDiZO5Ni7H5NcmBGYaKGc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292097", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '670'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82ZTA1ZTRjYy02ZTBkLTQyMTItYTQ0MC1hZTFl
-        ZWNmY2U4OTMvIiwgInRhc2tfaWQiOiAiNmUwNWU0Y2MtNmUwZC00MjEyLWE0
-        NDAtYWUxZWVjZmNlODkzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wMVQwMjowMTozN1oiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15
-        b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29y
-        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
-        by15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjODFlNTQ5NzVmNzFhNmE2
-        NjZlIn0sICJpZCI6ICI1NmFlYmM4MWU1NDk3NWY3MWE2YTY2NmUifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:37 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/8508b618-a00f-4bdc-ba28-b67fe64add42/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="Yj9xoTscXvW0XoiD7nXSnci9usuxGqNVmNa0UixQ",
-        oauth_signature="ne4wZU6DEv%2BN7EiFbL2FdysnNRw%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292097", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '652'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84NTA4YjYxOC1hMDBmLTRiZGMtYmEyOC1iNjdm
-        ZTY0YWRkNDIvIiwgInRhc2tfaWQiOiAiODUwOGI2MTgtYTAwZi00YmRjLWJh
-        MjgtYjY3ZmU2NGFkZDQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiBudWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBb
-        XSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRf
-        cmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRx
-        IiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
-        ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRv
-        aWQiOiAiNTZhZWJjODFlNTQ5NzVmNzFhNmE2NjZmIn0sICJpZCI6ICI1NmFl
-        YmM4MWU1NDk3NWY3MWE2YTY2NmYifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:37 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/9ea582ae-e6f7-4109-836a-39d2f1f04d2c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="QBgv5XfbvFAV52oZGpD5iKPcARZ05GMdF8gTfC1mLA",
-        oauth_signature="sulD%2BQ%2BpD7WB5N1JCSgRPuFY6u8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292098", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2310'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85ZWE1ODJhZS1lNmY3LTQxMDktODM2YS0zOWQyZjFmMDRk
-        MmMvIiwgInRhc2tfaWQiOiAiOWVhNTgyYWUtZTZmNy00MTA5LTgzNmEtMzlk
-        MmYxZjA0ZDJjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMjowMTozN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTozN1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNmUwNWU0Y2MtNmUwZC00MjEyLWE0NDAtYWUxZWVjZmNl
-        ODkzLyIsICJ0YXNrX2lkIjogIjZlMDVlNGNjLTZlMGQtNDIxMi1hNDQwLWFl
-        MWVlY2ZjZTg5MyJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84
-        NTA4YjYxOC1hMDBmLTRiZGMtYmEyOC1iNjdmZTY0YWRkNDIvIiwgInRhc2tf
-        aWQiOiAiODUwOGI2MTgtYTAwZi00YmRjLWJhMjgtYjY3ZmU2NGFkZDQyIn1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjODBkZTA0MDMzNDZiZmRhZDY4
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MjowMTozN1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAyOjAxOjM3WiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmM4MWRlMDQwMzRjZDky
-        ZGM1YjYiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmM4MGU1NDk3NWY3MWE2YTY2NWUifSwgImlkIjogIjU2YWViYzgwZTU0
-        OTc1ZjcxYTZhNjY1ZSJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:38 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/6e05e4cc-6e0d-4212-a440-ae1eecfce893/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="SWAYg9ndxpAEQlJT94nZUEjOqc450fjMmm968Cntts",
-        oauth_signature="ShrK8eiEdfZc2v9JT9kUGVuMZL4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292098", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82ZTA1ZTRjYy02ZTBkLTQyMTItYTQ0MC1hZTFl
-        ZWNmY2U4OTMvIiwgInRhc2tfaWQiOiAiNmUwNWU0Y2MtNmUwZC00MjEyLWE0
-        NDAtYWUxZWVjZmNlODkzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMjowMTozN1oiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTozN1oiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDI6MDE6MzdaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMjowMTozN1oiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmM4MWRlMDQwMzRjZDkyZGM1YjciLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjODFlNTQ5NzVmNzFhNmE2NjZlIn0s
-        ICJpZCI6ICI1NmFlYmM4MWU1NDk3NWY3MWE2YTY2NmUifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:38 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/8508b618-a00f-4bdc-ba28-b67fe64add42/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="9DTIP6DW8DwfTdYktSnJ7UFHa9EsKE1ebV8ewjJbDb0",
-        oauth_signature="QV1TG78NYR6uQwVJPiLrJGSfwpo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292098", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6923'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84NTA4YjYxOC1hMDBmLTRiZGMtYmEyOC1iNjdm
-        ZTY0YWRkNDIvIiwgInRhc2tfaWQiOiAiODUwOGI2MTgtYTAwZi00YmRjLWJh
-        MjgtYjY3ZmU2NGFkZDQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMjowMTozOFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTozN1oiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJkNjFjZjhkZi0zNzE2LTQ0ZWUtYmJmZi1kNGZiZDc1
-        YjI4ZDMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiOTM0ZGRjOWEtZWNlYi00Yzc5LWFmMjgtOWZkN2Y4YTNhM2QyIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiM2JjNGExZjItOWZlMi00OGM0LThiZGMt
-        MjI2OWI1NTc1ZWE5IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzUy
-        ZTBkZmUtNzQzZi00NTQ4LWE1NjUtMjY5NDFlMWY2ZWE5IiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjljZjQ1OGUxLTdhMGMtNDRmYy04ZjE0LWQwNDg5
-        MDdlZmZlNCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3MjkzODEz
-        ZS01MDZjLTQ3OTgtYmZlMy1hMTI4NjdmM2M2NDYiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI4NzgzNjAyZi0wNjZhLTQ0ZjQtYjIyZi0zNjBi
-        ZTg1YWRjNmUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIxZTU0NzhiZS1lZWI0LTRiZGMtOTgxYi1kMWM2ZGExOTQ1YjAi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlNmJh
-        NDQzMy01MTU0LTQwYWYtODc0YS0wODM2MzkwNDZjZDMiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhMzU4ZDQ1YS05YzE0
-        LTQwNjItOGM3OC1mZjgzNTFmNGY2NTciLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjY2MzdmOGY5LTMyNjYtNDM0
-        Yy1hOTNlLWMwNDI4NmU0ODA5NCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
-        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
-        c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTAxVDAyOjAxOjM3WiIsICJf
-        bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
-        MTYtMDItMDFUMDI6MDE6MzhaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
-        cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
-        IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
-        X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
-        RCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1z
-        IjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0
-        aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
-        SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
-        U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
-        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZhZWJjODJkZTA0MDM0Y2Q5MmRj
-        NWI4IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImQ2MWNmOGRmLTM3MTYtNDRlZS1iYmZmLWQ0ZmJkNzViMjhkMyIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
-        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5MzRk
-        ZGM5YS1lY2ViLTRjNzktYWYyOC05ZmQ3ZjhhM2EzZDIiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
-        c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICIzYmM0YTFmMi05ZmUyLTQ4YzQtOGJkYy0yMjY5YjU1NzVl
-        YTkiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
-        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjNTJlMGRmZS03NDNm
-        LTQ1NDgtYTU2NS0yNjk0MWUxZjZlYTkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
-        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiOWNmNDU4ZTEtN2EwYy00NGZjLThmMTQtZDA0ODkwN2VmZmU0Iiwg
-        Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
-        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjcyOTM4MTNlLTUwNmMtNDc5
-        OC1iZmUzLWExMjg2N2YzYzY0NiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
-        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
-        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjg3ODM2MDJmLTA2NmEtNDRmNC1iMjJmLTM2MGJlODVhZGM2ZSIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
-        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
-        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjFl
-        NTQ3OGJlLWVlYjQtNGJkYy05ODFiLWQxYzZkYTE5NDViMCIsICJudW1fcHJv
-        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
-        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
-        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImU2YmE0NDMzLTUxNTQt
-        NDBhZi04NzRhLTA4MzYzOTA0NmNkMyIsICJudW1fcHJvY2Vzc2VkIjogMH0s
-        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
-        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
-        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImEzNThkNDVhLTljMTQtNDA2Mi04Yzc4
-        LWZmODM1MWY0ZjY1NyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
-        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiNjYzN2Y4ZjktMzI2Ni00MzRjLWE5M2UtYzA0
-        Mjg2ZTQ4MDk0IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YWViYzgxZTU0OTc1ZjcxYTZhNjY2
-        ZiJ9LCAiaWQiOiAiNTZhZWJjODFlNTQ5NzVmNzFhNmE2NjZmIn0=
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:38 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/0e037106-68f4-46bd-b0d8-1799fa7b12f4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="Ldzt6hrupMrqGMmsciipyuzbPK3Hj6wYwBSGzore7E",
-        oauth_signature="57Sq%2BCS9z1fElGrFwu80xYdIrOg%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292098", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '645'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wZTAzNzEwNi02OGY0LTQ2YmQtYjBkOC0xNzk5ZmE3YjEy
-        ZjQvIiwgInRhc2tfaWQiOiAiMGUwMzcxMDYtNjhmNC00NmJkLWIwZDgtMTc5
-        OWZhN2IxMmY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3Rh
-        dGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmM4MmU1NDk3NWY3MWE2YTY2NzAifSwgImlkIjogIjU2YWViYzgyZTU0
-        OTc1ZjcxYTZhNjY3MCJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:38 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/0e037106-68f4-46bd-b0d8-1799fa7b12f4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="eqFO07QMBWx3w5ggWMVXEKOgAOxpCrz5oohEtk3NugE",
-        oauth_signature="A%2BBHp5uBqd1dOMHWPbaWQnWjg5o%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292099", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:39 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '682'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wZTAzNzEwNi02OGY0LTQ2YmQtYjBkOC0xNzk5ZmE3YjEy
-        ZjQvIiwgInRhc2tfaWQiOiAiMGUwMzcxMDYtNjhmNC00NmJkLWIwZDgtMTc5
-        OWZhN2IxMmY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTAxVDAyOjAxOjM5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTAxVDAyOjAxOjM5WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
-        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjODJl
-        NTQ5NzVmNzFhNmE2NjcwIn0sICJpZCI6ICI1NmFlYmM4MmU1NDk3NWY3MWE2
-        YTY2NzAifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:39 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/fa8816aa-3e53-4ad6-8b88-5b63657de22a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="xQsQWKhz4t3BAYKXHzpDPm9DOGgTLkR2MHQlqeMtE",
-        oauth_signature="JcroYmv6kqI7lB28TZExR%2BLvsXI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292100", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:40 GMT
+      - Tue, 23 Feb 2016 16:48:53 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -786,9 +37,9 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mYTg4MTZhYS0zZTUzLTRhZDYtOGI4OC01YjYzNjU3ZGUy
-        MmEvIiwgInRhc2tfaWQiOiAiZmE4ODE2YWEtM2U1My00YWQ2LThiODgtNWI2
-        MzY1N2RlMjJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9mOGQ4YmQzMi03YWM5LTRlN2ItYjA5OC0xMjM1MGZhMTA3
+        Y2EvIiwgInRhc2tfaWQiOiAiZjhkOGJkMzItN2FjOS00ZTdiLWIwOTgtMTIz
+        NTBmYTEwN2NhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
@@ -796,14 +47,14 @@ http_interactions:
         d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
         IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
         Y2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZh
-        ZWJjODRlNTQ5NzVmNzFhNmE2NjcxIn0sICJpZCI6ICI1NmFlYmM4NGU1NDk3
-        NWY3MWE2YTY2NzEifQ==
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZj
+        YzhkNzU5ODkwNTRmYzQ4YmEzMDQ4In0sICJpZCI6ICI1NmNjOGQ3NTk4OTA1
+        NGZjNDhiYTMwNDgifQ==
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:40 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:53 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/fa8816aa-3e53-4ad6-8b88-5b63657de22a/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/f8d8bd32-7ac9-4e7b-b098-12350fa107ca/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -814,12 +65,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="6rFhhVvNJ2RQL1sL1sQ9xNXWtfkfeME2q8LXrldFvc",
-        oauth_signature="wOEskTPkqf%2Bqx86edjwasPlC1zE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292101", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -828,13 +73,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:01:41 GMT
+      - Tue, 23 Feb 2016 16:48:54 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2310'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -844,61 +89,61 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mYTg4MTZhYS0zZTUzLTRhZDYtOGI4OC01YjYzNjU3ZGUy
-        MmEvIiwgInRhc2tfaWQiOiAiZmE4ODE2YWEtM2U1My00YWQ2LThiODgtNWI2
-        MzY1N2RlMjJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9mOGQ4YmQzMi03YWM5LTRlN2ItYjA5OC0xMjM1MGZhMTA3
+        Y2EvIiwgInRhc2tfaWQiOiAiZjhkOGJkMzItN2FjOS00ZTdiLWIwOTgtMTIz
+        NTBmYTEwN2NhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMjowMTo0MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTo0MFoiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0ODo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0ODo1M1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNmU5NTg4YWQtOGQ3ZC00ODdlLThlYTctMzE4Mjc5OGRk
-        Nzc2LyIsICJ0YXNrX2lkIjogIjZlOTU4OGFkLThkN2QtNDg3ZS04ZWE3LTMx
-        ODI3OThkZDc3NiJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9i
-        NGEyNmZkZS02ZTU0LTQyNTgtYWU5Ny1iMjEzOTA1ZjBiOGMvIiwgInRhc2tf
-        aWQiOiAiYjRhMjZmZGUtNmU1NC00MjU4LWFlOTctYjIxMzkwNWYwYjhjIn1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjODRkZTA0MDMzNDZkMTg5MDNj
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MjowMTo0MFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAyOjAxOjQwWiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmM4NGRlMDQwMzRjZDky
-        ZGM1YmMiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmM4NGU1NDk3NWY3MWE2YTY2NzEifSwgImlkIjogIjU2YWViYzg0ZTU0
-        OTc1ZjcxYTZhNjY3MSJ9
+        cGkvdjIvdGFza3MvOTc4MmU2MTAtNjk2ZS00YzNkLWE2MDUtZjJlMDIwYmU4
+        MDlhLyIsICJ0YXNrX2lkIjogIjk3ODJlNjEwLTY5NmUtNGMzZC1hNjA1LWYy
+        ZTAyMGJlODA5YSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ3NWRlMDQw
+        MzNmNDI2MmNhYzUifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjUzWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6NTRaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkNzZk
+        ZTA0MDMwODk3NThhOTQ0IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDc1OTg5MDU0ZmM0OGJhMzA0OCJ9LCAiaWQiOiAiNTZj
+        YzhkNzU5ODkwNTRmYzQ4YmEzMDQ4In0=
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:41 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:54 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/6e9588ad-8d7d-487e-8ea7-3182798dd776/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/9782e610-696e-4c3d-a605-f2e020be809a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -909,12 +154,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="PJBzchjncLCZEdbmyNJvlB7GdBuMwxrX5VF7x0JZtEY",
-        oauth_signature="C%2B3MY7IF1UWDVVafWsAIihGAvlQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292101", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -923,358 +162,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:01:41 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82ZTk1ODhhZC04ZDdkLTQ4N2UtOGVhNy0zMTgy
-        Nzk4ZGQ3NzYvIiwgInRhc2tfaWQiOiAiNmU5NTg4YWQtOGQ3ZC00ODdlLThl
-        YTctMzE4Mjc5OGRkNzc2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMjowMTo0MVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTo0MFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDI6MDE6NDBaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMjowMTo0MVoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmM4NWRlMDQwMzRjZDkyZGM1YmQiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjODRlNTQ5NzVmNzFhNmE2NjgxIn0s
-        ICJpZCI6ICI1NmFlYmM4NGU1NDk3NWY3MWE2YTY2ODEifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:41 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/b4a26fde-6e54-4258-ae97-b213905f0b8c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="C1xX5JyDODHwZ5PtZeSjxfdUhcormihxwwrVGIWH4",
-        oauth_signature="V%2FG3Sx8Nan3qgCNbX%2B7tueNF%2FFc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292101", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:41 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3517'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9iNGEyNmZkZS02ZTU0LTQyNTgtYWU5Ny1iMjEz
-        OTA1ZjBiOGMvIiwgInRhc2tfaWQiOiAiYjRhMjZmZGUtNmU1NC00MjU4LWFl
-        OTctYjIxMzkwNWYwYjhjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wMVQwMjowMTo0MVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5ZTFk
-        NGQ2ZC1iNDM4LTQ5ODgtYTgwNy1lNjk5ZDBlZjc1NDkiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDRiNDJiZjItMDJh
-        Mi00Yjc3LWJlNzEtMWUzMTlkZWU2ZTlmIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDIsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYjEwODFjOTUtZjViMi00MGY2LTkzY2UtNDY1M2U0ZDdmMWFiIiwg
-        Im51bV9wcm9jZXNzZWQiOiAyfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
-        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
-        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE0NzAyMjgzLTc3YWMt
-        NDM5Yy05NDRkLTU4ZjVhMjY2MWZlOCIsICJudW1fcHJvY2Vzc2VkIjogMH0s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
-        ZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIxYTY2YTYwYi1kNDY2LTQ3ZWMtOTkyMS1mZTI3NjI5N2IyN2Yi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5
-        cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
-        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzQxN2U2MTYtMjBm
-        Yi00Yjg4LWFhYWUtMTk3ZTU1YWJhOTQ3IiwgIm51bV9wcm9jZXNzZWQiOiAw
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiMTI0YzIzOTQtMTAwMS00ZWU3LWE4MDEtZTIzYTBh
-        N2NmZTk3IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
-        IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAi
-        c3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
-        ZXBfaWQiOiAiYjJjMGNjYjMtMGE5Yy00NzJkLTgyNGYtODJlMDEzNWEzOGYz
-        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
-        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
-        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        Ijc3ZmNlMTMxLTAyNzAtNGY2Zi04MzcyLTg0YzdhODRlZTAwNSIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjog
-        InB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjIzNDQ1
-        ZTkwLTQ4MzUtNDhlYy05ZGY3LTdjMGE0YzY2MmYyZiIsICJudW1fcHJvY2Vz
-        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
-        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
-        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjNhYjRm
-        NjItYTc5YS00YzZlLWJiYjktYTQ0ZmM0MjYyNTAyIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1
-        bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjODRl
-        NTQ5NzVmNzFhNmE2NjgyIn0sICJpZCI6ICI1NmFlYmM4NGU1NDk3NWY3MWE2
-        YTY2ODIifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:41 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/fa8816aa-3e53-4ad6-8b88-5b63657de22a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="3wERUKWxlhdaq3FylDfBxq5kvR3iEquu2pOrkDbQ",
-        oauth_signature="vPh9iP6G%2BQdc5nIa0vwsSVoYgdE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292101", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:41 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2310'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mYTg4MTZhYS0zZTUzLTRhZDYtOGI4OC01YjYzNjU3ZGUy
-        MmEvIiwgInRhc2tfaWQiOiAiZmE4ODE2YWEtM2U1My00YWQ2LThiODgtNWI2
-        MzY1N2RlMjJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMjowMTo0MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTo0MFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNmU5NTg4YWQtOGQ3ZC00ODdlLThlYTctMzE4Mjc5OGRk
-        Nzc2LyIsICJ0YXNrX2lkIjogIjZlOTU4OGFkLThkN2QtNDg3ZS04ZWE3LTMx
-        ODI3OThkZDc3NiJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9i
-        NGEyNmZkZS02ZTU0LTQyNTgtYWU5Ny1iMjEzOTA1ZjBiOGMvIiwgInRhc2tf
-        aWQiOiAiYjRhMjZmZGUtNmU1NC00MjU4LWFlOTctYjIxMzkwNWYwYjhjIn1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjODRkZTA0MDMzNDZkMTg5MDNj
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MjowMTo0MFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAyOjAxOjQwWiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmM4NGRlMDQwMzRjZDky
-        ZGM1YmMiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmM4NGU1NDk3NWY3MWE2YTY2NzEifSwgImlkIjogIjU2YWViYzg0ZTU0
-        OTc1ZjcxYTZhNjY3MSJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:41 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/6e9588ad-8d7d-487e-8ea7-3182798dd776/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="Jrwt3SD1VeAC2VuCbM1V18lxsMp6zBPpJ2SDW2Axo",
-        oauth_signature="gCwdt0Rw0izXlVxYty58FGLMIGA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292101", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:41 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82ZTk1ODhhZC04ZDdkLTQ4N2UtOGVhNy0zMTgy
-        Nzk4ZGQ3NzYvIiwgInRhc2tfaWQiOiAiNmU5NTg4YWQtOGQ3ZC00ODdlLThl
-        YTctMzE4Mjc5OGRkNzc2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMjowMTo0MVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTo0MFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDI6MDE6NDBaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMjowMTo0MVoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmM4NWRlMDQwMzRjZDkyZGM1YmQiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjODRlNTQ5NzVmNzFhNmE2NjgxIn0s
-        ICJpZCI6ICI1NmFlYmM4NGU1NDk3NWY3MWE2YTY2ODEifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:41 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/b4a26fde-6e54-4258-ae97-b213905f0b8c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="AcHP8AwTMsdYsmxVJSEXzEPmhoIyYEEtQZAHWkA",
-        oauth_signature="CmpbW7PVjBAEWADHKM0ECB2%2BJzY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292101", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:41 GMT
+      - Tue, 23 Feb 2016 16:48:54 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -1290,84 +178,84 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9iNGEyNmZkZS02ZTU0LTQyNTgtYWU5Ny1iMjEz
-        OTA1ZjBiOGMvIiwgInRhc2tfaWQiOiAiYjRhMjZmZGUtNmU1NC00MjU4LWFl
-        OTctYjIxMzkwNWYwYjhjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy85NzgyZTYxMC02OTZlLTRjM2QtYTYwNS1mMmUw
+        MjBiZTgwOWEvIiwgInRhc2tfaWQiOiAiOTc4MmU2MTAtNjk2ZS00YzNkLWE2
+        MDUtZjJlMDIwYmU4MDlhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMjowMTo0MVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTo0MVoiLCAi
+        bWUiOiAiMjAxNi0wMi0yM1QxNjo0ODo1NFoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0ODo1NFoiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI5ZTFkNGQ2ZC1iNDM4LTQ5ODgtYTgwNy1lNjk5ZDBl
-        Zjc1NDkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICJjYjQ0OWQ4My02M2I1LTQyYWYtYmJhNS0zZGVkOGRj
+        MjQyOTMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMDRiNDJiZjItMDJhMi00Yjc3LWJlNzEtMWUzMTlkZWU2ZTlmIiwg
+        aWQiOiAiY2ZlNjA3NTEtZTVlMS00OGRiLWEyZTQtMWJjMGIzNTJlZDAxIiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
         bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiYjEwODFjOTUtZjViMi00MGY2LTkzY2Ut
-        NDY1M2U0ZDdmMWFiIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZTM5NmUyZTUtOWM4Yy00NGVjLTgwZWEt
+        NWVjNjMxY2QxNTkxIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
         TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTQ3
-        MDIyODMtNzdhYy00MzljLTk0NGQtNThmNWEyNjYxZmU4IiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTcw
+        ODJkNTQtZGNmMC00NjQxLTg1ZGUtYmU3ZWIwMzFiYzMxIiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjFhNjZhNjBiLWQ0NjYtNDdlYy05OTIxLWZlMjc2
-        Mjk3YjI3ZiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        IDAsICJzdGVwX2lkIjogIjM5MDVjNjhkLWM3MTMtNGNkYy05ZTZjLWUxZTg2
+        ZjNlZWY5MyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
         OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
         InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzNDE3ZTYx
-        Ni0yMGZiLTRiODgtYWFhZS0xOTdlNTVhYmE5NDciLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkYmIyMWQy
+        Mi1jYjQ0LTQyMmEtYjA5Yi1kZDIwNDZhMmZjMjciLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
         Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIxMjRjMjM5NC0xMDAxLTRlZTctYTgwMS1lMjNh
-        MGE3Y2ZlOTciLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICI1OGZmY2FjMS1kMjU4LTQ3ZjktOWY4YS04YzRj
+        MjlhYmQ2MDQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
         ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJiMmMwY2NiMy0wYTljLTQ3MmQtODI0Zi04MmUwMTM1YTM4ZjMi
+        cF9pZCI6ICJlZDEwYjIxMi1kNjgxLTQ2MmMtOWYwZi02OWYyZTQzMDg4YWUi
         LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
         dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
         c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3N2Zj
-        ZTEzMS0wMjcwLTRmNmYtODM3Mi04NGM3YTg0ZWUwMDUiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhOWVi
+        Nzk4Yy05YzVmLTQ2MTMtYTViYy03NWQ1MTI4YzE0MzIiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
         aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyMzQ0NWU5MC00ODM1
-        LTQ4ZWMtOWRmNy03YzBhNGM2NjJmMmYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5YzE4Nzk0Ny02ZmY5
+        LTQxZDItOTcwYy1iYmI0ODZmOWY5ZDQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
         TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
         X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjYzYWI0ZjYyLWE3OWEtNGM2
-        ZS1iYmI5LWE0NGZjNDI2MjUwMiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImYzYzZiMWE1LTY2NWMtNDlk
+        OC1hNDY3LWIwYTNhMWNmMTM1NiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
         InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
         eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
         b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
         bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
         c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTAxVDAyOjAxOjQxWiIsICJf
+        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ4OjU0WiIsICJf
         bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
-        MTYtMDItMDFUMDI6MDE6NDFaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
+        MTYtMDItMjNUMTY6NDg6NTRaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
         cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
         IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
         X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
@@ -1376,77 +264,77 @@ http_interactions:
         aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
         SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
         U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
-        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZhZWJjODVkZTA0MDM0Y2Q5MmRj
-        NWJlIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZjYzhkNzZkZTA0MDMwODk3NThh
+        OTQ1IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
         dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
         cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
         IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjllMWQ0ZDZkLWI0MzgtNDk4OC1hODA3LWU2OTlkMGVmNzU0OSIsICJu
+        IjogImNiNDQ5ZDgzLTYzYjUtNDJhZi1iYmE1LTNkZWQ4ZGMyNDI5MyIsICJu
         dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
         cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
         cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNGI0
-        MmJmMi0wMmEyLTRiNzctYmU3MS0xZTMxOWRlZTZlOWYiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjZmU2
+        MDc1MS1lNWUxLTQ4ZGItYTJlNC0xYmMwYjM1MmVkMDEiLCAibnVtX3Byb2Nl
         c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
         c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICJiMTA4MWM5NS1mNWIyLTQwZjYtOTNjZS00NjUzZTRkN2Yx
-        YWIiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICJlMzk2ZTJlNS05YzhjLTQ0ZWMtODBlYS01ZWM2MzFjZDE1
+        OTEiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
         X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
         U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNDcwMjI4My03N2Fj
-        LTQzOWMtOTQ0ZC01OGY1YTI2NjFmZTgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1NzA4MmQ1NC1kY2Yw
+        LTQ2NDEtODVkZS1iZTdlYjAzMWJjMzEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
         LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
         bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
         YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMWE2NmE2MGItZDQ2Ni00N2VjLTk5MjEtZmUyNzYyOTdiMjdmIiwg
+        aWQiOiAiMzkwNWM2OGQtYzcxMy00Y2RjLTllNmMtZTFlODZmM2VlZjkzIiwg
         Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
         IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM0MTdlNjE2LTIwZmItNGI4
-        OC1hYWFlLTE5N2U1NWFiYTk0NyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImRiYjIxZDIyLWNiNDQtNDIy
+        YS1iMDliLWRkMjA0NmEyZmMyNyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
         bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
         ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
         dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
         OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjEyNGMyMzk0LTEwMDEtNGVlNy1hODAxLWUyM2EwYTdjZmU5NyIs
+        X2lkIjogIjU4ZmZjYWMxLWQyNTgtNDdmOS05ZjhhLThjNGMyOWFiZDYwNCIs
         ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
         Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
         ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImIy
-        YzBjY2IzLTBhOWMtNDcyZC04MjRmLTgyZTAxMzVhMzhmMyIsICJudW1fcHJv
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVk
+        MTBiMjEyLWQ2ODEtNDYyYy05ZjBmLTY5ZjJlNDMwODhhZSIsICJudW1fcHJv
         Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
         OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
         bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
         S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc3ZmNlMTMxLTAyNzAt
-        NGY2Zi04MzcyLTg0YzdhODRlZTAwNSIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE5ZWI3OThjLTljNWYt
+        NDYxMy1hNWJjLTc1ZDUxMjhjMTQzMiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
         IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
         ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
         b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjIzNDQ1ZTkwLTQ4MzUtNDhlYy05ZGY3
-        LTdjMGE0YzY2MmYyZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjljMTg3OTQ3LTZmZjktNDFkMi05NzBj
+        LWJiYjQ4NmY5ZjlkNCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
         Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
         aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
         LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
         b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiNjNhYjRmNjItYTc5YS00YzZlLWJiYjktYTQ0
-        ZmM0MjYyNTAyIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YWViYzg0ZTU0OTc1ZjcxYTZhNjY4
-        MiJ9LCAiaWQiOiAiNTZhZWJjODRlNTQ5NzVmNzFhNmE2NjgyIn0=
+        IjogMCwgInN0ZXBfaWQiOiAiZjNjNmIxYTUtNjY1Yy00OWQ4LWE0NjctYjBh
+        M2ExY2YxMzU2IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDc2OTg5MDU0ZmM0OGJhMzA1
+        OCJ9LCAiaWQiOiAiNTZjYzhkNzY5ODkwNTRmYzQ4YmEzMDU4In0=
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:41 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:54 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/9534ce1b-36f1-401c-a623-39011c1f9cc6/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/37561fa1-cb18-4ac9-af8a-4346ef7b8c98/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1457,12 +345,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="yuK1LrnqNFMFFDmCjiAwaIvaqJXKynyJUHMPU8rGLU",
-        oauth_signature="qVuaJzHa0YoDlhljCLkMxzU%2B%2BI8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292102", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -1471,13 +353,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:01:42 GMT
+      - Tue, 23 Feb 2016 16:48:55 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '663'
       Connection:
       - close
       Content-Type:
@@ -1487,22 +369,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85NTM0Y2UxYi0zNmYxLTQwMWMtYTYyMy0zOTAxMWMxZjlj
-        YzYvIiwgInRhc2tfaWQiOiAiOTUzNGNlMWItMzZmMS00MDFjLWE2MjMtMzkw
-        MTFjMWY5Y2M2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8zNzU2MWZhMS1jYjE4LTRhYzktYWY4YS00MzQ2ZWY3Yjhj
+        OTgvIiwgInRhc2tfaWQiOiAiMzc1NjFmYTEtY2IxOC00YWM5LWFmOGEtNDM0
+        NmVmN2I4Yzk4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmFlYmM4
-        NmU1NDk3NWY3MWE2YTY2ODMifSwgImlkIjogIjU2YWViYzg2ZTU0OTc1Zjcx
-        YTZhNjY4MyJ9
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ4OjU1WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ3Njk4OTA1NGZjNDhiYTMwNTkifSwg
+        ImlkIjogIjU2Y2M4ZDc2OTg5MDU0ZmM0OGJhMzA1OSJ9
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:42 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:55 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/9534ce1b-36f1-401c-a623-39011c1f9cc6/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/37561fa1-cb18-4ac9-af8a-4346ef7b8c98/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1513,12 +397,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="vQ67CxQA8G5fjs7uyTgIT9s4Tpdt7jg9vd7SGcEhg",
-        oauth_signature="3NdjXy1g235wLtHZ3P%2F0UCpWLEI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292103", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -1527,7 +405,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:01:43 GMT
+      - Tue, 23 Feb 2016 16:48:55 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -1543,98 +421,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85NTM0Y2UxYi0zNmYxLTQwMWMtYTYyMy0zOTAxMWMxZjlj
-        YzYvIiwgInRhc2tfaWQiOiAiOTUzNGNlMWItMzZmMS00MDFjLWE2MjMtMzkw
-        MTFjMWY5Y2M2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8zNzU2MWZhMS1jYjE4LTRhYzktYWY4YS00MzQ2ZWY3Yjhj
+        OTgvIiwgInRhc2tfaWQiOiAiMzc1NjFmYTEtY2IxOC00YWM5LWFmOGEtNDM0
+        NmVmN2I4Yzk4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTAxVDAyOjAxOjQyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTAxVDAyOjAxOjQyWiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ4OjU1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjU1WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
         MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
         aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
         a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjODZl
-        NTQ5NzVmNzFhNmE2NjgzIn0sICJpZCI6ICI1NmFlYmM4NmU1NDk3NWY3MWE2
-        YTY2ODMifQ==
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNzY5
+        ODkwNTRmYzQ4YmEzMDU5In0sICJpZCI6ICI1NmNjOGQ3Njk4OTA1NGZjNDhi
+        YTMwNTkifQ==
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:43 GMT
-- request:
-    method: post
-    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
-        LXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1
-        dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9j
-        b25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIiwiaHR0cCI6ZmFs
-        c2UsImh0dHBzIjp0cnVlLCJwcm90ZWN0ZWQiOnRydWV9LCJhdXRvX3B1Ymxp
-        c2giOnRydWUsImRpc3RyaWJ1dG9yX2lkIjoiRmVkb3JhXzE3In0seyJkaXN0
-        cmlidXRvcl90eXBlX2lkIjoieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwiZGlz
-        dHJpYnV0b3JfY29uZmlnIjp7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lk
-        IjoiRmVkb3JhXzE3In0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1
-        dG9yX2lkIjoiRmVkb3JhXzE3X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBl
-        X2lkIjoibm9kZXNfaHR0cF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2Nv
-        bmZpZyI6e30sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3JfaWQi
-        OiJGZWRvcmFfMTdfbm9kZXMifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJl
-        eHBvcnRfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0
-        cCI6ZmFsc2UsImh0dHBzIjpmYWxzZX0sImF1dG9fcHVibGlzaCI6ZmFsc2Us
-        ImRpc3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4",
-        oauth_nonce="s7I8zAorjtoBGrrCod4OD05zQ4GSIdjfxXM7UXDc", oauth_signature="vKMNhrwAmporyPuQSlEuZ0cQncY%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454292103", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '895'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:43 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '320'
-      Location:
-      - https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZhZWJjODdkZTA0MDMzNDZjZjY0OWVjIn0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:43 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:55 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/65e92886-63d2-4314-bb58-085848238790/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/a7fb0b86-3bb1-47aa-9ac9-de22724aa5b0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1645,12 +450,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="YedNDbOeiD3hULWWVuXcxhgFs0rJGYA1BwFY2o8",
-        oauth_signature="ZLMwlVKOPkcFMv6ewAYFTABZ36g%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292104", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -1659,13 +458,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:01:44 GMT
+      - Tue, 23 Feb 2016 16:48:56 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '1133'
       Connection:
       - close
       Content-Type:
@@ -1675,2667 +474,35 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NWU5Mjg4Ni02M2QyLTQzMTQtYmI1OC0wODU4NDgyMzg3
-        OTAvIiwgInRhc2tfaWQiOiAiNjVlOTI4ODYtNjNkMi00MzE0LWJiNTgtMDg1
-        ODQ4MjM4NzkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjODhl
-        NTQ5NzVmNzFhNmE2Njg0In0sICJpZCI6ICI1NmFlYmM4OGU1NDk3NWY3MWE2
-        YTY2ODQifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:44 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/65e92886-63d2-4314-bb58-085848238790/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="50pI3ERWcqqbmnf1O6cgWZBpCSnHSfjHd2inCXYkRM",
-        oauth_signature="ByS6pgxjYisY6jDIWMRjibXm574%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292104", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:44 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2310'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NWU5Mjg4Ni02M2QyLTQzMTQtYmI1OC0wODU4NDgyMzg3
-        OTAvIiwgInRhc2tfaWQiOiAiNjVlOTI4ODYtNjNkMi00MzE0LWJiNTgtMDg1
-        ODQ4MjM4NzkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMjowMTo0NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTo0NFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvODk5YjA5YWMtNmQ2NS00MGFhLTljZGYtMzEyOTE1MjI1
-        MDU4LyIsICJ0YXNrX2lkIjogIjg5OWIwOWFjLTZkNjUtNDBhYS05Y2RmLTMx
-        MjkxNTIyNTA1OCJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9k
-        NjlkMjU1My1mNDg3LTQ0NDEtOGE0OS01ZGRkODQwMzdiNTMvIiwgInRhc2tf
-        aWQiOiAiZDY5ZDI1NTMtZjQ4Ny00NDQxLThhNDktNWRkZDg0MDM3YjUzIn1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjODdkZTA0MDMzNDZjZjY0OWVk
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MjowMTo0NFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAyOjAxOjQ0WiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmM4OGRlMDQwMzRjZDky
-        ZGM1YzIiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmM4OGU1NDk3NWY3MWE2YTY2ODQifSwgImlkIjogIjU2YWViYzg4ZTU0
-        OTc1ZjcxYTZhNjY4NCJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:44 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/899b09ac-6d65-40aa-9cdf-312915225058/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="uINyXs8qUPSTSDp7iijuRawo7sDs4p5CwRc5lUE",
-        oauth_signature="9R4IdxEqgbKIJ95drxG7UA4ZX5s%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292104", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:44 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84OTliMDlhYy02ZDY1LTQwYWEtOWNkZi0zMTI5
-        MTUyMjUwNTgvIiwgInRhc2tfaWQiOiAiODk5YjA5YWMtNmQ2NS00MGFhLTlj
-        ZGYtMzEyOTE1MjI1MDU4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMjowMTo0NFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTo0NFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDI6MDE6NDRaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMjowMTo0NFoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmM4OGRlMDQwMzRjZDkyZGM1YzMiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjODhlNTQ5NzVmNzFhNmE2Njk0In0s
-        ICJpZCI6ICI1NmFlYmM4OGU1NDk3NWY3MWE2YTY2OTQifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:44 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/d69d2553-f487-4441-8a49-5ddd84037b53/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="REcWqHEUm3UkOQq6OGxVd2T0CW624PMi6cDjZh2c8",
-        oauth_signature="LvVIxOcNqGlZop9EvUw7XftPzlE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292104", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:44 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '670'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9kNjlkMjU1My1mNDg3LTQ0NDEtOGE0OS01ZGRk
-        ODQwMzdiNTMvIiwgInRhc2tfaWQiOiAiZDY5ZDI1NTMtZjQ4Ny00NDQxLThh
-        NDktNWRkZDg0MDM3YjUzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wMVQwMjowMTo0NFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15
-        b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29y
-        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
-        by15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjODhlNTQ5NzVmNzFhNmE2
-        Njk1In0sICJpZCI6ICI1NmFlYmM4OGU1NDk3NWY3MWE2YTY2OTUifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:44 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/65e92886-63d2-4314-bb58-085848238790/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="v4cAugFbxEBEpYtoiTApmD4FdS9Gx6OjtScwVzmbGcs",
-        oauth_signature="K7TGj8qL2rfaO73kT4Z8gXX0xkA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292105", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:45 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2310'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NWU5Mjg4Ni02M2QyLTQzMTQtYmI1OC0wODU4NDgyMzg3
-        OTAvIiwgInRhc2tfaWQiOiAiNjVlOTI4ODYtNjNkMi00MzE0LWJiNTgtMDg1
-        ODQ4MjM4NzkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMjowMTo0NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTo0NFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvODk5YjA5YWMtNmQ2NS00MGFhLTljZGYtMzEyOTE1MjI1
-        MDU4LyIsICJ0YXNrX2lkIjogIjg5OWIwOWFjLTZkNjUtNDBhYS05Y2RmLTMx
-        MjkxNTIyNTA1OCJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9k
-        NjlkMjU1My1mNDg3LTQ0NDEtOGE0OS01ZGRkODQwMzdiNTMvIiwgInRhc2tf
-        aWQiOiAiZDY5ZDI1NTMtZjQ4Ny00NDQxLThhNDktNWRkZDg0MDM3YjUzIn1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjODdkZTA0MDMzNDZjZjY0OWVk
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MjowMTo0NFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAyOjAxOjQ0WiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmM4OGRlMDQwMzRjZDky
-        ZGM1YzIiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmM4OGU1NDk3NWY3MWE2YTY2ODQifSwgImlkIjogIjU2YWViYzg4ZTU0
-        OTc1ZjcxYTZhNjY4NCJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:45 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/899b09ac-6d65-40aa-9cdf-312915225058/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="xfVyG0bhmTMAjum1Lv39LesDBiBj8atL7rkIcYOf8",
-        oauth_signature="8%2FtOY3hJucc89Typ11B3OpQ8gsE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292105", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:45 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84OTliMDlhYy02ZDY1LTQwYWEtOWNkZi0zMTI5
-        MTUyMjUwNTgvIiwgInRhc2tfaWQiOiAiODk5YjA5YWMtNmQ2NS00MGFhLTlj
-        ZGYtMzEyOTE1MjI1MDU4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMjowMTo0NFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTo0NFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDI6MDE6NDRaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMjowMTo0NFoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmM4OGRlMDQwMzRjZDkyZGM1YzMiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjODhlNTQ5NzVmNzFhNmE2Njk0In0s
-        ICJpZCI6ICI1NmFlYmM4OGU1NDk3NWY3MWE2YTY2OTQifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:45 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/d69d2553-f487-4441-8a49-5ddd84037b53/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="HfDxDpCXuDuH2OICrhECsXTUE3zFDOJi1u8yX597qs",
-        oauth_signature="LI1Bg00XbsJgtJruFRbwazuPijY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292105", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:45 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6923'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9kNjlkMjU1My1mNDg3LTQ0NDEtOGE0OS01ZGRk
-        ODQwMzdiNTMvIiwgInRhc2tfaWQiOiAiZDY5ZDI1NTMtZjQ4Ny00NDQxLThh
-        NDktNWRkZDg0MDM3YjUzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMjowMTo0NVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTo0NFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIxZDI5MGExOC1kN2FlLTQ5YmEtOGY5NS1kMjQ3MTdm
-        M2RkYWYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYjk0OGI4MTItNDBjMi00NGFkLWI5NDMtYTg5ZTljYmQ2OTQyIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNzVlOWE3NmYtYjU2Ni00MDk1LWJiNzct
-        NjU3MTc4MGM3MGY1IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzU3
-        NmM1ZjItMjNhMy00MGMzLWJiMDYtMzkxYzJiMjVhOWUyIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImVhOGVlM2Q1LWZmYzktNDVkMS05MTNhLTExMjk5
-        MWJjN2M1NyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0ZmQ1NmVi
-        NS1iM2FlLTQyYzAtOWU0YS1iMjIzNzIyYWQwZTkiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJjMzU4ZmE2MS01N2M1LTQ3ZjktYWNkOC1mNGE1
-        YTAyMDY4MWUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIxNTU4OWYzNS1jNDVkLTQ0MmQtYmUzZS1mYjc2MjVjOTYxZmUi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2Y2Zl
-        ZGRkNy1iMmIzLTRmNGItODBjZi0wODE2YzFhOWUxNWUiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3NDYzZDA4NC03NzFk
-        LTQ2MzItYmY5Ni00YTg2NDg4NDZlNjUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjFlNDE1YzRiLWU1ZjMtNDRj
-        OS1iZGE0LTgxYWFlMDE4ZGVlOSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
-        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
-        c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTAxVDAyOjAxOjQ0WiIsICJf
-        bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
-        MTYtMDItMDFUMDI6MDE6NDVaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
-        cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
-        IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
-        X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
-        RCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1z
-        IjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0
-        aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
-        SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
-        U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
-        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZhZWJjODlkZTA0MDM0Y2Q5MmRj
-        NWM0IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjFkMjkwYTE4LWQ3YWUtNDliYS04Zjk1LWQyNDcxN2YzZGRhZiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
-        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiOTQ4
-        YjgxMi00MGMyLTQ0YWQtYjk0My1hODllOWNiZDY5NDIiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
-        c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICI3NWU5YTc2Zi1iNTY2LTQwOTUtYmI3Ny02NTcxNzgwYzcw
-        ZjUiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
-        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzNTc2YzVmMi0yM2Ez
-        LTQwYzMtYmIwNi0zOTFjMmIyNWE5ZTIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
-        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZWE4ZWUzZDUtZmZjOS00NWQxLTkxM2EtMTEyOTkxYmM3YzU3Iiwg
-        Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
-        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRmZDU2ZWI1LWIzYWUtNDJj
-        MC05ZTRhLWIyMjM3MjJhZDBlOSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
-        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
-        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogImMzNThmYTYxLTU3YzUtNDdmOS1hY2Q4LWY0YTVhMDIwNjgxZSIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
-        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
-        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE1
-        NTg5ZjM1LWM0NWQtNDQyZC1iZTNlLWZiNzYyNWM5NjFmZSIsICJudW1fcHJv
-        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
-        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
-        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjZjZmVkZGQ3LWIyYjMt
-        NGY0Yi04MGNmLTA4MTZjMWE5ZTE1ZSIsICJudW1fcHJvY2Vzc2VkIjogMH0s
-        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
-        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
-        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjc0NjNkMDg0LTc3MWQtNDYzMi1iZjk2
-        LTRhODY0ODg0NmU2NSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
-        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiMWU0MTVjNGItZTVmMy00NGM5LWJkYTQtODFh
-        YWUwMThkZWU5IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YWViYzg4ZTU0OTc1ZjcxYTZhNjY5
-        NSJ9LCAiaWQiOiAiNTZhZWJjODhlNTQ5NzVmNzFhNmE2Njk1In0=
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:45 GMT
-- request:
-    method: post
-    uri: https://katello-yoda.example.com/pulp/api/v2/content/units/erratum/search/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMDE3OWE1
-        NGYtNWMyZC00YTNhLWEwMDItNzk1YzcwMTZhMWVjIiwiMjI3MTdiY2YtZmFj
-        NS00ZDBjLWFjMzktZDI1OTVjMWJiZTBjIiwiODg2NzJkOTgtOGQ3YS00MTNj
-        LTkwNmUtNjQ2ODZmZjVhZjhkIl19fX0sImluY2x1ZGVfcmVwb3MiOnRydWV9
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4",
-        oauth_nonce="pSpHImLrBVijneRyRn5Dt1lCyjgjHnBt5C2CYkBWq54", oauth_signature="vQNurivbV0R94K3DutyuvNQNNSM%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454292105", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '180'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:45 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4700'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJf
-        aHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9lcnJhdHVtLzAx
-        NzlhNTRmLTVjMmQtNGEzYS1hMDAyLTc5NWM3MDE2YTFlYy8iLCAiaXNzdWVk
-        IjogIjIwMTAtMTEtMTAgMDA6MDA6MDAiLCAicmVmZXJlbmNlcyI6IFt7Imhy
-        ZWYiOiAiaHR0cHM6Ly9yaG4ucmVkaGF0LmNvbS9lcnJhdGEvUkhTQS0yMDEw
-        LTA4NTguaHRtbCIsICJ0eXBlIjogInNlbGYiLCAiaWQiOiBudWxsLCAidGl0
-        bGUiOiBudWxsfSwgeyJocmVmIjogImh0dHBzOi8vYnVnemlsbGEucmVkaGF0
-        LmNvbS9idWd6aWxsYS9zaG93X2J1Zy5jZ2k/aWQ9NjI3ODgyIiwgInR5cGUi
-        OiAiYnVnemlsbGEiLCAiaWQiOiAiNjI3ODgyIiwgInRpdGxlIjogbnVsbH0s
-        IHsiaHJlZiI6ICJodHRwczovL3d3dy5yZWRoYXQuY29tL3NlY3VyaXR5L2Rh
-        dGEvY3ZlL0NWRS0yMDEwLTA0MDUuaHRtbCIsICJ0eXBlIjogImN2ZSIsICJp
-        ZCI6ICJDVkUtMjAxMC0wNDA1IiwgInRpdGxlIjogbnVsbH0sIHsiaHJlZiI6
-        ICJodHRwOi8vd3d3LnJlZGhhdC5jb20vc2VjdXJpdHkvdXBkYXRlcy9jbGFz
-        c2lmaWNhdGlvbi8jaW1wb3J0YW50IiwgInR5cGUiOiAib3RoZXIiLCAiaWQi
-        OiBudWxsLCAidGl0bGUiOiBudWxsfV0sICJwdWxwX3VzZXJfbWV0YWRhdGEi
-        OiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6ICJS
-        SFNBLTIwMTA6MDg1OCIsICJmcm9tIjogInNlY3VyaXR5QHJlZGhhdC5jb20i
-        LCAic2V2ZXJpdHkiOiAiSW1wb3J0YW50IiwgInRpdGxlIjogIkltcG9ydGFu
-        dDogYnppcDIgc2VjdXJpdHkgdXBkYXRlIiwgImNoaWxkcmVuIjoge30sICJ2
-        ZXJzaW9uIjogIjMiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlw
-        ZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFja2FnZXMiOiBbeyJz
-        cmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAi
-        YnppcDItZGV2ZWwiLCAic3VtIjogWyJzaGEyNTYiLCAiZWE2N2M2NjRkYTFm
-        Zjk2YTZkYzk0ZDMzMDA5YjczZDhmYWIzMWI1OTgyNDE4M2ZiNDVlOWJhMmVi
-        ZjgyZDU4MyJdLCAiZmlsZW5hbWUiOiAiYnppcDItZGV2ZWwtMS4wLjUtNy5l
-        bDZfMC5pNjg2LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4w
-        LjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7
-        InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6
-        ICJiemlwMi1saWJzIiwgInN1bSI6IFsic2hhMjU2IiwgImM5ZjA2NGE2ODYy
-        NTczZmI5ZjJhNmFmZjdjMzYyMWYxOTQwYjQ5MmRmMmVkZmMyZWJiZGMwYjgz
-        MDVmNTExNDciXSwgImZpbGVuYW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5l
-        bDZfMC5pNjg2LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4w
-        LjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7
-        InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6
-        ICJiemlwMiIsICJzdW0iOiBbInNoYTI1NiIsICJiOGEzZjcyYmMyYjBkODli
-        YTczNzA5OWFjOThiZjhkMmFmNGJlYTAyZDMxODg0YzAyZGI5N2Y3ZjY2YzNk
-        NWMyIl0sICJmaWxlbmFtZSI6ICJiemlwMi0xLjAuNS03LmVsNl8wLng4Nl82
-        NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJl
-        bGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9LCB7InNyYyI6
-        ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlw
-        Mi1kZXZlbCIsICJzdW0iOiBbInNoYTI1NiIsICI3ZjYzMTI0ZTQ2NTViN2M5
-        MmQyM2VjNGMzODIyNmY1ZDM3NDY1Njg4NTNkZmY3NTBmYzg1ZTA1OGU3NGI1
-        Y2Y2Il0sICJmaWxlbmFtZSI6ICJiemlwMi1kZXZlbC0xLjAuNS03LmVsNl8w
-        Lng4Nl82NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41
-        IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9LCB7
-        InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6
-        ICJiemlwMi1saWJzIiwgInN1bSI6IFsic2hhMjU2IiwgIjgwMmY0Mzk5ZGJk
-        ZDAxNDc2ZTI1NGMzYjMyYzQwYWZmNTljZjVkMjNhNDVmYTQ4OGM2OTE3Y2U4
-        OTA0ZDZiNGQiXSwgImZpbGVuYW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5l
-        bDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIx
-        LjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQi
-        fV0sICJuYW1lIjogIlJlZCBIYXQgRW50ZXJwcmlzZSBMaW51eCBTZXJ2ZXIg
-        KHYuIDYgZm9yIDY0LWJpdCB4ODZfNjQpIiwgInNob3J0IjogInJoZWwteDg2
-        XzY0LXNlcnZlci02In1dLCAic3RhdHVzIjogImZpbmFsIiwgInVwZGF0ZWQi
-        OiAiMjAxMC0xMS0xMCAwMDowMDowMCIsICJkZXNjcmlwdGlvbiI6ICJiemlw
-        MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
-        bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
-        c3QgYmUgcmVzdGFydGVkIGZvciB0aGUgdXBkYXRlIHRvIHRha2UgZWZmZWN0
-        LiIsICJfbGFzdF91cGRhdGVkIjogIjIwMTYtMDItMDFUMDI6MDE6NDRaIiwg
-        InB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjogIkNvcHlyaWdodCAyMDEwIFJl
-        ZCBIYXQgSW5jIiwgInNvbHV0aW9uIjogIkJlZm9yZSBhcHBseWluZyB0aGlz
-        IHVwZGF0ZSwgbWFrZSBzdXJlIGFsbCBwcmV2aW91c2x5LXJlbGVhc2VkIGVy
-        cmF0YVxucmVsZXZhbnQgdG8geW91ciBzeXN0ZW0gaGF2ZSBiZWVuIGFwcGxp
-        ZWQuXG5cblRoaXMgdXBkYXRlIGlzIGF2YWlsYWJsZSB2aWEgdGhlIFJlZCBI
-        YXQgTmV0d29yay4gRGV0YWlscyBvbiBob3cgdG9cbnVzZSB0aGUgUmVkIEhh
-        dCBOZXR3b3JrIHRvIGFwcGx5IHRoaXMgdXBkYXRlIGFyZSBhdmFpbGFibGUg
-        YXRcbmh0dHA6Ly9rYmFzZS5yZWRoYXQuY29tL2ZhcS9kb2NzL0RPQy0xMTI1
-        OSIsICJzdW1tYXJ5IjogIlVwZGF0ZWQgYnppcDIgcGFja2FnZXMgdGhhdCBm
-        aXggb25lIHNlY3VyaXR5IGlzc3VlIiwgInJlbGVhc2UiOiAiIiwgIl9pZCI6
-        ICIwMTc5YTU0Zi01YzJkLTRhM2EtYTAwMi03OTVjNzAxNmExZWMifSwgeyJy
-        ZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJGZWRvcmFfMTciXSwgIl9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL2VycmF0dW0vMjI3MTdi
-        Y2YtZmFjNS00ZDBjLWFjMzktZDI1OTVjMWJiZTBjLyIsICJpc3N1ZWQiOiAi
-        MjAxMC0wMS0wMSAwMTowMTowMSIsICJyZWZlcmVuY2VzIjogW10sICJwdWxw
-        X3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJy
-        YXR1bSIsICJpZCI6ICJSSEVBLTIwMTA6MDAwMiIsICJmcm9tIjogImx6YXAr
-        cHViQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjogIk9u
-        ZSBwYWNrYWdlIGVycmF0YSIsICJjaGlsZHJlbiI6IHt9LCAidmVyc2lvbiI6
-        ICIxIiwgInJlYm9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAic2Vj
-        dXJpdHkiLCAicGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjogImh0
-        dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJlbGVwaGFu
-        dCIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAu
-        OC5ub2FyY2gucnBtIiwgImVwb2NoIjogbnVsbCwgInZlcnNpb24iOiAiMC4z
-        IiwgInJlbGVhc2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFt
-        ZSI6ICIxIiwgInNob3J0IjogIiJ9XSwgInN0YXR1cyI6ICJzdGFibGUiLCAi
-        dXBkYXRlZCI6ICIiLCAiZGVzY3JpcHRpb24iOiAiT25lIHBhY2thZ2UgZXJy
-        YXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAiMjAxNi0wMi0wMVQwMjowMTo0NFoi
-        LCAicHVzaGNvdW50IjogIiIsICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjog
-        IiIsICJzdW1tYXJ5IjogIiIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjIy
-        NzE3YmNmLWZhYzUtNGQwYy1hYzM5LWQyNTk1YzFiYmUwYyJ9LCB7InJlcG9z
-        aXRvcnlfbWVtYmVyc2hpcHMiOiBbIkZlZG9yYV8xNyJdLCAiX2hyZWYiOiAi
-        L3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvZXJyYXR1bS84ODY3MmQ5OC04
-        ZDdhLTQxM2MtOTA2ZS02NDY4NmZmNWFmOGQvIiwgImlzc3VlZCI6ICIyMDEw
-        LTAxLTAxIDAxOjAxOjAxIiwgInJlZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNl
-        cl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
-        IiwgImlkIjogIlJIRUEtMjAxMDowMDAxIiwgImZyb20iOiAibHphcCtwdWJA
-        cmVkaGF0LmNvbSIsICJzZXZlcml0eSI6ICIiLCAidGl0bGUiOiAiRW1wdHkg
-        ZXJyYXRhIiwgImNoaWxkcmVuIjoge30sICJ2ZXJzaW9uIjogIjEiLCAicmVi
-        b290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJw
-        a2dsaXN0IjogW10sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAi
-        IiwgImRlc2NyaXB0aW9uIjogIkVtcHR5IGVycmF0YSIsICJfbGFzdF91cGRh
-        dGVkIjogIjIwMTYtMDItMDFUMDI6MDE6NDRaIiwgInB1c2hjb3VudCI6ICIi
-        LCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIi
-        LCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI4ODY3MmQ5OC04ZDdhLTQxM2Mt
-        OTA2ZS02NDY4NmZmNWFmOGQifV0=
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:45 GMT
-- request:
-    method: post
-    uri: https://katello-yoda.example.com/pulp/api/v2/content/units/erratum/search/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMDE3OWE1
-        NGYtNWMyZC00YTNhLWEwMDItNzk1YzcwMTZhMWVjIl19fX0sImluY2x1ZGVf
-        cmVwb3MiOnRydWV9
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4",
-        oauth_nonce="peQdciw77AWGrniU6EfPuNduG18LApzxQ9gwPx32k", oauth_signature="7llD7H3UBR0snvpqiOjZBUC%2Bkps%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454292105", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '102'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:45 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3146'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJf
-        aHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9lcnJhdHVtLzAx
-        NzlhNTRmLTVjMmQtNGEzYS1hMDAyLTc5NWM3MDE2YTFlYy8iLCAiaXNzdWVk
-        IjogIjIwMTAtMTEtMTAgMDA6MDA6MDAiLCAicmVmZXJlbmNlcyI6IFt7Imhy
-        ZWYiOiAiaHR0cHM6Ly9yaG4ucmVkaGF0LmNvbS9lcnJhdGEvUkhTQS0yMDEw
-        LTA4NTguaHRtbCIsICJ0eXBlIjogInNlbGYiLCAiaWQiOiBudWxsLCAidGl0
-        bGUiOiBudWxsfSwgeyJocmVmIjogImh0dHBzOi8vYnVnemlsbGEucmVkaGF0
-        LmNvbS9idWd6aWxsYS9zaG93X2J1Zy5jZ2k/aWQ9NjI3ODgyIiwgInR5cGUi
-        OiAiYnVnemlsbGEiLCAiaWQiOiAiNjI3ODgyIiwgInRpdGxlIjogbnVsbH0s
-        IHsiaHJlZiI6ICJodHRwczovL3d3dy5yZWRoYXQuY29tL3NlY3VyaXR5L2Rh
-        dGEvY3ZlL0NWRS0yMDEwLTA0MDUuaHRtbCIsICJ0eXBlIjogImN2ZSIsICJp
-        ZCI6ICJDVkUtMjAxMC0wNDA1IiwgInRpdGxlIjogbnVsbH0sIHsiaHJlZiI6
-        ICJodHRwOi8vd3d3LnJlZGhhdC5jb20vc2VjdXJpdHkvdXBkYXRlcy9jbGFz
-        c2lmaWNhdGlvbi8jaW1wb3J0YW50IiwgInR5cGUiOiAib3RoZXIiLCAiaWQi
-        OiBudWxsLCAidGl0bGUiOiBudWxsfV0sICJwdWxwX3VzZXJfbWV0YWRhdGEi
-        OiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6ICJS
-        SFNBLTIwMTA6MDg1OCIsICJmcm9tIjogInNlY3VyaXR5QHJlZGhhdC5jb20i
-        LCAic2V2ZXJpdHkiOiAiSW1wb3J0YW50IiwgInRpdGxlIjogIkltcG9ydGFu
-        dDogYnppcDIgc2VjdXJpdHkgdXBkYXRlIiwgImNoaWxkcmVuIjoge30sICJ2
-        ZXJzaW9uIjogIjMiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlw
-        ZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFja2FnZXMiOiBbeyJz
-        cmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAi
-        YnppcDItZGV2ZWwiLCAic3VtIjogWyJzaGEyNTYiLCAiZWE2N2M2NjRkYTFm
-        Zjk2YTZkYzk0ZDMzMDA5YjczZDhmYWIzMWI1OTgyNDE4M2ZiNDVlOWJhMmVi
-        ZjgyZDU4MyJdLCAiZmlsZW5hbWUiOiAiYnppcDItZGV2ZWwtMS4wLjUtNy5l
-        bDZfMC5pNjg2LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4w
-        LjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7
-        InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6
-        ICJiemlwMi1saWJzIiwgInN1bSI6IFsic2hhMjU2IiwgImM5ZjA2NGE2ODYy
-        NTczZmI5ZjJhNmFmZjdjMzYyMWYxOTQwYjQ5MmRmMmVkZmMyZWJiZGMwYjgz
-        MDVmNTExNDciXSwgImZpbGVuYW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5l
-        bDZfMC5pNjg2LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4w
-        LjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7
-        InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6
-        ICJiemlwMiIsICJzdW0iOiBbInNoYTI1NiIsICJiOGEzZjcyYmMyYjBkODli
-        YTczNzA5OWFjOThiZjhkMmFmNGJlYTAyZDMxODg0YzAyZGI5N2Y3ZjY2YzNk
-        NWMyIl0sICJmaWxlbmFtZSI6ICJiemlwMi0xLjAuNS03LmVsNl8wLng4Nl82
-        NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJl
-        bGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9LCB7InNyYyI6
-        ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlw
-        Mi1kZXZlbCIsICJzdW0iOiBbInNoYTI1NiIsICI3ZjYzMTI0ZTQ2NTViN2M5
-        MmQyM2VjNGMzODIyNmY1ZDM3NDY1Njg4NTNkZmY3NTBmYzg1ZTA1OGU3NGI1
-        Y2Y2Il0sICJmaWxlbmFtZSI6ICJiemlwMi1kZXZlbC0xLjAuNS03LmVsNl8w
-        Lng4Nl82NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41
-        IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9LCB7
-        InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6
-        ICJiemlwMi1saWJzIiwgInN1bSI6IFsic2hhMjU2IiwgIjgwMmY0Mzk5ZGJk
-        ZDAxNDc2ZTI1NGMzYjMyYzQwYWZmNTljZjVkMjNhNDVmYTQ4OGM2OTE3Y2U4
-        OTA0ZDZiNGQiXSwgImZpbGVuYW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5l
-        bDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIx
-        LjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQi
-        fV0sICJuYW1lIjogIlJlZCBIYXQgRW50ZXJwcmlzZSBMaW51eCBTZXJ2ZXIg
-        KHYuIDYgZm9yIDY0LWJpdCB4ODZfNjQpIiwgInNob3J0IjogInJoZWwteDg2
-        XzY0LXNlcnZlci02In1dLCAic3RhdHVzIjogImZpbmFsIiwgInVwZGF0ZWQi
-        OiAiMjAxMC0xMS0xMCAwMDowMDowMCIsICJkZXNjcmlwdGlvbiI6ICJiemlw
-        MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
-        bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
-        c3QgYmUgcmVzdGFydGVkIGZvciB0aGUgdXBkYXRlIHRvIHRha2UgZWZmZWN0
-        LiIsICJfbGFzdF91cGRhdGVkIjogIjIwMTYtMDItMDFUMDI6MDE6NDRaIiwg
-        InB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjogIkNvcHlyaWdodCAyMDEwIFJl
-        ZCBIYXQgSW5jIiwgInNvbHV0aW9uIjogIkJlZm9yZSBhcHBseWluZyB0aGlz
-        IHVwZGF0ZSwgbWFrZSBzdXJlIGFsbCBwcmV2aW91c2x5LXJlbGVhc2VkIGVy
-        cmF0YVxucmVsZXZhbnQgdG8geW91ciBzeXN0ZW0gaGF2ZSBiZWVuIGFwcGxp
-        ZWQuXG5cblRoaXMgdXBkYXRlIGlzIGF2YWlsYWJsZSB2aWEgdGhlIFJlZCBI
-        YXQgTmV0d29yay4gRGV0YWlscyBvbiBob3cgdG9cbnVzZSB0aGUgUmVkIEhh
-        dCBOZXR3b3JrIHRvIGFwcGx5IHRoaXMgdXBkYXRlIGFyZSBhdmFpbGFibGUg
-        YXRcbmh0dHA6Ly9rYmFzZS5yZWRoYXQuY29tL2ZhcS9kb2NzL0RPQy0xMTI1
-        OSIsICJzdW1tYXJ5IjogIlVwZGF0ZWQgYnppcDIgcGFja2FnZXMgdGhhdCBm
-        aXggb25lIHNlY3VyaXR5IGlzc3VlIiwgInJlbGVhc2UiOiAiIiwgIl9pZCI6
-        ICIwMTc5YTU0Zi01YzJkLTRhM2EtYTAwMi03OTVjNzAxNmExZWMifV0=
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:45 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/ebcba1cd-3980-4c11-8539-eef8172f4107/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="jQ4JT0KxLVGtodVXS7YOizswsp0okLxaJ5itUOyXa8",
-        oauth_signature="4wt2bXUrpMO6eVxlDVZopRBzb%2FI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292105", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:45 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lYmNiYTFjZC0zOTgwLTRjMTEtODUzOS1lZWY4MTcyZjQx
-        MDcvIiwgInRhc2tfaWQiOiAiZWJjYmExY2QtMzk4MC00YzExLTg1MzktZWVm
-        ODE3MmY0MTA3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmFlYmM4
-        OWU1NDk3NWY3MWE2YTY2OTYifSwgImlkIjogIjU2YWViYzg5ZTU0OTc1Zjcx
-        YTZhNjY5NiJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:45 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/ebcba1cd-3980-4c11-8539-eef8172f4107/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="JHTVK4M5UDbvaowQ3Kd90rPILxZi8gW11J2SYY",
-        oauth_signature="7wNPW6Qa2GIDdiUK0cwwQXgOf90%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292106", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:46 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '682'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lYmNiYTFjZC0zOTgwLTRjMTEtODUzOS1lZWY4MTcyZjQx
-        MDcvIiwgInRhc2tfaWQiOiAiZWJjYmExY2QtMzk4MC00YzExLTg1MzktZWVm
-        ODE3MmY0MTA3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTAxVDAyOjAxOjQ2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTAxVDAyOjAxOjQ2WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
-        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjODll
-        NTQ5NzVmNzFhNmE2Njk2In0sICJpZCI6ICI1NmFlYmM4OWU1NDk3NWY3MWE2
-        YTY2OTYifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:46 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/238ab6b1-6a34-4465-b291-4c2a5f0b5f96/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="1hQ3WAM7IiDSLHuGGfgn1v05zZM7U8JbLobxiHy90I",
-        oauth_signature="TNxH9HMXIKK885HrDCfOIUYYlJQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693886", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:06 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yMzhhYjZiMS02YTM0LTQ0NjUtYjI5MS00YzJhNWYwYjVm
-        OTYvIiwgInRhc2tfaWQiOiAiMjM4YWI2YjEtNmEzNC00NDY1LWIyOTEtNGMy
-        YTVmMGI1Zjk2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkZmU4
-        YWRhNDBkYjA0ZWUxMTUzIn0sICJpZCI6ICI1NmI0ZGRmZThhZGE0MGRiMDRl
-        ZTExNTMifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:06 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/238ab6b1-6a34-4465-b291-4c2a5f0b5f96/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="EYDEOBwZDEt2fB2fkwpbqHPt3KRqWGd3QCf0SGs",
-        oauth_signature="8QrqxvTasLFZUU9Oy764IFSX1uI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693886", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:06 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1084'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yMzhhYjZiMS02YTM0LTQ0NjUtYjI5MS00YzJhNWYwYjVm
-        OTYvIiwgInRhc2tfaWQiOiAiMjM4YWI2YjEtNmEzNC00NDY1LWIyOTEtNGMy
-        YTVmMGI1Zjk2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hN2ZiMGI4Ni0zYmIxLTQ3YWEtOWFjOS1kZTIyNzI0YWE1
+        YjAvIiwgInRhc2tfaWQiOiAiYTdmYjBiODYtM2JiMS00N2FhLTlhYzktZGUy
+        MjcyNGFhNWIwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0wNVQxNzozODowNloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJO
-        T1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIklOX1BS
-        T0dSRVNTIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
-        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
-        by0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmci
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        a2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGws
-        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkZmU4YWRh
-        NDBkYjA0ZWUxMTUzIn0sICJpZCI6ICI1NmI0ZGRmZThhZGE0MGRiMDRlZTEx
-        NTMifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:06 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/238ab6b1-6a34-4465-b291-4c2a5f0b5f96/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="6KtEBOaqWMStXT7wNKNglxu00nXsWyBYavGKo7eA8Y",
-        oauth_signature="%2BzQclGANl6rzJLP0HuNcVXPAMpY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693887", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:07 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yMzhhYjZiMS02YTM0LTQ0NjUtYjI5MS00YzJhNWYwYjVm
-        OTYvIiwgInRhc2tfaWQiOiAiMjM4YWI2YjEtNmEzNC00NDY1LWIyOTEtNGMy
-        YTVmMGI1Zjk2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozODowN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODowNloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvM2UzYjZmMTMtZGY1OS00MDVlLWE2ZjItMzU2MmVlNTYw
-        MGU2LyIsICJ0YXNrX2lkIjogIjNlM2I2ZjEzLWRmNTktNDA1ZS1hNmYyLTM1
-        NjJlZTU2MDBlNiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZGZlYzc4MjFiMzMwNWNlNTI2MiJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6Mzg6MDZaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozODow
-        N1oiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRkZmZjNzgyMWIzNDQ0ZmNjNDczIiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkZmU4YWRhNDBkYjA0ZWUxMTUzIn0s
-        ICJpZCI6ICI1NmI0ZGRmZThhZGE0MGRiMDRlZTExNTMifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:07 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/3e3b6f13-df59-405e-a6f2-3562ee5600e6/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="ek5Qh8hz485GTI7W5ljoD3rSxAyPjDMdlHaf1RjG9k",
-        oauth_signature="0k4dfCrZdD60euCrppycCm1OtD0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693887", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:07 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3494'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8zZTNiNmYxMy1kZjU5LTQwNWUtYTZmMi0zNTYy
-        ZWU1NjAwZTYvIiwgInRhc2tfaWQiOiAiM2UzYjZmMTMtZGY1OS00MDVlLWE2
-        ZjItMzU2MmVlNTYwMGU2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wNVQxNzozODowN1oiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlYzk1
-        OTQ1My05ZGY3LTQxZDgtYTRhMi02NWE2MmM1MzU3OWEiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTYwOTE2ZWYtZDQ5
-        ZC00NjgzLTk0MDItNWNhOTZlYjk3MjhlIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiZmQ0YmY4OTQtOTE5OS00ZmZlLTg2MTktYWYwYjU2ZTQzZmY2IiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjAzNmU3YTItZWVmOS00NDJjLWE2
-        YjUtOWNiYTk1NjUwZjI1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjcz
-        NWE4MjNmLTA1NjQtNDJhMy04ZGFjLTRkYTYwMDk0OGI2MiIsICJudW1fcHJv
-        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIxNmViOGIxNC0wZjQ2LTRkNTYtYmJkNy05
-        NjUzNDc3M2EzMWQiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEu
-        IiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJl
-        OTUzYTVhNy02ODk3LTRlNDEtODBiYS02ODA2MDU3ZDhlZjIiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9u
-        IjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xv
-        c2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjZThjOWJjZC1k
-        NDlkLTQ0YWYtYjM4MC0yNzMxMDhmYTY4YzMiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVy
-        YXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBz
-        cWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwZjU1YTA3ZS01ZTZjLTRiZDItYTJh
-        MC0wNjM4MzU1ZWQwZDQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMg
-        dG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI5YmY3MDRkNC03MDJiLTQ3Y2EtOGFlMi0xZGE1NDBk
-        NWI2NGYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjE2MTUxZGZjLWE4ZTAtNGM2My04NDc1LTEzMzRhNGE3MWFk
-        MyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVlIjogInJlc2VydmVk
-        X3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNv
-        bS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJl
-        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5leGFt
-        cGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YjRkZGZmOGFkYTQwZGIwNGVlMTE2MyJ9LCAiaWQi
-        OiAiNTZiNGRkZmY4YWRhNDBkYjA0ZWUxMTYzIn0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:07 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/238ab6b1-6a34-4465-b291-4c2a5f0b5f96/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="5Q1PTewGTpe6vdSSUpUM86lm7bUt8nBEkwauS0gI9I0",
-        oauth_signature="CPAUl7UnKKubQa3ONrMSehMaQKY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693888", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:08 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yMzhhYjZiMS02YTM0LTQ0NjUtYjI5MS00YzJhNWYwYjVm
-        OTYvIiwgInRhc2tfaWQiOiAiMjM4YWI2YjEtNmEzNC00NDY1LWIyOTEtNGMy
-        YTVmMGI1Zjk2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozODowN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODowNloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvM2UzYjZmMTMtZGY1OS00MDVlLWE2ZjItMzU2MmVlNTYw
-        MGU2LyIsICJ0YXNrX2lkIjogIjNlM2I2ZjEzLWRmNTktNDA1ZS1hNmYyLTM1
-        NjJlZTU2MDBlNiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZGZlYzc4MjFiMzMwNWNlNTI2MiJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6Mzg6MDZaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozODow
-        N1oiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRkZmZjNzgyMWIzNDQ0ZmNjNDczIiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRkZmU4YWRhNDBkYjA0ZWUxMTUzIn0s
-        ICJpZCI6ICI1NmI0ZGRmZThhZGE0MGRiMDRlZTExNTMifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:08 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/3e3b6f13-df59-405e-a6f2-3562ee5600e6/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Gxjc3H5aCJeJ4DL54654akJduv6xUyCGg8VDZg7V71w",
-        oauth_signature="MEvh%2Bfkrw6oTQVD4jYw2cF0jzv0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693888", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:08 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8zZTNiNmYxMy1kZjU5LTQwNWUtYTZmMi0zNTYy
-        ZWU1NjAwZTYvIiwgInRhc2tfaWQiOiAiM2UzYjZmMTMtZGY1OS00MDVlLWE2
-        ZjItMzU2MmVlNTYwMGU2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wNVQxNzozODowN1oiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODowN1oiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJlYzk1OTQ1My05ZGY3LTQxZDgtYTRhMi02NWE2MmM1
-        MzU3OWEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYTYwOTE2ZWYtZDQ5ZC00NjgzLTk0MDItNWNhOTZlYjk3MjhlIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZmQ0YmY4OTQtOTE5OS00ZmZlLTg2MTkt
-        YWYwYjU2ZTQzZmY2IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjAz
-        NmU3YTItZWVmOS00NDJjLWE2YjUtOWNiYTk1NjUwZjI1IiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjczNWE4MjNmLTA1NjQtNDJhMy04ZGFjLTRkYTYw
-        MDk0OGI2MiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNmViOGIx
-        NC0wZjQ2LTRkNTYtYmJkNy05NjUzNDc3M2EzMWQiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJlOTUzYTVhNy02ODk3LTRlNDEtODBiYS02ODA2
-        MDU3ZDhlZjIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJjZThjOWJjZC1kNDlkLTQ0YWYtYjM4MC0yNzMxMDhmYTY4YzMi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwZjU1
-        YTA3ZS01ZTZjLTRiZDItYTJhMC0wNjM4MzU1ZWQwZDQiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5YmY3MDRkNC03MDJi
-        LTQ3Y2EtOGFlMi0xZGE1NDBkNWI2NGYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE2MTUxZGZjLWE4ZTAtNGM2
-        My04NDc1LTEzMzRhNGE3MWFkMyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
-        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE3OjM4OjA3
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMDVUMTc6Mzg6MDdaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGRkZmZjNzgyMWIz
-        NDQ0ZmNjNDc0IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImVjOTU5NDUzLTlkZjctNDFkOC1hNGEyLTY1YTYyYzUzNTc5
-        YSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJhNjA5MTZlZi1kNDlkLTQ2ODMtOTQwMi01Y2E5NmViOTcyOGUiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJmZDRiZjg5NC05MTk5LTRmZmUtODYxOS1hZjBi
-        NTZlNDNmZjYiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyMDM2ZTdh
-        Mi1lZWY5LTQ0MmMtYTZiNS05Y2JhOTU2NTBmMjUiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiNzM1YTgyM2YtMDU2NC00MmEzLThkYWMtNGRhNjAwOTQ4
-        YjYyIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE2ZWI4YjE0LTBm
-        NDYtNGQ1Ni1iYmQ3LTk2NTM0NzczYTMxZCIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImU5NTNhNWE3LTY4OTctNGU0MS04MGJhLTY4MDYwNTdk
-        OGVmMiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImNlOGM5YmNkLWQ0OWQtNDRhZi1iMzgwLTI3MzEwOGZhNjhjMyIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBmNTVhMDdl
-        LTVlNmMtNGJkMi1hMmEwLTA2MzgzNTVlZDBkNCIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjliZjcwNGQ0LTcwMmItNDdj
-        YS04YWUyLTFkYTU0MGQ1YjY0ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTYxNTFkZmMtYThlMC00YzYzLTg0
-        NzUtMTMzNGE0YTcxYWQzIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRkZGZmOGFkYTQwZGIw
-        NGVlMTE2MyJ9LCAiaWQiOiAiNTZiNGRkZmY4YWRhNDBkYjA0ZWUxMTYzIn0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:08 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/d91b7a5b-b9dd-48b1-adbd-cb33343a63e9/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="8fUNMojrMbVWfHUATg8THSESsG6t5KFFMfvxHMt7oUA",
-        oauth_signature="fCxj%2FjU%2BByQPI%2FUqMOFJ2Xv6IKc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693888", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:08 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kOTFiN2E1Yi1iOWRkLTQ4YjEtYWRiZC1jYjMzMzQzYTYz
-        ZTkvIiwgInRhc2tfaWQiOiAiZDkxYjdhNWItYjlkZC00OGIxLWFkYmQtY2Iz
-        MzM0M2E2M2U5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0ZGUw
-        MDhhZGE0MGRiMDRlZTExNjQifSwgImlkIjogIjU2YjRkZTAwOGFkYTQwZGIw
-        NGVlMTE2NCJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:08 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/d91b7a5b-b9dd-48b1-adbd-cb33343a63e9/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="aQ75j3JvFgxQBHYliIYUruKvsMRzpRdrW0KKQEPJE",
-        oauth_signature="cIb1gnMLBJgdkLevrY2fPX3Wiuw%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693889", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:09 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kOTFiN2E1Yi1iOWRkLTQ4YjEtYWRiZC1jYjMzMzQzYTYz
-        ZTkvIiwgInRhc2tfaWQiOiAiZDkxYjdhNWItYjlkZC00OGIxLWFkYmQtY2Iz
-        MzM0M2E2M2U5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA1VDE3OjM4OjA5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE3OjM4OjA5WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        NGRlMDA4YWRhNDBkYjA0ZWUxMTY0In0sICJpZCI6ICI1NmI0ZGUwMDhhZGE0
-        MGRiMDRlZTExNjQifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:09 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/dcc71a42-2097-4089-8026-c92759b8a4bb/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="yd5YJbV8TW7O0vubEFUTzwjIU9NW3rrIfxQABBa3FUU",
-        oauth_signature="Y0qjButjYy14Kn2cQvYKIXWjQlo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693890", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:10 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kY2M3MWE0Mi0yMDk3LTQwODktODAyNi1jOTI3NTliOGE0
-        YmIvIiwgInRhc2tfaWQiOiAiZGNjNzFhNDItMjA5Ny00MDg5LTgwMjYtYzky
-        NzU5YjhhNGJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMDI4
-        YWRhNDBkYjA0ZWUxMTY1In0sICJpZCI6ICI1NmI0ZGUwMjhhZGE0MGRiMDRl
-        ZTExNjUifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:10 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/dcc71a42-2097-4089-8026-c92759b8a4bb/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="aX1R8gWFcWpCsNklcyIZUdh5R02EnmqemauIWKw20",
-        oauth_signature="8Bd6hRMaFjGDvWHapsJGi8lT8ZA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693891", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:11 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1087'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kY2M3MWE0Mi0yMDk3LTQwODktODAyNi1jOTI3NTliOGE0
-        YmIvIiwgInRhc2tfaWQiOiAiZGNjNzFhNDItMjA5Ny00MDg5LTgwMjYtYzky
-        NzU5YjhhNGJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0wNVQxNzozODoxMFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJO
-        T1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
-        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0
-        ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5p
-        bmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMDI4
-        YWRhNDBkYjA0ZWUxMTY1In0sICJpZCI6ICI1NmI0ZGUwMjhhZGE0MGRiMDRl
-        ZTExNjUifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:11 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/dcc71a42-2097-4089-8026-c92759b8a4bb/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Crblvr4QjAvDyZY4cYogxWeWDxMaZ0HLHA64rRBR4",
-        oauth_signature="1429evLGLauoI1%2FMc19um9hAFqI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693891", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:11 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kY2M3MWE0Mi0yMDk3LTQwODktODAyNi1jOTI3NTliOGE0
-        YmIvIiwgInRhc2tfaWQiOiAiZGNjNzFhNDItMjA5Ny00MDg5LTgwMjYtYzky
-        NzU5YjhhNGJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozODoxMVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODoxMFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNmMyOTUxM2YtMWUyZi00MmI1LTlkYjMtNDliYWYwNTVi
-        NjFhLyIsICJ0YXNrX2lkIjogIjZjMjk1MTNmLTFlMmYtNDJiNS05ZGIzLTQ5
-        YmFmMDU1YjYxYSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZTAyYzc4MjFiMzMwMzRiYWZjNSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6Mzg6MTFaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozODox
-        MVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRlMDNjNzgyMWIzNDQ0ZmNjNDc4IiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMDI4YWRhNDBkYjA0ZWUxMTY1In0s
-        ICJpZCI6ICI1NmI0ZGUwMjhhZGE0MGRiMDRlZTExNjUifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:12 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/6c29513f-1e2f-42b5-9db3-49baf055b61a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="lia2SQ0ztP2Z6tOkpZDXOYiB4t7JqZl0dOK2kKW8U",
-        oauth_signature="Zf%2BYQsZm1bA%2B7jokB1r6z64nTtQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693892", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:12 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3510'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82YzI5NTEzZi0xZTJmLTQyYjUtOWRiMy00OWJh
-        ZjA1NWI2MWEvIiwgInRhc2tfaWQiOiAiNmMyOTUxM2YtMWUyZi00MmI1LTlk
-        YjMtNDliYWYwNTViNjFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wNVQxNzozODoxMVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3ZmFk
-        Yjg5MC0zNTAwLTQ5N2EtYWEyYi05OTVjOGUxMDFjZWIiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmE4YzRkMWMtY2Uz
-        Ny00ZDVlLWFlYjEtZGExNjQ1YTk2MmIwIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiMWYwZDAyMWYtMGNjOS00MTJiLWFlMWQtZDhmMjdmYWFmNThiIiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTE3YTk1NDktNWFhMS00OTU4LTg3
-        NzQtMTA5MDVmMGE5MDk3IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjlj
-        ZDQ2ZjdlLTdkZTUtNDllNC1hY2ExLTRlNDAwMzA2ZTBmOSIsICJudW1fcHJv
-        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIxMjIzMjQ1OS1iODcxLTQ2YzAtODNiOC1j
-        MGM1NjAzN2E0YTQiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEu
-        IiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICIxZTA3NzY3MS03MjkxLTQ3Y2EtOTliNy1jMGNmMGVmMmZmMDMiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
-        aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAi
-        Y2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmYmFl
-        N2VlZC1jMTFlLTQ1OGYtODRiMS1hZDZhYTIxZWE1MzEiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
-        IkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5l
-        cmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
-        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDFhOGNjMjktMjhl
-        YS00NmE4LWEyMTktZTc0ZDA1MjRlYjVlIiwgIm51bV9wcm9jZXNzZWQiOiAw
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJl
-        Y3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjk1OWJlMGQtMzI2NS00Mjg1
-        LTk1ZGYtNDhjOTk0YzQxOTExIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
-        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3Rp
-        bmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRh
-        ZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5M2YxMTcxMy0zODY5LTRlN2Ut
-        YjEwMC01NzEwMDI3YTUxN2EiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJx
-        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTIt
-        OC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
-        bGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
-        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0ZGUwMzhhZGE0MGRi
-        MDRlZTExNzUifSwgImlkIjogIjU2YjRkZTAzOGFkYTQwZGIwNGVlMTE3NSJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:12 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/dcc71a42-2097-4089-8026-c92759b8a4bb/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="y7Jxn7DUYbQz9At5DMZIejrKkanwh4dlsMOOVk63uak",
-        oauth_signature="uWQLSw6QFuvI6pLLHOVq6micZhM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693892", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:12 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kY2M3MWE0Mi0yMDk3LTQwODktODAyNi1jOTI3NTliOGE0
-        YmIvIiwgInRhc2tfaWQiOiAiZGNjNzFhNDItMjA5Ny00MDg5LTgwMjYtYzky
-        NzU5YjhhNGJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozODoxMVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODoxMFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNmMyOTUxM2YtMWUyZi00MmI1LTlkYjMtNDliYWYwNTVi
-        NjFhLyIsICJ0YXNrX2lkIjogIjZjMjk1MTNmLTFlMmYtNDJiNS05ZGIzLTQ5
-        YmFmMDU1YjYxYSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZTAyYzc4MjFiMzMwMzRiYWZjNSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6Mzg6MTFaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozODox
-        MVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRlMDNjNzgyMWIzNDQ0ZmNjNDc4IiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMDI4YWRhNDBkYjA0ZWUxMTY1In0s
-        ICJpZCI6ICI1NmI0ZGUwMjhhZGE0MGRiMDRlZTExNjUifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:12 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/6c29513f-1e2f-42b5-9db3-49baf055b61a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="rcL4aFWTuMTcFZMT9nY08vJBkgUFYu1DdhFvsumY",
-        oauth_signature="cgPT5OmQqWBiwCfrgSvH5svRG6A%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693892", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:12 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82YzI5NTEzZi0xZTJmLTQyYjUtOWRiMy00OWJh
-        ZjA1NWI2MWEvIiwgInRhc2tfaWQiOiAiNmMyOTUxM2YtMWUyZi00MmI1LTlk
-        YjMtNDliYWYwNTViNjFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wNVQxNzozODoxMloiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODoxMVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI3ZmFkYjg5MC0zNTAwLTQ5N2EtYWEyYi05OTVjOGUx
-        MDFjZWIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZmE4YzRkMWMtY2UzNy00ZDVlLWFlYjEtZGExNjQ1YTk2MmIwIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMWYwZDAyMWYtMGNjOS00MTJiLWFlMWQt
-        ZDhmMjdmYWFmNThiIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTE3
-        YTk1NDktNWFhMS00OTU4LTg3NzQtMTA5MDVmMGE5MDk3IiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjljZDQ2ZjdlLTdkZTUtNDllNC1hY2ExLTRlNDAw
-        MzA2ZTBmOSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxMjIzMjQ1
-        OS1iODcxLTQ2YzAtODNiOC1jMGM1NjAzN2E0YTQiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIxZTA3NzY3MS03MjkxLTQ3Y2EtOTliNy1jMGNm
-        MGVmMmZmMDMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJmYmFlN2VlZC1jMTFlLTQ1OGYtODRiMS1hZDZhYTIxZWE1MzEi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0MWE4
-        Y2MyOS0yOGVhLTQ2YTgtYTIxOS1lNzRkMDUyNGViNWUiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyOTU5YmUwZC0zMjY1
-        LTQyODUtOTVkZi00OGM5OTRjNDE5MTEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjkzZjExNzEzLTM4NjktNGU3
-        ZS1iMTAwLTU3MTAwMjdhNTE3YSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
-        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE3OjM4OjEx
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMDVUMTc6Mzg6MTJaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGRlMDRjNzgyMWIz
-        NDQ0ZmNjNDc5IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjdmYWRiODkwLTM1MDAtNDk3YS1hYTJiLTk5NWM4ZTEwMWNl
-        YiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJmYThjNGQxYy1jZTM3LTRkNWUtYWViMS1kYTE2NDVhOTYyYjAiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIxZjBkMDIxZi0wY2M5LTQxMmItYWUxZC1kOGYy
-        N2ZhYWY1OGIiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5MTdhOTU0
-        OS01YWExLTQ5NTgtODc3NC0xMDkwNWYwYTkwOTciLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiOWNkNDZmN2UtN2RlNS00OWU0LWFjYTEtNGU0MDAzMDZl
-        MGY5IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjEyMjMyNDU5LWI4
-        NzEtNDZjMC04M2I4LWMwYzU2MDM3YTRhNCIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjFlMDc3NjcxLTcyOTEtNDdjYS05OWI3LWMwY2YwZWYy
-        ZmYwMyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImZiYWU3ZWVkLWMxMWUtNDU4Zi04NGIxLWFkNmFhMjFlYTUzMSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQxYThjYzI5
-        LTI4ZWEtNDZhOC1hMjE5LWU3NGQwNTI0ZWI1ZSIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI5NTliZTBkLTMyNjUtNDI4
-        NS05NWRmLTQ4Yzk5NGM0MTkxMSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTNmMTE3MTMtMzg2OS00ZTdlLWIx
-        MDAtNTcxMDAyN2E1MTdhIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRkZTAzOGFkYTQwZGIw
-        NGVlMTE3NSJ9LCAiaWQiOiAiNTZiNGRlMDM4YWRhNDBkYjA0ZWUxMTc1In0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:12 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/01586a51-5133-42de-af95-9460747f2e2b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="JKftZXNDiilEsd8riVPR9XstX6JIjhT2XhaEI5S6Yw",
-        oauth_signature="%2FaFm2e4ZXeOd9zZrG1woMijSRhs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693893", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:13 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '651'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wMTU4NmE1MS01MTMzLTQyZGUtYWY5NS05NDYwNzQ3ZjJl
-        MmIvIiwgInRhc2tfaWQiOiAiMDE1ODZhNTEtNTEzMy00MmRlLWFmOTUtOTQ2
-        MDc0N2YyZTJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAi
-        c3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
-        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20i
-        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmI0ZGUwNThhZGE0MGRiMDRlZTExNzYifSwgImlkIjogIjU2YjRk
-        ZTA1OGFkYTQwZGIwNGVlMTE3NiJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:13 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/01586a51-5133-42de-af95-9460747f2e2b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="vXFEaZif8yq2pfAdJfmvvH46IfKa9z7BUsj70g",
-        oauth_signature="zDAj8tPsjikBxnrrDzr7GjA5MZ0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693893", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:13 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wMTU4NmE1MS01MTMzLTQyZGUtYWY5NS05NDYwNzQ3ZjJl
-        MmIvIiwgInRhc2tfaWQiOiAiMDE1ODZhNTEtNTEzMy00MmRlLWFmOTUtOTQ2
-        MDc0N2YyZTJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA1VDE3OjM4OjEzWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE3OjM4OjEzWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        NGRlMDU4YWRhNDBkYjA0ZWUxMTc2In0sICJpZCI6ICI1NmI0ZGUwNThhZGE0
-        MGRiMDRlZTExNzYifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:13 GMT
-- request:
-    method: post
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
-        IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRp
-        c3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwi
-        OiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3Rl
-        Y3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJleHBvcnRfZGlzdHJpYnV0
-        b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBz
-        IjpmYWxzZSwicmVsYXRpdmVfdXJsIjpudWxsfSwiYXV0b19wdWJsaXNoIjpm
-        YWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJleHBvcnRfZGlzdHJpYnV0b3IifV19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
-        oauth_nonce="b061hpSV2YnxFUU4i4OPkRO62d68rlxDMyxt48wok", oauth_signature="43f6Ki6sPLiFwaV3LFbcoWOuP70%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454693894", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '810'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:14 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '320'
-      Location:
-      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiNGRlMDZjNzgyMWIzMzAzNGJhZmNlIn0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:15 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/d2a5a230-7b6d-43c9-84fe-b89324362fc0/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="7KrAO4CdNyyKsHM51TPiA7hR0pUVRUs2w3rTTlvpsw0",
-        oauth_signature="saaHyM8DAXwm7gTrF0On70DFRSY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693895", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kMmE1YTIzMC03YjZkLTQzYzktODRmZS1iODkzMjQzNjJm
-        YzAvIiwgInRhc2tfaWQiOiAiZDJhNWEyMzAtN2I2ZC00M2M5LTg0ZmUtYjg5
-        MzI0MzYyZmMwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMDc4
-        YWRhNDBkYjA0ZWUxMTc3In0sICJpZCI6ICI1NmI0ZGUwNzhhZGE0MGRiMDRl
-        ZTExNzcifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:15 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/d2a5a230-7b6d-43c9-84fe-b89324362fc0/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="gK5yc7beXKVgPGUleJqCV65ewVV4mRhHy6dGq45DtY4",
-        oauth_signature="laujclmz%2FKVa5dAIt2cnhpiKF5I%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693895", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1093'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kMmE1YTIzMC03YjZkLTQzYzktODRmZS1iODkzMjQzNjJm
-        YzAvIiwgInRhc2tfaWQiOiAiZDJhNWEyMzAtN2I2ZC00M2M5LTg0ZmUtYjg5
-        MzI0MzYyZmMwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0wNVQxNzozODoxNVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        Mi0yM1QxNjo0ODo1NloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
         dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
         IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
         T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
         IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
         ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJOT1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
-        bCI6IDAsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiSU5fUFJP
-        R1JFU1MifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjog
-        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        NGRlMDc4YWRhNDBkYjA0ZWUxMTc3In0sICJpZCI6ICI1NmI0ZGUwNzhhZGE0
-        MGRiMDRlZTExNzcifQ==
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
+        T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDc4
+        OTg5MDU0ZmM0OGJhMzA1YSJ9LCAiaWQiOiAiNTZjYzhkNzg5ODkwNTRmYzQ4
+        YmEzMDVhIn0=
     http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:15 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:56 GMT
 - request:
     method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/d2a5a230-7b6d-43c9-84fe-b89324362fc0/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/a7fb0b86-3bb1-47aa-9ac9-de22724aa5b0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4346,12 +513,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="vdKndVJaqtFlgkTpXPnC73bMNG27veGASY8P5pwQ",
-        oauth_signature="%2FYcPGPZOjZMKq395QopnTZTnn0Q%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693896", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -4360,13 +521,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 05 Feb 2016 17:38:16 GMT
+      - Tue, 23 Feb 2016 16:48:57 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2194'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -4376,58 +537,61 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kMmE1YTIzMC03YjZkLTQzYzktODRmZS1iODkzMjQzNjJm
-        YzAvIiwgInRhc2tfaWQiOiAiZDJhNWEyMzAtN2I2ZC00M2M5LTg0ZmUtYjg5
-        MzI0MzYyZmMwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hN2ZiMGI4Ni0zYmIxLTQ3YWEtOWFjOS1kZTIyNzI0YWE1
+        YjAvIiwgInRhc2tfaWQiOiAiYTdmYjBiODYtM2JiMS00N2FhLTlhYzktZGUy
+        MjcyNGFhNWIwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozODoxNloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODoxNVoiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0ODo1NloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0ODo1NloiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZGUyNmM2NmQtMGViYS00MGE0LWJmM2YtMWNjN2JiMmEw
-        MDFiLyIsICJ0YXNrX2lkIjogImRlMjZjNjZkLTBlYmEtNDBhNC1iZjNmLTFj
-        YzdiYjJhMDAxYiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvZjAxMTIyOGQtMzYxZi00NjQxLWFlYzctMzc1YWE4ZWNh
+        NjMwLyIsICJ0YXNrX2lkIjogImYwMTEyMjhkLTM2MWYtNDY0MS1hZWM3LTM3
+        NWFhOGVjYTYzMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
         IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
         ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZTA2Yzc4MjFiMzMwMzRiYWZjZiJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6Mzg6MTVaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozODox
-        NloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRlMDhjNzgyMWIzNDQ0ZmNjNDdkIiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMDc4YWRhNDBkYjA0ZWUxMTc3In0s
-        ICJpZCI6ICI1NmI0ZGUwNzhhZGE0MGRiMDRlZTExNzcifQ==
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ3OGRlMDQw
+        MzNmNDM1MTRmYWQifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjU2WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6NTZaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkNzhk
+        ZTA0MDMwODk3NThhOTQ5IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDc4OTg5MDU0ZmM0OGJhMzA1YSJ9LCAiaWQiOiAiNTZj
+        YzhkNzg5ODkwNTRmYzQ4YmEzMDVhIn0=
     http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:16 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:57 GMT
 - request:
     method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/de26c66d-0eba-40a4-bf3f-1cc7bb2a001b/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/f011228d-361f-4641-aec7-375aa8eca630/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4438,12 +602,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="LP1fc7gbdmT5hvNhN0RjLe0s7jqwS4htL4mlMlelaI",
-        oauth_signature="Fq8fWWMZxLDKv5cNnxW4v7vjbCc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693896", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -4452,13 +610,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 05 Feb 2016 17:38:16 GMT
+      - Tue, 23 Feb 2016 16:48:57 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '3523'
+      - '6923'
       Connection:
       - close
       Content-Type:
@@ -4468,4036 +626,163 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9kZTI2YzY2ZC0wZWJhLTQwYTQtYmYzZi0xY2M3
-        YmIyYTAwMWIvIiwgInRhc2tfaWQiOiAiZGUyNmM2NmQtMGViYS00MGE0LWJm
-        M2YtMWNjN2JiMmEwMDFiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy9mMDExMjI4ZC0zNjFmLTQ2NDEtYWVjNy0zNzVh
+        YThlY2E2MzAvIiwgInRhc2tfaWQiOiAiZjAxMTIyOGQtMzYxZi00NjQxLWFl
+        YzctMzc1YWE4ZWNhNjMwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wNVQxNzozODoxNloiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlY2Ew
-        YTA4NS1kZTY1LTRlMzAtYTU0ZC0wYzQ2YzNmNmZlMmIiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjY4Zjk5YzUtZTE0
-        Mi00ZjdkLWExYTEtZDJjYWU2YzM4OTcwIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMWJmNTgxYmItMTdmOC00ZDc5LWExNzEtZDViODc2YzgyZmFlIiwg
-        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
-        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
-        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjljOGM5MzYwLTFhYTct
-        NGVmZi05NjQ0LTI0Y2I2N2VhMjUwYSIsICJudW1fcHJvY2Vzc2VkIjogMH0s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
-        ZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJmMTczOTg3Ny1mOWE5LTQwOGQtOTFkNS05YWRmZjQwYTNlNGMi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5
-        cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
-        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTMwYzdhNDYtNGJl
-        My00Nzk3LWFlOGQtMzBjOGU2MWFhNTEyIiwgIm51bV9wcm9jZXNzZWQiOiAw
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiNDA3NzkxYmMtMjZlOS00YWJiLTkxMWMtYTZiNDBi
-        ZDE1OWE4IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
-        IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAi
-        c3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
-        ZXBfaWQiOiAiNTIzOGJhNjUtODA2Ny00YjJkLWI3YTItMGM5MDhhMmM3ODY2
-        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
-        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
-        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjY0YjM3YzlkLWY2YzItNDEwNy04YmNmLWM2ODYwYzlmN2NlNiIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjog
-        InB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdkYTQ2
-        NmU2LWIyNGEtNGJlMy1hYTBhLTMzMDE3ZTZiYWExOSIsICJudW1fcHJvY2Vz
-        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
-        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
-        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzRkYzk0
-        MzEtZDE1Yi00Mjk2LWFkNzEtNWUzYjAyZjAwMjA1IiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjog
-        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        NGRlMDg4YWRhNDBkYjA0ZWUxMTg3In0sICJpZCI6ICI1NmI0ZGUwODhhZGE0
-        MGRiMDRlZTExODcifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:16 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/d2a5a230-7b6d-43c9-84fe-b89324362fc0/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="84YH5BlO7V1g6Gx0c6DjzcTVkhHRwpQvONB8q65YlaQ",
-        oauth_signature="VnZ8iy%2BGU6CJ8rI0qObX1O9YB1A%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693897", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:17 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kMmE1YTIzMC03YjZkLTQzYzktODRmZS1iODkzMjQzNjJm
-        YzAvIiwgInRhc2tfaWQiOiAiZDJhNWEyMzAtN2I2ZC00M2M5LTg0ZmUtYjg5
-        MzI0MzYyZmMwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozODoxNloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODoxNVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZGUyNmM2NmQtMGViYS00MGE0LWJmM2YtMWNjN2JiMmEw
-        MDFiLyIsICJ0YXNrX2lkIjogImRlMjZjNjZkLTBlYmEtNDBhNC1iZjNmLTFj
-        YzdiYjJhMDAxYiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZTA2Yzc4MjFiMzMwMzRiYWZjZiJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6Mzg6MTVaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozODox
-        NloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRlMDhjNzgyMWIzNDQ0ZmNjNDdkIiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMDc4YWRhNDBkYjA0ZWUxMTc3In0s
-        ICJpZCI6ICI1NmI0ZGUwNzhhZGE0MGRiMDRlZTExNzcifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:17 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/de26c66d-0eba-40a4-bf3f-1cc7bb2a001b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="YK4ccmQoy6URgxWMcSiLg2aOBKZmGRtJgA2v6P4X0Ms",
-        oauth_signature="q4eWMT37gwYvS0eJ1SQeq%2F5yASQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693897", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:17 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9kZTI2YzY2ZC0wZWJhLTQwYTQtYmYzZi0xY2M3
-        YmIyYTAwMWIvIiwgInRhc2tfaWQiOiAiZGUyNmM2NmQtMGViYS00MGE0LWJm
-        M2YtMWNjN2JiMmEwMDFiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wNVQxNzozODoxNloiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODoxNloiLCAi
+        bWUiOiAiMjAxNi0wMi0yM1QxNjo0ODo1NloiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0ODo1NloiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJlY2EwYTA4NS1kZTY1LTRlMzAtYTU0ZC0wYzQ2YzNm
-        NmZlMmIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICJhMzI5YTYwOS1iYTliLTQ2Y2QtODczOS02YTllZTQ5
+        OTliNzYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZjY4Zjk5YzUtZTE0Mi00ZjdkLWExYTEtZDJjYWU2YzM4OTcwIiwg
+        aWQiOiAiNDhmOTU5YjMtYWEwYi00ZjAxLThlNjAtYWI0YTZhMTgwOWIzIiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
         bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMWJmNTgxYmItMTdmOC00ZDc5LWExNzEt
-        ZDViODc2YzgyZmFlIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZWZiM2E5ODgtOGYzOS00YWFmLWI0OTMt
+        OWZkZWQyNzA5ODQwIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
         TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOWM4
-        YzkzNjAtMWFhNy00ZWZmLTk2NDQtMjRjYjY3ZWEyNTBhIiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYmZh
+        OTc5NWEtMDkzZS00OGJjLWEzNTgtNDczZjhhZTk0YmI5IiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImYxNzM5ODc3LWY5YTktNDA4ZC05MWQ1LTlhZGZm
-        NDBhM2U0YyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        IDAsICJzdGVwX2lkIjogIjgwZGJlNWY0LTc3NmUtNGUwNC05YjU0LWExODIx
+        YzViZDhlZiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
         OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
         InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1MzBjN2E0
-        Ni00YmUzLTQ3OTctYWU4ZC0zMGM4ZTYxYWE1MTIiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwOTgxMWMx
+        OC1iYzVjLTQ2ODgtYWQ3Ny0yYjUyNWVhZDU0MmQiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
         Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI0MDc3OTFiYy0yNmU5LTRhYmItOTExYy1hNmI0
-        MGJkMTU5YTgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICJmODZmODIzYS1lZjYxLTRiOGUtOGZmMC1jNmVi
+        NTEwYjRkMTMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
         ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI1MjM4YmE2NS04MDY3LTRiMmQtYjdhMi0wYzkwOGEyYzc4NjYi
+        cF9pZCI6ICIzNmRmMGFkMS0zOGI1LTQ0ZWItYmE2Yi0wNTdjMWVjNzcxOGUi
         LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
         dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
         c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2NGIz
-        N2M5ZC1mNmMyLTQxMDctOGJjZi1jNjg2MGM5ZjdjZTYiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1NzI4
+        ZmIwYi0yMTQ2LTQ0OGQtYTg0MC1lOTE4YzRlZmNmZTMiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
         aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3ZGE0NjZlNi1iMjRh
-        LTRiZTMtYWEwYS0zMzAxN2U2YmFhMTkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlYmUyNzIxMy0yYzc2
+        LTQwZGQtOGQyNy02M2VjNjcwZmQxNGQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
         TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
         X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM0ZGM5NDMxLWQxNWItNDI5
-        Ni1hZDcxLTVlM2IwMmYwMDIwNSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE1OWU0ZTU1LWMwOWUtNGIw
+        NS1hZmE0LWJkNmVhNTc2MjIzNiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
         InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
-        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE3OjM4OjE2
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMDVUMTc6Mzg6MTZaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGRlMDhjNzgyMWIz
-        NDQ0ZmNjNDdlIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImVjYTBhMDg1LWRlNjUtNGUzMC1hNTRkLTBjNDZjM2Y2ZmUy
-        YiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJmNjhmOTljNS1lMTQyLTRmN2QtYTFhMS1kMmNhZTZjMzg5NzAiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIxYmY1ODFiYi0xN2Y4LTRkNzktYTE3MS1kNWI4
-        NzZjODJmYWUiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5YzhjOTM2
-        MC0xYWE3LTRlZmYtOTY0NC0yNGNiNjdlYTI1MGEiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiZjE3Mzk4NzctZjlhOS00MDhkLTkxZDUtOWFkZmY0MGEz
-        ZTRjIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjUzMGM3YTQ2LTRi
-        ZTMtNDc5Ny1hZThkLTMwYzhlNjFhYTUxMiIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjQwNzc5MWJjLTI2ZTktNGFiYi05MTFjLWE2YjQwYmQx
-        NTlhOCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
+        c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
+        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ4OjU2WiIsICJf
+        bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
+        MTYtMDItMjNUMTY6NDg6NTZaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
+        cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
+        IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
+        X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
+        RCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1z
+        IjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0
+        aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
+        SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
+        U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
+        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZjYzhkNzhkZTA0MDMwODk3NThh
+        OTRhIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
         IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjUyMzhiYTY1LTgwNjctNGIyZC1iN2EyLTBjOTA4YTJjNzg2NiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjY0YjM3Yzlk
-        LWY2YzItNDEwNy04YmNmLWM2ODYwYzlmN2NlNiIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdkYTQ2NmU2LWIyNGEtNGJl
-        My1hYTBhLTMzMDE3ZTZiYWExOSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzRkYzk0MzEtZDE1Yi00Mjk2LWFk
-        NzEtNWUzYjAyZjAwMjA1IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRkZTA4OGFkYTQwZGIw
-        NGVlMTE4NyJ9LCAiaWQiOiAiNTZiNGRlMDg4YWRhNDBkYjA0ZWUxMTg3In0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:17 GMT
-- request:
-    method: post
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/content/units/erratum/search/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMDc3ZmM1
-        OTQtNTVmOS00YzYyLWJjYjYtZWNlZGMyYjdhYzc5IiwiMGJkMjI3ZDAtMjA5
-        ZS00ODJhLTkyZGItMDZlNjY3NDJiOWE3IiwiNGU3N2IxODktYTZlYS00YjMy
-        LWI3YjUtNzYwOGFkMTRmMGM3Il19fX0sImluY2x1ZGVfcmVwb3MiOnRydWV9
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
-        oauth_nonce="6Vjir6Jv3C2q8EaPvevdRB13ZYCPfz0nDvnc84BM63E", oauth_signature="8z6d0V%2FjvwQDpFN%2FJzeE77LTdtk%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454693897", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '180'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:17 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4700'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJf
-        aHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9lcnJhdHVtLzA3
-        N2ZjNTk0LTU1ZjktNGM2Mi1iY2I2LWVjZWRjMmI3YWM3OS8iLCAiaXNzdWVk
-        IjogIjIwMTAtMDEtMDEgMDE6MDE6MDEiLCAicmVmZXJlbmNlcyI6IFtdLCAi
-        cHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lkIjog
-        ImVycmF0dW0iLCAiaWQiOiAiUkhFQS0yMDEwOjAwMDIiLCAiZnJvbSI6ICJs
-        emFwK3B1YkByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRsZSI6
-        ICJPbmUgcGFja2FnZSBlcnJhdGEiLCAiY2hpbGRyZW4iOiB7fSwgInZlcnNp
-        b24iOiAiMSIsICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjog
-        InNlY3VyaXR5IiwgInBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6
-        ICJodHRwOi8vd3d3LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAiZWxl
-        cGhhbnQiLCAic3VtIjogbnVsbCwgImZpbGVuYW1lIjogImVsZXBoYW50LTAu
-        My0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6IG51bGwsICJ2ZXJzaW9uIjog
-        IjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJhcmNoIjogIm5vYXJjaCJ9XSwg
-        Im5hbWUiOiAiMSIsICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxl
-        IiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjogIk9uZSBwYWNrYWdl
-        IGVycmF0YSIsICJfbGFzdF91cGRhdGVkIjogIjIwMTYtMDItMDVUMTc6Mzg6
-        MTZaIiwgInB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjogIiIsICJzb2x1dGlv
-        biI6ICIiLCAic3VtbWFyeSI6ICIiLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6
-        ICIwNzdmYzU5NC01NWY5LTRjNjItYmNiNi1lY2VkYzJiN2FjNzkifSwgeyJy
-        ZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJGZWRvcmFfMTciXSwgIl9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL2VycmF0dW0vMGJkMjI3
-        ZDAtMjA5ZS00ODJhLTkyZGItMDZlNjY3NDJiOWE3LyIsICJpc3N1ZWQiOiAi
-        MjAxMC0xMS0xMCAwMDowMDowMCIsICJyZWZlcmVuY2VzIjogW3siaHJlZiI6
-        ICJodHRwczovL3Jobi5yZWRoYXQuY29tL2VycmF0YS9SSFNBLTIwMTAtMDg1
-        OC5odG1sIiwgInR5cGUiOiAic2VsZiIsICJpZCI6IG51bGwsICJ0aXRsZSI6
-        IG51bGx9LCB7ImhyZWYiOiAiaHR0cHM6Ly9idWd6aWxsYS5yZWRoYXQuY29t
-        L2J1Z3ppbGxhL3Nob3dfYnVnLmNnaT9pZD02Mjc4ODIiLCAidHlwZSI6ICJi
-        dWd6aWxsYSIsICJpZCI6ICI2Mjc4ODIiLCAidGl0bGUiOiBudWxsfSwgeyJo
-        cmVmIjogImh0dHBzOi8vd3d3LnJlZGhhdC5jb20vc2VjdXJpdHkvZGF0YS9j
-        dmUvQ1ZFLTIwMTAtMDQwNS5odG1sIiwgInR5cGUiOiAiY3ZlIiwgImlkIjog
-        IkNWRS0yMDEwLTA0MDUiLCAidGl0bGUiOiBudWxsfSwgeyJocmVmIjogImh0
-        dHA6Ly93d3cucmVkaGF0LmNvbS9zZWN1cml0eS91cGRhdGVzL2NsYXNzaWZp
-        Y2F0aW9uLyNpbXBvcnRhbnQiLCAidHlwZSI6ICJvdGhlciIsICJpZCI6IG51
-        bGwsICJ0aXRsZSI6IG51bGx9XSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9
-        LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIlJIU0Et
-        MjAxMDowODU4IiwgImZyb20iOiAic2VjdXJpdHlAcmVkaGF0LmNvbSIsICJz
-        ZXZlcml0eSI6ICJJbXBvcnRhbnQiLCAidGl0bGUiOiAiSW1wb3J0YW50OiBi
-        emlwMiBzZWN1cml0eSB1cGRhdGUiLCAiY2hpbGRyZW4iOiB7fSwgInZlcnNp
-        b24iOiAiMyIsICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjog
-        InNlY3VyaXR5IiwgInBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6
-        ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlw
-        Mi1kZXZlbCIsICJzdW0iOiBbInNoYTI1NiIsICJlYTY3YzY2NGRhMWZmOTZh
-        NmRjOTRkMzMwMDliNzNkOGZhYjMxYjU5ODI0MTgzZmI0NWU5YmEyZWJmODJk
-        NTgzIl0sICJmaWxlbmFtZSI6ICJiemlwMi1kZXZlbC0xLjAuNS03LmVsNl8w
-        Lmk2ODYucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIs
-        ICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJjaCI6ICJpNjg2In0sIHsic3Jj
-        IjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3JjLnJwbSIsICJuYW1lIjogImJ6
-        aXAyLWxpYnMiLCAic3VtIjogWyJzaGEyNTYiLCAiYzlmMDY0YTY4NjI1NzNm
-        YjlmMmE2YWZmN2MzNjIxZjE5NDBiNDkyZGYyZWRmYzJlYmJkYzBiODMwNWY1
-        MTE0NyJdLCAiZmlsZW5hbWUiOiAiYnppcDItbGlicy0xLjAuNS03LmVsNl8w
-        Lmk2ODYucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIs
-        ICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJjaCI6ICJpNjg2In0sIHsic3Jj
-        IjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3JjLnJwbSIsICJuYW1lIjogImJ6
-        aXAyIiwgInN1bSI6IFsic2hhMjU2IiwgImI4YTNmNzJiYzJiMGQ4OWJhNzM3
-        MDk5YWM5OGJmOGQyYWY0YmVhMDJkMzE4ODRjMDJkYjk3ZjdmNjZjM2Q1YzIi
-        XSwgImZpbGVuYW1lIjogImJ6aXAyLTEuMC41LTcuZWw2XzAueDg2XzY0LnJw
-        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFz
-        ZSI6ICI3LmVsNl8wIiwgImFyY2giOiAieDg2XzY0In0sIHsic3JjIjogImJ6
-        aXAyLTEuMC41LTcuZWw2XzAuc3JjLnJwbSIsICJuYW1lIjogImJ6aXAyLWRl
-        dmVsIiwgInN1bSI6IFsic2hhMjU2IiwgIjdmNjMxMjRlNDY1NWI3YzkyZDIz
-        ZWM0YzM4MjI2ZjVkMzc0NjU2ODg1M2RmZjc1MGZjODVlMDU4ZTc0YjVjZjYi
-        XSwgImZpbGVuYW1lIjogImJ6aXAyLWRldmVsLTEuMC41LTcuZWw2XzAueDg2
-        XzY0LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAi
-        cmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAieDg2XzY0In0sIHsic3Jj
-        IjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3JjLnJwbSIsICJuYW1lIjogImJ6
-        aXAyLWxpYnMiLCAic3VtIjogWyJzaGEyNTYiLCAiODAyZjQzOTlkYmRkMDE0
-        NzZlMjU0YzNiMzJjNDBhZmY1OWNmNWQyM2E0NWZhNDg4YzY5MTdjZTg5MDRk
-        NmI0ZCJdLCAiZmlsZW5hbWUiOiAiYnppcDItbGlicy0xLjAuNS03LmVsNl8w
-        Lng4Nl82NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41
-        IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9XSwg
-        Im5hbWUiOiAiUmVkIEhhdCBFbnRlcnByaXNlIExpbnV4IFNlcnZlciAodi4g
-        NiBmb3IgNjQtYml0IHg4Nl82NCkiLCAic2hvcnQiOiAicmhlbC14ODZfNjQt
-        c2VydmVyLTYifV0sICJzdGF0dXMiOiAiZmluYWwiLCAidXBkYXRlZCI6ICIy
-        MDEwLTExLTEwIDAwOjAwOjAwIiwgImRlc2NyaXB0aW9uIjogImJ6aXAyIGlz
-        IGEgZnJlZWx5IGF2YWlsYWJsZSwgaGlnaC1xdWFsaXR5IGRhdGEgY29tcHJl
-        c3Nvci4gSXQgcHJvdmlkZXMgYm90aFxubGliYnoyIGxpYnJhcnkgbXVzdCBi
-        ZSByZXN0YXJ0ZWQgZm9yIHRoZSB1cGRhdGUgdG8gdGFrZSBlZmZlY3QuIiwg
-        Il9sYXN0X3VwZGF0ZWQiOiAiMjAxNi0wMi0wNVQxNzozODoxNloiLCAicHVz
-        aGNvdW50IjogIiIsICJyaWdodHMiOiAiQ29weXJpZ2h0IDIwMTAgUmVkIEhh
-        dCBJbmMiLCAic29sdXRpb24iOiAiQmVmb3JlIGFwcGx5aW5nIHRoaXMgdXBk
-        YXRlLCBtYWtlIHN1cmUgYWxsIHByZXZpb3VzbHktcmVsZWFzZWQgZXJyYXRh
-        XG5yZWxldmFudCB0byB5b3VyIHN5c3RlbSBoYXZlIGJlZW4gYXBwbGllZC5c
-        blxuVGhpcyB1cGRhdGUgaXMgYXZhaWxhYmxlIHZpYSB0aGUgUmVkIEhhdCBO
-        ZXR3b3JrLiBEZXRhaWxzIG9uIGhvdyB0b1xudXNlIHRoZSBSZWQgSGF0IE5l
-        dHdvcmsgdG8gYXBwbHkgdGhpcyB1cGRhdGUgYXJlIGF2YWlsYWJsZSBhdFxu
-        aHR0cDovL2tiYXNlLnJlZGhhdC5jb20vZmFxL2RvY3MvRE9DLTExMjU5Iiwg
-        InN1bW1hcnkiOiAiVXBkYXRlZCBiemlwMiBwYWNrYWdlcyB0aGF0IGZpeCBv
-        bmUgc2VjdXJpdHkgaXNzdWUiLCAicmVsZWFzZSI6ICIiLCAiX2lkIjogIjBi
-        ZDIyN2QwLTIwOWUtNDgyYS05MmRiLTA2ZTY2NzQyYjlhNyJ9LCB7InJlcG9z
-        aXRvcnlfbWVtYmVyc2hpcHMiOiBbIkZlZG9yYV8xNyJdLCAiX2hyZWYiOiAi
-        L3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvZXJyYXR1bS80ZTc3YjE4OS1h
-        NmVhLTRiMzItYjdiNS03NjA4YWQxNGYwYzcvIiwgImlzc3VlZCI6ICIyMDEw
-        LTAxLTAxIDAxOjAxOjAxIiwgInJlZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNl
-        cl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
-        IiwgImlkIjogIlJIRUEtMjAxMDowMDAxIiwgImZyb20iOiAibHphcCtwdWJA
-        cmVkaGF0LmNvbSIsICJzZXZlcml0eSI6ICIiLCAidGl0bGUiOiAiRW1wdHkg
-        ZXJyYXRhIiwgImNoaWxkcmVuIjoge30sICJ2ZXJzaW9uIjogIjEiLCAicmVi
-        b290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJw
-        a2dsaXN0IjogW10sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAi
-        IiwgImRlc2NyaXB0aW9uIjogIkVtcHR5IGVycmF0YSIsICJfbGFzdF91cGRh
-        dGVkIjogIjIwMTYtMDItMDVUMTc6Mzg6MTZaIiwgInB1c2hjb3VudCI6ICIi
-        LCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIi
-        LCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI0ZTc3YjE4OS1hNmVhLTRiMzIt
-        YjdiNS03NjA4YWQxNGYwYzcifV0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:17 GMT
-- request:
-    method: post
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/content/units/erratum/search/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMGJkMjI3
-        ZDAtMjA5ZS00ODJhLTkyZGItMDZlNjY3NDJiOWE3Il19fX0sImluY2x1ZGVf
-        cmVwb3MiOnRydWV9
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
-        oauth_nonce="BAZDNDe8k5oHGqbFiDZYheGnRkJV527SiUeffa909M", oauth_signature="RPeFfmswE1dy%2Br6huKzxU7RcSO4%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454693897", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '102'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:17 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3146'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJf
-        aHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9lcnJhdHVtLzBi
-        ZDIyN2QwLTIwOWUtNDgyYS05MmRiLTA2ZTY2NzQyYjlhNy8iLCAiaXNzdWVk
-        IjogIjIwMTAtMTEtMTAgMDA6MDA6MDAiLCAicmVmZXJlbmNlcyI6IFt7Imhy
-        ZWYiOiAiaHR0cHM6Ly9yaG4ucmVkaGF0LmNvbS9lcnJhdGEvUkhTQS0yMDEw
-        LTA4NTguaHRtbCIsICJ0eXBlIjogInNlbGYiLCAiaWQiOiBudWxsLCAidGl0
-        bGUiOiBudWxsfSwgeyJocmVmIjogImh0dHBzOi8vYnVnemlsbGEucmVkaGF0
-        LmNvbS9idWd6aWxsYS9zaG93X2J1Zy5jZ2k/aWQ9NjI3ODgyIiwgInR5cGUi
-        OiAiYnVnemlsbGEiLCAiaWQiOiAiNjI3ODgyIiwgInRpdGxlIjogbnVsbH0s
-        IHsiaHJlZiI6ICJodHRwczovL3d3dy5yZWRoYXQuY29tL3NlY3VyaXR5L2Rh
-        dGEvY3ZlL0NWRS0yMDEwLTA0MDUuaHRtbCIsICJ0eXBlIjogImN2ZSIsICJp
-        ZCI6ICJDVkUtMjAxMC0wNDA1IiwgInRpdGxlIjogbnVsbH0sIHsiaHJlZiI6
-        ICJodHRwOi8vd3d3LnJlZGhhdC5jb20vc2VjdXJpdHkvdXBkYXRlcy9jbGFz
-        c2lmaWNhdGlvbi8jaW1wb3J0YW50IiwgInR5cGUiOiAib3RoZXIiLCAiaWQi
-        OiBudWxsLCAidGl0bGUiOiBudWxsfV0sICJwdWxwX3VzZXJfbWV0YWRhdGEi
-        OiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6ICJS
-        SFNBLTIwMTA6MDg1OCIsICJmcm9tIjogInNlY3VyaXR5QHJlZGhhdC5jb20i
-        LCAic2V2ZXJpdHkiOiAiSW1wb3J0YW50IiwgInRpdGxlIjogIkltcG9ydGFu
-        dDogYnppcDIgc2VjdXJpdHkgdXBkYXRlIiwgImNoaWxkcmVuIjoge30sICJ2
-        ZXJzaW9uIjogIjMiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlw
-        ZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFja2FnZXMiOiBbeyJz
-        cmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAi
-        YnppcDItZGV2ZWwiLCAic3VtIjogWyJzaGEyNTYiLCAiZWE2N2M2NjRkYTFm
-        Zjk2YTZkYzk0ZDMzMDA5YjczZDhmYWIzMWI1OTgyNDE4M2ZiNDVlOWJhMmVi
-        ZjgyZDU4MyJdLCAiZmlsZW5hbWUiOiAiYnppcDItZGV2ZWwtMS4wLjUtNy5l
-        bDZfMC5pNjg2LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4w
-        LjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7
-        InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6
-        ICJiemlwMi1saWJzIiwgInN1bSI6IFsic2hhMjU2IiwgImM5ZjA2NGE2ODYy
-        NTczZmI5ZjJhNmFmZjdjMzYyMWYxOTQwYjQ5MmRmMmVkZmMyZWJiZGMwYjgz
-        MDVmNTExNDciXSwgImZpbGVuYW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5l
-        bDZfMC5pNjg2LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4w
-        LjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7
-        InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6
-        ICJiemlwMiIsICJzdW0iOiBbInNoYTI1NiIsICJiOGEzZjcyYmMyYjBkODli
-        YTczNzA5OWFjOThiZjhkMmFmNGJlYTAyZDMxODg0YzAyZGI5N2Y3ZjY2YzNk
-        NWMyIl0sICJmaWxlbmFtZSI6ICJiemlwMi0xLjAuNS03LmVsNl8wLng4Nl82
-        NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJl
-        bGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9LCB7InNyYyI6
-        ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlw
-        Mi1kZXZlbCIsICJzdW0iOiBbInNoYTI1NiIsICI3ZjYzMTI0ZTQ2NTViN2M5
-        MmQyM2VjNGMzODIyNmY1ZDM3NDY1Njg4NTNkZmY3NTBmYzg1ZTA1OGU3NGI1
-        Y2Y2Il0sICJmaWxlbmFtZSI6ICJiemlwMi1kZXZlbC0xLjAuNS03LmVsNl8w
-        Lng4Nl82NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41
-        IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9LCB7
-        InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6
-        ICJiemlwMi1saWJzIiwgInN1bSI6IFsic2hhMjU2IiwgIjgwMmY0Mzk5ZGJk
-        ZDAxNDc2ZTI1NGMzYjMyYzQwYWZmNTljZjVkMjNhNDVmYTQ4OGM2OTE3Y2U4
-        OTA0ZDZiNGQiXSwgImZpbGVuYW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5l
-        bDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIx
-        LjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQi
-        fV0sICJuYW1lIjogIlJlZCBIYXQgRW50ZXJwcmlzZSBMaW51eCBTZXJ2ZXIg
-        KHYuIDYgZm9yIDY0LWJpdCB4ODZfNjQpIiwgInNob3J0IjogInJoZWwteDg2
-        XzY0LXNlcnZlci02In1dLCAic3RhdHVzIjogImZpbmFsIiwgInVwZGF0ZWQi
-        OiAiMjAxMC0xMS0xMCAwMDowMDowMCIsICJkZXNjcmlwdGlvbiI6ICJiemlw
-        MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
-        bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
-        c3QgYmUgcmVzdGFydGVkIGZvciB0aGUgdXBkYXRlIHRvIHRha2UgZWZmZWN0
-        LiIsICJfbGFzdF91cGRhdGVkIjogIjIwMTYtMDItMDVUMTc6Mzg6MTZaIiwg
-        InB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjogIkNvcHlyaWdodCAyMDEwIFJl
-        ZCBIYXQgSW5jIiwgInNvbHV0aW9uIjogIkJlZm9yZSBhcHBseWluZyB0aGlz
-        IHVwZGF0ZSwgbWFrZSBzdXJlIGFsbCBwcmV2aW91c2x5LXJlbGVhc2VkIGVy
-        cmF0YVxucmVsZXZhbnQgdG8geW91ciBzeXN0ZW0gaGF2ZSBiZWVuIGFwcGxp
-        ZWQuXG5cblRoaXMgdXBkYXRlIGlzIGF2YWlsYWJsZSB2aWEgdGhlIFJlZCBI
-        YXQgTmV0d29yay4gRGV0YWlscyBvbiBob3cgdG9cbnVzZSB0aGUgUmVkIEhh
-        dCBOZXR3b3JrIHRvIGFwcGx5IHRoaXMgdXBkYXRlIGFyZSBhdmFpbGFibGUg
-        YXRcbmh0dHA6Ly9rYmFzZS5yZWRoYXQuY29tL2ZhcS9kb2NzL0RPQy0xMTI1
-        OSIsICJzdW1tYXJ5IjogIlVwZGF0ZWQgYnppcDIgcGFja2FnZXMgdGhhdCBm
-        aXggb25lIHNlY3VyaXR5IGlzc3VlIiwgInJlbGVhc2UiOiAiIiwgIl9pZCI6
-        ICIwYmQyMjdkMC0yMDllLTQ4MmEtOTJkYi0wNmU2Njc0MmI5YTcifV0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:17 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/07321e71-9ed2-4fb6-9f85-dd74704470ad/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="FVL8sXAgKGRvos7fJLFXd1UTLbxnFDAubFftND3Jnk",
-        oauth_signature="OUzzo3PUhB1xCyfehSghEy%2BRz20%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693897", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:17 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '651'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wNzMyMWU3MS05ZWQyLTRmYjYtOWY4NS1kZDc0NzA0NDcw
-        YWQvIiwgInRhc2tfaWQiOiAiMDczMjFlNzEtOWVkMi00ZmI2LTlmODUtZGQ3
-        NDcwNDQ3MGFkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAi
-        c3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
-        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20i
-        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmI0ZGUwOThhZGE0MGRiMDRlZTExODgifSwgImlkIjogIjU2YjRk
-        ZTA5OGFkYTQwZGIwNGVlMTE4OCJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:17 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/07321e71-9ed2-4fb6-9f85-dd74704470ad/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="ls2kkMmrpOloPrhe2SEgYZDUOSocRxfCWj6EK3l88Q",
-        oauth_signature="mnja3uGC8UMPOU%2FyM4ZhrSSpAVs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693898", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:18 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wNzMyMWU3MS05ZWQyLTRmYjYtOWY4NS1kZDc0NzA0NDcw
-        YWQvIiwgInRhc2tfaWQiOiAiMDczMjFlNzEtOWVkMi00ZmI2LTlmODUtZGQ3
-        NDcwNDQ3MGFkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA1VDE3OjM4OjE3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE3OjM4OjE3WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        NGRlMDk4YWRhNDBkYjA0ZWUxMTg4In0sICJpZCI6ICI1NmI0ZGUwOThhZGE0
-        MGRiMDRlZTExODgifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:18 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/ef0b86da-9ca9-4958-9c57-16d048825f07/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="8CQvXLuUaCG8SoZjqrCIYHmGso2k9V6x7pZEHEMlYg",
-        oauth_signature="ykAMb8RC%2FqQikyR82WJtuoA6jtM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950194", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:49:54 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '661'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lZjBiODZkYS05Y2E5LTQ5NTgtOWM1Ny0xNmQwNDg4MjVm
-        MDcvIiwgInRhc2tfaWQiOiAiZWYwYjg2ZGEtOWNhOS00OTU4LTljNTctMTZk
-        MDQ4ODI1ZjA3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRx
-        IiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
-        ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
-        aWQiOiB7IiRvaWQiOiAiNTZiOGM3MzJjMTlmZjUwNzk4MjNmNDQ5In0sICJp
-        ZCI6ICI1NmI4YzczMmMxOWZmNTA3OTgyM2Y0NDkifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:49:54 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/ef0b86da-9ca9-4958-9c57-16d048825f07/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="QJLhnLNiroNf13dBgePk0urAxRFpKm2YILlhiSN9Yhw",
-        oauth_signature="jcARZN7LPxkNn7nlm2IpKWWwGfE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950194", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:49:54 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lZjBiODZkYS05Y2E5LTQ5NTgtOWM1Ny0xNmQwNDg4MjVm
-        MDcvIiwgInRhc2tfaWQiOiAiZWYwYjg2ZGEtOWNhOS00OTU4LTljNTctMTZk
-        MDQ4ODI1ZjA3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo0OTo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo0OTo1NFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMTAxNDI0MWEtOGMwYS00OGJhLWJhZjktNDQ1YjZiMDBk
-        ZmIxLyIsICJ0YXNrX2lkIjogIjEwMTQyNDFhLThjMGEtNDhiYS1iYWY5LTQ0
-        NWI2YjAwZGZiMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjNzMxMTdmMjVlMGRhNWE3Yzg3ZiJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NDk6NTRaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo0OTo1NFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjNzMyMTdmMjVlMTEyYWU4OGI2NyIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNzMyYzE5ZmY1
-        MDc5ODIzZjQ0OSJ9LCAiaWQiOiAiNTZiOGM3MzJjMTlmZjUwNzk4MjNmNDQ5
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:49:54 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/1014241a-8c0a-48ba-baf9-445b6b00dfb1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="DL0ZVsUnIWSCUmN6g1RImHBUz5IuZ7gP1abbD9vwFec",
-        oauth_signature="Pplh3LnwL8PkJ8PoKSGgAsWZG3s%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950194", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:49:54 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6941'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8xMDE0MjQxYS04YzBhLTQ4YmEtYmFmOS00NDVi
-        NmIwMGRmYjEvIiwgInRhc2tfaWQiOiAiMTAxNDI0MWEtOGMwYS00OGJhLWJh
-        ZjktNDQ1YjZiMDBkZmIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wOFQxNjo0OTo1NFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo0OTo1NFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIwYmMyYTE0My05YjU2LTQ4YTEtYTJhOC1iOGYyZjkz
-        N2JmOGIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZmI0ZmY2MjEtYmQ2NC00YjI2LTg2MmMtNmVkOTBhZTA2MWE5Iiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZTQyYmI1NGEtZGY0Yi00NzUwLTg0NGMt
-        MTRmZTA4YzU3ZTdlIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTVi
-        YjBhMTgtMTNkMy00NTMwLWEwNDktMTk0ZDZlYzA2YWI5IiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjAxMDExNGRiLTY0NmItNDUyYi1hODlkLWY3MmVh
-        M2Q5NGNmOCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhMjFjODVm
-        My1kN2VlLTQzMTAtOTY3Ni1hZmE0MjA5OWQyNmMiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIzNmQ0YzMxNC04MDQwLTQ2MzQtYmIyZC1kNzBk
-        ZmYzYTkyY2QiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI0YzMzZDZhMy1jZmQ4LTQ3NTctYjIxYS04ZWY1ZGM4Y2U4Y2Qi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1MDg5
-        ZmYzZi00M2Y2LTRkMzMtOGVhNC1kZmFiZTFlMTY5ZWIiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwOGU0MTM5NS1lMmNi
-        LTQ2YjQtYjQwOS1kNjk1YmNjZmIwNTYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdlNDEyMmU2LTA3ZTItNDQ2
-        YS1hZmQ2LTJjM2VlMDQ5YTFjYyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Y2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAy
-        LTA4VDE2OjQ5OjU0WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMi
-        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMDhUMTY6NDk6NTRaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0
-        cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJ
-        UFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQi
-        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjog
-        IkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklO
-        SVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hf
-        ZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIs
-        ICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51
-        bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZi
-        OGM3MzIxN2YyNWUxMTJhZTg4YjY4IiwgImRldGFpbHMiOiBbeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
-        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
-        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjBiYzJhMTQzLTliNTYtNDhhMS1hMmE4
-        LWI4ZjJmOTM3YmY4YiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
-        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJmYjRmZjYyMS1iZDY0LTRiMjYtODYyYy02ZWQ5MGFl
-        MDYxYTkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        OCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
-        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlNDJiYjU0YS1kZjRiLTQ3
-        NTAtODQ0Yy0xNGZlMDhjNTdlN2UiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7
-        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI1NWJiMGExOC0xM2QzLTQ1MzAtYTA0OS0xOTRkNmVjMDZhYjkiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
-        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDEwMTE0ZGItNjQ2Yi00NTJiLWE4
-        OWQtZjcyZWEzZDk0Y2Y4IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBz
-        IGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjog
-        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImEyMWM4NWYzLWQ3ZWUtNDMxMC05Njc2LWFmYTQyMDk5ZDI2YyIsICJudW1f
-        cHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM2ZDRjMzE0LTgwNDAtNDYzNC1i
-        YjJkLWQ3MGRmZjNhOTJjZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjRjMzNkNmEzLWNmZDgtNDc1Ny1iMjFhLThlZjVk
-        YzhjZThjZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMi
-        LCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjUwODlmZjNmLTQzZjYtNGQzMy04ZWE0LWRmYWJlMWUxNjllYiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBl
-        IjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA4ZTQx
-        Mzk1LWUyY2ItNDZiNC1iNDA5LWQ2OTViY2NmYjA1NiIsICJudW1fcHJvY2Vz
-        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
-        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiN2U0MTIyZTYt
-        MDdlMi00NDZhLWFmZDYtMmMzZWUwNDlhMWNjIiwgIm51bV9wcm9jZXNzZWQi
-        OiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Yjhj
-        NzMyYzE5ZmY1MDc5ODIzZjQ1OSJ9LCAiaWQiOiAiNTZiOGM3MzJjMTlmZjUw
-        Nzk4MjNmNDU5In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:49:54 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/759c988d-400b-4a8a-8e0f-ef790dd3b3e8/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="4YExD46bwHxNysqoETInFj2LTfH1dFN2BXttzGBY",
-        oauth_signature="%2B5%2BjqkF7x2Z3gH2DxNXx2KcW4gQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950195", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:49:55 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83NTljOTg4ZC00MDBiLTRhOGEtOGUwZi1lZjc5MGRkM2Iz
-        ZTgvIiwgInRhc2tfaWQiOiAiNzU5Yzk4OGQtNDAwYi00YThhLThlMGYtZWY3
-        OTBkZDNiM2U4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI4Yzcz
-        M2MxOWZmNTA3OTgyM2Y0NWEifSwgImlkIjogIjU2YjhjNzMzYzE5ZmY1MDc5
-        ODIzZjQ1YSJ9
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:49:55 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/759c988d-400b-4a8a-8e0f-ef790dd3b3e8/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="4XZtg1Du3xjr8UHBDIfJJCu6vG1WslTbNHukJu0aYsE",
-        oauth_signature="bVJkHpwcTE4kMVc7Det2QMCPa%2Bw%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950195", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:49:55 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '700'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83NTljOTg4ZC00MDBiLTRhOGEtOGUwZi1lZjc5MGRkM2Iz
-        ZTgvIiwgInRhc2tfaWQiOiAiNzU5Yzk4OGQtNDAwYi00YThhLThlMGYtZWY3
-        OTBkZDNiM2U4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA4VDE2OjQ5OjU1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA4VDE2OjQ5OjU1WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20uZHEiLCAic3Rh
-        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUu
-        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNTZiOGM3MzNjMTlmZjUwNzk4MjNmNDVhIn0sICJpZCI6ICI1
-        NmI4YzczM2MxOWZmNTA3OTgyM2Y0NWEifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:49:55 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/b9403672-c1c9-4893-a956-808e89c1f558/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="4wyt5bVroGBqATIJkMLUO7Urmelouoie543iwwo6II",
-        oauth_signature="2qy9%2FwdML%2FbVvlIjLMea0gHm0bQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950196", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:49:56 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iOTQwMzY3Mi1jMWM5LTQ4OTMtYTk1Ni04MDhlODljMWY1
-        NTgvIiwgInRhc2tfaWQiOiAiYjk0MDM2NzItYzFjOS00ODkzLWE5NTYtODA4
-        ZTg5YzFmNTU4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiOGM3MzRj
-        MTlmZjUwNzk4MjNmNDViIn0sICJpZCI6ICI1NmI4YzczNGMxOWZmNTA3OTgy
-        M2Y0NWIifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:49:56 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/b9403672-c1c9-4893-a956-808e89c1f558/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="eYKCSbeLrgweJqOpCC5C8wqSHsmUJZxxZtRiiRG8hI",
-        oauth_signature="tWo1gvZYtpLDq70IYQmC%2FXNpuqo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950197", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:49:57 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iOTQwMzY3Mi1jMWM5LTQ4OTMtYTk1Ni04MDhlODljMWY1
-        NTgvIiwgInRhc2tfaWQiOiAiYjk0MDM2NzItYzFjOS00ODkzLWE5NTYtODA4
-        ZTg5YzFmNTU4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo0OTo1N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo0OTo1N1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvY2FmNGRlMjgtYjE2Yy00ZDUxLTk1N2EtNDE2YTE3OTJi
-        Yjc4LyIsICJ0YXNrX2lkIjogImNhZjRkZTI4LWIxNmMtNGQ1MS05NTdhLTQx
-        NmExNzkyYmI3OCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjNzM0MTdmMjVlMGRhNDhiODQ4ZCJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NDk6NTdaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo0OTo1N1oiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjNzM1MTdmMjVlMTEyYWU4OGI2YyIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNzM0YzE5ZmY1
-        MDc5ODIzZjQ1YiJ9LCAiaWQiOiAiNTZiOGM3MzRjMTlmZjUwNzk4MjNmNDVi
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:49:57 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/caf4de28-b16c-4d51-957a-416a1792bb78/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="PaxXSkJ1Y7G2Flh0j9lJpI4eAUNZ6WzQQjBVFsH0",
-        oauth_signature="aTfX8nvHUkJplL%2BFtWwn%2BRUmXxk%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950197", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:49:57 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3509'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9jYWY0ZGUyOC1iMTZjLTRkNTEtOTU3YS00MTZh
-        MTc5MmJiNzgvIiwgInRhc2tfaWQiOiAiY2FmNGRlMjgtYjE2Yy00ZDUxLTk1
-        N2EtNDE2YTE3OTJiYjc4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wOFQxNjo0OTo1N1oiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        IjogImEzMjlhNjA5LWJhOWItNDZjZC04NzM5LTZhOWVlNDk5OWI3NiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4MjRi
-        YjQzMy00Nzc0LTQyMTAtOTcyNy01OTczZTllNTFmOTQiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWRlMDVkMWMtNjI1
-        Yi00NmNiLTliNmQtNmIwYzM1NTRlYTE4IiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiNDMxNzg2NDMtZGQwYi00ODA5LTg0NTAtMmFjYjg3NDc1ZDBjIiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTJhYzIxN2EtZTU2NS00OWI5LWFl
-        ZmItZDkzZWFkNDIzMTFhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0OGY5
+        NTliMy1hYTBiLTRmMDEtOGU2MC1hYjRhNmExODA5YjMiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICJlZmIzYTk4OC04ZjM5LTRhYWYtYjQ5My05ZmRlZDI3MDk4
+        NDAiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiZmE5Nzk1YS0wOTNl
+        LTQ4YmMtYTM1OC00NzNmOGFlOTRiYjkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiODBkYmU1ZjQtNzc2ZS00ZTA0LTliNTQtYTE4MjFjNWJkOGVmIiwg
+        Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
+        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA5ODExYzE4LWJjNWMtNDY4
+        OC1hZDc3LTJiNTI1ZWFkNTQyZCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
+        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogImY4NmY4MjNhLWVmNjEtNGI4ZS04ZmYwLWM2ZWI1MTBiNGQxMyIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQ1
-        MDI1OGI3LTc2NjQtNDU2OS05OTQ5LTczZWZkOWRiZDlmNSIsICJudW1fcHJv
-        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJjN2NjY2RjMi02NzJiLTQ3ODAtODg5Zi1h
-        NjgzNzY5ZGRlYmUiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEu
-        IiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJi
-        N2E3MWJmNy1hOWRlLTQxZDMtOTMzYi1jYWNiOWJjMGI2NjgiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9u
-        IjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xv
-        c2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3ODY4NTE1NC1l
-        NjE1LTQ4MzMtYmJiMS1kMmU1NWRiNzQ5OWYiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVy
-        YXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBz
-        cWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmM2E3ZDAxOC1jOWVkLTRkZTAtODU3
-        NC05ZjJlY2JjZjlhN2QiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMg
-        dG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI2NmVhY2Y0ZC1kMDhlLTRjNzAtYWZiZi0yYTM5NDZi
-        MjgzNTEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImEwYWM1YTQ4LTJhMzAtNGQ0ZS1iZDIxLTkzMWRlZWE5
-        MjE4MCIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5l
-        eGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9u
-        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2Vu
-        dG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNzM1YzE5ZmY1MDc5
-        ODIzZjQ2YiJ9LCAiaWQiOiAiNTZiOGM3MzVjMTlmZjUwNzk4MjNmNDZiIn0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:49:57 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/b9403672-c1c9-4893-a956-808e89c1f558/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="Rc3GXlSOMTLMpiZKQ9zDSj7JYUBId059AoVAVWTooMQ",
-        oauth_signature="YSJbnYLondrw3ZaXvhinQOEamrY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950198", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:49:58 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iOTQwMzY3Mi1jMWM5LTQ4OTMtYTk1Ni04MDhlODljMWY1
-        NTgvIiwgInRhc2tfaWQiOiAiYjk0MDM2NzItYzFjOS00ODkzLWE5NTYtODA4
-        ZTg5YzFmNTU4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo0OTo1N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo0OTo1N1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvY2FmNGRlMjgtYjE2Yy00ZDUxLTk1N2EtNDE2YTE3OTJi
-        Yjc4LyIsICJ0YXNrX2lkIjogImNhZjRkZTI4LWIxNmMtNGQ1MS05NTdhLTQx
-        NmExNzkyYmI3OCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjNzM0MTdmMjVlMGRhNDhiODQ4ZCJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NDk6NTdaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo0OTo1N1oiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjNzM1MTdmMjVlMTEyYWU4OGI2YyIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNzM0YzE5ZmY1
-        MDc5ODIzZjQ1YiJ9LCAiaWQiOiAiNTZiOGM3MzRjMTlmZjUwNzk4MjNmNDVi
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:49:58 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/caf4de28-b16c-4d51-957a-416a1792bb78/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="MeeNlnPqEsRO5v10xZOAc9GGAWPUjcyZASXAxXp8tE",
-        oauth_signature="2mgh%2BAUWWD5HG%2BG3w69tfl9Bj%2BM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950198", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:49:58 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6941'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9jYWY0ZGUyOC1iMTZjLTRkNTEtOTU3YS00MTZh
-        MTc5MmJiNzgvIiwgInRhc2tfaWQiOiAiY2FmNGRlMjgtYjE2Yy00ZDUxLTk1
-        N2EtNDE2YTE3OTJiYjc4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wOFQxNjo0OTo1N1oiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo0OTo1N1oiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI4MjRiYjQzMy00Nzc0LTQyMTAtOTcyNy01OTczZTll
-        NTFmOTQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYWRlMDVkMWMtNjI1Yi00NmNiLTliNmQtNmIwYzM1NTRlYTE4Iiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNDMxNzg2NDMtZGQwYi00ODA5LTg0NTAt
-        MmFjYjg3NDc1ZDBjIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTJh
-        YzIxN2EtZTU2NS00OWI5LWFlZmItZDkzZWFkNDIzMTFhIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjQ1MDI1OGI3LTc2NjQtNDU2OS05OTQ5LTczZWZk
-        OWRiZDlmNSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjN2NjY2Rj
-        Mi02NzJiLTQ3ODAtODg5Zi1hNjgzNzY5ZGRlYmUiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJiN2E3MWJmNy1hOWRlLTQxZDMtOTMzYi1jYWNi
-        OWJjMGI2NjgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI3ODY4NTE1NC1lNjE1LTQ4MzMtYmJiMS1kMmU1NWRiNzQ5OWYi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmM2E3
-        ZDAxOC1jOWVkLTRkZTAtODU3NC05ZjJlY2JjZjlhN2QiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2NmVhY2Y0ZC1kMDhl
-        LTRjNzAtYWZiZi0yYTM5NDZiMjgzNTEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImEwYWM1YTQ4LTJhMzAtNGQ0
-        ZS1iZDIxLTkzMWRlZWE5MjE4MCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Y2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAy
-        LTA4VDE2OjQ5OjU3WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMi
-        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMDhUMTY6NDk6NTdaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0
-        cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJ
-        UFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQi
-        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjog
-        IkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklO
-        SVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hf
-        ZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIs
-        ICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51
-        bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZi
-        OGM3MzUxN2YyNWUxMTJhZTg4YjZkIiwgImRldGFpbHMiOiBbeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
-        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
-        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM2
+        ZGYwYWQxLTM4YjUtNDRlYi1iYTZiLTA1N2MxZWM3NzE4ZSIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
+        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
+        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjU3MjhmYjBiLTIxNDYt
+        NDQ4ZC1hODQwLWU5MThjNGVmY2ZlMyIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
+        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjgyNGJiNDMzLTQ3NzQtNDIxMC05NzI3
-        LTU5NzNlOWU1MWY5NCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
-        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJhZGUwNWQxYy02MjViLTQ2Y2ItOWI2ZC02YjBjMzU1
-        NGVhMTgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        OCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
-        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0MzE3ODY0My1kZDBiLTQ4
-        MDktODQ1MC0yYWNiODc0NzVkMGMiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7
-        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICIxMmFjMjE3YS1lNTY1LTQ5YjktYWVmYi1kOTNlYWQ0MjMxMWEiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
-        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDUwMjU4YjctNzY2NC00NTY5LTk5
-        NDktNzNlZmQ5ZGJkOWY1IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBz
-        IGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjog
-        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImM3Y2NjZGMyLTY3MmItNDc4MC04ODlmLWE2ODM3NjlkZGViZSIsICJudW1f
-        cHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI3YTcxYmY3LWE5ZGUtNDFkMy05
-        MzNiLWNhY2I5YmMwYjY2OCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjc4Njg1MTU0LWU2MTUtNDgzMy1iYmIxLWQyZTU1
-        ZGI3NDk5ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMi
-        LCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImYzYTdkMDE4LWM5ZWQtNGRlMC04NTc0LTlmMmVjYmNmOWE3ZCIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBl
-        IjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjY2ZWFj
-        ZjRkLWQwOGUtNGM3MC1hZmJmLTJhMzk0NmIyODM1MSIsICJudW1fcHJvY2Vz
-        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
-        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTBhYzVhNDgt
-        MmEzMC00ZDRlLWJkMjEtOTMxZGVlYTkyMTgwIiwgIm51bV9wcm9jZXNzZWQi
-        OiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Yjhj
-        NzM1YzE5ZmY1MDc5ODIzZjQ2YiJ9LCAiaWQiOiAiNTZiOGM3MzVjMTlmZjUw
-        Nzk4MjNmNDZiIn0=
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImViZTI3MjEzLTJjNzYtNDBkZC04ZDI3
+        LTYzZWM2NzBmZDE0ZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
+        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiMTU5ZTRlNTUtYzA5ZS00YjA1LWFmYTQtYmQ2
+        ZWE1NzYyMjM2IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDc4OTg5MDU0ZmM0OGJhMzA2
+        YSJ9LCAiaWQiOiAiNTZjYzhkNzg5ODkwNTRmYzQ4YmEzMDZhIn0=
     http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:49:58 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/0881ff83-b864-44e4-bebc-c05d2e09effe/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="q5UAzdOhgznHMzzQQXlMXlXUg7kbTBegfSPuywig",
-        oauth_signature="khjo%2FpatAXx4VRB7iviCbMIX8Gw%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950198", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:49:58 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wODgxZmY4My1iODY0LTQ0ZTQtYmViYy1jMDVkMmUwOWVm
-        ZmUvIiwgInRhc2tfaWQiOiAiMDg4MWZmODMtYjg2NC00NGU0LWJlYmMtYzA1
-        ZDJlMDllZmZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI4Yzcz
-        NmMxOWZmNTA3OTgyM2Y0NmMifSwgImlkIjogIjU2YjhjNzM2YzE5ZmY1MDc5
-        ODIzZjQ2YyJ9
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:49:58 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/0881ff83-b864-44e4-bebc-c05d2e09effe/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="iJo1yTLWvpvzJh4jEcusxSrx6SLV9riCwYFLsXFqWw",
-        oauth_signature="BzhhsGEbdlARacJgvCH3kwBn2Gs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950199", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:49:59 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '700'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wODgxZmY4My1iODY0LTQ0ZTQtYmViYy1jMDVkMmUwOWVm
-        ZmUvIiwgInRhc2tfaWQiOiAiMDg4MWZmODMtYjg2NC00NGU0LWJlYmMtYzA1
-        ZDJlMDllZmZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA4VDE2OjQ5OjU4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA4VDE2OjQ5OjU4WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20uZHEiLCAic3Rh
-        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUu
-        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNTZiOGM3MzZjMTlmZjUwNzk4MjNmNDZjIn0sICJpZCI6ICI1
-        NmI4YzczNmMxOWZmNTA3OTgyM2Y0NmMifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:49:59 GMT
+  recorded_at: Tue, 23 Feb 2016 16:48:57 GMT
 - request:
     method: post
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
-        IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRp
-        c3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwi
-        OiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3Rl
-        Y3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJleHBvcnRfZGlzdHJpYnV0
-        b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBz
-        IjpmYWxzZSwicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIn0sImF1dG9fcHVi
-        bGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1
-        dG9yIn1dfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb",
-        oauth_nonce="5Q7Sfk3wwro6tcO3nslUPs8OvQXeYlbZbQJFoyXRvkE", oauth_signature="ZF%2BmdDYV0mVTlYr2SHSCvYMd5%2B0%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454950200", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '817'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:50:00 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '320'
-      Location:
-      - https://katello-centos7-devel.example.com/pulp/api/v2/repositories/Fedora_17/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: US-ASCII
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiOGM3MzgxN2YyNWUwZGE0OGI4NDkxIn0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:50:00 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/1877d756-5b9e-48ca-9267-af159d99046b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="3i6XcBOJqe9yceCfLa0F1IqwN3u4Bcfbk8l40ZnnpEA",
-        oauth_signature="rGmk8W3rqRV6Mu%2Fs2TvqqosJA0U%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950200", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:50:00 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xODc3ZDc1Ni01YjllLTQ4Y2EtOTI2Ny1hZjE1OWQ5OTA0
-        NmIvIiwgInRhc2tfaWQiOiAiMTg3N2Q3NTYtNWI5ZS00OGNhLTkyNjctYWYx
-        NTlkOTkwNDZiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiOGM3Mzhj
-        MTlmZjUwNzk4MjNmNDZkIn0sICJpZCI6ICI1NmI4YzczOGMxOWZmNTA3OTgy
-        M2Y0NmQifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:50:00 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/1877d756-5b9e-48ca-9267-af159d99046b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="jS3gQUDBYmfai62elzxV4CQIArRSuPTXMn0QS0CDlw",
-        oauth_signature="dIUGA7z6mDnAXcX18fu6ThKPC%2F4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950200", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:50:00 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xODc3ZDc1Ni01YjllLTQ4Y2EtOTI2Ny1hZjE1OWQ5OTA0
-        NmIvIiwgInRhc2tfaWQiOiAiMTg3N2Q3NTYtNWI5ZS00OGNhLTkyNjctYWYx
-        NTlkOTkwNDZiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo1MDowMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo1MDowMFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMjk5MjFjN2QtZDQ4My00MzhhLTllY2EtN2IwYjEzODYz
-        MzRjLyIsICJ0YXNrX2lkIjogIjI5OTIxYzdkLWQ0ODMtNDM4YS05ZWNhLTdi
-        MGIxMzg2MzM0YyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjNzM4MTdmMjVlMGRhNDhiODQ5MiJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NTA6MDBaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo1MDowMFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjNzM4MTdmMjVlMTEyYWU4OGI3MSIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNzM4YzE5ZmY1
-        MDc5ODIzZjQ2ZCJ9LCAiaWQiOiAiNTZiOGM3MzhjMTlmZjUwNzk4MjNmNDZk
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:50:00 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/29921c7d-d483-438a-9eca-7b0b1386334c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="fe06s0FfjDOSCTJpFlGGA9BS9wewQaLBki9WwpMtb4",
-        oauth_signature="LlJmFWQheK8f4mEzQSHmZUV%2FHpI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950200", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:50:00 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3528'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8yOTkyMWM3ZC1kNDgzLTQzOGEtOWVjYS03YjBi
-        MTM4NjMzNGMvIiwgInRhc2tfaWQiOiAiMjk5MjFjN2QtZDQ4My00MzhhLTll
-        Y2EtN2IwYjEzODYzMzRjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wOFQxNjo1MDowMFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjODJl
-        ZmNlMi1iNGQ4LTQyM2EtYmQxMi0zMzE4ZDY5NWRiOGMiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzI1ZGI4N2EtMzM3
-        ZS00Zjk2LTgxMmQtNTY2YTAxMGFlY2FiIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiNTk1MTFhYzAtZjM1Yi00NGNiLThmNjAtMzI2YmJkNzc0ODI3IiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWZhNmVmNTctNGJkZi00ZTcyLWFi
-        NGItNjMxNzkzZWYwMzczIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImM2OTk1NjRjLTI3ZmEtNDlhMi05Y2E4LWNiYzQ4NDU3MTMzZiIsICJudW1f
-        cHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJj
-        b21wcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlOTQ5YjU1OC0yYWRjLTQ1MTEt
-        YTU4Mi1lZGZkOWIyZWI4NzIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
-        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0
-        YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI4MjViMmM0Yi00NGVhLTQ3ZDktYWFhOC1kNDdlOWFjNjQ1YTgi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICIzY2M5NWZlYS03ZDcyLTRhNTktYTRhNi02ZjQzYjBhNDhjYTYiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
-        aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTcwYzVk
-        MmUtZDdhNS00MGQwLWE5OWUtZDkzNTI2NDFhNDQ3IiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
-        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
-        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGQ1YzcxY2MtMTgx
-        Yy00Y2I2LWEzNTAtMDhlMDU0MDAzNDgwIiwgIm51bV9wcm9jZXNzZWQiOiAw
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5n
-        IExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVw
-        b19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
-        U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjZTc3MTk2NS0xYzg4
-        LTRmNmItYjI2My04ZWU5NmM1MTI0MzMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
-        bGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        cnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
-        b3JrZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20iLCAi
-        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
-        ICI1NmI4YzczOGMxOWZmNTA3OTgyM2Y0N2QifSwgImlkIjogIjU2YjhjNzM4
-        YzE5ZmY1MDc5ODIzZjQ3ZCJ9
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:50:01 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/1877d756-5b9e-48ca-9267-af159d99046b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="SsygHsVsadBskRs02TWn29HK91blnBDdYR5rkKFoWo",
-        oauth_signature="uPtssrcZqW1E8JpjXbmgc1SLmB4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950201", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:50:01 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xODc3ZDc1Ni01YjllLTQ4Y2EtOTI2Ny1hZjE1OWQ5OTA0
-        NmIvIiwgInRhc2tfaWQiOiAiMTg3N2Q3NTYtNWI5ZS00OGNhLTkyNjctYWYx
-        NTlkOTkwNDZiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo1MDowMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo1MDowMFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMjk5MjFjN2QtZDQ4My00MzhhLTllY2EtN2IwYjEzODYz
-        MzRjLyIsICJ0YXNrX2lkIjogIjI5OTIxYzdkLWQ0ODMtNDM4YS05ZWNhLTdi
-        MGIxMzg2MzM0YyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjNzM4MTdmMjVlMGRhNDhiODQ5MiJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NTA6MDBaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo1MDowMFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjNzM4MTdmMjVlMTEyYWU4OGI3MSIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNzM4YzE5ZmY1
-        MDc5ODIzZjQ2ZCJ9LCAiaWQiOiAiNTZiOGM3MzhjMTlmZjUwNzk4MjNmNDZk
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:50:01 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/29921c7d-d483-438a-9eca-7b0b1386334c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="9JF901eHOGy81DC3THckTkRQhF7d13ueeVkbpFRH0ik",
-        oauth_signature="679ArTUG4ymgbBSY1wG2PzA0%2B%2Bs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950201", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:50:01 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6941'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8yOTkyMWM3ZC1kNDgzLTQzOGEtOWVjYS03YjBi
-        MTM4NjMzNGMvIiwgInRhc2tfaWQiOiAiMjk5MjFjN2QtZDQ4My00MzhhLTll
-        Y2EtN2IwYjEzODYzMzRjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wOFQxNjo1MDowMVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo1MDowMFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJjODJlZmNlMi1iNGQ4LTQyM2EtYmQxMi0zMzE4ZDY5
-        NWRiOGMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMzI1ZGI4N2EtMzM3ZS00Zjk2LTgxMmQtNTY2YTAxMGFlY2FiIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNTk1MTFhYzAtZjM1Yi00NGNiLThmNjAt
-        MzI2YmJkNzc0ODI3IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWZh
-        NmVmNTctNGJkZi00ZTcyLWFiNGItNjMxNzkzZWYwMzczIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImM2OTk1NjRjLTI3ZmEtNDlhMi05Y2E4LWNiYzQ4
-        NDU3MTMzZiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlOTQ5YjU1
-        OC0yYWRjLTQ1MTEtYTU4Mi1lZGZkOWIyZWI4NzIiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI4MjViMmM0Yi00NGVhLTQ3ZDktYWFhOC1kNDdl
-        OWFjNjQ1YTgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIzY2M5NWZlYS03ZDcyLTRhNTktYTRhNi02ZjQzYjBhNDhjYTYi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5NzBj
-        NWQyZS1kN2E1LTQwZDAtYTk5ZS1kOTM1MjY0MWE0NDciLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwZDVjNzFjYy0xODFj
-        LTRjYjYtYTM1MC0wOGUwNTQwMDM0ODAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNlNzcxOTY1LTFjODgtNGY2
-        Yi1iMjYzLThlZTk2YzUxMjQzMyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Y2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAy
-        LTA4VDE2OjUwOjAwWiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMi
-        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMDhUMTY6NTA6MDFaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0
-        cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJ
-        UFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQi
-        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjog
-        IkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklO
-        SVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hf
-        ZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIs
-        ICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51
-        bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZi
-        OGM3MzkxN2YyNWUxMTJhZTg4YjcyIiwgImRldGFpbHMiOiBbeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
-        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
-        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImM4MmVmY2UyLWI0ZDgtNDIzYS1iZDEy
-        LTMzMThkNjk1ZGI4YyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
-        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIzMjVkYjg3YS0zMzdlLTRmOTYtODEyZC01NjZhMDEw
-        YWVjYWIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        OCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
-        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1OTUxMWFjMC1mMzViLTQ0
-        Y2ItOGY2MC0zMjZiYmQ3NzQ4MjciLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7
-        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICJhZmE2ZWY1Ny00YmRmLTRlNzItYWI0Yi02MzE3OTNlZjAzNzMiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
-        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzY5OTU2NGMtMjdmYS00OWEyLTlj
-        YTgtY2JjNDg0NTcxMzNmIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBz
-        IGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjog
-        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImU5NDliNTU4LTJhZGMtNDUxMS1hNTgyLWVkZmQ5YjJlYjg3MiIsICJudW1f
-        cHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjgyNWIyYzRiLTQ0ZWEtNDdkOS1h
-        YWE4LWQ0N2U5YWM2NDVhOCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjNjYzk1ZmVhLTdkNzItNGE1OS1hNGE2LTZmNDNi
-        MGE0OGNhNiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMi
-        LCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjk3MGM1ZDJlLWQ3YTUtNDBkMC1hOTllLWQ5MzUyNjQxYTQ0NyIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBl
-        IjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBkNWM3
-        MWNjLTE4MWMtNGNiNi1hMzUwLTA4ZTA1NDAwMzQ4MCIsICJudW1fcHJvY2Vz
-        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
-        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiY2U3NzE5NjUt
-        MWM4OC00ZjZiLWIyNjMtOGVlOTZjNTEyNDMzIiwgIm51bV9wcm9jZXNzZWQi
-        OiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Yjhj
-        NzM4YzE5ZmY1MDc5ODIzZjQ3ZCJ9LCAiaWQiOiAiNTZiOGM3MzhjMTlmZjUw
-        Nzk4MjNmNDdkIn0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:50:01 GMT
-- request:
-    method: post
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/content/units/erratum/search/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiM2NlYzU2
-        N2EtNjVmYi00ODExLTk1MDYtNDA5ODMxOWJjMWE5IiwiYTQxNWYyMmUtOTIx
-        OC00Mzg2LWFmZDctYTg2MWEwNzNhYjJlIiwiYWNkYzA3MmEtNTkyNC00ZDgx
-        LWJhN2EtNjgxOTZmNzQyY2VjIl19fX0sImluY2x1ZGVfcmVwb3MiOnRydWV9
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb",
-        oauth_nonce="jJgy0Dl1YYMbc8fjrGLNVTgRMxxdSuV7w3nlsOMbuo", oauth_signature="PAMn9CfjwmSS9qk1M%2BfnysG65E0%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454950201", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '180'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:50:01 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4700'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJf
-        aHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9lcnJhdHVtLzNj
-        ZWM1NjdhLTY1ZmItNDgxMS05NTA2LTQwOTgzMTliYzFhOS8iLCAiaXNzdWVk
-        IjogIjIwMTAtMDEtMDEgMDE6MDE6MDEiLCAicmVmZXJlbmNlcyI6IFtdLCAi
-        cHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lkIjog
-        ImVycmF0dW0iLCAiaWQiOiAiUkhFQS0yMDEwOjAwMDEiLCAiZnJvbSI6ICJs
-        emFwK3B1YkByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRsZSI6
-        ICJFbXB0eSBlcnJhdGEiLCAiY2hpbGRyZW4iOiB7fSwgInZlcnNpb24iOiAi
-        MSIsICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3Vy
-        aXR5IiwgInBrZ2xpc3QiOiBbXSwgInN0YXR1cyI6ICJzdGFibGUiLCAidXBk
-        YXRlZCI6ICIiLCAiZGVzY3JpcHRpb24iOiAiRW1wdHkgZXJyYXRhIiwgIl9s
-        YXN0X3VwZGF0ZWQiOiAiMjAxNi0wMi0wOFQxNjo1MDowMFoiLCAicHVzaGNv
-        dW50IjogIiIsICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1t
-        YXJ5IjogIiIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjNjZWM1NjdhLTY1
-        ZmItNDgxMS05NTA2LTQwOTgzMTliYzFhOSJ9LCB7InJlcG9zaXRvcnlfbWVt
-        YmVyc2hpcHMiOiBbIkZlZG9yYV8xNyJdLCAiX2hyZWYiOiAiL3B1bHAvYXBp
-        L3YyL2NvbnRlbnQvdW5pdHMvZXJyYXR1bS9hNDE1ZjIyZS05MjE4LTQzODYt
-        YWZkNy1hODYxYTA3M2FiMmUvIiwgImlzc3VlZCI6ICIyMDEwLTAxLTAxIDAx
-        OjAxOjAxIiwgInJlZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0
-        YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjog
-        IlJIRUEtMjAxMDowMDAyIiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0LmNv
-        bSIsICJzZXZlcml0eSI6ICIiLCAidGl0bGUiOiAiT25lIHBhY2thZ2UgZXJy
-        YXRhIiwgImNoaWxkcmVuIjoge30sICJ2ZXJzaW9uIjogIjEiLCAicmVib290
-        X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2ds
-        aXN0IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRv
-        cmFwcm9qZWN0Lm9yZyIsICJuYW1lIjogImVsZXBoYW50IiwgInN1bSI6IG51
-        bGwsICJmaWxlbmFtZSI6ICJlbGVwaGFudC0wLjMtMC44Lm5vYXJjaC5ycG0i
-        LCAiZXBvY2giOiBudWxsLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6
-        ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogIjEiLCAic2hv
-        cnQiOiAiIn1dLCAic3RhdHVzIjogInN0YWJsZSIsICJ1cGRhdGVkIjogIiIs
-        ICJkZXNjcmlwdGlvbiI6ICJPbmUgcGFja2FnZSBlcnJhdGEiLCAiX2xhc3Rf
-        dXBkYXRlZCI6ICIyMDE2LTAyLTA4VDE2OjUwOjAwWiIsICJwdXNoY291bnQi
-        OiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnki
-        OiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiYTQxNWYyMmUtOTIxOC00
-        Mzg2LWFmZDctYTg2MWEwNzNhYjJlIn0sIHsicmVwb3NpdG9yeV9tZW1iZXJz
-        aGlwcyI6IFsiRmVkb3JhXzE3Il0sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIv
-        Y29udGVudC91bml0cy9lcnJhdHVtL2FjZGMwNzJhLTU5MjQtNGQ4MS1iYTdh
-        LTY4MTk2Zjc0MmNlYy8iLCAiaXNzdWVkIjogIjIwMTAtMTEtMTAgMDA6MDA6
-        MDAiLCAicmVmZXJlbmNlcyI6IFt7ImhyZWYiOiAiaHR0cHM6Ly9yaG4ucmVk
-        aGF0LmNvbS9lcnJhdGEvUkhTQS0yMDEwLTA4NTguaHRtbCIsICJ0eXBlIjog
-        InNlbGYiLCAiaWQiOiBudWxsLCAidGl0bGUiOiBudWxsfSwgeyJocmVmIjog
-        Imh0dHBzOi8vYnVnemlsbGEucmVkaGF0LmNvbS9idWd6aWxsYS9zaG93X2J1
-        Zy5jZ2k/aWQ9NjI3ODgyIiwgInR5cGUiOiAiYnVnemlsbGEiLCAiaWQiOiAi
-        NjI3ODgyIiwgInRpdGxlIjogbnVsbH0sIHsiaHJlZiI6ICJodHRwczovL3d3
-        dy5yZWRoYXQuY29tL3NlY3VyaXR5L2RhdGEvY3ZlL0NWRS0yMDEwLTA0MDUu
-        aHRtbCIsICJ0eXBlIjogImN2ZSIsICJpZCI6ICJDVkUtMjAxMC0wNDA1Iiwg
-        InRpdGxlIjogbnVsbH0sIHsiaHJlZiI6ICJodHRwOi8vd3d3LnJlZGhhdC5j
-        b20vc2VjdXJpdHkvdXBkYXRlcy9jbGFzc2lmaWNhdGlvbi8jaW1wb3J0YW50
-        IiwgInR5cGUiOiAib3RoZXIiLCAiaWQiOiBudWxsLCAidGl0bGUiOiBudWxs
-        fV0sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAiZXJyYXR1bSIsICJpZCI6ICJSSFNBLTIwMTA6MDg1OCIsICJmcm9t
-        IjogInNlY3VyaXR5QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiSW1wb3J0
-        YW50IiwgInRpdGxlIjogIkltcG9ydGFudDogYnppcDIgc2VjdXJpdHkgdXBk
-        YXRlIiwgImNoaWxkcmVuIjoge30sICJ2ZXJzaW9uIjogIjMiLCAicmVib290
-        X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2ds
-        aXN0IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiYnppcDItMS4wLjUtNy5l
-        bDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDItZGV2ZWwiLCAic3VtIjog
-        WyJzaGEyNTYiLCAiZWE2N2M2NjRkYTFmZjk2YTZkYzk0ZDMzMDA5YjczZDhm
-        YWIzMWI1OTgyNDE4M2ZiNDVlOWJhMmViZjgyZDU4MyJdLCAiZmlsZW5hbWUi
-        OiAiYnppcDItZGV2ZWwtMS4wLjUtNy5lbDZfMC5pNjg2LnJwbSIsICJlcG9j
-        aCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVs
-        Nl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03
-        LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJzIiwgInN1bSI6
-        IFsic2hhMjU2IiwgImM5ZjA2NGE2ODYyNTczZmI5ZjJhNmFmZjdjMzYyMWYx
-        OTQwYjQ5MmRmMmVkZmMyZWJiZGMwYjgzMDVmNTExNDciXSwgImZpbGVuYW1l
-        IjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC5pNjg2LnJwbSIsICJlcG9j
-        aCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVs
-        Nl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03
-        LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMiIsICJzdW0iOiBbInNo
-        YTI1NiIsICJiOGEzZjcyYmMyYjBkODliYTczNzA5OWFjOThiZjhkMmFmNGJl
-        YTAyZDMxODg0YzAyZGI5N2Y3ZjY2YzNkNWMyIl0sICJmaWxlbmFtZSI6ICJi
-        emlwMi0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0iLCAiZXBvY2giOiAiMCIs
-        ICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJh
-        cmNoIjogIng4Nl82NCJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8w
-        LnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1kZXZlbCIsICJzdW0iOiBbInNo
-        YTI1NiIsICI3ZjYzMTI0ZTQ2NTViN2M5MmQyM2VjNGMzODIyNmY1ZDM3NDY1
-        Njg4NTNkZmY3NTBmYzg1ZTA1OGU3NGI1Y2Y2Il0sICJmaWxlbmFtZSI6ICJi
-        emlwMi1kZXZlbC0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0iLCAiZXBvY2gi
-        OiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZf
-        MCIsICJhcmNoIjogIng4Nl82NCJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03
-        LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJzIiwgInN1bSI6
-        IFsic2hhMjU2IiwgIjgwMmY0Mzk5ZGJkZDAxNDc2ZTI1NGMzYjMyYzQwYWZm
-        NTljZjVkMjNhNDVmYTQ4OGM2OTE3Y2U4OTA0ZDZiNGQiXSwgImZpbGVuYW1l
-        IjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVw
-        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcu
-        ZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQifV0sICJuYW1lIjogIlJlZCBIYXQg
-        RW50ZXJwcmlzZSBMaW51eCBTZXJ2ZXIgKHYuIDYgZm9yIDY0LWJpdCB4ODZf
-        NjQpIiwgInNob3J0IjogInJoZWwteDg2XzY0LXNlcnZlci02In1dLCAic3Rh
-        dHVzIjogImZpbmFsIiwgInVwZGF0ZWQiOiAiMjAxMC0xMS0xMCAwMDowMDow
-        MCIsICJkZXNjcmlwdGlvbiI6ICJiemlwMiBpcyBhIGZyZWVseSBhdmFpbGFi
-        bGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNvbXByZXNzb3IuIEl0IHByb3ZpZGVz
-        IGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11c3QgYmUgcmVzdGFydGVkIGZvciB0
-        aGUgdXBkYXRlIHRvIHRha2UgZWZmZWN0LiIsICJfbGFzdF91cGRhdGVkIjog
-        IjIwMTYtMDItMDhUMTY6NTA6MDBaIiwgInB1c2hjb3VudCI6ICIiLCAicmln
-        aHRzIjogIkNvcHlyaWdodCAyMDEwIFJlZCBIYXQgSW5jIiwgInNvbHV0aW9u
-        IjogIkJlZm9yZSBhcHBseWluZyB0aGlzIHVwZGF0ZSwgbWFrZSBzdXJlIGFs
-        bCBwcmV2aW91c2x5LXJlbGVhc2VkIGVycmF0YVxucmVsZXZhbnQgdG8geW91
-        ciBzeXN0ZW0gaGF2ZSBiZWVuIGFwcGxpZWQuXG5cblRoaXMgdXBkYXRlIGlz
-        IGF2YWlsYWJsZSB2aWEgdGhlIFJlZCBIYXQgTmV0d29yay4gRGV0YWlscyBv
-        biBob3cgdG9cbnVzZSB0aGUgUmVkIEhhdCBOZXR3b3JrIHRvIGFwcGx5IHRo
-        aXMgdXBkYXRlIGFyZSBhdmFpbGFibGUgYXRcbmh0dHA6Ly9rYmFzZS5yZWRo
-        YXQuY29tL2ZhcS9kb2NzL0RPQy0xMTI1OSIsICJzdW1tYXJ5IjogIlVwZGF0
-        ZWQgYnppcDIgcGFja2FnZXMgdGhhdCBmaXggb25lIHNlY3VyaXR5IGlzc3Vl
-        IiwgInJlbGVhc2UiOiAiIiwgIl9pZCI6ICJhY2RjMDcyYS01OTI0LTRkODEt
-        YmE3YS02ODE5NmY3NDJjZWMifV0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:50:01 GMT
-- request:
-    method: post
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/content/units/erratum/search/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiYWNkYzA3
-        MmEtNTkyNC00ZDgxLWJhN2EtNjgxOTZmNzQyY2VjIl19fX0sImluY2x1ZGVf
-        cmVwb3MiOnRydWV9
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb",
-        oauth_nonce="SnvIgnU1pPvW49fkcONvr31aCZKLbh6j026BGGg", oauth_signature="0UKXp0%2B5XwDDhH5gqol0eWDpNHY%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454950201", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '102'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:50:01 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3146'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJf
-        aHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9lcnJhdHVtL2Fj
-        ZGMwNzJhLTU5MjQtNGQ4MS1iYTdhLTY4MTk2Zjc0MmNlYy8iLCAiaXNzdWVk
-        IjogIjIwMTAtMTEtMTAgMDA6MDA6MDAiLCAicmVmZXJlbmNlcyI6IFt7Imhy
-        ZWYiOiAiaHR0cHM6Ly9yaG4ucmVkaGF0LmNvbS9lcnJhdGEvUkhTQS0yMDEw
-        LTA4NTguaHRtbCIsICJ0eXBlIjogInNlbGYiLCAiaWQiOiBudWxsLCAidGl0
-        bGUiOiBudWxsfSwgeyJocmVmIjogImh0dHBzOi8vYnVnemlsbGEucmVkaGF0
-        LmNvbS9idWd6aWxsYS9zaG93X2J1Zy5jZ2k/aWQ9NjI3ODgyIiwgInR5cGUi
-        OiAiYnVnemlsbGEiLCAiaWQiOiAiNjI3ODgyIiwgInRpdGxlIjogbnVsbH0s
-        IHsiaHJlZiI6ICJodHRwczovL3d3dy5yZWRoYXQuY29tL3NlY3VyaXR5L2Rh
-        dGEvY3ZlL0NWRS0yMDEwLTA0MDUuaHRtbCIsICJ0eXBlIjogImN2ZSIsICJp
-        ZCI6ICJDVkUtMjAxMC0wNDA1IiwgInRpdGxlIjogbnVsbH0sIHsiaHJlZiI6
-        ICJodHRwOi8vd3d3LnJlZGhhdC5jb20vc2VjdXJpdHkvdXBkYXRlcy9jbGFz
-        c2lmaWNhdGlvbi8jaW1wb3J0YW50IiwgInR5cGUiOiAib3RoZXIiLCAiaWQi
-        OiBudWxsLCAidGl0bGUiOiBudWxsfV0sICJwdWxwX3VzZXJfbWV0YWRhdGEi
-        OiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6ICJS
-        SFNBLTIwMTA6MDg1OCIsICJmcm9tIjogInNlY3VyaXR5QHJlZGhhdC5jb20i
-        LCAic2V2ZXJpdHkiOiAiSW1wb3J0YW50IiwgInRpdGxlIjogIkltcG9ydGFu
-        dDogYnppcDIgc2VjdXJpdHkgdXBkYXRlIiwgImNoaWxkcmVuIjoge30sICJ2
-        ZXJzaW9uIjogIjMiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlw
-        ZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFja2FnZXMiOiBbeyJz
-        cmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAi
-        YnppcDItZGV2ZWwiLCAic3VtIjogWyJzaGEyNTYiLCAiZWE2N2M2NjRkYTFm
-        Zjk2YTZkYzk0ZDMzMDA5YjczZDhmYWIzMWI1OTgyNDE4M2ZiNDVlOWJhMmVi
-        ZjgyZDU4MyJdLCAiZmlsZW5hbWUiOiAiYnppcDItZGV2ZWwtMS4wLjUtNy5l
-        bDZfMC5pNjg2LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4w
-        LjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7
-        InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6
-        ICJiemlwMi1saWJzIiwgInN1bSI6IFsic2hhMjU2IiwgImM5ZjA2NGE2ODYy
-        NTczZmI5ZjJhNmFmZjdjMzYyMWYxOTQwYjQ5MmRmMmVkZmMyZWJiZGMwYjgz
-        MDVmNTExNDciXSwgImZpbGVuYW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5l
-        bDZfMC5pNjg2LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4w
-        LjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7
-        InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6
-        ICJiemlwMiIsICJzdW0iOiBbInNoYTI1NiIsICJiOGEzZjcyYmMyYjBkODli
-        YTczNzA5OWFjOThiZjhkMmFmNGJlYTAyZDMxODg0YzAyZGI5N2Y3ZjY2YzNk
-        NWMyIl0sICJmaWxlbmFtZSI6ICJiemlwMi0xLjAuNS03LmVsNl8wLng4Nl82
-        NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJl
-        bGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9LCB7InNyYyI6
-        ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlw
-        Mi1kZXZlbCIsICJzdW0iOiBbInNoYTI1NiIsICI3ZjYzMTI0ZTQ2NTViN2M5
-        MmQyM2VjNGMzODIyNmY1ZDM3NDY1Njg4NTNkZmY3NTBmYzg1ZTA1OGU3NGI1
-        Y2Y2Il0sICJmaWxlbmFtZSI6ICJiemlwMi1kZXZlbC0xLjAuNS03LmVsNl8w
-        Lng4Nl82NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41
-        IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9LCB7
-        InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6
-        ICJiemlwMi1saWJzIiwgInN1bSI6IFsic2hhMjU2IiwgIjgwMmY0Mzk5ZGJk
-        ZDAxNDc2ZTI1NGMzYjMyYzQwYWZmNTljZjVkMjNhNDVmYTQ4OGM2OTE3Y2U4
-        OTA0ZDZiNGQiXSwgImZpbGVuYW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5l
-        bDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIx
-        LjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQi
-        fV0sICJuYW1lIjogIlJlZCBIYXQgRW50ZXJwcmlzZSBMaW51eCBTZXJ2ZXIg
-        KHYuIDYgZm9yIDY0LWJpdCB4ODZfNjQpIiwgInNob3J0IjogInJoZWwteDg2
-        XzY0LXNlcnZlci02In1dLCAic3RhdHVzIjogImZpbmFsIiwgInVwZGF0ZWQi
-        OiAiMjAxMC0xMS0xMCAwMDowMDowMCIsICJkZXNjcmlwdGlvbiI6ICJiemlw
-        MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
-        bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
-        c3QgYmUgcmVzdGFydGVkIGZvciB0aGUgdXBkYXRlIHRvIHRha2UgZWZmZWN0
-        LiIsICJfbGFzdF91cGRhdGVkIjogIjIwMTYtMDItMDhUMTY6NTA6MDBaIiwg
-        InB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjogIkNvcHlyaWdodCAyMDEwIFJl
-        ZCBIYXQgSW5jIiwgInNvbHV0aW9uIjogIkJlZm9yZSBhcHBseWluZyB0aGlz
-        IHVwZGF0ZSwgbWFrZSBzdXJlIGFsbCBwcmV2aW91c2x5LXJlbGVhc2VkIGVy
-        cmF0YVxucmVsZXZhbnQgdG8geW91ciBzeXN0ZW0gaGF2ZSBiZWVuIGFwcGxp
-        ZWQuXG5cblRoaXMgdXBkYXRlIGlzIGF2YWlsYWJsZSB2aWEgdGhlIFJlZCBI
-        YXQgTmV0d29yay4gRGV0YWlscyBvbiBob3cgdG9cbnVzZSB0aGUgUmVkIEhh
-        dCBOZXR3b3JrIHRvIGFwcGx5IHRoaXMgdXBkYXRlIGFyZSBhdmFpbGFibGUg
-        YXRcbmh0dHA6Ly9rYmFzZS5yZWRoYXQuY29tL2ZhcS9kb2NzL0RPQy0xMTI1
-        OSIsICJzdW1tYXJ5IjogIlVwZGF0ZWQgYnppcDIgcGFja2FnZXMgdGhhdCBm
-        aXggb25lIHNlY3VyaXR5IGlzc3VlIiwgInJlbGVhc2UiOiAiIiwgIl9pZCI6
-        ICJhY2RjMDcyYS01OTI0LTRkODEtYmE3YS02ODE5NmY3NDJjZWMifV0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:50:01 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/6d1ae533-2e89-4b82-8ee0-1d370e544d3c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="DhfyT7ssdhlMknxUL941QVXcbUjWSxbvSspLd2GWbM",
-        oauth_signature="1OKhbDTKqbxJKj3saxTCYRsNkEY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950202", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:50:02 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82ZDFhZTUzMy0yZTg5LTRiODItOGVlMC0xZDM3MGU1NDRk
-        M2MvIiwgInRhc2tfaWQiOiAiNmQxYWU1MzMtMmU4OS00YjgyLThlZTAtMWQz
-        NzBlNTQ0ZDNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI4Yzcz
-        YWMxOWZmNTA3OTgyM2Y0N2UifSwgImlkIjogIjU2YjhjNzNhYzE5ZmY1MDc5
-        ODIzZjQ3ZSJ9
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:50:02 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/6d1ae533-2e89-4b82-8ee0-1d370e544d3c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="VmcxS2aYo22JIKWemGNdbxgxPovDKSJUeKmE1QO8BRI",
-        oauth_signature="uoz7QjGpskYr3lCnFVW%2FCdVr2QU%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950202", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:50:02 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '700'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82ZDFhZTUzMy0yZTg5LTRiODItOGVlMC0xZDM3MGU1NDRk
-        M2MvIiwgInRhc2tfaWQiOiAiNmQxYWU1MzMtMmU4OS00YjgyLThlZTAtMWQz
-        NzBlNTQ0ZDNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA4VDE2OjUwOjAyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA4VDE2OjUwOjAyWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20uZHEiLCAic3Rh
-        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUu
-        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNTZiOGM3M2FjMTlmZjUwNzk4MjNmNDdlIn0sICJpZCI6ICI1
-        NmI4YzczYWMxOWZmNTA3OTgyM2Y0N2UifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:50:02 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/8c0ab33d-fc1f-446b-b32b-45b975c469d2/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:02:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84YzBhYjMzZC1mYzFmLTQ0NmItYjMyYi00NWI5NzVjNDY5
-        ZDIvIiwgInRhc2tfaWQiOiAiOGMwYWIzM2QtZmMxZi00NDZiLWIzMmItNDVi
-        OTc1YzQ2OWQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiZDA0ZmUz
-        NDQ3MWU0MDA3MGIwYjdhIn0sICJpZCI6ICI1NmJkMDRmZTM0NDcxZTQwMDcw
-        YjBiN2EifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:38 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/8c0ab33d-fc1f-446b-b32b-45b975c469d2/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:02:39 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2324'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84YzBhYjMzZC1mYzFmLTQ0NmItYjMyYi00NWI5NzVjNDY5
-        ZDIvIiwgInRhc2tfaWQiOiAiOGMwYWIzM2QtZmMxZi00NDZiLWIzMmItNDVi
-        OTc1YzQ2OWQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMjowMjozOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMjowMjozOFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZGUwMzA4ZDYtODdmZC00NDJiLWI0MWQtZTVmZmFiOGUw
-        NmUwLyIsICJ0YXNrX2lkIjogImRlMDMwOGQ2LTg3ZmQtNDQyYi1iNDFkLWU1
-        ZmZhYjhlMDZlMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDRm
-        ZTY3N2M3NDJkMDVhZjM4MjQifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIyOjAyOjM4WiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjI6MDI6Mzha
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA0ZmU2NzdjNzQwODEyMzIyNDdmIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNGZlMzQ0NzFlNDAwNzBiMGI3YSJ9LCAiaWQi
-        OiAiNTZiZDA0ZmUzNDQ3MWU0MDA3MGIwYjdhIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:39 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/de0308d6-87fd-442b-b41d-e5ffab8e06e0/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:02:39 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3523'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9kZTAzMDhkNi04N2ZkLTQ0MmItYjQxZC1lNWZm
-        YWI4ZTA2ZTAvIiwgInRhc2tfaWQiOiAiZGUwMzA4ZDYtODdmZC00NDJiLWI0
-        MWQtZTVmZmFiOGUwNmUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0xMVQyMjowMjozOFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3YTdi
-        YTdmOC0zY2JlLTQ5ZjMtOTFjMi1jYWFjOTFjNDllMWEiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOGFlODk1MzQtNzM3
-        OC00ZjI2LThmYjEtZGQ5YWE4OWJjODc3IiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiODA2M2E2YWUtMDdlNS00YjE0LWI2ZDUtYzRhN2ZjNGVkM2ZmIiwg
-        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
-        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
-        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZmYjUxNTdmLWQ1OTgt
-        NGMyOS05ZDdkLTBhNDcxOThmYzdjZSIsICJudW1fcHJvY2Vzc2VkIjogMH0s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
-        ZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI0NTQ4ZDEzNy1lMjkzLTRhYzYtYmRkYi01YjgxNDQxNGRmOTIi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5
-        cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
-        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDg2YjY3YjctMjc1
-        MS00OTNlLWFjMzktY2NiNTkxZGUzNWZiIiwgIm51bV9wcm9jZXNzZWQiOiAw
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiOTc3YjI2MDctZWJjYi00MTY1LTlhNDYtMGRkYWJi
-        YTMwNmQ4IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
-        IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAi
-        c3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
-        ZXBfaWQiOiAiMGIyYmMzNDgtOWJlMy00MTEyLTllNWYtMjM3OTNiYzA1ZDg4
-        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
-        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
-        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        Ijc5NzBjODcxLTJiNGMtNGNlOS1iZDFlLTA3ZGE0OGVmYWE4NiIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjog
-        InB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNiMTRm
-        YTY3LTM5OTYtNDE3My1hODkwLTg4MTIzZWZjNmMzYiIsICJudW1fcHJvY2Vz
-        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
-        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
-        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiY2E1ZGVm
-        MzgtZmFmMi00Yzc1LWI4YzMtZmMxYzEwNDI0MDRmIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjog
-        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZDA0ZmUzNDQ3MWU0MDA3MGIwYjhhIn0sICJpZCI6ICI1NmJkMDRmZTM0NDcx
-        ZTQwMDcwYjBiOGEifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:39 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/8c0ab33d-fc1f-446b-b32b-45b975c469d2/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:02:39 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2324'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84YzBhYjMzZC1mYzFmLTQ0NmItYjMyYi00NWI5NzVjNDY5
-        ZDIvIiwgInRhc2tfaWQiOiAiOGMwYWIzM2QtZmMxZi00NDZiLWIzMmItNDVi
-        OTc1YzQ2OWQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMjowMjozOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMjowMjozOFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZGUwMzA4ZDYtODdmZC00NDJiLWI0MWQtZTVmZmFiOGUw
-        NmUwLyIsICJ0YXNrX2lkIjogImRlMDMwOGQ2LTg3ZmQtNDQyYi1iNDFkLWU1
-        ZmZhYjhlMDZlMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDRm
-        ZTY3N2M3NDJkMDVhZjM4MjQifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIyOjAyOjM4WiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjI6MDI6Mzha
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA0ZmU2NzdjNzQwODEyMzIyNDdmIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNGZlMzQ0NzFlNDAwNzBiMGI3YSJ9LCAiaWQi
-        OiAiNTZiZDA0ZmUzNDQ3MWU0MDA3MGIwYjdhIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:39 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/de0308d6-87fd-442b-b41d-e5ffab8e06e0/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:02:39 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9kZTAzMDhkNi04N2ZkLTQ0MmItYjQxZC1lNWZm
-        YWI4ZTA2ZTAvIiwgInRhc2tfaWQiOiAiZGUwMzA4ZDYtODdmZC00NDJiLWI0
-        MWQtZTVmZmFiOGUwNmUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0xMVQyMjowMjozOVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMjowMjozOFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI3YTdiYTdmOC0zY2JlLTQ5ZjMtOTFjMi1jYWFjOTFj
-        NDllMWEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiOGFlODk1MzQtNzM3OC00ZjI2LThmYjEtZGQ5YWE4OWJjODc3Iiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiODA2M2E2YWUtMDdlNS00YjE0LWI2ZDUt
-        YzRhN2ZjNGVkM2ZmIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmZi
-        NTE1N2YtZDU5OC00YzI5LTlkN2QtMGE0NzE5OGZjN2NlIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjQ1NDhkMTM3LWUyOTMtNGFjNi1iZGRiLTViODE0
-        NDE0ZGY5MiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0ODZiNjdi
-        Ny0yNzUxLTQ5M2UtYWMzOS1jY2I1OTFkZTM1ZmIiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI5NzdiMjYwNy1lYmNiLTQxNjUtOWE0Ni0wZGRh
-        YmJhMzA2ZDgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIwYjJiYzM0OC05YmUzLTQxMTItOWU1Zi0yMzc5M2JjMDVkODgi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3OTcw
-        Yzg3MS0yYjRjLTRjZTktYmQxZS0wN2RhNDhlZmFhODYiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjYjE0ZmE2Ny0zOTk2
-        LTQxNzMtYTg5MC04ODEyM2VmYzZjM2IiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNhNWRlZjM4LWZhZjItNGM3
-        NS1iOGMzLWZjMWMxMDQyNDA0ZiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8t
-        YnVycml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBr
-        YXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTExVDIyOjAyOjM4
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMTFUMjI6MDI6MzlaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiZDA0ZmY2NzdjNzQw
-        ODEyMzIyNDgwIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjdhN2JhN2Y4LTNjYmUtNDlmMy05MWMyLWNhYWM5MWM0OWUx
-        YSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI4YWU4OTUzNC03Mzc4LTRmMjYtOGZiMS1kZDlhYTg5YmM4NzciLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI4MDYzYTZhZS0wN2U1LTRiMTQtYjZkNS1jNGE3
-        ZmM0ZWQzZmYiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmZmI1MTU3
-        Zi1kNTk4LTRjMjktOWQ3ZC0wYTQ3MTk4ZmM3Y2UiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiNDU0OGQxMzctZTI5My00YWM2LWJkZGItNWI4MTQ0MTRk
-        ZjkyIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQ4NmI2N2I3LTI3
-        NTEtNDkzZS1hYzM5LWNjYjU5MWRlMzVmYiIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjk3N2IyNjA3LWViY2ItNDE2NS05YTQ2LTBkZGFiYmEz
-        MDZkOCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjBiMmJjMzQ4LTliZTMtNDExMi05ZTVmLTIzNzkzYmMwNWQ4OCIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc5NzBjODcx
-        LTJiNGMtNGNlOS1iZDFlLTA3ZGE0OGVmYWE4NiIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNiMTRmYTY3LTM5OTYtNDE3
-        My1hODkwLTg4MTIzZWZjNmMzYiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiY2E1ZGVmMzgtZmFmMi00Yzc1LWI4
-        YzMtZmMxYzEwNDI0MDRmIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmQwNGZlMzQ0NzFlNDAw
-        NzBiMGI4YSJ9LCAiaWQiOiAiNTZiZDA0ZmUzNDQ3MWU0MDA3MGIwYjhhIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:39 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/f34cdea2-050a-4293-a253-bf8995212a6a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:02:40 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mMzRjZGVhMi0wNTBhLTQyOTMtYTI1My1iZjg5OTUyMTJh
-        NmEvIiwgInRhc2tfaWQiOiAiZjM0Y2RlYTItMDUwYS00MjkzLWEyNTMtYmY4
-        OTk1MjEyYTZhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJkMDUw
-        MDM0NDcxZTQwMDcwYjBiOGIifSwgImlkIjogIjU2YmQwNTAwMzQ0NzFlNDAw
-        NzBiMGI4YiJ9
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:40 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/f34cdea2-050a-4293-a253-bf8995212a6a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:02:41 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mMzRjZGVhMi0wNTBhLTQyOTMtYTI1My1iZjg5OTUyMTJh
-        NmEvIiwgInRhc2tfaWQiOiAiZjM0Y2RlYTItMDUwYS00MjkzLWEyNTMtYmY4
-        OTk1MjEyYTZhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTExVDIyOjAyOjQwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTExVDIyOjAyOjQwWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZDA1MDAzNDQ3MWU0MDA3MGIwYjhiIn0sICJpZCI6ICI1NmJkMDUwMDM0NDcx
-        ZTQwMDcwYjBiOGIifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:41 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/4afec5fa-1fb4-4f00-aa87-80b938483d97/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:02:42 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80YWZlYzVmYS0xZmI0LTRmMDAtYWE4Ny04MGI5Mzg0ODNk
-        OTcvIiwgInRhc2tfaWQiOiAiNGFmZWM1ZmEtMWZiNC00ZjAwLWFhODctODBi
-        OTM4NDgzZDk3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiZDA1MDIz
-        NDQ3MWU0MDA3MGIwYjhjIn0sICJpZCI6ICI1NmJkMDUwMjM0NDcxZTQwMDcw
-        YjBiOGMifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:42 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/4afec5fa-1fb4-4f00-aa87-80b938483d97/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:02:43 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2324'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80YWZlYzVmYS0xZmI0LTRmMDAtYWE4Ny04MGI5Mzg0ODNk
-        OTcvIiwgInRhc2tfaWQiOiAiNGFmZWM1ZmEtMWZiNC00ZjAwLWFhODctODBi
-        OTM4NDgzZDk3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMjowMjo0M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMjowMjo0MloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvOTkxNTk1YmMtYmY5My00OGM2LTkxZDItYTgyZDBkNDMx
-        ZjNmLyIsICJ0YXNrX2lkIjogIjk5MTU5NWJjLWJmOTMtNDhjNi05MWQyLWE4
-        MmQwZDQzMWYzZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDUw
-        MjY3N2M3NDJkMDVhZjM4MmIifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIyOjAyOjQyWiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjI6MDI6NDNa
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA1MDM2NzdjNzQwODEyMzIyNDg0IiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNTAyMzQ0NzFlNDAwNzBiMGI4YyJ9LCAiaWQi
-        OiAiNTZiZDA1MDIzNDQ3MWU0MDA3MGIwYjhjIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:43 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/991595bc-bf93-48c6-91d2-a82d0d431f3f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:02:43 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '658'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy85OTE1OTViYy1iZjkzLTQ4YzYtOTFkMi1hODJk
-        MGQ0MzFmM2YvIiwgInRhc2tfaWQiOiAiOTkxNTk1YmMtYmY5My00OGM2LTkx
-        ZDItYTgyZDBkNDMxZjNmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiBudWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBb
-        XSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRf
-        cmVzb3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29t
-        LmRxIiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVz
-        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQi
-        OiB7IiRvaWQiOiAiNTZiZDA1MDMzNDQ3MWU0MDA3MGIwYjljIn0sICJpZCI6
-        ICI1NmJkMDUwMzM0NDcxZTQwMDcwYjBiOWMifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:43 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/4afec5fa-1fb4-4f00-aa87-80b938483d97/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:02:44 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2324'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80YWZlYzVmYS0xZmI0LTRmMDAtYWE4Ny04MGI5Mzg0ODNk
-        OTcvIiwgInRhc2tfaWQiOiAiNGFmZWM1ZmEtMWZiNC00ZjAwLWFhODctODBi
-        OTM4NDgzZDk3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMjowMjo0M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMjowMjo0MloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvOTkxNTk1YmMtYmY5My00OGM2LTkxZDItYTgyZDBkNDMx
-        ZjNmLyIsICJ0YXNrX2lkIjogIjk5MTU5NWJjLWJmOTMtNDhjNi05MWQyLWE4
-        MmQwZDQzMWYzZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDUw
-        MjY3N2M3NDJkMDVhZjM4MmIifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIyOjAyOjQyWiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjI6MDI6NDNa
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA1MDM2NzdjNzQwODEyMzIyNDg0IiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNTAyMzQ0NzFlNDAwNzBiMGI4YyJ9LCAiaWQi
-        OiAiNTZiZDA1MDIzNDQ3MWU0MDA3MGIwYjhjIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:44 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/991595bc-bf93-48c6-91d2-a82d0d431f3f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:02:44 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy85OTE1OTViYy1iZjkzLTQ4YzYtOTFkMi1hODJk
-        MGQ0MzFmM2YvIiwgInRhc2tfaWQiOiAiOTkxNTk1YmMtYmY5My00OGM2LTkx
-        ZDItYTgyZDBkNDMxZjNmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0xMVQyMjowMjo0M1oiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMjowMjo0M1oiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIyZGNkZmI4MC02MTE1LTRmN2EtOGY3MS0yYjQ0MjY2
-        NDE2NmMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYWQzOWU0MGEtYTg3OS00MDU4LTg3MjUtYTk5YzQ0MDJkN2FhIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiYzQzMmYyZGEtM2U1Ny00ZjY4LTg3M2Yt
-        Y2ZlYjkyNGE3ZTdjIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmYx
-        M2U2NmItNzE1NC00YmUzLTkwMjMtMmVkZGEyM2MwNzQ2IiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImNiMGJkMDNiLTkyMDAtNDJlMy1hMzUxLWQ2YWIy
-        NGY4N2FhNiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3MmI4Zjg0
-        Ny01MzJlLTQ5MGQtODgxZS0yZWI0OTdjZjJmMGUiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI3ZTM4NDI3ZS0zNjZhLTRhNWYtOTBlMC1kNzIz
-        NjQ1MjU2OTEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJlOTgyY2E4Ni1jZDQ4LTQ5OTEtOWRiMC00YTRiNTgyNzE3NDci
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2ZTdh
-        MGI1NS1kMzRhLTQ4NDYtYTY0Mi1hNjEzZTM1ZTRkMDMiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2YWJmODk3ZS03Yjgz
-        LTRiNzUtOTgzMy1kZGQ1ZDU5NDQ1MGYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjIyZDI0NjkzLTBmYTktNDI2
-        OS05NDQzLTNmMTVhY2Q2OWU4NCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8t
-        YnVycml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBr
-        YXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTExVDIyOjAyOjQz
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMTFUMjI6MDI6NDNaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiZDA1MDM2NzdjNzQw
-        ODEyMzIyNDg1IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjJkY2RmYjgwLTYxMTUtNGY3YS04ZjcxLTJiNDQyNjY0MTY2
-        YyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJhZDM5ZTQwYS1hODc5LTQwNTgtODcyNS1hOTljNDQwMmQ3YWEiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJjNDMyZjJkYS0zZTU3LTRmNjgtODczZi1jZmVi
-        OTI0YTdlN2MiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmZjEzZTY2
-        Yi03MTU0LTRiZTMtOTAyMy0yZWRkYTIzYzA3NDYiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiY2IwYmQwM2ItOTIwMC00MmUzLWEzNTEtZDZhYjI0Zjg3
-        YWE2IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjcyYjhmODQ3LTUz
-        MmUtNDkwZC04ODFlLTJlYjQ5N2NmMmYwZSIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjdlMzg0MjdlLTM2NmEtNGE1Zi05MGUwLWQ3MjM2NDUy
-        NTY5MSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImU5ODJjYTg2LWNkNDgtNDk5MS05ZGIwLTRhNGI1ODI3MTc0NyIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjZlN2EwYjU1
-        LWQzNGEtNDg0Ni1hNjQyLWE2MTNlMzVlNGQwMyIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjZhYmY4OTdlLTdiODMtNGI3
-        NS05ODMzLWRkZDVkNTk0NDUwZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjJkMjQ2OTMtMGZhOS00MjY5LTk0
-        NDMtM2YxNWFjZDY5ZTg0IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmQwNTAzMzQ0NzFlNDAw
-        NzBiMGI5YyJ9LCAiaWQiOiAiNTZiZDA1MDMzNDQ3MWU0MDA3MGIwYjljIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:44 GMT
-- request:
-    method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -8520,7 +805,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:02:44 GMT
+      - Tue, 23 Feb 2016 16:48:57 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -8534,26 +819,26 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIzM2EzNzU0NC00ZjViLTQwMTAtOGNk
-        MC1iOTJkOGRlY2Y4OTEiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
-        In0sICJfaWQiOiB7IiRvaWQiOiAiNTZiZDA1MDMzNDQ3MWU0MDA3MGIwYjk2
-        In0sICJ1bml0X2lkIjogIjMzYTM3NTQ0LTRmNWItNDAxMC04Y2QwLWI5MmQ4
-        ZGVjZjg5MSIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
-        YXRhIjogeyJfaWQiOiAiNjViNGU5MTQtNzY3ZS00ZTAxLWEzMGUtZTU3MDk4
-        YzE5OGZiIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNTAzMzQ0NzFlNDAwNzBiMGI5NyJ9LCAidW5p
-        dF9pZCI6ICI2NWI0ZTkxNC03NjdlLTRlMDEtYTMwZS1lNTcwOThjMTk4ZmIi
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIyOTlhMTczZS01Mjk3LTRlYzYtODM5
+        Zi01ZGIxZWY1YzA4ZTgiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
+        In0sICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNzg5ODkwNTRmYzQ4YmEzMDY0
+        In0sICJ1bml0X2lkIjogIjI5OWExNzNlLTUyOTctNGVjNi04MzlmLTVkYjFl
+        ZjVjMDhlOCIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
+        YXRhIjogeyJfaWQiOiAiNWU2OGE3NDgtY2E3OS00OTI5LTkxYjgtMmMyMjBh
+        OWJiZGYxIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
+        IjogeyIkb2lkIjogIjU2Y2M4ZDc4OTg5MDU0ZmM0OGJhMzA2NiJ9LCAidW5p
+        dF9pZCI6ICI1ZTY4YTc0OC1jYTc5LTQ5MjktOTFiOC0yYzIyMGE5YmJkZjEi
         LCAidW5pdF90eXBlX2lkIjogImVycmF0dW0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogIjhlOTIxNjNkLWIwNGEtNDBiZC1hNWZiLWM0MGRlMzBjZDE5MCIs
+        X2lkIjogImZmOTAxYjM2LWMwNDctNDVlMi1iYjIxLTQ5ZjcwMGYwZmY4NSIs
         ICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0ifSwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmJkMDUwMzM0NDcxZTQwMDcwYjBiOTgifSwgInVuaXRfaWQiOiAi
-        OGU5MjE2M2QtYjA0YS00MGJkLWE1ZmItYzQwZGUzMGNkMTkwIiwgInVuaXRf
+        ZCI6ICI1NmNjOGQ3ODk4OTA1NGZjNDhiYTMwNjUifSwgInVuaXRfaWQiOiAi
+        ZmY5MDFiMzYtYzA0Ny00NWUyLWJiMjEtNDlmNzAwZjBmZjg1IiwgInVuaXRf
         dHlwZV9pZCI6ICJlcnJhdHVtIn1d
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:44 GMT
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:57 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/ee19e63e-37b8-4355-825e-ffe090cc8945/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/5b846a37-e517-4b53-ac15-2127c1b29310/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -8572,13 +857,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:02:44 GMT
+      - Tue, 23 Feb 2016 16:48:57 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -8588,75 +873,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lZTE5ZTYzZS0zN2I4LTQzNTUtODI1ZS1mZmUwOTBjYzg5
-        NDUvIiwgInRhc2tfaWQiOiAiZWUxOWU2M2UtMzdiOC00MzU1LTgyNWUtZmZl
-        MDkwY2M4OTQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJkMDUw
-        NDM0NDcxZTQwMDcwYjBiOWQifSwgImlkIjogIjU2YmQwNTA0MzQ0NzFlNDAw
-        NzBiMGI5ZCJ9
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:44 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/ee19e63e-37b8-4355-825e-ffe090cc8945/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:02:45 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lZTE5ZTYzZS0zN2I4LTQzNTUtODI1ZS1mZmUwOTBjYzg5
-        NDUvIiwgInRhc2tfaWQiOiAiZWUxOWU2M2UtMzdiOC00MzU1LTgyNWUtZmZl
-        MDkwY2M4OTQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy81Yjg0NmEzNy1lNTE3LTRiNTMtYWMxNS0yMTI3YzFiMjkz
+        MTAvIiwgInRhc2tfaWQiOiAiNWI4NDZhMzctZTUxNy00YjUzLWFjMTUtMjEy
+        N2MxYjI5MzEwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTExVDIyOjAyOjQ0WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTExVDIyOjAyOjQ0WiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ4OjU3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjU3WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZDA1MDQzNDQ3MWU0MDA3MGIwYjlkIn0sICJpZCI6ICI1NmJkMDUwNDM0NDcx
-        ZTQwMDcwYjBiOWQifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:45 GMT
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkNzk5
+        ODkwNTRmYzQ4YmEzMDZiIn0sICJpZCI6ICI1NmNjOGQ3OTk4OTA1NGZjNDhi
+        YTMwNmIifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:57 GMT
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -8665,16 +900,20 @@ http_interactions:
         b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
         ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
         IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
-        IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRp
-        c3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwi
-        OiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3Rl
-        Y3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifV19
+        IjpudWxsLCJyZW1vdmVfbWlzc2luZyI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
+        LXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1
+        dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9j
+        b25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIiwiaHR0cCI6ZmFs
+        c2UsImh0dHBzIjp0cnVlLCJwcm90ZWN0ZWQiOnRydWV9LCJhdXRvX3B1Ymxp
+        c2giOnRydWUsImRpc3RyaWJ1dG9yX2lkIjoiRmVkb3JhXzE3In0seyJkaXN0
+        cmlidXRvcl90eXBlX2lkIjoieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwiZGlz
+        dHJpYnV0b3JfY29uZmlnIjp7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lk
+        IjoiRmVkb3JhXzE3In0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1
+        dG9yX2lkIjoiRmVkb3JhXzE3X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBl
+        X2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmln
+        Ijp7Imh0dHAiOmZhbHNlLCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6
+        InRlc3RfcGF0aCJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRv
+        cl9pZCI6ImV4cG9ydF9kaXN0cmlidXRvciJ9XX0=
     headers:
       Accept:
       - application/json
@@ -8683,7 +922,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '636'
+      - '839'
       User-Agent:
       - Ruby
   response:
@@ -8692,13 +931,13 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:02:46 GMT
+      - Tue, 23 Feb 2016 16:48:58 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
       - '320'
       Location:
-      - https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/
+      - https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/
       Connection:
       - close
       Content-Type:
@@ -8711,14 +950,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiZDA1MDY2NzdjNzQyZDA1YWYzODJmIn0sICJpZCI6ICJGZWRvcmFfMTci
+        NTZjYzhkN2FkZTA0MDMzZjQzNTE0ZmIxIn0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:46 GMT
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:58 GMT
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -8741,7 +980,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:02:47 GMT
+      - Tue, 23 Feb 2016 16:48:58 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -8754,14 +993,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzIzN2M2OGI5LWNhMjktNDk2MS05ZGYwLTlhZmMyYTFlNWE5Ny8iLCAi
-        dGFza19pZCI6ICIyMzdjNjhiOS1jYTI5LTQ5NjEtOWRmMC05YWZjMmExZTVh
-        OTcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:47 GMT
+        c2tzLzNlOTRjYmQ5LTNkZWItNGI2ZC05ZjVlLTU0ZDA4ZWI2N2FhYy8iLCAi
+        dGFza19pZCI6ICIzZTk0Y2JkOS0zZGViLTRiNmQtOWY1ZS01NGQwOGViNjdh
+        YWMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:58 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/237c68b9-ca29-4961-9df0-9afc2a1e5a97/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/3e94cbd9-3deb-4b6d-9f5e-54d08eb67aac/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -8780,13 +1019,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:02:47 GMT
+      - Tue, 23 Feb 2016 16:48:58 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '649'
+      - '661'
       Connection:
       - close
       Content-Type:
@@ -8796,24 +1035,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yMzdjNjhiOS1jYTI5LTQ5NjEtOWRmMC05YWZjMmExZTVh
-        OTcvIiwgInRhc2tfaWQiOiAiMjM3YzY4YjktY2EyOS00OTYxLTlkZjAtOWFm
-        YzJhMWU1YTk3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8zZTk0Y2JkOS0zZGViLTRiNmQtOWY1ZS01NGQwOGViNjdh
+        YWMvIiwgInRhc2tfaWQiOiAiM2U5NGNiZDktM2RlYi00YjZkLTlmNWUtNTRk
+        MDhlYjY3YWFjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tLmRxIiwgInN0
-        YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwg
-        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNTZiZDA1MDczNDQ3MWU0MDA3MGIwYjllIn0sICJpZCI6ICI1NmJkMDUw
-        NzM0NDcxZTQwMDcwYjBiOWUifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:47 GMT
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0ODo1OFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4
+        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNTZjYzhkN2E5ODkwNTRmYzQ4YmEzMDZjIn0sICJp
+        ZCI6ICI1NmNjOGQ3YTk4OTA1NGZjNDhiYTMwNmMifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:58 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/237c68b9-ca29-4961-9df0-9afc2a1e5a97/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/3e94cbd9-3deb-4b6d-9f5e-54d08eb67aac/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -8832,13 +1071,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:02:47 GMT
+      - Tue, 23 Feb 2016 16:48:59 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2324'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -8848,16 +1087,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yMzdjNjhiOS1jYTI5LTQ5NjEtOWRmMC05YWZjMmExZTVh
-        OTcvIiwgInRhc2tfaWQiOiAiMjM3YzY4YjktY2EyOS00OTYxLTlkZjAtOWFm
-        YzJhMWU1YTk3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8zZTk0Y2JkOS0zZGViLTRiNmQtOWY1ZS01NGQwOGViNjdh
+        YWMvIiwgInRhc2tfaWQiOiAiM2U5NGNiZDktM2RlYi00YjZkLTlmNWUtNTRk
+        MDhlYjY3YWFjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMjowMjo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMjowMjo0N1oiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0ODo1OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0ODo1OFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvM2ZkYTA0NDAtOGRmNS00YjE0LWJmMjItNTZhOGY1NmM2
-        ZjI4LyIsICJ0YXNrX2lkIjogIjNmZGEwNDQwLThkZjUtNGIxNC1iZjIyLTU2
-        YThmNTZjNmYyOCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvMGE3MmE4ZGMtOTczNS00MzgzLWIwOTctODQzMWQwOTI4
+        NGIxLyIsICJ0YXNrX2lkIjogIjBhNzJhOGRjLTk3MzUtNDM4My1iMDk3LTg0
+        MzFkMDkyODRiMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -8868,41 +1107,41 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDUw
-        NjY3N2M3NDJkMDVhZjM4MzAifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIyOjAyOjQ3WiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjI6MDI6NDda
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA1MDc2NzdjNzQwODEyMzIyNDg5IiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNTA3MzQ0NzFlNDAwNzBiMGI5ZSJ9LCAiaWQi
-        OiAiNTZiZDA1MDczNDQ3MWU0MDA3MGIwYjllIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:47 GMT
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ3YWRlMDQw
+        MzNmNDM1MTRmYjIifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ4OjU4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDg6NThaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkN2Fk
+        ZTA0MDMwODk3NThhOTRlIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDdhOTg5MDU0ZmM0OGJhMzA2YyJ9LCAiaWQiOiAiNTZj
+        YzhkN2E5ODkwNTRmYzQ4YmEzMDZjIn0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:59 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/3fda0440-8df5-4b14-bf22-56a8f56c6f28/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/0a72a8dc-9735-4383-b097-8431d09284b1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -8921,13 +1160,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:02:47 GMT
+      - Tue, 23 Feb 2016 16:48:59 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '3529'
+      - '6923'
       Connection:
       - close
       Content-Type:
@@ -8937,368 +1176,163 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8zZmRhMDQ0MC04ZGY1LTRiMTQtYmYyMi01NmE4
-        ZjU2YzZmMjgvIiwgInRhc2tfaWQiOiAiM2ZkYTA0NDAtOGRmNS00YjE0LWJm
-        MjItNTZhOGY1NmM2ZjI4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy8wYTcyYThkYy05NzM1LTQzODMtYjA5Ny04NDMx
+        ZDA5Mjg0YjEvIiwgInRhc2tfaWQiOiAiMGE3MmE4ZGMtOTczNS00MzgzLWIw
+        OTctODQzMWQwOTI4NGIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0xMVQyMjowMjo0N1oiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIw
-        NWJjNDdkOC03M2NkLTQ3YTctODMyNi1jZDA1ZGY3MGRlYzIiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlw
-        ZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNmY0YWY2
-        OWEtZDU5OC00YTQ1LWFlNDMtZGIwOGFmMTI0ZDM1IiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNf
-        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiNmZmMzhmYmYtZjYxMC00MjRkLTliNDQtZjk3MmRiMzZm
-        ZGQ1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3Rl
-        cF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZjNjQyMTQ2
-        LTU4MGEtNDk0YS1iZTlhLTBlZDFlMGY3Y2U5MSIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVt
-        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIxNjEwYzFhOS1mMzBmLTQzYzMtYjE5ZC1hNWNiZmU2
-        YjExYzAiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJz
-        dGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMThlNDA5
-        MWItYzg3Yy00MmE2LThlZTEtMzA1YjgzOTJjODRmIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEi
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZjViMzQ5NWEtNjM1My00Yzk3LTg2ZmQt
-        Y2EzZDRkMTY3NmNmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRh
-        dGEiLCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiMWQ5OTgwZmUtYTEwNS00Yzk0LTlkMGMtYjIzNjFi
-        N2FkZTI4IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
-        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIs
-        ICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogImYzZWFkOTNmLWQ4MTQtNDIwNS1iMGJmLWE2YzI0OGRmYjJiZiIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
-        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90
-        eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjRhZDI2NzZlLWY5M2MtNDk2OS1hZmMwLWE0YjgyOWUzMGMxZiIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJp
-        bml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        YmEwZDU3ZGUtYTczZC00ZGQyLTgwZWUtNGE2ZTFlZjc0OWJjIiwgIm51bV9w
-        cm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tLmRxIiwgInN0
-        YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwg
-        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNTZiZDA1MDczNDQ3MWU0MDA3MGIwYmFlIn0sICJpZCI6ICI1NmJkMDUw
-        NzM0NDcxZTQwMDcwYjBiYWUifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:47 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/237c68b9-ca29-4961-9df0-9afc2a1e5a97/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:02:48 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2324'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yMzdjNjhiOS1jYTI5LTQ5NjEtOWRmMC05YWZjMmExZTVh
-        OTcvIiwgInRhc2tfaWQiOiAiMjM3YzY4YjktY2EyOS00OTYxLTlkZjAtOWFm
-        YzJhMWU1YTk3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMjowMjo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMjowMjo0N1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvM2ZkYTA0NDAtOGRmNS00YjE0LWJmMjItNTZhOGY1NmM2
-        ZjI4LyIsICJ0YXNrX2lkIjogIjNmZGEwNDQwLThkZjUtNGIxNC1iZjIyLTU2
-        YThmNTZjNmYyOCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDUw
-        NjY3N2M3NDJkMDVhZjM4MzAifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIyOjAyOjQ3WiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjI6MDI6NDda
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA1MDc2NzdjNzQwODEyMzIyNDg5IiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNTA3MzQ0NzFlNDAwNzBiMGI5ZSJ9LCAiaWQi
-        OiAiNTZiZDA1MDczNDQ3MWU0MDA3MGIwYjllIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:48 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/3fda0440-8df5-4b14-bf22-56a8f56c6f28/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:02:48 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8zZmRhMDQ0MC04ZGY1LTRiMTQtYmYyMi01NmE4
-        ZjU2YzZmMjgvIiwgInRhc2tfaWQiOiAiM2ZkYTA0NDAtOGRmNS00YjE0LWJm
-        MjItNTZhOGY1NmM2ZjI4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0xMVQyMjowMjo0N1oiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMjowMjo0N1oiLCAi
+        bWUiOiAiMjAxNi0wMi0yM1QxNjo0ODo1OVoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0ODo1OFoiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIwNWJjNDdkOC03M2NkLTQ3YTctODMyNi1jZDA1ZGY3
-        MGRlYzIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICI1MjQ5ODAwOS03MGI5LTRmYzAtYWQwOS02Y2MxNmJm
+        MmZmZWIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNmY0YWY2OWEtZDU5OC00YTQ1LWFlNDMtZGIwOGFmMTI0ZDM1Iiwg
+        aWQiOiAiZjY0MDg4OTEtZjhkYS00NWE0LTg0OTgtNDVhNGQwMTZkOTU1Iiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
         bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNmZmMzhmYmYtZjYxMC00MjRkLTliNDQt
-        Zjk3MmRiMzZmZGQ1IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMTkzMDRlZWYtNWRiNC00MjdhLTllOTAt
+        NmE5Nzg2ZjkwZTNkIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
         TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmM2
-        NDIxNDYtNTgwYS00OTRhLWJlOWEtMGVkMWUwZjdjZTkxIiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDkw
+        NWZiZTItOTlkNi00ZmVkLWFjNDQtYTU0MjdiODkwMjBmIiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjE2MTBjMWE5LWYzMGYtNDNjMy1iMTlkLWE1Y2Jm
-        ZTZiMTFjMCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        IDAsICJzdGVwX2lkIjogImQzY2EwOWU2LTMzZWEtNDJkZi1iYzU3LWM5NDc5
+        NjE3ZWJmNyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
         OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
         InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxOGU0MDkx
-        Yi1jODdjLTQyYTYtOGVlMS0zMDViODM5MmM4NGYiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1NzM5NmY4
+        Ny0zNDIxLTQ3MzEtYjQ1OS1lZjdmZWUxOGUzM2MiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
         Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJmNWIzNDk1YS02MzUzLTRjOTctODZmZC1jYTNk
-        NGQxNjc2Y2YiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICI3MWE3NDFiYi1mNjExLTQ4MWYtYjliYy0yY2Iw
+        ZGEzMGE0ZWQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
         ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIxZDk5ODBmZS1hMTA1LTRjOTQtOWQwYy1iMjM2MWI3YWRlMjgi
+        cF9pZCI6ICI1YmQyOWI3MS1iYzdiLTQ4YmYtODgxZC1hMjdjZGQ5OTBlNGUi
         LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
         dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
         c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmM2Vh
-        ZDkzZi1kODE0LTQyMDUtYjBiZi1hNmMyNDhkZmIyYmYiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhYzA3
+        MzUwNi05MTdiLTQxOTUtODQ5Zi1mZjNiZjhmZjkwYzQiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
         aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0YWQyNjc2ZS1mOTNj
-        LTQ5NjktYWZjMC1hNGI4MjllMzBjMWYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjNWU5ZjY3NC1jNTMw
+        LTQwZGMtYWY0Ny1hZmFkYjExMTA3NTYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
         TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
         X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJhMGQ1N2RlLWE3M2QtNGRk
-        Mi04MGVlLTRhNmUxZWY3NDliYyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8t
-        YnVycml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBr
-        YXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTExVDIyOjAyOjQ3
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMTFUMjI6MDI6NDdaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiZDA1MDc2NzdjNzQw
-        ODEyMzIyNDhhIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjA1YmM0N2Q4LTczY2QtNDdhNy04MzI2LWNkMDVkZjcwZGVj
-        MiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI2ZjRhZjY5YS1kNTk4LTRhNDUtYWU0My1kYjA4YWYxMjRkMzUiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI2ZmYzOGZiZi1mNjEwLTQyNGQtOWI0NC1mOTcy
-        ZGIzNmZkZDUiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmYzY0MjE0
-        Ni01ODBhLTQ5NGEtYmU5YS0wZWQxZTBmN2NlOTEiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiMTYxMGMxYTktZjMwZi00M2MzLWIxOWQtYTVjYmZlNmIx
-        MWMwIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE4ZTQwOTFiLWM4
-        N2MtNDJhNi04ZWUxLTMwNWI4MzkyYzg0ZiIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImY1YjM0OTVhLTYzNTMtNGM5Ny04NmZkLWNhM2Q0ZDE2
-        NzZjZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQyNjdlYjJkLTE5NzEtNDY4
+        My1hNWJlLTMxNDE2OTNhZDg2MCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
+        c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
+        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ4OjU4WiIsICJf
+        bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
+        MTYtMDItMjNUMTY6NDg6NTlaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
+        cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
+        IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
+        X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
+        RCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1z
+        IjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0
+        aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
+        SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
+        U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
+        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZjYzhkN2JkZTA0MDMwODk3NThh
+        OTRmIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
         IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjFkOTk4MGZlLWExMDUtNGM5NC05ZDBjLWIyMzYxYjdhZGUyOCIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImYzZWFkOTNm
-        LWQ4MTQtNDIwNS1iMGJmLWE2YzI0OGRmYjJiZiIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        IjogIjUyNDk4MDA5LTcwYjktNGZjMC1hZDA5LTZjYzE2YmYyZmZlYiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmNjQw
+        ODg5MS1mOGRhLTQ1YTQtODQ5OC00NWE0ZDAxNmQ5NTUiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICIxOTMwNGVlZi01ZGI0LTQyN2EtOWU5MC02YTk3ODZmOTBl
+        M2QiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0OTA1ZmJlMi05OWQ2
+        LTRmZWQtYWM0NC1hNTQyN2I4OTAyMGYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiZDNjYTA5ZTYtMzNlYS00MmRmLWJjNTctYzk0Nzk2MTdlYmY3Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
+        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRhZDI2NzZlLWY5M2MtNDk2
-        OS1hZmMwLWE0YjgyOWUzMGMxZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYmEwZDU3ZGUtYTczZC00ZGQyLTgw
-        ZWUtNGE2ZTFlZjc0OWJjIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmQwNTA3MzQ0NzFlNDAw
-        NzBiMGJhZSJ9LCAiaWQiOiAiNTZiZDA1MDczNDQ3MWU0MDA3MGIwYmFlIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:48 GMT
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjU3Mzk2Zjg3LTM0MjEtNDcz
+        MS1iNDU5LWVmN2ZlZTE4ZTMzYyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
+        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjcxYTc0MWJiLWY2MTEtNDgxZi1iOWJjLTJjYjBkYTMwYTRlZCIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjVi
+        ZDI5YjcxLWJjN2ItNDhiZi04ODFkLWEyN2NkZDk5MGU0ZSIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
+        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
+        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFjMDczNTA2LTkxN2It
+        NDE5NS04NDlmLWZmM2JmOGZmOTBjNCIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
+        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImM1ZTlmNjc0LWM1MzAtNDBkYy1hZjQ3
+        LWFmYWRiMTExMDc1NiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
+        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiNDI2N2ViMmQtMTk3MS00NjgzLWE1YmUtMzE0
+        MTY5M2FkODYwIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDdhOTg5MDU0ZmM0OGJhMzA3
+        YyJ9LCAiaWQiOiAiNTZjYzhkN2E5ODkwNTRmYzQ4YmEzMDdjIn0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:59 GMT
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -9321,7 +1355,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:02:48 GMT
+      - Tue, 23 Feb 2016 16:48:59 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -9335,33 +1369,33 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIzM2EzNzU0NC00ZjViLTQwMTAtOGNk
-        MC1iOTJkOGRlY2Y4OTEiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
-        In0sICJfaWQiOiB7IiRvaWQiOiAiNTZiZDA1MDczNDQ3MWU0MDA3MGIwYmE4
-        In0sICJ1bml0X2lkIjogIjMzYTM3NTQ0LTRmNWItNDAxMC04Y2QwLWI5MmQ4
-        ZGVjZjg5MSIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
-        YXRhIjogeyJfaWQiOiAiNjViNGU5MTQtNzY3ZS00ZTAxLWEzMGUtZTU3MDk4
-        YzE5OGZiIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNTA3MzQ0NzFlNDAwNzBiMGJhOSJ9LCAidW5p
-        dF9pZCI6ICI2NWI0ZTkxNC03NjdlLTRlMDEtYTMwZS1lNTcwOThjMTk4ZmIi
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIyOTlhMTczZS01Mjk3LTRlYzYtODM5
+        Zi01ZGIxZWY1YzA4ZTgiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
+        In0sICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkN2E5ODkwNTRmYzQ4YmEzMDc2
+        In0sICJ1bml0X2lkIjogIjI5OWExNzNlLTUyOTctNGVjNi04MzlmLTVkYjFl
+        ZjVjMDhlOCIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
+        YXRhIjogeyJfaWQiOiAiNWU2OGE3NDgtY2E3OS00OTI5LTkxYjgtMmMyMjBh
+        OWJiZGYxIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
+        IjogeyIkb2lkIjogIjU2Y2M4ZDdhOTg5MDU0ZmM0OGJhMzA3OCJ9LCAidW5p
+        dF9pZCI6ICI1ZTY4YTc0OC1jYTc5LTQ5MjktOTFiOC0yYzIyMGE5YmJkZjEi
         LCAidW5pdF90eXBlX2lkIjogImVycmF0dW0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogIjhlOTIxNjNkLWIwNGEtNDBiZC1hNWZiLWM0MGRlMzBjZDE5MCIs
+        X2lkIjogImZmOTAxYjM2LWMwNDctNDVlMi1iYjIxLTQ5ZjcwMGYwZmY4NSIs
         ICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0ifSwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmJkMDUwNzM0NDcxZTQwMDcwYjBiYWEifSwgInVuaXRfaWQiOiAi
-        OGU5MjE2M2QtYjA0YS00MGJkLWE1ZmItYzQwZGUzMGNkMTkwIiwgInVuaXRf
+        ZCI6ICI1NmNjOGQ3YTk4OTA1NGZjNDhiYTMwNzcifSwgInVuaXRfaWQiOiAi
+        ZmY5MDFiMzYtYzA0Ny00NWUyLWJiMjEtNDlmNzAwZjBmZjg1IiwgInVuaXRf
         dHlwZV9pZCI6ICJlcnJhdHVtIn1d
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:48 GMT
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:59 GMT
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/content/units/erratum/search/
+    uri: https://katello-yoda.example.com/pulp/api/v2/content/units/erratum/search/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMzNhMzc1
-        NDQtNGY1Yi00MDEwLThjZDAtYjkyZDhkZWNmODkxIiwiNjViNGU5MTQtNzY3
-        ZS00ZTAxLWEzMGUtZTU3MDk4YzE5OGZiIiwiOGU5MjE2M2QtYjA0YS00MGJk
-        LWE1ZmItYzQwZGUzMGNkMTkwIl19fX0sImluY2x1ZGVfcmVwb3MiOnRydWV9
+        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMjk5YTE3
+        M2UtNTI5Ny00ZWM2LTgzOWYtNWRiMWVmNWMwOGU4IiwiNWU2OGE3NDgtY2E3
+        OS00OTI5LTkxYjgtMmMyMjBhOWJiZGYxIiwiZmY5MDFiMzYtYzA0Ny00NWUy
+        LWJiMjEtNDlmNzAwZjBmZjg1Il19fX0sImluY2x1ZGVfcmVwb3MiOnRydWV9
     headers:
       Accept:
       - application/json
@@ -9379,13 +1413,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:02:48 GMT
+      - Tue, 23 Feb 2016 16:48:59 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '4700'
+      - '4735'
       Connection:
       - close
       Content-Type:
@@ -9393,121 +1427,122 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJf
-        aHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9lcnJhdHVtLzMz
-        YTM3NTQ0LTRmNWItNDAxMC04Y2QwLWI5MmQ4ZGVjZjg5MS8iLCAiaXNzdWVk
-        IjogIjIwMTAtMDEtMDEgMDE6MDE6MDEiLCAicmVmZXJlbmNlcyI6IFtdLCAi
-        cHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lkIjog
-        ImVycmF0dW0iLCAiaWQiOiAiUkhFQS0yMDEwOjAwMDEiLCAiZnJvbSI6ICJs
-        emFwK3B1YkByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRsZSI6
-        ICJFbXB0eSBlcnJhdGEiLCAiY2hpbGRyZW4iOiB7fSwgInZlcnNpb24iOiAi
-        MSIsICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3Vy
-        aXR5IiwgInBrZ2xpc3QiOiBbXSwgInN0YXR1cyI6ICJzdGFibGUiLCAidXBk
-        YXRlZCI6ICIiLCAiZGVzY3JpcHRpb24iOiAiRW1wdHkgZXJyYXRhIiwgIl9s
-        YXN0X3VwZGF0ZWQiOiAiMjAxNi0wMi0xMVQyMjowMjo0N1oiLCAicHVzaGNv
-        dW50IjogIiIsICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1t
-        YXJ5IjogIiIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjMzYTM3NTQ0LTRm
-        NWItNDAxMC04Y2QwLWI5MmQ4ZGVjZjg5MSJ9LCB7InJlcG9zaXRvcnlfbWVt
-        YmVyc2hpcHMiOiBbIkZlZG9yYV8xNyJdLCAiX2hyZWYiOiAiL3B1bHAvYXBp
-        L3YyL2NvbnRlbnQvdW5pdHMvZXJyYXR1bS82NWI0ZTkxNC03NjdlLTRlMDEt
-        YTMwZS1lNTcwOThjMTk4ZmIvIiwgImlzc3VlZCI6ICIyMDEwLTExLTEwIDAw
-        OjAwOjAwIiwgInJlZmVyZW5jZXMiOiBbeyJocmVmIjogImh0dHBzOi8vcmhu
-        LnJlZGhhdC5jb20vZXJyYXRhL1JIU0EtMjAxMC0wODU4Lmh0bWwiLCAidHlw
-        ZSI6ICJzZWxmIiwgImlkIjogbnVsbCwgInRpdGxlIjogbnVsbH0sIHsiaHJl
-        ZiI6ICJodHRwczovL2J1Z3ppbGxhLnJlZGhhdC5jb20vYnVnemlsbGEvc2hv
-        d19idWcuY2dpP2lkPTYyNzg4MiIsICJ0eXBlIjogImJ1Z3ppbGxhIiwgImlk
-        IjogIjYyNzg4MiIsICJ0aXRsZSI6IG51bGx9LCB7ImhyZWYiOiAiaHR0cHM6
-        Ly93d3cucmVkaGF0LmNvbS9zZWN1cml0eS9kYXRhL2N2ZS9DVkUtMjAxMC0w
-        NDA1Lmh0bWwiLCAidHlwZSI6ICJjdmUiLCAiaWQiOiAiQ1ZFLTIwMTAtMDQw
-        NSIsICJ0aXRsZSI6IG51bGx9LCB7ImhyZWYiOiAiaHR0cDovL3d3dy5yZWRo
-        YXQuY29tL3NlY3VyaXR5L3VwZGF0ZXMvY2xhc3NpZmljYXRpb24vI2ltcG9y
-        dGFudCIsICJ0eXBlIjogIm90aGVyIiwgImlkIjogbnVsbCwgInRpdGxlIjog
-        bnVsbH1dLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90
-        eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiUkhTQS0yMDEwOjA4NTgiLCAi
-        ZnJvbSI6ICJzZWN1cml0eUByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIklt
-        cG9ydGFudCIsICJ0aXRsZSI6ICJJbXBvcnRhbnQ6IGJ6aXAyIHNlY3VyaXR5
-        IHVwZGF0ZSIsICJjaGlsZHJlbiI6IHt9LCAidmVyc2lvbiI6ICIzIiwgInJl
-        Ym9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAi
-        cGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjogImJ6aXAyLTEuMC41
-        LTcuZWw2XzAuc3JjLnJwbSIsICJuYW1lIjogImJ6aXAyLWRldmVsIiwgInN1
-        bSI6IFsic2hhMjU2IiwgImVhNjdjNjY0ZGExZmY5NmE2ZGM5NGQzMzAwOWI3
-        M2Q4ZmFiMzFiNTk4MjQxODNmYjQ1ZTliYTJlYmY4MmQ1ODMiXSwgImZpbGVu
-        YW1lIjogImJ6aXAyLWRldmVsLTEuMC41LTcuZWw2XzAuaTY4Ni5ycG0iLCAi
-        ZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAi
-        Ny5lbDZfMCIsICJhcmNoIjogImk2ODYifSwgeyJzcmMiOiAiYnppcDItMS4w
-        LjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDItbGlicyIsICJz
-        dW0iOiBbInNoYTI1NiIsICJjOWYwNjRhNjg2MjU3M2ZiOWYyYTZhZmY3YzM2
-        MjFmMTk0MGI0OTJkZjJlZGZjMmViYmRjMGI4MzA1ZjUxMTQ3Il0sICJmaWxl
-        bmFtZSI6ICJiemlwMi1saWJzLTEuMC41LTcuZWw2XzAuaTY4Ni5ycG0iLCAi
-        ZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAi
-        Ny5lbDZfMCIsICJhcmNoIjogImk2ODYifSwgeyJzcmMiOiAiYnppcDItMS4w
-        LjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDIiLCAic3VtIjog
-        WyJzaGEyNTYiLCAiYjhhM2Y3MmJjMmIwZDg5YmE3MzcwOTlhYzk4YmY4ZDJh
-        ZjRiZWEwMmQzMTg4NGMwMmRiOTdmN2Y2NmMzZDVjMiJdLCAiZmlsZW5hbWUi
-        OiAiYnppcDItMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjog
-        IjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAi
-        LCAiYXJjaCI6ICJ4ODZfNjQifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5l
-        bDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDItZGV2ZWwiLCAic3VtIjog
-        WyJzaGEyNTYiLCAiN2Y2MzEyNGU0NjU1YjdjOTJkMjNlYzRjMzgyMjZmNWQz
-        NzQ2NTY4ODUzZGZmNzUwZmM4NWUwNThlNzRiNWNmNiJdLCAiZmlsZW5hbWUi
-        OiAiYnppcDItZGV2ZWwtMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVw
-        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcu
-        ZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQifSwgeyJzcmMiOiAiYnppcDItMS4w
-        LjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDItbGlicyIsICJz
-        dW0iOiBbInNoYTI1NiIsICI4MDJmNDM5OWRiZGQwMTQ3NmUyNTRjM2IzMmM0
-        MGFmZjU5Y2Y1ZDIzYTQ1ZmE0ODhjNjkxN2NlODkwNGQ2YjRkIl0sICJmaWxl
-        bmFtZSI6ICJiemlwMi1saWJzLTEuMC41LTcuZWw2XzAueDg2XzY0LnJwbSIs
-        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6
-        ICI3LmVsNl8wIiwgImFyY2giOiAieDg2XzY0In1dLCAibmFtZSI6ICJSZWQg
-        SGF0IEVudGVycHJpc2UgTGludXggU2VydmVyICh2LiA2IGZvciA2NC1iaXQg
-        eDg2XzY0KSIsICJzaG9ydCI6ICJyaGVsLXg4Nl82NC1zZXJ2ZXItNiJ9XSwg
-        InN0YXR1cyI6ICJmaW5hbCIsICJ1cGRhdGVkIjogIjIwMTAtMTEtMTAgMDA6
-        MDA6MDAiLCAiZGVzY3JpcHRpb24iOiAiYnppcDIgaXMgYSBmcmVlbHkgYXZh
-        aWxhYmxlLCBoaWdoLXF1YWxpdHkgZGF0YSBjb21wcmVzc29yLiBJdCBwcm92
-        aWRlcyBib3RoXG5saWJiejIgbGlicmFyeSBtdXN0IGJlIHJlc3RhcnRlZCBm
-        b3IgdGhlIHVwZGF0ZSB0byB0YWtlIGVmZmVjdC4iLCAiX2xhc3RfdXBkYXRl
-        ZCI6ICIyMDE2LTAyLTExVDIyOjAyOjQ3WiIsICJwdXNoY291bnQiOiAiIiwg
-        InJpZ2h0cyI6ICJDb3B5cmlnaHQgMjAxMCBSZWQgSGF0IEluYyIsICJzb2x1
-        dGlvbiI6ICJCZWZvcmUgYXBwbHlpbmcgdGhpcyB1cGRhdGUsIG1ha2Ugc3Vy
-        ZSBhbGwgcHJldmlvdXNseS1yZWxlYXNlZCBlcnJhdGFcbnJlbGV2YW50IHRv
-        IHlvdXIgc3lzdGVtIGhhdmUgYmVlbiBhcHBsaWVkLlxuXG5UaGlzIHVwZGF0
-        ZSBpcyBhdmFpbGFibGUgdmlhIHRoZSBSZWQgSGF0IE5ldHdvcmsuIERldGFp
-        bHMgb24gaG93IHRvXG51c2UgdGhlIFJlZCBIYXQgTmV0d29yayB0byBhcHBs
-        eSB0aGlzIHVwZGF0ZSBhcmUgYXZhaWxhYmxlIGF0XG5odHRwOi8va2Jhc2Uu
-        cmVkaGF0LmNvbS9mYXEvZG9jcy9ET0MtMTEyNTkiLCAic3VtbWFyeSI6ICJV
-        cGRhdGVkIGJ6aXAyIHBhY2thZ2VzIHRoYXQgZml4IG9uZSBzZWN1cml0eSBp
-        c3N1ZSIsICJyZWxlYXNlIjogIiIsICJfaWQiOiAiNjViNGU5MTQtNzY3ZS00
-        ZTAxLWEzMGUtZTU3MDk4YzE5OGZiIn0sIHsicmVwb3NpdG9yeV9tZW1iZXJz
-        aGlwcyI6IFsiRmVkb3JhXzE3Il0sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIv
-        Y29udGVudC91bml0cy9lcnJhdHVtLzhlOTIxNjNkLWIwNGEtNDBiZC1hNWZi
-        LWM0MGRlMzBjZDE5MC8iLCAiaXNzdWVkIjogIjIwMTAtMDEtMDEgMDE6MDE6
-        MDEiLCAicmVmZXJlbmNlcyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRhIjog
-        e30sICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiUkhF
-        QS0yMDEwOjAwMDIiLCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwg
-        InNldmVyaXR5IjogIiIsICJ0aXRsZSI6ICJPbmUgcGFja2FnZSBlcnJhdGEi
-        LCAiY2hpbGRyZW4iOiB7fSwgInZlcnNpb24iOiAiMSIsICJyZWJvb3Rfc3Vn
-        Z2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5IiwgInBrZ2xpc3Qi
-        OiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJodHRwOi8vd3d3LmZlZG9yYXBy
-        b2plY3Qub3JnIiwgIm5hbWUiOiAiZWxlcGhhbnQiLCAic3VtIjogbnVsbCwg
-        ImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsICJl
-        cG9jaCI6IG51bGwsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAu
-        OCIsICJhcmNoIjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiMSIsICJzaG9ydCI6
-        ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRl
-        c2NyaXB0aW9uIjogIk9uZSBwYWNrYWdlIGVycmF0YSIsICJfbGFzdF91cGRh
-        dGVkIjogIjIwMTYtMDItMTFUMjI6MDI6NDdaIiwgInB1c2hjb3VudCI6ICIi
-        LCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIi
-        LCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI4ZTkyMTYzZC1iMDRhLTQwYmQt
-        YTVmYi1jNDBkZTMwY2QxOTAifV0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:48 GMT
+        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsicmVpbnRlcm1lZGlhdGUi
+        LCAiRmVkb3JhXzE3Il0sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVu
+        dC91bml0cy9lcnJhdHVtLzI5OWExNzNlLTUyOTctNGVjNi04MzlmLTVkYjFl
+        ZjVjMDhlOC8iLCAiaXNzdWVkIjogIjIwMTAtMDEtMDEgMDE6MDE6MDEiLCAi
+        cmVmZXJlbmNlcyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJf
+        Y29udGVudF90eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiUkhFQS0yMDEw
+        OjAwMDEiLCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNldmVy
+        aXR5IjogIiIsICJ0aXRsZSI6ICJFbXB0eSBlcnJhdGEiLCAiY2hpbGRyZW4i
+        OiB7fSwgInZlcnNpb24iOiAiMSIsICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFs
+        c2UsICJ0eXBlIjogInNlY3VyaXR5IiwgInBrZ2xpc3QiOiBbXSwgInN0YXR1
+        cyI6ICJzdGFibGUiLCAidXBkYXRlZCI6ICIiLCAiZGVzY3JpcHRpb24iOiAi
+        RW1wdHkgZXJyYXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAiMjAxNi0wMi0yM1Qx
+        Njo0ODo1OFoiLCAicHVzaGNvdW50IjogIiIsICJyaWdodHMiOiAiIiwgInNv
+        bHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxlYXNlIjogIjEiLCAi
+        X2lkIjogIjI5OWExNzNlLTUyOTctNGVjNi04MzlmLTVkYjFlZjVjMDhlOCJ9
+        LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBbInJlaW50ZXJtZWRpYXRl
+        IiwgIkZlZG9yYV8xNyJdLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRl
+        bnQvdW5pdHMvZXJyYXR1bS81ZTY4YTc0OC1jYTc5LTQ5MjktOTFiOC0yYzIy
+        MGE5YmJkZjEvIiwgImlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAxIiwg
+        InJlZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAi
+        X2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIlJIRUEtMjAx
+        MDowMDAyIiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0LmNvbSIsICJzZXZl
+        cml0eSI6ICIiLCAidGl0bGUiOiAiT25lIHBhY2thZ2UgZXJyYXRhIiwgImNo
+        aWxkcmVuIjoge30sICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dlc3Rl
+        ZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3si
+        cGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0
+        Lm9yZyIsICJuYW1lIjogImVsZXBoYW50IiwgInN1bSI6IG51bGwsICJmaWxl
+        bmFtZSI6ICJlbGVwaGFudC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2gi
+        OiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJh
+        cmNoIjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiMSIsICJzaG9ydCI6ICIifV0s
+        ICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0
+        aW9uIjogIk9uZSBwYWNrYWdlIGVycmF0YSIsICJfbGFzdF91cGRhdGVkIjog
+        IjIwMTYtMDItMjNUMTY6NDg6NThaIiwgInB1c2hjb3VudCI6ICIiLCAicmln
+        aHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIiLCAicmVs
+        ZWFzZSI6ICIxIiwgIl9pZCI6ICI1ZTY4YTc0OC1jYTc5LTQ5MjktOTFiOC0y
+        YzIyMGE5YmJkZjEifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJG
+        ZWRvcmFfMTciXSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3Vu
+        aXRzL2VycmF0dW0vZmY5MDFiMzYtYzA0Ny00NWUyLWJiMjEtNDlmNzAwZjBm
+        Zjg1LyIsICJpc3N1ZWQiOiAiMjAxMC0xMS0xMCAwMDowMDowMCIsICJyZWZl
+        cmVuY2VzIjogW3siaHJlZiI6ICJodHRwczovL3Jobi5yZWRoYXQuY29tL2Vy
+        cmF0YS9SSFNBLTIwMTAtMDg1OC5odG1sIiwgInR5cGUiOiAic2VsZiIsICJp
+        ZCI6IG51bGwsICJ0aXRsZSI6IG51bGx9LCB7ImhyZWYiOiAiaHR0cHM6Ly9i
+        dWd6aWxsYS5yZWRoYXQuY29tL2J1Z3ppbGxhL3Nob3dfYnVnLmNnaT9pZD02
+        Mjc4ODIiLCAidHlwZSI6ICJidWd6aWxsYSIsICJpZCI6ICI2Mjc4ODIiLCAi
+        dGl0bGUiOiBudWxsfSwgeyJocmVmIjogImh0dHBzOi8vd3d3LnJlZGhhdC5j
+        b20vc2VjdXJpdHkvZGF0YS9jdmUvQ1ZFLTIwMTAtMDQwNS5odG1sIiwgInR5
+        cGUiOiAiY3ZlIiwgImlkIjogIkNWRS0yMDEwLTA0MDUiLCAidGl0bGUiOiBu
+        dWxsfSwgeyJocmVmIjogImh0dHA6Ly93d3cucmVkaGF0LmNvbS9zZWN1cml0
+        eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCAidHlwZSI6
+        ICJvdGhlciIsICJpZCI6IG51bGwsICJ0aXRsZSI6IG51bGx9XSwgInB1bHBf
+        dXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJh
+        dHVtIiwgImlkIjogIlJIU0EtMjAxMDowODU4IiwgImZyb20iOiAic2VjdXJp
+        dHlAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6ICJJbXBvcnRhbnQiLCAidGl0
+        bGUiOiAiSW1wb3J0YW50OiBiemlwMiBzZWN1cml0eSB1cGRhdGUiLCAiY2hp
+        bGRyZW4iOiB7fSwgInZlcnNpb24iOiAiMyIsICJyZWJvb3Rfc3VnZ2VzdGVk
+        IjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5IiwgInBrZ2xpc3QiOiBbeyJw
+        YWNrYWdlcyI6IFt7InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5y
+        cG0iLCAibmFtZSI6ICJiemlwMi1kZXZlbCIsICJzdW0iOiBbInNoYTI1NiIs
+        ICJlYTY3YzY2NGRhMWZmOTZhNmRjOTRkMzMwMDliNzNkOGZhYjMxYjU5ODI0
+        MTgzZmI0NWU5YmEyZWJmODJkNTgzIl0sICJmaWxlbmFtZSI6ICJiemlwMi1k
+        ZXZlbC0xLjAuNS03LmVsNl8wLmk2ODYucnBtIiwgImVwb2NoIjogIjAiLCAi
+        dmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJj
+        aCI6ICJpNjg2In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3Jj
+        LnJwbSIsICJuYW1lIjogImJ6aXAyLWxpYnMiLCAic3VtIjogWyJzaGEyNTYi
+        LCAiYzlmMDY0YTY4NjI1NzNmYjlmMmE2YWZmN2MzNjIxZjE5NDBiNDkyZGYy
+        ZWRmYzJlYmJkYzBiODMwNWY1MTE0NyJdLCAiZmlsZW5hbWUiOiAiYnppcDIt
+        bGlicy0xLjAuNS03LmVsNl8wLmk2ODYucnBtIiwgImVwb2NoIjogIjAiLCAi
+        dmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJj
+        aCI6ICJpNjg2In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3Jj
+        LnJwbSIsICJuYW1lIjogImJ6aXAyIiwgInN1bSI6IFsic2hhMjU2IiwgImI4
+        YTNmNzJiYzJiMGQ4OWJhNzM3MDk5YWM5OGJmOGQyYWY0YmVhMDJkMzE4ODRj
+        MDJkYjk3ZjdmNjZjM2Q1YzIiXSwgImZpbGVuYW1lIjogImJ6aXAyLTEuMC41
+        LTcuZWw2XzAueDg2XzY0LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24i
+        OiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAieDg2
+        XzY0In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3JjLnJwbSIs
+        ICJuYW1lIjogImJ6aXAyLWRldmVsIiwgInN1bSI6IFsic2hhMjU2IiwgIjdm
+        NjMxMjRlNDY1NWI3YzkyZDIzZWM0YzM4MjI2ZjVkMzc0NjU2ODg1M2RmZjc1
+        MGZjODVlMDU4ZTc0YjVjZjYiXSwgImZpbGVuYW1lIjogImJ6aXAyLWRldmVs
+        LTEuMC41LTcuZWw2XzAueDg2XzY0LnJwbSIsICJlcG9jaCI6ICIwIiwgInZl
+        cnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2gi
+        OiAieDg2XzY0In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3Jj
+        LnJwbSIsICJuYW1lIjogImJ6aXAyLWxpYnMiLCAic3VtIjogWyJzaGEyNTYi
+        LCAiODAyZjQzOTlkYmRkMDE0NzZlMjU0YzNiMzJjNDBhZmY1OWNmNWQyM2E0
+        NWZhNDg4YzY5MTdjZTg5MDRkNmI0ZCJdLCAiZmlsZW5hbWUiOiAiYnppcDIt
+        bGlicy0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0iLCAiZXBvY2giOiAiMCIs
+        ICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJh
+        cmNoIjogIng4Nl82NCJ9XSwgIm5hbWUiOiAiUmVkIEhhdCBFbnRlcnByaXNl
+        IExpbnV4IFNlcnZlciAodi4gNiBmb3IgNjQtYml0IHg4Nl82NCkiLCAic2hv
+        cnQiOiAicmhlbC14ODZfNjQtc2VydmVyLTYifV0sICJzdGF0dXMiOiAiZmlu
+        YWwiLCAidXBkYXRlZCI6ICIyMDEwLTExLTEwIDAwOjAwOjAwIiwgImRlc2Ny
+        aXB0aW9uIjogImJ6aXAyIGlzIGEgZnJlZWx5IGF2YWlsYWJsZSwgaGlnaC1x
+        dWFsaXR5IGRhdGEgY29tcHJlc3Nvci4gSXQgcHJvdmlkZXMgYm90aFxubGli
+        YnoyIGxpYnJhcnkgbXVzdCBiZSByZXN0YXJ0ZWQgZm9yIHRoZSB1cGRhdGUg
+        dG8gdGFrZSBlZmZlY3QuIiwgIl9sYXN0X3VwZGF0ZWQiOiAiMjAxNi0wMi0y
+        M1QxNjo0ODo1OFoiLCAicHVzaGNvdW50IjogIiIsICJyaWdodHMiOiAiQ29w
+        eXJpZ2h0IDIwMTAgUmVkIEhhdCBJbmMiLCAic29sdXRpb24iOiAiQmVmb3Jl
+        IGFwcGx5aW5nIHRoaXMgdXBkYXRlLCBtYWtlIHN1cmUgYWxsIHByZXZpb3Vz
+        bHktcmVsZWFzZWQgZXJyYXRhXG5yZWxldmFudCB0byB5b3VyIHN5c3RlbSBo
+        YXZlIGJlZW4gYXBwbGllZC5cblxuVGhpcyB1cGRhdGUgaXMgYXZhaWxhYmxl
+        IHZpYSB0aGUgUmVkIEhhdCBOZXR3b3JrLiBEZXRhaWxzIG9uIGhvdyB0b1xu
+        dXNlIHRoZSBSZWQgSGF0IE5ldHdvcmsgdG8gYXBwbHkgdGhpcyB1cGRhdGUg
+        YXJlIGF2YWlsYWJsZSBhdFxuaHR0cDovL2tiYXNlLnJlZGhhdC5jb20vZmFx
+        L2RvY3MvRE9DLTExMjU5IiwgInN1bW1hcnkiOiAiVXBkYXRlZCBiemlwMiBw
+        YWNrYWdlcyB0aGF0IGZpeCBvbmUgc2VjdXJpdHkgaXNzdWUiLCAicmVsZWFz
+        ZSI6ICIiLCAiX2lkIjogImZmOTAxYjM2LWMwNDctNDVlMi1iYjIxLTQ5Zjcw
+        MGYwZmY4NSJ9XQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:59 GMT
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/content/units/erratum/search/
+    uri: https://katello-yoda.example.com/pulp/api/v2/content/units/erratum/search/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiNjViNGU5
-        MTQtNzY3ZS00ZTAxLWEzMGUtZTU3MDk4YzE5OGZiIl19fX0sImluY2x1ZGVf
+        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiZmY5MDFi
+        MzYtYzA0Ny00NWUyLWJiMjEtNDlmNzAwZjBmZjg1Il19fX0sImluY2x1ZGVf
         cmVwb3MiOnRydWV9
     headers:
       Accept:
@@ -9526,7 +1561,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:02:48 GMT
+      - Tue, 23 Feb 2016 16:48:59 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -9541,8 +1576,8 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJf
-        aHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9lcnJhdHVtLzY1
-        YjRlOTE0LTc2N2UtNGUwMS1hMzBlLWU1NzA5OGMxOThmYi8iLCAiaXNzdWVk
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9lcnJhdHVtL2Zm
+        OTAxYjM2LWMwNDctNDVlMi1iYjIxLTQ5ZjcwMGYwZmY4NS8iLCAiaXNzdWVk
         IjogIjIwMTAtMTEtMTAgMDA6MDA6MDAiLCAicmVmZXJlbmNlcyI6IFt7Imhy
         ZWYiOiAiaHR0cHM6Ly9yaG4ucmVkaGF0LmNvbS9lcnJhdGEvUkhTQS0yMDEw
         LTA4NTguaHRtbCIsICJ0eXBlIjogInNlbGYiLCAiaWQiOiBudWxsLCAidGl0
@@ -9598,7 +1633,7 @@ http_interactions:
         MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
         bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
         c3QgYmUgcmVzdGFydGVkIGZvciB0aGUgdXBkYXRlIHRvIHRha2UgZWZmZWN0
-        LiIsICJfbGFzdF91cGRhdGVkIjogIjIwMTYtMDItMTFUMjI6MDI6NDdaIiwg
+        LiIsICJfbGFzdF91cGRhdGVkIjogIjIwMTYtMDItMjNUMTY6NDg6NThaIiwg
         InB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjogIkNvcHlyaWdodCAyMDEwIFJl
         ZCBIYXQgSW5jIiwgInNvbHV0aW9uIjogIkJlZm9yZSBhcHBseWluZyB0aGlz
         IHVwZGF0ZSwgbWFrZSBzdXJlIGFsbCBwcmV2aW91c2x5LXJlbGVhc2VkIGVy
@@ -9609,12 +1644,12 @@ http_interactions:
         YXRcbmh0dHA6Ly9rYmFzZS5yZWRoYXQuY29tL2ZhcS9kb2NzL0RPQy0xMTI1
         OSIsICJzdW1tYXJ5IjogIlVwZGF0ZWQgYnppcDIgcGFja2FnZXMgdGhhdCBm
         aXggb25lIHNlY3VyaXR5IGlzc3VlIiwgInJlbGVhc2UiOiAiIiwgIl9pZCI6
-        ICI2NWI0ZTkxNC03NjdlLTRlMDEtYTMwZS1lNTcwOThjMTk4ZmIifV0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:48 GMT
+        ICJmZjkwMWIzNi1jMDQ3LTQ1ZTItYmIyMS00OWY3MDBmMGZmODUifV0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:59 GMT
 - request:
     method: delete
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -9633,7 +1668,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:02:49 GMT
+      - Tue, 23 Feb 2016 16:48:59 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -9646,14 +1681,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzkwYTBlNmZjLWY4NjMtNDRiMy04M2Y5LTFhNDk2MTVjOWZjMy8iLCAi
-        dGFza19pZCI6ICI5MGEwZTZmYy1mODYzLTQ0YjMtODNmOS0xYTQ5NjE1Yzlm
-        YzMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:49 GMT
+        c2tzLzEwMWY5ZWEwLTA4NTEtNDkwNy1iY2FhLTczMDkwNDA5MjIzZS8iLCAi
+        dGFza19pZCI6ICIxMDFmOWVhMC0wODUxLTQ5MDctYmNhYS03MzA5MDQwOTIy
+        M2UifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:59 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/90a0e6fc-f863-44b3-83f9-1a49615c9fc3/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/101f9ea0-0851-4907-bcaa-73090409223e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -9672,13 +1707,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:02:49 GMT
+      - Tue, 23 Feb 2016 16:48:59 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '645'
       Connection:
       - close
       Content-Type:
@@ -9688,22 +1723,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85MGEwZTZmYy1mODYzLTQ0YjMtODNmOS0xYTQ5NjE1Yzlm
-        YzMvIiwgInRhc2tfaWQiOiAiOTBhMGU2ZmMtZjg2My00NGIzLTgzZjktMWE0
-        OTYxNWM5ZmMzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xMDFmOWVhMC0wODUxLTQ5MDctYmNhYS03MzA5MDQwOTIy
+        M2UvIiwgInRhc2tfaWQiOiAiMTAxZjllYTAtMDg1MS00OTA3LWJjYWEtNzMw
+        OTA0MDkyMjNlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
         bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
         ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJkMDUw
-        OTM0NDcxZTQwMDcwYjBiYWYifSwgImlkIjogIjU2YmQwNTA5MzQ0NzFlNDAw
-        NzBiMGJhZiJ9
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:49 GMT
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3Rh
+        dGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        NmNjOGQ3Yjk4OTA1NGZjNDhiYTMwN2QifSwgImlkIjogIjU2Y2M4ZDdiOTg5
+        MDU0ZmM0OGJhMzA3ZCJ9
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:48:59 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/90a0e6fc-f863-44b3-83f9-1a49615c9fc3/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/101f9ea0-0851-4907-bcaa-73090409223e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -9722,13 +1759,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:02:50 GMT
+      - Tue, 23 Feb 2016 16:49:00 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '688'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -9738,20 +1775,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85MGEwZTZmYy1mODYzLTQ0YjMtODNmOS0xYTQ5NjE1Yzlm
-        YzMvIiwgInRhc2tfaWQiOiAiOTBhMGU2ZmMtZjg2My00NGIzLTgzZjktMWE0
-        OTYxNWM5ZmMzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xMDFmOWVhMC0wODUxLTQ5MDctYmNhYS03MzA5MDQwOTIy
+        M2UvIiwgInRhc2tfaWQiOiAiMTAxZjllYTAtMDg1MS00OTA3LWJjYWEtNzMw
+        OTA0MDkyMjNlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTExVDIyOjAyOjUwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTExVDIyOjAyOjUwWiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ4OjU5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ4OjU5WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZDA1MDkzNDQ3MWU0MDA3MGIwYmFmIn0sICJpZCI6ICI1NmJkMDUwOTM0NDcx
-        ZTQwMDcwYjBiYWYifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:02:50 GMT
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkN2I5
+        ODkwNTRmYzQ4YmEzMDdkIn0sICJpZCI6ICI1NmNjOGQ3Yjk4OTA1NGZjNDhi
+        YTMwN2QifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:49:00 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/services/pulp/package_group.yml
+++ b/test/fixtures/vcr_cassettes/services/pulp/package_group.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/cb65f266-90cd-4604-94e3-654b6de9773b/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/01ddfe71-cae4-436e-a49f-310466f6c5bc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -13,12 +13,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="SlPUEj2LwRk0odZIUaBF754Y0O4EET2rIwC6pcR0",
-        oauth_signature="7tGRtNz%2F%2BMlf95LgcaMNEk4AAfA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292107", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -27,13 +21,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:01:47 GMT
+      - Tue, 23 Feb 2016 16:49:01 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '661'
       Connection:
       - close
       Content-Type:
@@ -43,22 +37,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jYjY1ZjI2Ni05MGNkLTQ2MDQtOTRlMy02NTRiNmRlOTc3
-        M2IvIiwgInRhc2tfaWQiOiAiY2I2NWYyNjYtOTBjZC00NjA0LTk0ZTMtNjU0
-        YjZkZTk3NzNiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8wMWRkZmU3MS1jYWU0LTQzNmUtYTQ5Zi0zMTA0NjZmNmM1
+        YmMvIiwgInRhc2tfaWQiOiAiMDFkZGZlNzEtY2FlNC00MzZlLWE0OWYtMzEw
+        NDY2ZjZjNWJjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjOGJl
-        NTQ5NzVmNzFhNmE2Njk3In0sICJpZCI6ICI1NmFlYmM4YmU1NDk3NWY3MWE2
-        YTY2OTcifQ==
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0OTowMVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4
+        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNTZjYzhkN2Q5ODkwNTRmYzQ4YmEzMDdlIn0sICJp
+        ZCI6ICI1NmNjOGQ3ZDk4OTA1NGZjNDhiYTMwN2UifQ==
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:47 GMT
+  recorded_at: Tue, 23 Feb 2016 16:49:01 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/cb65f266-90cd-4604-94e3-654b6de9773b/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/01ddfe71-cae4-436e-a49f-310466f6c5bc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -69,12 +65,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="Ra3nwZiWJMcTEG2WOa2vcg7QrSOPTXkJPSR3VyWu68",
-        oauth_signature="Jra%2Fz8ALNjhuQWgossKemuPqM3I%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292108", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -83,13 +73,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:01:48 GMT
+      - Tue, 23 Feb 2016 16:49:01 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2310'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -99,61 +89,61 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jYjY1ZjI2Ni05MGNkLTQ2MDQtOTRlMy02NTRiNmRlOTc3
-        M2IvIiwgInRhc2tfaWQiOiAiY2I2NWYyNjYtOTBjZC00NjA0LTk0ZTMtNjU0
-        YjZkZTk3NzNiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8wMWRkZmU3MS1jYWU0LTQzNmUtYTQ5Zi0zMTA0NjZmNmM1
+        YmMvIiwgInRhc2tfaWQiOiAiMDFkZGZlNzEtY2FlNC00MzZlLWE0OWYtMzEw
+        NDY2ZjZjNWJjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMjowMTo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTo0N1oiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0OTowMVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0OTowMVoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZWZjZWRhMjAtOTI2Yy00MTJjLThjOTMtNjcyOGJjNTVm
-        NmIxLyIsICJ0YXNrX2lkIjogImVmY2VkYTIwLTkyNmMtNDEyYy04YzkzLTY3
-        MjhiYzU1ZjZiMSJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9l
-        MzM0N2QyZC0xZmIyLTRiMjItYmI5Ny0zNDFkOGRjOTc1YjAvIiwgInRhc2tf
-        aWQiOiAiZTMzNDdkMmQtMWZiMi00YjIyLWJiOTctMzQxZDhkYzk3NWIwIn1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjOGJkZTA0MDMzNDZkMTg5MDQ4
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MjowMTo0N1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAyOjAxOjQ3WiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmM4YmRlMDQwMzRjZDky
-        ZGM1YzgiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmM4YmU1NDk3NWY3MWE2YTY2OTcifSwgImlkIjogIjU2YWViYzhiZTU0
-        OTc1ZjcxYTZhNjY5NyJ9
+        cGkvdjIvdGFza3MvY2YyMzZhNzEtMjBkOS00MDk5LTk5ZjgtOTYxYWVkMDg4
+        MTk4LyIsICJ0YXNrX2lkIjogImNmMjM2YTcxLTIwZDktNDA5OS05OWY4LTk2
+        MWFlZDA4ODE5OCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ3Y2RlMDQw
+        MzNmNDM1MTRmYmEifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ5OjAxWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDk6MDFaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkN2Rk
+        ZTA0MDMwODk3NThhOTUzIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDdkOTg5MDU0ZmM0OGJhMzA3ZSJ9LCAiaWQiOiAiNTZj
+        YzhkN2Q5ODkwNTRmYzQ4YmEzMDdlIn0=
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:48 GMT
+  recorded_at: Tue, 23 Feb 2016 16:49:01 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/efceda20-926c-412c-8c93-6728bc55f6b1/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/cf236a71-20d9-4099-99f8-961aed088198/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -164,12 +154,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="3zG7iqcVFVsc55CcvGRSET1XxvdJwb0tZExouHxYghU",
-        oauth_signature="YMg3xnHq0Rg%2FqajCJlPETrn2QfU%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292108", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -178,294 +162,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:01:48 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9lZmNlZGEyMC05MjZjLTQxMmMtOGM5My02NzI4
-        YmM1NWY2YjEvIiwgInRhc2tfaWQiOiAiZWZjZWRhMjAtOTI2Yy00MTJjLThj
-        OTMtNjcyOGJjNTVmNmIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMjowMTo0OFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTo0OFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDI6MDE6NDhaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMjowMTo0OFoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmM4Y2RlMDQwMzRjZDkyZGM1YzkiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjOGJlNTQ5NzVmNzFhNmE2NmE3In0s
-        ICJpZCI6ICI1NmFlYmM4YmU1NDk3NWY3MWE2YTY2YTcifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:48 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/e3347d2d-1fb2-4b22-bb97-341d8dc975b0/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="R6eZcJuOBnwYOg0JJGRRgmEkowsvhoxhLRsK3r8Fg98",
-        oauth_signature="VUPHel54sO45tur3iujU8QIcldQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292108", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:48 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '652'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9lMzM0N2QyZC0xZmIyLTRiMjItYmI5Ny0zNDFk
-        OGRjOTc1YjAvIiwgInRhc2tfaWQiOiAiZTMzNDdkMmQtMWZiMi00YjIyLWJi
-        OTctMzQxZDhkYzk3NWIwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiBudWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBb
-        XSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRf
-        cmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRx
-        IiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
-        ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRv
-        aWQiOiAiNTZhZWJjOGJlNTQ5NzVmNzFhNmE2NmE4In0sICJpZCI6ICI1NmFl
-        YmM4YmU1NDk3NWY3MWE2YTY2YTgifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:48 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/cb65f266-90cd-4604-94e3-654b6de9773b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="T1jh2bi7LDXmV25iUKQUVKrG9IY8WkED05UDfMzLZz0",
-        oauth_signature="Sl9z24l99rxUIwFtxz7EubRq1m4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292108", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:48 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2310'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jYjY1ZjI2Ni05MGNkLTQ2MDQtOTRlMy02NTRiNmRlOTc3
-        M2IvIiwgInRhc2tfaWQiOiAiY2I2NWYyNjYtOTBjZC00NjA0LTk0ZTMtNjU0
-        YjZkZTk3NzNiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMjowMTo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTo0N1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZWZjZWRhMjAtOTI2Yy00MTJjLThjOTMtNjcyOGJjNTVm
-        NmIxLyIsICJ0YXNrX2lkIjogImVmY2VkYTIwLTkyNmMtNDEyYy04YzkzLTY3
-        MjhiYzU1ZjZiMSJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9l
-        MzM0N2QyZC0xZmIyLTRiMjItYmI5Ny0zNDFkOGRjOTc1YjAvIiwgInRhc2tf
-        aWQiOiAiZTMzNDdkMmQtMWZiMi00YjIyLWJiOTctMzQxZDhkYzk3NWIwIn1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjOGJkZTA0MDMzNDZkMTg5MDQ4
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MjowMTo0N1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAyOjAxOjQ3WiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmM4YmRlMDQwMzRjZDky
-        ZGM1YzgiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmM4YmU1NDk3NWY3MWE2YTY2OTcifSwgImlkIjogIjU2YWViYzhiZTU0
-        OTc1ZjcxYTZhNjY5NyJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:48 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/efceda20-926c-412c-8c93-6728bc55f6b1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="tEsXin5mwiwbV6JQTV8S47MGdiMq5tS04MRyljXTA",
-        oauth_signature="SkxuhwMjyORKM%2F9K9eG0FSs1kLk%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292108", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:48 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9lZmNlZGEyMC05MjZjLTQxMmMtOGM5My02NzI4
-        YmM1NWY2YjEvIiwgInRhc2tfaWQiOiAiZWZjZWRhMjAtOTI2Yy00MTJjLThj
-        OTMtNjcyOGJjNTVmNmIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMjowMTo0OFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTo0OFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDI6MDE6NDhaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMjowMTo0OFoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmM4Y2RlMDQwMzRjZDkyZGM1YzkiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjOGJlNTQ5NzVmNzFhNmE2NmE3In0s
-        ICJpZCI6ICI1NmFlYmM4YmU1NDk3NWY3MWE2YTY2YTcifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:48 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/e3347d2d-1fb2-4b22-bb97-341d8dc975b0/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="NdEJNh6DnPriLrtKuhTnRrriOMZke18Lel6Pd0C8U",
-        oauth_signature="qiO8i%2BW0uKba9z1Y9Uzo7JSRmoc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292108", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:48 GMT
+      - Tue, 23 Feb 2016 16:49:01 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -481,84 +178,84 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9lMzM0N2QyZC0xZmIyLTRiMjItYmI5Ny0zNDFk
-        OGRjOTc1YjAvIiwgInRhc2tfaWQiOiAiZTMzNDdkMmQtMWZiMi00YjIyLWJi
-        OTctMzQxZDhkYzk3NWIwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy9jZjIzNmE3MS0yMGQ5LTQwOTktOTlmOC05NjFh
+        ZWQwODgxOTgvIiwgInRhc2tfaWQiOiAiY2YyMzZhNzEtMjBkOS00MDk5LTk5
+        ZjgtOTYxYWVkMDg4MTk4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMjowMTo0OFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTo0OFoiLCAi
+        bWUiOiAiMjAxNi0wMi0yM1QxNjo0OTowMVoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0OTowMVoiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI2NzhhOWIxOS1iNDgyLTQ1MmUtYjExYi02YjBiNzc4
-        Yzg1ZDYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICIxNzY1YzlmNC1iZTE0LTQxM2EtYTdiNy0xMTI0YjE1
+        ZGRmNjQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYTcyZGIzOWYtYzg2My00NWRjLWJiMzktZDUwODA3ZTEzZTBhIiwg
+        aWQiOiAiNTk5ODNjYjctN2VjOS00OTU5LWEwNDAtYjBmOTdmODRmOTFkIiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
         bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMGE2YzlmYjYtYTJkYy00NzNlLWEwYjYt
-        ZmNjNjkyNTQ4NjE1IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZDMxZjM3NDYtZDA2Mi00NDQ0LTg5M2Ut
+        YzdiYmYxODMzYTk2IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
         TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDYx
-        M2Y0Y2QtM2RmZC00NmIzLWExYjYtZDdjNWVhMjA3MDQwIiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiN2E1
+        NDhmYzktODYyYS00MGM2LTljZTQtOTk4YTc3NmNlYTZiIiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjJkYjU5OTU0LTY0ZDMtNGM1Mi04NjZlLTJjMzdm
-        OTdhNDExNCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        IDAsICJzdGVwX2lkIjogIjA3OTU1OWYzLTRhODQtNDU5My1iYTI2LTA4MDMz
+        ZmNjMTEwYyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
         OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
         InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjNGNjYzU0
-        Yy1mMTc5LTQ5NGItOTNlMi1mNjAwOWQ2MzM1ZDkiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlY2IxNmM0
+        OS1lY2JlLTQ3ZGMtODc0Ni1iODgxZjc4MzBkMWIiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
         Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI2ODcwZDZhYi1iMmE3LTQ5MzAtOWY4Zi1hYTQ5
-        ZTEyOTA0MWIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICI3NWQwMWRhOS00YmQ0LTQxNGEtYWI2NS0yMmUx
+        MTUwODc2OWUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
         ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJiNjkyODI2Yi0wNDU2LTQ5MGMtOWZkNi04ODhlOGQyY2ZhZjIi
+        cF9pZCI6ICI0MDZmOGU3Ny1mYTc4LTQ3ZTYtYTVmOS1kZDQxMGI5NGFhNmMi
         LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
         dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
         c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2NmNh
-        NzI1Mi00MzEyLTRiNzQtYmYzZS02MzVkZGI2ZjllZDgiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyOWRl
+        MmM2Ny0yYjhjLTQyNTEtYjRmZS1lNWU1OGI3NzE3OWEiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
         aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzZDUwZGU4NC1jODhj
-        LTRhMTUtODVhNC00MjRkYjM2MTdjZTEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4OTg0ZWRiZC0yMjZl
+        LTQ5NWYtYjc0ZC04ZGU0YjI5ZjdiZGQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
         TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
         X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjgyYTcyNGZhLWMwMzktNDAw
-        Yy1iNTZkLThiMjJmNTBhNGZhZiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImViOTViZDZiLWNlMzUtNGY1
+        YS1hNjQ5LWM0ZTlmODY4ZDhiOCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
         InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
         eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
         b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
         bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
         c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTAxVDAyOjAxOjQ4WiIsICJf
+        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ5OjAxWiIsICJf
         bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
-        MTYtMDItMDFUMDI6MDE6NDhaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
+        MTYtMDItMjNUMTY6NDk6MDFaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
         cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
         IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
         X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
@@ -567,82 +264,82 @@ http_interactions:
         aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
         SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
         U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
-        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZhZWJjOGNkZTA0MDM0Y2Q5MmRj
-        NWNhIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZjYzhkN2RkZTA0MDMwODk3NThh
+        OTU0IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
         dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
         cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
         IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjY3OGE5YjE5LWI0ODItNDUyZS1iMTFiLTZiMGI3NzhjODVkNiIsICJu
+        IjogIjE3NjVjOWY0LWJlMTQtNDEzYS1hN2I3LTExMjRiMTVkZGY2NCIsICJu
         dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
         cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
         cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNzJk
-        YjM5Zi1jODYzLTQ1ZGMtYmIzOS1kNTA4MDdlMTNlMGEiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1OTk4
+        M2NiNy03ZWM5LTQ5NTktYTA0MC1iMGY5N2Y4NGY5MWQiLCAibnVtX3Byb2Nl
         c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
         c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICIwYTZjOWZiNi1hMmRjLTQ3M2UtYTBiNi1mY2M2OTI1NDg2
-        MTUiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICJkMzFmMzc0Ni1kMDYyLTQ0NDQtODkzZS1jN2JiZjE4MzNh
+        OTYiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
         X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
         U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNjEzZjRjZC0zZGZk
-        LTQ2YjMtYTFiNi1kN2M1ZWEyMDcwNDAiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3YTU0OGZjOS04NjJh
+        LTQwYzYtOWNlNC05OThhNzc2Y2VhNmIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
         LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
         bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
         YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMmRiNTk5NTQtNjRkMy00YzUyLTg2NmUtMmMzN2Y5N2E0MTE0Iiwg
+        aWQiOiAiMDc5NTU5ZjMtNGE4NC00NTkzLWJhMjYtMDgwMzNmY2MxMTBjIiwg
         Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
         IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM0Y2NjNTRjLWYxNzktNDk0
-        Yi05M2UyLWY2MDA5ZDYzMzVkOSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVjYjE2YzQ5LWVjYmUtNDdk
+        Yy04NzQ2LWI4ODFmNzgzMGQxYiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
         bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
         ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
         dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
         OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjY4NzBkNmFiLWIyYTctNDkzMC05ZjhmLWFhNDllMTI5MDQxYiIs
+        X2lkIjogIjc1ZDAxZGE5LTRiZDQtNDE0YS1hYjY1LTIyZTExNTA4NzY5ZSIs
         ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
         Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
         ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI2
-        OTI4MjZiLTA0NTYtNDkwYy05ZmQ2LTg4OGU4ZDJjZmFmMiIsICJudW1fcHJv
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQw
+        NmY4ZTc3LWZhNzgtNDdlNi1hNWY5LWRkNDEwYjk0YWE2YyIsICJudW1fcHJv
         Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
         OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
         bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
         S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjY2Y2E3MjUyLTQzMTIt
-        NGI3NC1iZjNlLTYzNWRkYjZmOWVkOCIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI5ZGUyYzY3LTJiOGMt
+        NDI1MS1iNGZlLWU1ZTU4Yjc3MTc5YSIsICJudW1fcHJvY2Vzc2VkIjogMH0s
         IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
         ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
         b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjNkNTBkZTg0LWM4OGMtNGExNS04NWE0
-        LTQyNGRiMzYxN2NlMSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjg5ODRlZGJkLTIyNmUtNDk1Zi1iNzRk
+        LThkZTRiMjlmN2JkZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
         Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
         aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
         LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
         b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiODJhNzI0ZmEtYzAzOS00MDBjLWI1NmQtOGIy
-        MmY1MGE0ZmFmIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YWViYzhiZTU0OTc1ZjcxYTZhNjZh
-        OCJ9LCAiaWQiOiAiNTZhZWJjOGJlNTQ5NzVmNzFhNmE2NmE4In0=
+        IjogMCwgInN0ZXBfaWQiOiAiZWI5NWJkNmItY2UzNS00ZjVhLWE2NDktYzRl
+        OWY4NjhkOGI4IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDdkOTg5MDU0ZmM0OGJhMzA4
+        ZSJ9LCAiaWQiOiAiNTZjYzhkN2Q5ODkwNTRmYzQ4YmEzMDhlIn0=
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:48 GMT
+  recorded_at: Tue, 23 Feb 2016 16:49:01 GMT
 - request:
     method: post
     uri: https://katello-yoda.example.com/pulp/api/v2/content/units/package_group/search/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiOWYyYWEx
-        NjAtZDM2Yi00ODk3LWFjYjEtNDg5MjRjMTVlMDM4Il19fX0sImluY2x1ZGVf
+        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiZmM4ZjI4
+        ZDEtMmVhZC00YjQ3LWFhOTgtYTM0NzBlNzIzYmJiIl19fX0sImluY2x1ZGVf
         cmVwb3MiOnRydWV9
     headers:
       Accept:
@@ -651,12 +348,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4",
-        oauth_nonce="ZiFzaVShj84dBgESpPjcH2uJAAQa2zPUIjQ3BXPyUk", oauth_signature="8ba%2BCXBKYKL4cB%2BQzZ%2Fh8dV2wt4%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454292109", oauth_version="1.0"
-      Pulp-User:
-      - admin
       Content-Length:
       - '102'
       User-Agent:
@@ -667,7 +358,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:01:49 GMT
+      - Tue, 23 Feb 2016 16:49:02 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -685,21 +376,21 @@ http_interactions:
         YW5kYXRvcnlfcGFja2FnZV9uYW1lcyI6IFsicGVuZ3VpbiJdLCAicmVwb19p
         ZCI6ICJGZWRvcmFfMTciLCAibmFtZSI6ICJiaXJkIiwgInVzZXJfdmlzaWJs
         ZSI6IHRydWUsICJkZWZhdWx0IjogdHJ1ZSwgIl9sYXN0X3VwZGF0ZWQiOiAi
-        MjAxNi0wMi0wMVQwMTo1OTo1NVoiLCAiY2hpbGRyZW4iOiB7fSwgIm9wdGlv
+        MjAxNi0wMi0yM1QxNjo0Nzo0OFoiLCAiY2hpbGRyZW4iOiB7fSwgIm9wdGlv
         bmFsX3BhY2thZ2VfbmFtZXMiOiBbXSwgInRyYW5zbGF0ZWRfbmFtZSI6IHt9
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcGFja2Fn
-        ZV9ncm91cC85ZjJhYTE2MC1kMzZiLTQ4OTctYWNiMS00ODkyNGMxNWUwMzgv
+        ZV9ncm91cC9mYzhmMjhkMS0yZWFkLTRiNDctYWE5OC1hMzQ3MGU3MjNiYmIv
         IiwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24iOiB7fSwgInB1bHBfdXNlcl9t
         ZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNrYWdlX25hbWVzIjogW10sICJf
         Y29udGVudF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAiaWQiOiAiYmly
-        ZCIsICJfaWQiOiAiOWYyYWExNjAtZDM2Yi00ODk3LWFjYjEtNDg5MjRjMTVl
-        MDM4IiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxfcGFj
+        ZCIsICJfaWQiOiAiZmM4ZjI4ZDEtMmVhZC00YjQ3LWFhOTgtYTM0NzBlNzIz
+        YmJiIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxfcGFj
         a2FnZV9uYW1lcyI6IFtdfV0=
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:49 GMT
+  recorded_at: Tue, 23 Feb 2016 16:49:02 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/239afa86-c1d3-4a95-81ea-0a62165870c7/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/17450b59-56f8-4325-9c3f-8d9a81ccc997/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -710,12 +401,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="1xRSowAhefmt4VAFghtr4FhVayoQwmWVmu1D4ditA",
-        oauth_signature="ynbSx9FWnSY3Uh%2FQ%2Fb%2FdEBU6DQ8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292109", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -724,7 +409,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:01:49 GMT
+      - Tue, 23 Feb 2016 16:49:02 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -740,22 +425,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yMzlhZmE4Ni1jMWQzLTRhOTUtODFlYS0wYTYyMTY1ODcw
-        YzcvIiwgInRhc2tfaWQiOiAiMjM5YWZhODYtYzFkMy00YTk1LTgxZWEtMGE2
-        MjE2NTg3MGM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xNzQ1MGI1OS01NmY4LTQzMjUtOWMzZi04ZDlhODFjY2M5
+        OTcvIiwgInRhc2tfaWQiOiAiMTc0NTBiNTktNTZmOC00MzI1LTljM2YtOGQ5
+        YTgxY2NjOTk3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
         bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
         ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
         Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
         IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmFlYmM4
-        ZGU1NDk3NWY3MWE2YTY2YTkifSwgImlkIjogIjU2YWViYzhkZTU0OTc1Zjcx
-        YTZhNjZhOSJ9
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ3
+        ZTk4OTA1NGZjNDhiYTMwOGYifSwgImlkIjogIjU2Y2M4ZDdlOTg5MDU0ZmM0
+        OGJhMzA4ZiJ9
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:49 GMT
+  recorded_at: Tue, 23 Feb 2016 16:49:02 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/239afa86-c1d3-4a95-81ea-0a62165870c7/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/17450b59-56f8-4325-9c3f-8d9a81ccc997/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -766,12 +451,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="Cpdn0289ZLP17Kgdo62pOcCaCZ3ZOn7a6GZ2ouI",
-        oauth_signature="oBJfistWmWrUM6%2FT3k4jgdlPPX4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292109", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -780,7 +459,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:01:49 GMT
+      - Tue, 23 Feb 2016 16:49:02 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -796,25 +475,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yMzlhZmE4Ni1jMWQzLTRhOTUtODFlYS0wYTYyMTY1ODcw
-        YzcvIiwgInRhc2tfaWQiOiAiMjM5YWZhODYtYzFkMy00YTk1LTgxZWEtMGE2
-        MjE2NTg3MGM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xNzQ1MGI1OS01NmY4LTQzMjUtOWMzZi04ZDlhODFjY2M5
+        OTcvIiwgInRhc2tfaWQiOiAiMTc0NTBiNTktNTZmOC00MzI1LTljM2YtOGQ5
+        YTgxY2NjOTk3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTAxVDAyOjAxOjQ5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTAxVDAyOjAxOjQ5WiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ5OjAyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ5OjAyWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
         MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
         aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
         a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjOGRl
-        NTQ5NzVmNzFhNmE2NmE5In0sICJpZCI6ICI1NmFlYmM4ZGU1NDk3NWY3MWE2
-        YTY2YTkifQ==
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkN2U5
+        ODkwNTRmYzQ4YmEzMDhmIn0sICJpZCI6ICI1NmNjOGQ3ZTk4OTA1NGZjNDhi
+        YTMwOGYifQ==
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:49 GMT
+  recorded_at: Tue, 23 Feb 2016 16:49:02 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/8480b455-4597-4eae-bf28-3d5cfc73c234/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/567c8a8c-335c-47d7-9eac-061f1801e4e0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -825,12 +504,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="3KLNnDlFZ12B7qQN5v8c0MdLuub5kZIP2RCdlUsRdQ",
-        oauth_signature="3ZQTZvd7gtZMUsIDoATRFv5aqDk%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292110", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -839,13 +512,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:01:50 GMT
+      - Tue, 23 Feb 2016 16:49:03 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '661'
       Connection:
       - close
       Content-Type:
@@ -855,22 +528,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84NDgwYjQ1NS00NTk3LTRlYWUtYmYyOC0zZDVjZmM3M2My
-        MzQvIiwgInRhc2tfaWQiOiAiODQ4MGI0NTUtNDU5Ny00ZWFlLWJmMjgtM2Q1
-        Y2ZjNzNjMjM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy81NjdjOGE4Yy0zMzVjLTQ3ZDctOWVhYy0wNjFmMTgwMWU0
+        ZTAvIiwgInRhc2tfaWQiOiAiNTY3YzhhOGMtMzM1Yy00N2Q3LTllYWMtMDYx
+        ZjE4MDFlNGUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjOGVl
-        NTQ5NzVmNzFhNmE2NmFhIn0sICJpZCI6ICI1NmFlYmM4ZWU1NDk3NWY3MWE2
-        YTY2YWEifQ==
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0OTowM1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4
+        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNTZjYzhkN2Y5ODkwNTRmYzQ4YmEzMDkwIn0sICJp
+        ZCI6ICI1NmNjOGQ3Zjk4OTA1NGZjNDhiYTMwOTAifQ==
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:50 GMT
+  recorded_at: Tue, 23 Feb 2016 16:49:03 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/8480b455-4597-4eae-bf28-3d5cfc73c234/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/567c8a8c-335c-47d7-9eac-061f1801e4e0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -881,12 +556,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="2XIAIi13yQGAn6zRMiTDBhM7W58cdQn6mWRW9uds",
-        oauth_signature="vGQOTQy%2FmS4eLxtOEiC2QT37cds%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292111", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -895,13 +564,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:01:51 GMT
+      - Tue, 23 Feb 2016 16:49:04 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2310'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -911,61 +580,61 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84NDgwYjQ1NS00NTk3LTRlYWUtYmYyOC0zZDVjZmM3M2My
-        MzQvIiwgInRhc2tfaWQiOiAiODQ4MGI0NTUtNDU5Ny00ZWFlLWJmMjgtM2Q1
-        Y2ZjNzNjMjM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy81NjdjOGE4Yy0zMzVjLTQ3ZDctOWVhYy0wNjFmMTgwMWU0
+        ZTAvIiwgInRhc2tfaWQiOiAiNTY3YzhhOGMtMzM1Yy00N2Q3LTllYWMtMDYx
+        ZjE4MDFlNGUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMjowMTo1MVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTo1MFoiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0OTowM1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0OTowM1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNDg1NDAyODItNzBhMi00Y2IzLWFjNjYtZGViNjU4MWJj
-        Nzg1LyIsICJ0YXNrX2lkIjogIjQ4NTQwMjgyLTcwYTItNGNiMy1hYzY2LWRl
-        YjY1ODFiYzc4NSJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8y
-        NWJlOWNhMi1kNjc3LTQwZDUtOWFlNS1iNTI5Y2QxMmZiOTMvIiwgInRhc2tf
-        aWQiOiAiMjViZTljYTItZDY3Ny00MGQ1LTlhZTUtYjUyOWNkMTJmYjkzIn1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjOGVkZTA0MDMzNDZiZmRhZDc2
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MjowMTo1MFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAyOjAxOjUxWiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmM4ZmRlMDQwMzRjZDky
-        ZGM1Y2UiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmM4ZWU1NDk3NWY3MWE2YTY2YWEifSwgImlkIjogIjU2YWViYzhlZTU0
-        OTc1ZjcxYTZhNjZhYSJ9
+        cGkvdjIvdGFza3MvMmViZTgxY2QtMjQ5OS00NDAzLWI2YWQtMjFmMzRmOTQ1
+        NzI3LyIsICJ0YXNrX2lkIjogIjJlYmU4MWNkLTI0OTktNDQwMy1iNmFkLTIx
+        ZjM0Zjk0NTcyNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ3ZmRlMDQw
+        MzNmNDI2MmNhZDUifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ5OjAzWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDk6MDNaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkN2Zk
+        ZTA0MDMwODk3NThhOTU4IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDdmOTg5MDU0ZmM0OGJhMzA5MCJ9LCAiaWQiOiAiNTZj
+        YzhkN2Y5ODkwNTRmYzQ4YmEzMDkwIn0=
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:51 GMT
+  recorded_at: Tue, 23 Feb 2016 16:49:04 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/48540282-70a2-4cb3-ac66-deb6581bc785/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/2ebe81cd-2499-4403-b6ad-21f34f945727/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -976,12 +645,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="rte2AstZ4xZTVE78KdkuWl7apZ0JJt5dnofcQlkrkk",
-        oauth_signature="bGQoxw620H0NnItJdsYU3v6LbM0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292111", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -990,358 +653,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:01:51 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80ODU0MDI4Mi03MGEyLTRjYjMtYWM2Ni1kZWI2
-        NTgxYmM3ODUvIiwgInRhc2tfaWQiOiAiNDg1NDAyODItNzBhMi00Y2IzLWFj
-        NjYtZGViNjU4MWJjNzg1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMjowMTo1MVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTo1MVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDI6MDE6NTFaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMjowMTo1MVoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmM4ZmRlMDQwMzRjZDkyZGM1Y2YiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjOGZlNTQ5NzVmNzFhNmE2NmJhIn0s
-        ICJpZCI6ICI1NmFlYmM4ZmU1NDk3NWY3MWE2YTY2YmEifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:51 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/25be9ca2-d677-40d5-9ae5-b529cd12fb93/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="ytMaIZbkiyyaI62AXoU147mp5KBDH9tsIOVgHWVOvp0",
-        oauth_signature="9nKRzqjWLfQ8X89XIxJNCzzra8U%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292111", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:51 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3523'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8yNWJlOWNhMi1kNjc3LTQwZDUtOWFlNS1iNTI5
-        Y2QxMmZiOTMvIiwgInRhc2tfaWQiOiAiMjViZTljYTItZDY3Ny00MGQ1LTlh
-        ZTUtYjUyOWNkMTJmYjkzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wMVQwMjowMTo1MVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1
-        YmRmOTM5Mi1mODIwLTQwN2EtYjQ5Mi0xNmUxMWE3MmJhM2EiLCAibnVtX3By
-        b2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlw
-        ZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODJlOGMx
-        YjMtMmFhMC00ZDEwLWJlOGUtZmIyZGZlN2NjYjk5IiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNf
-        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiOTJkODM3MjktNmU5YS00MGYzLTg5YjctN2I5MGEwZDM0
-        MGQ3IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3Rl
-        cF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI0YWViNTk2
-        LTdiM2QtNGIxNi1hZmE0LTc5NjMyYzJmNzE0MCIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVt
-        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI1YmFhMTZjMC03MjQxLTQwYjUtOTQ4MS1hMWE0ZjYx
-        NWYzMjIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJz
-        dGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZGU3Yzdm
-        MTQtOTRkOS00YWUwLWIzNjItYWRhMzM2MzQyN2FiIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEi
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiN2U2NTAxOTctN2YwNi00NTE5LTk3ODQt
-        ZmYyM2M5N2Y4YWE1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRh
-        dGEiLCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiYmIxYmMwNTMtZjIxOC00YzI5LWE1ZjgtNGQ2YTY5
-        MDM0MmY5IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
-        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIs
-        ICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjEyYzBiZDA2LTY3YzUtNGY0MC05M2ExLTRmMzI1NmI5YTAxZCIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
-        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90
-        eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImUwOTA1MmJkLTE1NjMtNGE5ZC1hMGMwLTZhZjBmNGQ5ZGNmMiIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJp
-        bml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        MTBhMDVjZTQtYmNiMy00MDA0LTk3N2ItMDYzZjQ4YTU3ZWM1IiwgIm51bV9w
-        cm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
-        Y2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZh
-        ZWJjOGZlNTQ5NzVmNzFhNmE2NmJiIn0sICJpZCI6ICI1NmFlYmM4ZmU1NDk3
-        NWY3MWE2YTY2YmIifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:51 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/8480b455-4597-4eae-bf28-3d5cfc73c234/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="nFDoBuQaCG3aGzfQDx65umMNRLJetE4cBxaDkU0tukU",
-        oauth_signature="yvJ0cnNnRBXgt%2FDrHs2k5q8iess%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292111", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:51 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2310'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84NDgwYjQ1NS00NTk3LTRlYWUtYmYyOC0zZDVjZmM3M2My
-        MzQvIiwgInRhc2tfaWQiOiAiODQ4MGI0NTUtNDU5Ny00ZWFlLWJmMjgtM2Q1
-        Y2ZjNzNjMjM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMjowMTo1MVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTo1MFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNDg1NDAyODItNzBhMi00Y2IzLWFjNjYtZGViNjU4MWJj
-        Nzg1LyIsICJ0YXNrX2lkIjogIjQ4NTQwMjgyLTcwYTItNGNiMy1hYzY2LWRl
-        YjY1ODFiYzc4NSJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8y
-        NWJlOWNhMi1kNjc3LTQwZDUtOWFlNS1iNTI5Y2QxMmZiOTMvIiwgInRhc2tf
-        aWQiOiAiMjViZTljYTItZDY3Ny00MGQ1LTlhZTUtYjUyOWNkMTJmYjkzIn1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjOGVkZTA0MDMzNDZiZmRhZDc2
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MjowMTo1MFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAyOjAxOjUxWiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmM4ZmRlMDQwMzRjZDky
-        ZGM1Y2UiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmM4ZWU1NDk3NWY3MWE2YTY2YWEifSwgImlkIjogIjU2YWViYzhlZTU0
-        OTc1ZjcxYTZhNjZhYSJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:51 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/48540282-70a2-4cb3-ac66-deb6581bc785/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="0EU2g2Cm0Fp3W8xOT7xBrZowfnEJj1S0YgRRM5QpM4",
-        oauth_signature="nFL1O3RiyIpw6hQ1WosEKB28C%2F4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292111", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:51 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80ODU0MDI4Mi03MGEyLTRjYjMtYWM2Ni1kZWI2
-        NTgxYmM3ODUvIiwgInRhc2tfaWQiOiAiNDg1NDAyODItNzBhMi00Y2IzLWFj
-        NjYtZGViNjU4MWJjNzg1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMjowMTo1MVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTo1MVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDI6MDE6NTFaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMjowMTo1MVoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmM4ZmRlMDQwMzRjZDkyZGM1Y2YiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjOGZlNTQ5NzVmNzFhNmE2NmJhIn0s
-        ICJpZCI6ICI1NmFlYmM4ZmU1NDk3NWY3MWE2YTY2YmEifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:51 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/25be9ca2-d677-40d5-9ae5-b529cd12fb93/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="XnqbgrXWYimOtSsk6Q3RXKweHgjy9qIsAYMeHvqsDSA",
-        oauth_signature="XhR%2Bd3wypcWRHA9NmTr8qDFBsBM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292112", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:52 GMT
+      - Tue, 23 Feb 2016 16:49:04 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -1357,84 +669,84 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8yNWJlOWNhMi1kNjc3LTQwZDUtOWFlNS1iNTI5
-        Y2QxMmZiOTMvIiwgInRhc2tfaWQiOiAiMjViZTljYTItZDY3Ny00MGQ1LTlh
-        ZTUtYjUyOWNkMTJmYjkzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy8yZWJlODFjZC0yNDk5LTQ0MDMtYjZhZC0yMWYz
+        NGY5NDU3MjcvIiwgInRhc2tfaWQiOiAiMmViZTgxY2QtMjQ5OS00NDAzLWI2
+        YWQtMjFmMzRmOTQ1NzI3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMjowMTo1MVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTo1MVoiLCAi
+        bWUiOiAiMjAxNi0wMi0yM1QxNjo0OTowNFoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0OTowNFoiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI1YmRmOTM5Mi1mODIwLTQwN2EtYjQ5Mi0xNmUxMWE3
-        MmJhM2EiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICJlN2FhY2RiOS0xM2IyLTQxMzAtOTVkYi1iMWU3MDQw
+        MDViYzIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiODJlOGMxYjMtMmFhMC00ZDEwLWJlOGUtZmIyZGZlN2NjYjk5Iiwg
+        aWQiOiAiMjNiNTUyNzItMDFiNi00OWM0LTkzYmItOWE3ZGZkZTc2MzdjIiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
         bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiOTJkODM3MjktNmU5YS00MGYzLTg5Yjct
-        N2I5MGEwZDM0MGQ3IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiOGM5N2M5NWEtNWE1OS00NmZkLTgxOTkt
+        YjNkZWUyY2JmM2Q1IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
         TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjRh
-        ZWI1OTYtN2IzZC00YjE2LWFmYTQtNzk2MzJjMmY3MTQwIiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjEz
+        YzkwYjItZTU1Ni00YjlhLWE3ZjktMzYxNGRlY2I5MDMzIiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjViYWExNmMwLTcyNDEtNDBiNS05NDgxLWExYTRm
-        NjE1ZjMyMiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        IDAsICJzdGVwX2lkIjogIjY5MzZjNWNiLWMwMDctNGNjMy05YTRiLTlkMGVk
+        YTdmMTIwYyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
         OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
         InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkZTdjN2Yx
-        NC05NGQ5LTRhZTAtYjM2Mi1hZGEzMzYzNDI3YWIiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyYTFlZWE5
+        ZS02NTE3LTRiZDYtYTM5Ni00OTFiMjIzNmE0NzgiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
         Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI3ZTY1MDE5Ny03ZjA2LTQ1MTktOTc4NC1mZjIz
-        Yzk3ZjhhYTUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICIyMzI0NzBiNC05N2Y1LTQwNjYtOWFiZS1hNWNi
+        ZDMyOGFhZWQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
         ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJiYjFiYzA1My1mMjE4LTRjMjktYTVmOC00ZDZhNjkwMzQyZjki
+        cF9pZCI6ICJlYjAzMzVjNS1jMDZiLTQwM2EtOTRmMi05ODEwNjBmODU2NWIi
         LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
         dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
         c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxMmMw
-        YmQwNi02N2M1LTRmNDAtOTNhMS00ZjMyNTZiOWEwMWQiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0N2Q1
+        MGVlNi1iYzdjLTRhYTctYWFlNC0wOWJiODhjNTk4ZGIiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
         aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlMDkwNTJiZC0xNTYz
-        LTRhOWQtYTBjMC02YWYwZjRkOWRjZjIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5NjMzNzZmOC1mNTA5
+        LTQxM2EtYmU2ZC0wNDg2MGVlMTU0NDAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
         TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
         X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjEwYTA1Y2U0LWJjYjMtNDAw
-        NC05NzdiLTA2M2Y0OGE1N2VjNSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI0NzEzMGFiLTE1MTgtNDAw
+        YS04ZWRhLTA2MGM4ZTMzNTYyNSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
         InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
         eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
         b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
         bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
         c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTAxVDAyOjAxOjUxWiIsICJf
+        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ5OjA0WiIsICJf
         bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
-        MTYtMDItMDFUMDI6MDE6NTFaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
+        MTYtMDItMjNUMTY6NDk6MDRaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
         cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
         IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
         X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
@@ -1443,77 +755,77 @@ http_interactions:
         aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
         SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
         U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
-        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZhZWJjOGZkZTA0MDM0Y2Q5MmRj
-        NWQwIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZjYzhkODBkZTA0MDMwODk3NThh
+        OTU5IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
         dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
         cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
         IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjViZGY5MzkyLWY4MjAtNDA3YS1iNDkyLTE2ZTExYTcyYmEzYSIsICJu
+        IjogImU3YWFjZGI5LTEzYjItNDEzMC05NWRiLWIxZTcwNDAwNWJjMiIsICJu
         dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
         cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
         cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4MmU4
-        YzFiMy0yYWEwLTRkMTAtYmU4ZS1mYjJkZmU3Y2NiOTkiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyM2I1
+        NTI3Mi0wMWI2LTQ5YzQtOTNiYi05YTdkZmRlNzYzN2MiLCAibnVtX3Byb2Nl
         c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
         c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICI5MmQ4MzcyOS02ZTlhLTQwZjMtODliNy03YjkwYTBkMzQw
-        ZDciLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICI4Yzk3Yzk1YS01YTU5LTQ2ZmQtODE5OS1iM2RlZTJjYmYz
+        ZDUiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
         X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
         U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiNGFlYjU5Ni03YjNk
-        LTRiMTYtYWZhNC03OTYzMmMyZjcxNDAiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMTNjOTBiMi1lNTU2
+        LTRiOWEtYTdmOS0zNjE0ZGVjYjkwMzMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
         LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
         bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
         YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNWJhYTE2YzAtNzI0MS00MGI1LTk0ODEtYTFhNGY2MTVmMzIyIiwg
+        aWQiOiAiNjkzNmM1Y2ItYzAwNy00Y2MzLTlhNGItOWQwZWRhN2YxMjBjIiwg
         Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
         IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImRlN2M3ZjE0LTk0ZDktNGFl
-        MC1iMzYyLWFkYTMzNjM0MjdhYiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjJhMWVlYTllLTY1MTctNGJk
+        Ni1hMzk2LTQ5MWIyMjM2YTQ3OCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
         bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
         ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
         dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
         OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjdlNjUwMTk3LTdmMDYtNDUxOS05Nzg0LWZmMjNjOTdmOGFhNSIs
+        X2lkIjogIjIzMjQ3MGI0LTk3ZjUtNDA2Ni05YWJlLWE1Y2JkMzI4YWFlZCIs
         ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
         Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
         ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJi
-        MWJjMDUzLWYyMTgtNGMyOS1hNWY4LTRkNmE2OTAzNDJmOSIsICJudW1fcHJv
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVi
+        MDMzNWM1LWMwNmItNDAzYS05NGYyLTk4MTA2MGY4NTY1YiIsICJudW1fcHJv
         Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
         OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
         bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
         S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjEyYzBiZDA2LTY3YzUt
-        NGY0MC05M2ExLTRmMzI1NmI5YTAxZCIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQ3ZDUwZWU2LWJjN2Mt
+        NGFhNy1hYWU0LTA5YmI4OGM1OThkYiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
         IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
         ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
         b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImUwOTA1MmJkLTE1NjMtNGE5ZC1hMGMw
-        LTZhZjBmNGQ5ZGNmMiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjk2MzM3NmY4LWY1MDktNDEzYS1iZTZk
+        LTA0ODYwZWUxNTQ0MCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
         Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
         aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
         LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
         b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiMTBhMDVjZTQtYmNiMy00MDA0LTk3N2ItMDYz
-        ZjQ4YTU3ZWM1IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YWViYzhmZTU0OTc1ZjcxYTZhNjZi
-        YiJ9LCAiaWQiOiAiNTZhZWJjOGZlNTQ5NzVmNzFhNmE2NmJiIn0=
+        IjogMCwgInN0ZXBfaWQiOiAiMjQ3MTMwYWItMTUxOC00MDBhLThlZGEtMDYw
+        YzhlMzM1NjI1IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDdmOTg5MDU0ZmM0OGJhMzBh
+        MCJ9LCAiaWQiOiAiNTZjYzhkN2Y5ODkwNTRmYzQ4YmEzMGEwIn0=
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:52 GMT
+  recorded_at: Tue, 23 Feb 2016 16:49:04 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/02d4e27a-ac51-49c0-bcd1-ff00566ddb3e/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/92408f3f-a9f3-4db2-8130-098dc12658e6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1524,12 +836,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="SYNOKHjxvIcLZpsEWPigfhDK7wsYL1rNgBRPLWg",
-        oauth_signature="nep0kThRus81f3yFV54YuAHQ6cQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292112", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -1538,13 +844,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:01:52 GMT
+      - Tue, 23 Feb 2016 16:49:04 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '663'
       Connection:
       - close
       Content-Type:
@@ -1554,22 +860,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wMmQ0ZTI3YS1hYzUxLTQ5YzAtYmNkMS1mZjAwNTY2ZGRi
-        M2UvIiwgInRhc2tfaWQiOiAiMDJkNGUyN2EtYWM1MS00OWMwLWJjZDEtZmYw
-        MDU2NmRkYjNlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy85MjQwOGYzZi1hOWYzLTRkYjItODEzMC0wOThkYzEyNjU4
+        ZTYvIiwgInRhc2tfaWQiOiAiOTI0MDhmM2YtYTlmMy00ZGIyLTgxMzAtMDk4
+        ZGMxMjY1OGU2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmFlYmM5
-        MGU1NDk3NWY3MWE2YTY2YmMifSwgImlkIjogIjU2YWViYzkwZTU0OTc1Zjcx
-        YTZhNjZiYyJ9
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ5OjA0WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ4MDk4OTA1NGZjNDhiYTMwYTEifSwg
+        ImlkIjogIjU2Y2M4ZDgwOTg5MDU0ZmM0OGJhMzBhMSJ9
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:52 GMT
+  recorded_at: Tue, 23 Feb 2016 16:49:04 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/02d4e27a-ac51-49c0-bcd1-ff00566ddb3e/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/92408f3f-a9f3-4db2-8130-098dc12658e6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1580,12 +888,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="2y6DMHxklxJgUtTbTfq8PkCgpPGb1ybJqAfmNIh7E",
-        oauth_signature="WfwX9VoNHOM3SUjd%2B4%2BWtwwCeRI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292112", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -1594,7 +896,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:01:52 GMT
+      - Tue, 23 Feb 2016 16:49:05 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -1610,22 +912,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wMmQ0ZTI3YS1hYzUxLTQ5YzAtYmNkMS1mZjAwNTY2ZGRi
-        M2UvIiwgInRhc2tfaWQiOiAiMDJkNGUyN2EtYWM1MS00OWMwLWJjZDEtZmYw
-        MDU2NmRkYjNlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy85MjQwOGYzZi1hOWYzLTRkYjItODEzMC0wOThkYzEyNjU4
+        ZTYvIiwgInRhc2tfaWQiOiAiOTI0MDhmM2YtYTlmMy00ZGIyLTgxMzAtMDk4
+        ZGMxMjY1OGU2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTAxVDAyOjAxOjUyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTAxVDAyOjAxOjUyWiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ5OjA0WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ5OjA0WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
         MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
         aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
         a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjOTBl
-        NTQ5NzVmNzFhNmE2NmJjIn0sICJpZCI6ICI1NmFlYmM5MGU1NDk3NWY3MWE2
-        YTY2YmMifQ==
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkODA5
+        ODkwNTRmYzQ4YmEzMGExIn0sICJpZCI6ICI1NmNjOGQ4MDk4OTA1NGZjNDhi
+        YTMwYTEifQ==
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:52 GMT
+  recorded_at: Tue, 23 Feb 2016 16:49:05 GMT
 - request:
     method: post
     uri: https://katello-yoda.example.com/pulp/api/v2/repositories/
@@ -1636,7 +938,8 @@ http_interactions:
         ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
         b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
         ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
+        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
+        IjpudWxsLCJyZW1vdmVfbWlzc2luZyI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
         LXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1
         dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9j
         b25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIiwiaHR0cCI6ZmFs
@@ -1646,12 +949,10 @@ http_interactions:
         dHJpYnV0b3JfY29uZmlnIjp7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lk
         IjoiRmVkb3JhXzE3In0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1
         dG9yX2lkIjoiRmVkb3JhXzE3X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBl
-        X2lkIjoibm9kZXNfaHR0cF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2Nv
-        bmZpZyI6e30sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3JfaWQi
-        OiJGZWRvcmFfMTdfbm9kZXMifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJl
-        eHBvcnRfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0
-        cCI6ZmFsc2UsImh0dHBzIjpmYWxzZX0sImF1dG9fcHVibGlzaCI6ZmFsc2Us
-        ImRpc3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
+        X2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmln
+        Ijp7Imh0dHAiOmZhbHNlLCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6
+        InRlc3RfcGF0aCJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRv
+        cl9pZCI6ImV4cG9ydF9kaXN0cmlidXRvciJ9XX0=
     headers:
       Accept:
       - application/json
@@ -1659,14 +960,8 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4",
-        oauth_nonce="Bkkk3XTcqZanywtbFHWWWDQAgqTdx6ySngA02fL4oPg", oauth_signature="KFgtHA4yMKGXD6agIw6Idj3VBbo%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454292113", oauth_version="1.0"
-      Pulp-User:
-      - admin
       Content-Length:
-      - '895'
+      - '839'
       User-Agent:
       - Ruby
   response:
@@ -1675,7 +970,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:01:53 GMT
+      - Tue, 23 Feb 2016 16:49:05 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -1694,6142 +989,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZhZWJjOTFkZTA0MDMzNDZjZjY0OWY1In0sICJpZCI6ICJGZWRvcmFfMTci
+        NTZjYzhkODFkZTA0MDMzZjQzNTE0ZmJlIn0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:53 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/b590ed49-2c02-4407-bd9b-b06f03388bbe/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="P0UtCQXm2mVpJ3cquoD5ZwZ51m483AgX9Q15nYGuFYM",
-        oauth_signature="XjIuTjL4mYPRb3VXgd3jHqb7V1w%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292113", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:53 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '643'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iNTkwZWQ0OS0yYzAyLTQ0MDctYmQ5Yi1iMDZmMDMzODhi
-        YmUvIiwgInRhc2tfaWQiOiAiYjU5MGVkNDktMmMwMi00NDA3LWJkOWItYjA2
-        ZjAzMzg4YmJlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
-        Y2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZh
-        ZWJjOTFlNTQ5NzVmNzFhNmE2NmJkIn0sICJpZCI6ICI1NmFlYmM5MWU1NDk3
-        NWY3MWE2YTY2YmQifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:53 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/b590ed49-2c02-4407-bd9b-b06f03388bbe/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="yQZZRuc2wT5fiBwUVTTHRUUfVFP7NvvgGBeFIK8g4",
-        oauth_signature="ZvlyJx0jjfZ0kMakWghuTnyjrHY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292114", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:54 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2310'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iNTkwZWQ0OS0yYzAyLTQ0MDctYmQ5Yi1iMDZmMDMzODhi
-        YmUvIiwgInRhc2tfaWQiOiAiYjU5MGVkNDktMmMwMi00NDA3LWJkOWItYjA2
-        ZjAzMzg4YmJlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMjowMTo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTo1M1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvOGQzZWJiYTMtMTNjNC00ZmEyLWFjMDgtOWIwZGI5YmEz
-        NzkzLyIsICJ0YXNrX2lkIjogIjhkM2ViYmEzLTEzYzQtNGZhMi1hYzA4LTli
-        MGRiOWJhMzc5MyJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8y
-        MDA3NTRkMi02OGI1LTQ5ZGYtYWZiNS1lN2QxMGEzMTM2NDQvIiwgInRhc2tf
-        aWQiOiAiMjAwNzU0ZDItNjhiNS00OWRmLWFmYjUtZTdkMTBhMzEzNjQ0In1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjOTFkZTA0MDMzNDZjZjY0OWY2
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MjowMTo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAyOjAxOjU0WiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmM5MmRlMDQwMzRjZDky
-        ZGM1ZDQiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmM5MWU1NDk3NWY3MWE2YTY2YmQifSwgImlkIjogIjU2YWViYzkxZTU0
-        OTc1ZjcxYTZhNjZiZCJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:54 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/8d3ebba3-13c4-4fa2-ac08-9b0db9ba3793/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="SP7opDD3ouhCFTElR4uOK4i88LzpmHUdtlP3naz2fs",
-        oauth_signature="9Rmi7S9kNNjzherkNLdFfPy0kQI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292114", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:54 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84ZDNlYmJhMy0xM2M0LTRmYTItYWMwOC05YjBk
-        YjliYTM3OTMvIiwgInRhc2tfaWQiOiAiOGQzZWJiYTMtMTNjNC00ZmEyLWFj
-        MDgtOWIwZGI5YmEzNzkzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMjowMTo1NFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTo1NFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDI6MDE6NTRaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMjowMTo1NFoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmM5MmRlMDQwMzRjZDkyZGM1ZDUiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjOTJlNTQ5NzVmNzFhNmE2NmNkIn0s
-        ICJpZCI6ICI1NmFlYmM5MmU1NDk3NWY3MWE2YTY2Y2QifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:54 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/200754d2-68b5-49df-afb5-e7d10a313644/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="1ydlUN13HECUtMgx8ygeeXLtQ8iFt6vVIt4TLMtFVA",
-        oauth_signature="%2FISFy1rXryHECilWgDaxXUS7syk%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292114", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:54 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6923'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8yMDA3NTRkMi02OGI1LTQ5ZGYtYWZiNS1lN2Qx
-        MGEzMTM2NDQvIiwgInRhc2tfaWQiOiAiMjAwNzU0ZDItNjhiNS00OWRmLWFm
-        YjUtZTdkMTBhMzEzNjQ0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMjowMTo1NFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMTo1NFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJkMTJiZGM0Ni1mNTg0LTQ5OTYtODNiMy1jYzFhMzQy
-        MzMwZjkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMTA5Yzc5MTYtZmUwZi00YzczLWIxMmQtMGYwOGE4ODk5NmJmIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiOGQ2MjlmMWUtYjg3MC00NWJkLTg0YzEt
-        NDNkOWIxYWNmM2JlIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTVi
-        NzFlZjYtNTBiNi00ZmU0LTlmYmMtNjkyN2Y2ZDU5ZmJhIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjdiMDBhMjAwLWUwNDYtNGIyNy1hNmQ2LTFhZTlh
-        NDNhNzE4ZiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjZDRlNzI3
-        NC1jOTg5LTRjMTItOWQ0YS1lYjFjMzY1MjViZTgiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIzZjNlOWRiMy1lNGJlLTRlYjMtYjY1My02NTY4
-        MTQ5NDM0M2YiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIxNTM5Yzc4Ny1mM2I1LTRjMmYtOTY1Yy02MWEwZTZkMzE3MzIi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5Zjlm
-        ZjQ5Mi02ODQ5LTQ3ZDYtYmYzNy1hYmQ0NGViZmU3ZTciLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxOTM0YTNiMy1iNDZl
-        LTQ3MzEtOTk4MS0zMmM3MGEzOTBlZGYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjAwNDMzMjQxLWM4NTItNGMw
-        OS05NjhmLWQ2N2FhNGFjYjFiNiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
-        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
-        c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTAxVDAyOjAxOjU0WiIsICJf
-        bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
-        MTYtMDItMDFUMDI6MDE6NTRaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
-        cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
-        IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
-        X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
-        RCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1z
-        IjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0
-        aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
-        SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
-        U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
-        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZhZWJjOTJkZTA0MDM0Y2Q5MmRj
-        NWQ2IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImQxMmJkYzQ2LWY1ODQtNDk5Ni04M2IzLWNjMWEzNDIzMzBmOSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
-        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxMDlj
-        NzkxNi1mZTBmLTRjNzMtYjEyZC0wZjA4YTg4OTk2YmYiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
-        c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICI4ZDYyOWYxZS1iODcwLTQ1YmQtODRjMS00M2Q5YjFhY2Yz
-        YmUiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
-        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNWI3MWVmNi01MGI2
-        LTRmZTQtOWZiYy02OTI3ZjZkNTlmYmEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
-        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiN2IwMGEyMDAtZTA0Ni00YjI3LWE2ZDYtMWFlOWE0M2E3MThmIiwg
-        Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
-        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNkNGU3Mjc0LWM5ODktNGMx
-        Mi05ZDRhLWViMWMzNjUyNWJlOCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
-        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
-        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjNmM2U5ZGIzLWU0YmUtNGViMy1iNjUzLTY1NjgxNDk0MzQzZiIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
-        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
-        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE1
-        MzljNzg3LWYzYjUtNGMyZi05NjVjLTYxYTBlNmQzMTczMiIsICJudW1fcHJv
-        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
-        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
-        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjlmOWZmNDkyLTY4NDkt
-        NDdkNi1iZjM3LWFiZDQ0ZWJmZTdlNyIsICJudW1fcHJvY2Vzc2VkIjogMH0s
-        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
-        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
-        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjE5MzRhM2IzLWI0NmUtNDczMS05OTgx
-        LTMyYzcwYTM5MGVkZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
-        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiMDA0MzMyNDEtYzg1Mi00YzA5LTk2OGYtZDY3
-        YWE0YWNiMWI2IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YWViYzkyZTU0OTc1ZjcxYTZhNjZj
-        ZSJ9LCAiaWQiOiAiNTZhZWJjOTJlNTQ5NzVmNzFhNmE2NmNlIn0=
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:54 GMT
+  recorded_at: Tue, 23 Feb 2016 16:49:05 GMT
 - request:
     method: post
-    uri: https://katello-yoda.example.com/pulp/api/v2/content/units/package_group/search/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiOGViZDNh
-        MjYtMTVhYS00NDc3LWI3NGItMThmNzlhOWY0NWJkIl19fX0sImluY2x1ZGVf
-        cmVwb3MiOnRydWV9
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4",
-        oauth_nonce="vuJmVxe9Ez7J6GDiChdGTkZBPe2aIFLfE0WpCynkH6s", oauth_signature="H9Bp%2FwPqUvPKRniRzT9fpHrfAyU%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454292114", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '102'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:54 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '670'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJt
-        YW5kYXRvcnlfcGFja2FnZV9uYW1lcyI6IFsiZWxlcGhhbnQsZ2lyYWZmZSxj
-        aGVldGFoLGxpb24sbW9ua2V5LHBlbmd1aW4sc3F1aXJyZWwsd2FscnVzIiwg
-        InBlbmd1aW4iXSwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5hbWUiOiAi
-        bWFtbWFsIiwgInVzZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0IjogdHJ1
-        ZSwgIl9sYXN0X3VwZGF0ZWQiOiAiMjAxNi0wMi0wMVQwMTo1OTo1NVoiLCAi
-        Y2hpbGRyZW4iOiB7fSwgIm9wdGlvbmFsX3BhY2thZ2VfbmFtZXMiOiBbXSwg
-        InRyYW5zbGF0ZWRfbmFtZSI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
-        L2NvbnRlbnQvdW5pdHMvcGFja2FnZV9ncm91cC84ZWJkM2EyNi0xNWFhLTQ0
-        NzctYjc0Yi0xOGY3OWE5ZjQ1YmQvIiwgInRyYW5zbGF0ZWRfZGVzY3JpcHRp
-        b24iOiB7fSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9w
-        YWNrYWdlX25hbWVzIjogW10sICJfY29udGVudF90eXBlX2lkIjogInBhY2th
-        Z2VfZ3JvdXAiLCAiaWQiOiAibWFtbWFsIiwgIl9pZCI6ICI4ZWJkM2EyNi0x
-        NWFhLTQ0NzctYjc0Yi0xOGY3OWE5ZjQ1YmQiLCAiZGlzcGxheV9vcmRlciI6
-        IDEwMjQsICJjb25kaXRpb25hbF9wYWNrYWdlX25hbWVzIjogW119XQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:54 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/f096432c-3782-43c5-be5d-c5b882aa6d17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="2Abl6llu26nQPyazSZLiWROMPhPLuwECyuKPzDjiw",
-        oauth_signature="ejMG3GpPeD3jx89K2GPK1eSmw9I%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292115", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:55 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mMDk2NDMyYy0zNzgyLTQzYzUtYmU1ZC1jNWI4ODJhYTZk
-        MTcvIiwgInRhc2tfaWQiOiAiZjA5NjQzMmMtMzc4Mi00M2M1LWJlNWQtYzVi
-        ODgyYWE2ZDE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmFlYmM5
-        M2U1NDk3NWY3MWE2YTY2Y2YifSwgImlkIjogIjU2YWViYzkzZTU0OTc1Zjcx
-        YTZhNjZjZiJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:55 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/f096432c-3782-43c5-be5d-c5b882aa6d17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="Ye5Qn8cTbmCGi9j5wXHiPGMaUA0FGinIePyDKJGfck",
-        oauth_signature="yCfXDkjEM6%2FIUjI1gH8gwYNOFDg%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292115", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:01:55 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '682'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mMDk2NDMyYy0zNzgyLTQzYzUtYmU1ZC1jNWI4ODJhYTZk
-        MTcvIiwgInRhc2tfaWQiOiAiZjA5NjQzMmMtMzc4Mi00M2M1LWJlNWQtYzVi
-        ODgyYWE2ZDE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTAxVDAyOjAxOjU1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTAxVDAyOjAxOjU1WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
-        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjOTNl
-        NTQ5NzVmNzFhNmE2NmNmIn0sICJpZCI6ICI1NmFlYmM5M2U1NDk3NWY3MWE2
-        YTY2Y2YifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:01:55 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/382c3d71-1177-4826-bf36-7d988f0cfdbb/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="OWqX9BgkHQXF9RybKAZD5bC1YIR4O5Kz7j71ZlOksc",
-        oauth_signature="Syp%2F4eP7AtEG2kH5DVz13j1dWYs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693899", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:19 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zODJjM2Q3MS0xMTc3LTQ4MjYtYmYzNi03ZDk4OGYwY2Zk
-        YmIvIiwgInRhc2tfaWQiOiAiMzgyYzNkNzEtMTE3Ny00ODI2LWJmMzYtN2Q5
-        ODhmMGNmZGJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMGI4
-        YWRhNDBkYjA0ZWUxMTg5In0sICJpZCI6ICI1NmI0ZGUwYjhhZGE0MGRiMDRl
-        ZTExODkifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:19 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/382c3d71-1177-4826-bf36-7d988f0cfdbb/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="WbBIiO7HNZDh0mr0C3s4COS7Z6tzaQRJJyVF2dTcw",
-        oauth_signature="pTBd4rJXran6ft7Vkj897JYcE54%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693900", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:20 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1087'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zODJjM2Q3MS0xMTc3LTQ4MjYtYmYzNi03ZDk4OGYwY2Zk
-        YmIvIiwgInRhc2tfaWQiOiAiMzgyYzNkNzEtMTE3Ny00ODI2LWJmMzYtN2Q5
-        ODhmMGNmZGJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0wNVQxNzozODoyMFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJO
-        T1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDAsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
-        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0
-        ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5p
-        bmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMGI4
-        YWRhNDBkYjA0ZWUxMTg5In0sICJpZCI6ICI1NmI0ZGUwYjhhZGE0MGRiMDRl
-        ZTExODkifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:20 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/382c3d71-1177-4826-bf36-7d988f0cfdbb/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="KfNX4PyOklGY8b3w050NALBM7agRt0Z30dEAnOCiJA",
-        oauth_signature="RzMDSNfQxv%2Blm%2BuYNBA8Ii72IF0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693901", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:21 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zODJjM2Q3MS0xMTc3LTQ4MjYtYmYzNi03ZDk4OGYwY2Zk
-        YmIvIiwgInRhc2tfaWQiOiAiMzgyYzNkNzEtMTE3Ny00ODI2LWJmMzYtN2Q5
-        ODhmMGNmZGJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozODoyMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODoyMFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvM2FlMGEyZWYtM2U0ZS00M2ZmLWEyZDYtZTczYjdmNzEx
-        NThjLyIsICJ0YXNrX2lkIjogIjNhZTBhMmVmLTNlNGUtNDNmZi1hMmQ2LWU3
-        M2I3ZjcxMTU4YyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZTBiYzc4MjFiMzMwNWNlNTI2ZCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6Mzg6MjBaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozODoy
-        MFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRlMGNjNzgyMWIzNDQ0ZmNjNDgyIiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMGI4YWRhNDBkYjA0ZWUxMTg5In0s
-        ICJpZCI6ICI1NmI0ZGUwYjhhZGE0MGRiMDRlZTExODkifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:21 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/3ae0a2ef-3e4e-43ff-a2d6-e73b7f71158c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="bJup6ldEix6K3F5TJJKP0vAXUir3yPLsRl3RlzFQ",
-        oauth_signature="KKLF%2FoG%2BupfcaYnbaPkRgc%2BNbUc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693901", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:21 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3523'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8zYWUwYTJlZi0zZTRlLTQzZmYtYTJkNi1lNzNi
-        N2Y3MTE1OGMvIiwgInRhc2tfaWQiOiAiM2FlMGEyZWYtM2U0ZS00M2ZmLWEy
-        ZDYtZTczYjdmNzExNThjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wNVQxNzozODoyMVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlZjcx
-        OTQ1ZC0wZmYyLTQ1OGEtYjhlNS00MjBmNDE5ODQ1YjUiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGQxZGQ0MDItMjFl
-        Yy00NWFlLTkzNzctYWYyMjRjNWNhZDIxIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNzJhMWNhMGMtZjhhYi00ZWYxLWEzNzgtNWE5MjQyZmY5NmRlIiwg
-        Im51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
-        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
-        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjlhODIzMTczLWM3ODct
-        NDVkZS05YTQzLTI4NGU5NWExNGE2YSIsICJudW1fcHJvY2Vzc2VkIjogMH0s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
-        ZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI5YjVjYWRkZi1jMzE1LTQyNzAtYjhmMi05ODkwYmQ1NGNhMGUi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5
-        cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
-        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNmM2MzRkOTEtZmYx
-        OC00ODJiLTg3MjAtYjhjYTcyMzE5MTkzIiwgIm51bV9wcm9jZXNzZWQiOiAw
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiOWU3NWQ0YmYtNGI5Yy00Y2Y5LWFlMjktNGI0YTJh
-        MWQ2ZTFhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
-        IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAi
-        c3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
-        ZXBfaWQiOiAiMjgyM2I4MjctYTEzZi00NTQxLTg0OGEtNjBlM2E5YjE5YzQx
-        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
-        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
-        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjYxMjIyZmJkLThmY2YtNGZmOS04MTgwLTNjZjMwMzYxNDVhNSIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjog
-        InB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA2ZGU2
-        NTRhLWEzNDQtNGI3ZS05NWM4LTIyOGVkYjk5ZTViZSIsICJudW1fcHJvY2Vz
-        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
-        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
-        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGE2M2I2
-        YWEtMzgwNy00YjQ3LWI4OGYtMWEzZDY3MmU3OTczIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjog
-        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        NGRlMGM4YWRhNDBkYjA0ZWUxMTk5In0sICJpZCI6ICI1NmI0ZGUwYzhhZGE0
-        MGRiMDRlZTExOTkifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:21 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/382c3d71-1177-4826-bf36-7d988f0cfdbb/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="qh0XCEwIJH7Ej3Bwj1FAgKbPMiHfSNjke3D5QKJU",
-        oauth_signature="YlUFe0tu2ooUuEZi%2FDKMsqOyioE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693901", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:21 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zODJjM2Q3MS0xMTc3LTQ4MjYtYmYzNi03ZDk4OGYwY2Zk
-        YmIvIiwgInRhc2tfaWQiOiAiMzgyYzNkNzEtMTE3Ny00ODI2LWJmMzYtN2Q5
-        ODhmMGNmZGJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozODoyMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODoyMFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvM2FlMGEyZWYtM2U0ZS00M2ZmLWEyZDYtZTczYjdmNzEx
-        NThjLyIsICJ0YXNrX2lkIjogIjNhZTBhMmVmLTNlNGUtNDNmZi1hMmQ2LWU3
-        M2I3ZjcxMTU4YyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZTBiYzc4MjFiMzMwNWNlNTI2ZCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6Mzg6MjBaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozODoy
-        MFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRlMGNjNzgyMWIzNDQ0ZmNjNDgyIiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMGI4YWRhNDBkYjA0ZWUxMTg5In0s
-        ICJpZCI6ICI1NmI0ZGUwYjhhZGE0MGRiMDRlZTExODkifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:21 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/3ae0a2ef-3e4e-43ff-a2d6-e73b7f71158c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="wScLcxPdYociWDL5wp6mb0Qk5UDUYVKUxQ6n7nM1dXk",
-        oauth_signature="e3eq5WR8W0BnOa5xxH%2BANd%2BA5eA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693901", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:21 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8zYWUwYTJlZi0zZTRlLTQzZmYtYTJkNi1lNzNi
-        N2Y3MTE1OGMvIiwgInRhc2tfaWQiOiAiM2FlMGEyZWYtM2U0ZS00M2ZmLWEy
-        ZDYtZTczYjdmNzExNThjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wNVQxNzozODoyMVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODoyMVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJlZjcxOTQ1ZC0wZmYyLTQ1OGEtYjhlNS00MjBmNDE5
-        ODQ1YjUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMGQxZGQ0MDItMjFlYy00NWFlLTkzNzctYWYyMjRjNWNhZDIxIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNzJhMWNhMGMtZjhhYi00ZWYxLWEzNzgt
-        NWE5MjQyZmY5NmRlIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOWE4
-        MjMxNzMtYzc4Ny00NWRlLTlhNDMtMjg0ZTk1YTE0YTZhIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjliNWNhZGRmLWMzMTUtNDI3MC1iOGYyLTk4OTBi
-        ZDU0Y2EwZSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2YzYzNGQ5
-        MS1mZjE4LTQ4MmItODcyMC1iOGNhNzIzMTkxOTMiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI5ZTc1ZDRiZi00YjljLTRjZjktYWUyOS00YjRh
-        MmExZDZlMWEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIyODIzYjgyNy1hMTNmLTQ1NDEtODQ4YS02MGUzYTliMTljNDEi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2MTIy
-        MmZiZC04ZmNmLTRmZjktODE4MC0zY2YzMDM2MTQ1YTUiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNmRlNjU0YS1hMzQ0
-        LTRiN2UtOTVjOC0yMjhlZGI5OWU1YmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRhNjNiNmFhLTM4MDctNGI0
-        Ny1iODhmLTFhM2Q2NzJlNzk3MyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
-        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE3OjM4OjIw
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMDVUMTc6Mzg6MjFaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGRlMGRjNzgyMWIz
-        NDQ0ZmNjNDgzIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImVmNzE5NDVkLTBmZjItNDU4YS1iOGU1LTQyMGY0MTk4NDVi
-        NSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICIwZDFkZDQwMi0yMWVjLTQ1YWUtOTM3Ny1hZjIyNGM1Y2FkMjEiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI3MmExY2EwYy1mOGFiLTRlZjEtYTM3OC01YTky
-        NDJmZjk2ZGUiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5YTgyMzE3
-        My1jNzg3LTQ1ZGUtOWE0My0yODRlOTVhMTRhNmEiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiOWI1Y2FkZGYtYzMxNS00MjcwLWI4ZjItOTg5MGJkNTRj
-        YTBlIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjZjNjM0ZDkxLWZm
-        MTgtNDgyYi04NzIwLWI4Y2E3MjMxOTE5MyIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjllNzVkNGJmLTRiOWMtNGNmOS1hZTI5LTRiNGEyYTFk
-        NmUxYSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjI4MjNiODI3LWExM2YtNDU0MS04NDhhLTYwZTNhOWIxOWM0MSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjYxMjIyZmJk
-        LThmY2YtNGZmOS04MTgwLTNjZjMwMzYxNDVhNSIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA2ZGU2NTRhLWEzNDQtNGI3
-        ZS05NWM4LTIyOGVkYjk5ZTViZSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGE2M2I2YWEtMzgwNy00YjQ3LWI4
-        OGYtMWEzZDY3MmU3OTczIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRkZTBjOGFkYTQwZGIw
-        NGVlMTE5OSJ9LCAiaWQiOiAiNTZiNGRlMGM4YWRhNDBkYjA0ZWUxMTk5In0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:21 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/1c744059-55a0-4a87-b994-0d4c2061134b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="PHGcpaiCfeV7gd8sd4WK8L2wEda5ez0PVbtviWBIMc",
-        oauth_signature="ZqhgvZIDyarxx4wkPI3UepXBFZs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693902", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:22 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xYzc0NDA1OS01NWEwLTRhODctYjk5NC0wZDRjMjA2MTEz
-        NGIvIiwgInRhc2tfaWQiOiAiMWM3NDQwNTktNTVhMC00YTg3LWI5OTQtMGQ0
-        YzIwNjExMzRiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0ZGUw
-        ZThhZGE0MGRiMDRlZTExOWEifSwgImlkIjogIjU2YjRkZTBlOGFkYTQwZGIw
-        NGVlMTE5YSJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:22 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/1c744059-55a0-4a87-b994-0d4c2061134b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="3m8JohElnOn8spf91ws0dImRM9aadpmKk8dzwwvzs",
-        oauth_signature="DRuFi3LbawIo2kF88QunZg3x9mg%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693902", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:22 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xYzc0NDA1OS01NWEwLTRhODctYjk5NC0wZDRjMjA2MTEz
-        NGIvIiwgInRhc2tfaWQiOiAiMWM3NDQwNTktNTVhMC00YTg3LWI5OTQtMGQ0
-        YzIwNjExMzRiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA1VDE3OjM4OjIyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE3OjM4OjIyWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        NGRlMGU4YWRhNDBkYjA0ZWUxMTlhIn0sICJpZCI6ICI1NmI0ZGUwZThhZGE0
-        MGRiMDRlZTExOWEifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:22 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/67ca14b3-a289-4d41-9d79-85c367029f60/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="ny0j3spMmsQHWY0gvX3XweALJnxYOjzou511Lo4",
-        oauth_signature="n9d0Yu%2FjjgCvJaFXM7QbHxBXUjE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693904", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:24 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82N2NhMTRiMy1hMjg5LTRkNDEtOWQ3OS04NWMzNjcwMjlm
-        NjAvIiwgInRhc2tfaWQiOiAiNjdjYTE0YjMtYTI4OS00ZDQxLTlkNzktODVj
-        MzY3MDI5ZjYwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMTA4
-        YWRhNDBkYjA0ZWUxMTliIn0sICJpZCI6ICI1NmI0ZGUxMDhhZGE0MGRiMDRl
-        ZTExOWIifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:24 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/67ca14b3-a289-4d41-9d79-85c367029f60/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="gGIfTtKpkxeCbvPm6IId3IR1PVyTikXkJZr4ksIo",
-        oauth_signature="64LHy3vMTr6Eun1PdS1K5I5kweY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693904", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:24 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1087'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82N2NhMTRiMy1hMjg5LTRkNDEtOWQ3OS04NWMzNjcwMjlm
-        NjAvIiwgInRhc2tfaWQiOiAiNjdjYTE0YjMtYTI4OS00ZDQxLTlkNzktODVj
-        MzY3MDI5ZjYwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0wNVQxNzozODoyNFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJO
-        T1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJpdGVtc19sZWZ0IjogMn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
-        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0
-        ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5p
-        bmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMTA4
-        YWRhNDBkYjA0ZWUxMTliIn0sICJpZCI6ICI1NmI0ZGUxMDhhZGE0MGRiMDRl
-        ZTExOWIifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:24 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/67ca14b3-a289-4d41-9d79-85c367029f60/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="AUHEIMXxO3oYdbcytwCBOlXiXEc2sx5a0oqoMC4",
-        oauth_signature="QZCiG2te5YI5tUwtEkw6tXSBHfc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693905", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:25 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82N2NhMTRiMy1hMjg5LTRkNDEtOWQ3OS04NWMzNjcwMjlm
-        NjAvIiwgInRhc2tfaWQiOiAiNjdjYTE0YjMtYTI4OS00ZDQxLTlkNzktODVj
-        MzY3MDI5ZjYwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozODoyNVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODoyNFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvODIzNTgzMGMtMTc2ZC00Y2I4LTkzMDMtYjY2MTQ5MmM3
-        OWQ0LyIsICJ0YXNrX2lkIjogIjgyMzU4MzBjLTE3NmQtNGNiOC05MzAzLWI2
-        NjE0OTJjNzlkNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZTEwYzc4MjFiMzMwNWNlNTI3MiJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6Mzg6MjRaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozODoy
-        NVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRlMTFjNzgyMWIzNDQ0ZmNjNDg3IiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMTA4YWRhNDBkYjA0ZWUxMTliIn0s
-        ICJpZCI6ICI1NmI0ZGUxMDhhZGE0MGRiMDRlZTExOWIifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:25 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/8235830c-176d-4cb8-9303-b661492c79d4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="fva2dd1Ok0d4eqi5QQdeMEQRFcZqqkrmZglD58hBRHc",
-        oauth_signature="Mqz%2B%2FXbq8ImMaAf3TTjku5b9HWo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693905", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:25 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3513'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84MjM1ODMwYy0xNzZkLTRjYjgtOTMwMy1iNjYx
-        NDkyYzc5ZDQvIiwgInRhc2tfaWQiOiAiODIzNTgzMGMtMTc2ZC00Y2I4LTkz
-        MDMtYjY2MTQ5MmM3OWQ0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wNVQxNzozODoyNVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhMjYx
-        YTM3NC0yNGI1LTQ0YWUtOTIyNS1kMWU4ZWMyZTU0MDYiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjBjMDlmZWItNDMz
-        NC00NGM2LWIyYjktOWY5YmNkYTI1NGViIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiNmFlZWRhZTYtNTFhMy00MjE4LThkY2ItNjE5ZjM5Yzg0NDlkIiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGUxNzFjYzUtYzI1Ni00YzI2LWFi
-        MzQtOTM5ZDZjNGViNjE0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjk3
-        NWEyODY1LTk1ZmQtNDA2ZS05NmFhLTJiZTg5YWEyZGM2NiIsICJudW1fcHJv
-        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4ZWU4YmE0MC0zNzljLTQ1ZTctYWMz
-        Ni00OWJhYjAzMzVkOWYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9z
-        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRh
-        dGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI3MTZiMTU0ZS0wN2EyLTRjMDQtOTVjOC02NWU5NTkyMDE5NmIiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUi
-        OiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4
-        ZGRhZjhkYi0zOTY2LTQwYWUtOTRiYy00MWM4Zjc2ZDUzODUiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJn
-        ZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTEzZmQ0ZWEt
-        ZDVhNi00NjZiLThhZWMtNDYwZTRmNDY4NjA4IiwgIm51bV9wcm9jZXNzZWQi
-        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJs
-        aXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9k
-        aXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
-        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTIzODkyMjMtM2Y3NC00
-        ODI4LTg2NTEtZTA2ZTYxMGJmNmZiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
-        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExp
-        c3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19t
-        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RB
-        UlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzMzkyYTdkZi04ZWEwLTQ3
-        OWMtOGEyOS03MmIwZWMzOThmZjciLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0s
-        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
-        LTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
-        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwg
-        ImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0ZGUxMThhZGE0
-        MGRiMDRlZTExYWIifSwgImlkIjogIjU2YjRkZTExOGFkYTQwZGIwNGVlMTFh
-        YiJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:25 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/67ca14b3-a289-4d41-9d79-85c367029f60/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="iCtIXqaKnN4nZkyGyM88NA0uvbQHyxTqQGBS2W60EzQ",
-        oauth_signature="vFGunkWCbOVi6DZJYhn1DAOdd90%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693906", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:26 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82N2NhMTRiMy1hMjg5LTRkNDEtOWQ3OS04NWMzNjcwMjlm
-        NjAvIiwgInRhc2tfaWQiOiAiNjdjYTE0YjMtYTI4OS00ZDQxLTlkNzktODVj
-        MzY3MDI5ZjYwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozODoyNVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODoyNFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvODIzNTgzMGMtMTc2ZC00Y2I4LTkzMDMtYjY2MTQ5MmM3
-        OWQ0LyIsICJ0YXNrX2lkIjogIjgyMzU4MzBjLTE3NmQtNGNiOC05MzAzLWI2
-        NjE0OTJjNzlkNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZTEwYzc4MjFiMzMwNWNlNTI3MiJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6Mzg6MjRaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozODoy
-        NVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRlMTFjNzgyMWIzNDQ0ZmNjNDg3IiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMTA4YWRhNDBkYjA0ZWUxMTliIn0s
-        ICJpZCI6ICI1NmI0ZGUxMDhhZGE0MGRiMDRlZTExOWIifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:26 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/8235830c-176d-4cb8-9303-b661492c79d4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="B3GcqVDovyHADxFusyHuzK85M2dBavTDc2mrPRrW2Y",
-        oauth_signature="RUyzi8FfMR5wvlVbdQcRnzmvsgA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693906", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:26 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84MjM1ODMwYy0xNzZkLTRjYjgtOTMwMy1iNjYx
-        NDkyYzc5ZDQvIiwgInRhc2tfaWQiOiAiODIzNTgzMGMtMTc2ZC00Y2I4LTkz
-        MDMtYjY2MTQ5MmM3OWQ0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wNVQxNzozODoyNVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODoyNVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJhMjYxYTM3NC0yNGI1LTQ0YWUtOTIyNS1kMWU4ZWMy
-        ZTU0MDYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZjBjMDlmZWItNDMzNC00NGM2LWIyYjktOWY5YmNkYTI1NGViIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNmFlZWRhZTYtNTFhMy00MjE4LThkY2It
-        NjE5ZjM5Yzg0NDlkIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGUx
-        NzFjYzUtYzI1Ni00YzI2LWFiMzQtOTM5ZDZjNGViNjE0IiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjk3NWEyODY1LTk1ZmQtNDA2ZS05NmFhLTJiZTg5
-        YWEyZGM2NiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4ZWU4YmE0
-        MC0zNzljLTQ1ZTctYWMzNi00OWJhYjAzMzVkOWYiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI3MTZiMTU0ZS0wN2EyLTRjMDQtOTVjOC02NWU5
-        NTkyMDE5NmIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI4ZGRhZjhkYi0zOTY2LTQwYWUtOTRiYy00MWM4Zjc2ZDUzODUi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhMTNm
-        ZDRlYS1kNWE2LTQ2NmItOGFlYy00NjBlNGY0Njg2MDgiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlMjM4OTIyMy0zZjc0
-        LTQ4MjgtODY1MS1lMDZlNjEwYmY2ZmIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjMzOTJhN2RmLThlYTAtNDc5
-        Yy04YTI5LTcyYjBlYzM5OGZmNyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
-        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE3OjM4OjI1
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMDVUMTc6Mzg6MjVaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGRlMTFjNzgyMWIz
-        NDQ0ZmNjNDg4IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImEyNjFhMzc0LTI0YjUtNDRhZS05MjI1LWQxZThlYzJlNTQw
-        NiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJmMGMwOWZlYi00MzM0LTQ0YzYtYjJiOS05ZjliY2RhMjU0ZWIiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI2YWVlZGFlNi01MWEzLTQyMTgtOGRjYi02MTlm
-        MzljODQ0OWQiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0ZTE3MWNj
-        NS1jMjU2LTRjMjYtYWIzNC05MzlkNmM0ZWI2MTQiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiOTc1YTI4NjUtOTVmZC00MDZlLTk2YWEtMmJlODlhYTJk
-        YzY2IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjhlZThiYTQwLTM3
-        OWMtNDVlNy1hYzM2LTQ5YmFiMDMzNWQ5ZiIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjcxNmIxNTRlLTA3YTItNGMwNC05NWM4LTY1ZTk1OTIw
-        MTk2YiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjhkZGFmOGRiLTM5NjYtNDBhZS05NGJjLTQxYzhmNzZkNTM4NSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImExM2ZkNGVh
-        LWQ1YTYtNDY2Yi04YWVjLTQ2MGU0ZjQ2ODYwOCIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUyMzg5MjIzLTNmNzQtNDgy
-        OC04NjUxLWUwNmU2MTBiZjZmYiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzM5MmE3ZGYtOGVhMC00NzljLThh
-        MjktNzJiMGVjMzk4ZmY3IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRkZTExOGFkYTQwZGIw
-        NGVlMTFhYiJ9LCAiaWQiOiAiNTZiNGRlMTE4YWRhNDBkYjA0ZWUxMWFiIn0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:26 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/e983d952-7f9f-42e6-aa5a-0769a0b4a6ca/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Lyo8RbrNYIojmZfgWO0lf15RBgOnOrPNnAXEk6B6g",
-        oauth_signature="1DpWFANHiICCjuMr2tfDK7Ldfwc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693906", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:26 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '651'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lOTgzZDk1Mi03ZjlmLTQyZTYtYWE1YS0wNzY5YTBiNGE2
-        Y2EvIiwgInRhc2tfaWQiOiAiZTk4M2Q5NTItN2Y5Zi00MmU2LWFhNWEtMDc2
-        OWEwYjRhNmNhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAi
-        c3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
-        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20i
-        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmI0ZGUxMjhhZGE0MGRiMDRlZTExYWMifSwgImlkIjogIjU2YjRk
-        ZTEyOGFkYTQwZGIwNGVlMTFhYyJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:26 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/e983d952-7f9f-42e6-aa5a-0769a0b4a6ca/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="QpX8KPWpi8mNYhzMG3q5CsMWJbXFSkD3zTMTLdpo8MM",
-        oauth_signature="p4EaiNSfOjVho8eLbz0qXdU3%2FYQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693907", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:27 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lOTgzZDk1Mi03ZjlmLTQyZTYtYWE1YS0wNzY5YTBiNGE2
-        Y2EvIiwgInRhc2tfaWQiOiAiZTk4M2Q5NTItN2Y5Zi00MmU2LWFhNWEtMDc2
-        OWEwYjRhNmNhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA1VDE3OjM4OjI2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE3OjM4OjI2WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        NGRlMTI4YWRhNDBkYjA0ZWUxMWFjIn0sICJpZCI6ICI1NmI0ZGUxMjhhZGE0
-        MGRiMDRlZTExYWMifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:27 GMT
-- request:
-    method: post
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
-        IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRp
-        c3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwi
-        OiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3Rl
-        Y3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJleHBvcnRfZGlzdHJpYnV0
-        b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBz
-        IjpmYWxzZSwicmVsYXRpdmVfdXJsIjpudWxsfSwiYXV0b19wdWJsaXNoIjpm
-        YWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJleHBvcnRfZGlzdHJpYnV0b3IifV19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
-        oauth_nonce="EAkK4GZBjkUQzdPVRR08jzIYCvfDCL0X8dhlIax0", oauth_signature="Pc%2BUJCWrSfpPAe4%2BHbd8jEksQ2o%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454693908", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '810'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:28 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '320'
-      Location:
-      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiNGRlMTRjNzgyMWIzMzA1Y2U1Mjc3In0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:28 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/17a40482-c843-47cb-877c-f7fb7ac25734/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="HbL2x2yjdFAXOvW1VnGQz7tSe1kCc1vL9806yrNoRQs",
-        oauth_signature="Oq0jAU2S1nDX%2B%2BWWtWzVYao86x8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693908", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:28 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xN2E0MDQ4Mi1jODQzLTQ3Y2ItODc3Yy1mN2ZiN2FjMjU3
-        MzQvIiwgInRhc2tfaWQiOiAiMTdhNDA0ODItYzg0My00N2NiLTg3N2MtZjdm
-        YjdhYzI1NzM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMTQ4
-        YWRhNDBkYjA0ZWUxMWFkIn0sICJpZCI6ICI1NmI0ZGUxNDhhZGE0MGRiMDRl
-        ZTExYWQifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:28 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/17a40482-c843-47cb-877c-f7fb7ac25734/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="V8I3626In8xYExhwojuaToiYpXXjmetZ8vnUmpnfW5E",
-        oauth_signature="pphJQhViX9Hq5MAm8NtNm4ILc6o%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693909", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:29 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1081'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xN2E0MDQ4Mi1jODQzLTQ3Y2ItODc3Yy1mN2ZiN2FjMjU3
-        MzQvIiwgInRhc2tfaWQiOiAiMTdhNDA0ODItYzg0My00N2NiLTg3N2MtZjdm
-        YjdhYzI1NzM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0wNVQxNzozODoyOFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJJ
-        Tl9QUk9HUkVTUyJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAi
-        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0
-        ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJl
-        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMTQ4YWRhNDBk
-        YjA0ZWUxMWFkIn0sICJpZCI6ICI1NmI0ZGUxNDhhZGE0MGRiMDRlZTExYWQi
-        fQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:29 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/17a40482-c843-47cb-877c-f7fb7ac25734/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="M9KBMfvJFnJYUqXbG3Sd9YiCpKitXL0bVxk385TIOg",
-        oauth_signature="vCBJI7%2BWX6SkxR4paZ0bvq2vZQU%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693909", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:29 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xN2E0MDQ4Mi1jODQzLTQ3Y2ItODc3Yy1mN2ZiN2FjMjU3
-        MzQvIiwgInRhc2tfaWQiOiAiMTdhNDA0ODItYzg0My00N2NiLTg3N2MtZjdm
-        YjdhYzI1NzM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozODoyOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODoyOFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNmE5M2RlYWMtZmM3Ni00MTFkLTk4YmEtOWQ4NzI1MTk4
-        MDdkLyIsICJ0YXNrX2lkIjogIjZhOTNkZWFjLWZjNzYtNDExZC05OGJhLTlk
-        ODcyNTE5ODA3ZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZTE0Yzc4MjFiMzMwNWNlNTI3OCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6Mzg6MjhaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozODoy
-        OVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRlMTVjNzgyMWIzNDQ0ZmNjNDhjIiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMTQ4YWRhNDBkYjA0ZWUxMWFkIn0s
-        ICJpZCI6ICI1NmI0ZGUxNDhhZGE0MGRiMDRlZTExYWQifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:29 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/6a93deac-fc76-411d-98ba-9d872519807d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="p8Yj2KDbMZEvb0Pxx2gmFDfgTTWc0Ym7NfwfYUVwr0",
-        oauth_signature="rBuO%2F2mv67qMBHxV1gKP%2Fpztw%2B0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693909", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:29 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3494'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82YTkzZGVhYy1mYzc2LTQxMWQtOThiYS05ZDg3
-        MjUxOTgwN2QvIiwgInRhc2tfaWQiOiAiNmE5M2RlYWMtZmM3Ni00MTFkLTk4
-        YmEtOWQ4NzI1MTk4MDdkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wNVQxNzozODoyOVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjNzgx
-        M2JmOC1iNDhkLTRhM2ItODE4NC1mY2VhYWQwNWJkMTciLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmY2ZjNhOWMtMDVm
-        Yi00NWJiLTlkZDEtODI0MzRkMGExYTMwIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiNTM4N2U2ZjktMDZlOC00M2I1LWE5OTYtZTk1NTNiZjIxYjAyIiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTA2OWVhYzgtOTgyYi00OTgyLWIw
-        ZTctYjFmNzdlMmU4NzFlIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjAz
-        YTk3NjBhLWI1YjktNGY5OS1hMWRkLTc3MjBmNmI4YWMxYyIsICJudW1fcHJv
-        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI0ZjkyYmMwOC05YzM1LTRlMzktYjNiOS00
-        OTY2YzIyYmFkNzIiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEu
-        IiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3
-        MWQ0NDI0Yi0wNWZmLTQ5ZmYtOTk2NC1hZDdmZGQ1ZTBiYTciLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9u
-        IjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xv
-        c2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1ZGNjMDhiOC0y
-        NGNmLTRkYjAtOTgzNS01NTVhOWM2ZWQ3NGIiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVy
-        YXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBz
-        cWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlZjY5NDVkYy0xYzc4LTRmOWItOGI2
-        MC04ODYwN2RjMDk1YjIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMg
-        dG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIxYmRiOWY2Ni1lM2I2LTRhYmEtYjk3OS00YmQ0ODY1
-        ZmNmYmEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImI2MjljZmNkLTAyOGItNDY5Yy1iNWY2LWIzNGUwY2QwMmUw
-        MyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVlIjogInJlc2VydmVk
-        X3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNv
-        bS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJl
-        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5leGFt
-        cGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YjRkZTE1OGFkYTQwZGIwNGVlMTFiZCJ9LCAiaWQi
-        OiAiNTZiNGRlMTU4YWRhNDBkYjA0ZWUxMWJkIn0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:29 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/17a40482-c843-47cb-877c-f7fb7ac25734/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="hnzduQNCBnr3lFRbc481KtLEJoEbjAowkbiCAzgPzs",
-        oauth_signature="iUHoQIPCYsUsnPdWmrt38QRzEIA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693910", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:30 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xN2E0MDQ4Mi1jODQzLTQ3Y2ItODc3Yy1mN2ZiN2FjMjU3
-        MzQvIiwgInRhc2tfaWQiOiAiMTdhNDA0ODItYzg0My00N2NiLTg3N2MtZjdm
-        YjdhYzI1NzM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozODoyOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODoyOFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNmE5M2RlYWMtZmM3Ni00MTFkLTk4YmEtOWQ4NzI1MTk4
-        MDdkLyIsICJ0YXNrX2lkIjogIjZhOTNkZWFjLWZjNzYtNDExZC05OGJhLTlk
-        ODcyNTE5ODA3ZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZTE0Yzc4MjFiMzMwNWNlNTI3OCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6Mzg6MjhaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozODoy
-        OVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRlMTVjNzgyMWIzNDQ0ZmNjNDhjIiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMTQ4YWRhNDBkYjA0ZWUxMWFkIn0s
-        ICJpZCI6ICI1NmI0ZGUxNDhhZGE0MGRiMDRlZTExYWQifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:30 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/6a93deac-fc76-411d-98ba-9d872519807d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="aRoJMDtapAEhASUf1YOaQqnrmTdQu6ZEeHaKlCpY8h0",
-        oauth_signature="UnWBh4Y2Hav7f89K2F3azMIDGoo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693910", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:30 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82YTkzZGVhYy1mYzc2LTQxMWQtOThiYS05ZDg3
-        MjUxOTgwN2QvIiwgInRhc2tfaWQiOiAiNmE5M2RlYWMtZmM3Ni00MTFkLTk4
-        YmEtOWQ4NzI1MTk4MDdkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wNVQxNzozODoyOVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODoyOVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJjNzgxM2JmOC1iNDhkLTRhM2ItODE4NC1mY2VhYWQw
-        NWJkMTciLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZmY2ZjNhOWMtMDVmYi00NWJiLTlkZDEtODI0MzRkMGExYTMwIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNTM4N2U2ZjktMDZlOC00M2I1LWE5OTYt
-        ZTk1NTNiZjIxYjAyIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTA2
-        OWVhYzgtOTgyYi00OTgyLWIwZTctYjFmNzdlMmU4NzFlIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjAzYTk3NjBhLWI1YjktNGY5OS1hMWRkLTc3MjBm
-        NmI4YWMxYyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0ZjkyYmMw
-        OC05YzM1LTRlMzktYjNiOS00OTY2YzIyYmFkNzIiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI3MWQ0NDI0Yi0wNWZmLTQ5ZmYtOTk2NC1hZDdm
-        ZGQ1ZTBiYTciLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI1ZGNjMDhiOC0yNGNmLTRkYjAtOTgzNS01NTVhOWM2ZWQ3NGIi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlZjY5
-        NDVkYy0xYzc4LTRmOWItOGI2MC04ODYwN2RjMDk1YjIiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxYmRiOWY2Ni1lM2I2
-        LTRhYmEtYjk3OS00YmQ0ODY1ZmNmYmEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI2MjljZmNkLTAyOGItNDY5
-        Yy1iNWY2LWIzNGUwY2QwMmUwMyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
-        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE3OjM4OjI5
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMDVUMTc6Mzg6MjlaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGRlMTVjNzgyMWIz
-        NDQ0ZmNjNDhkIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImM3ODEzYmY4LWI0OGQtNGEzYi04MTg0LWZjZWFhZDA1YmQx
-        NyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJmZjZmM2E5Yy0wNWZiLTQ1YmItOWRkMS04MjQzNGQwYTFhMzAiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI1Mzg3ZTZmOS0wNmU4LTQzYjUtYTk5Ni1lOTU1
-        M2JmMjFiMDIiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlMDY5ZWFj
-        OC05ODJiLTQ5ODItYjBlNy1iMWY3N2UyZTg3MWUiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiMDNhOTc2MGEtYjViOS00Zjk5LWExZGQtNzcyMGY2Yjhh
-        YzFjIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRmOTJiYzA4LTlj
-        MzUtNGUzOS1iM2I5LTQ5NjZjMjJiYWQ3MiIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjcxZDQ0MjRiLTA1ZmYtNDlmZi05OTY0LWFkN2ZkZDVl
-        MGJhNyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjVkY2MwOGI4LTI0Y2YtNGRiMC05ODM1LTU1NWE5YzZlZDc0YiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVmNjk0NWRj
-        LTFjNzgtNGY5Yi04YjYwLTg4NjA3ZGMwOTViMiIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjFiZGI5ZjY2LWUzYjYtNGFi
-        YS1iOTc5LTRiZDQ4NjVmY2ZiYSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjYyOWNmY2QtMDI4Yi00NjljLWI1
-        ZjYtYjM0ZTBjZDAyZTAzIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRkZTE1OGFkYTQwZGIw
-        NGVlMTFiZCJ9LCAiaWQiOiAiNTZiNGRlMTU4YWRhNDBkYjA0ZWUxMWJkIn0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:30 GMT
-- request:
-    method: post
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/content/units/package_group/search/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiM2VhZDhi
-        ZDUtMjkxMy00NWE0LWFlYTYtMGQ2MGFhYmNlMGQ5Il19fX0sImluY2x1ZGVf
-        cmVwb3MiOnRydWV9
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
-        oauth_nonce="cXb1kdGxe7tx9krfa2zYybM5uQ7K15qbSUNsraN3Zoc", oauth_signature="bTl638jmDBMAz6GLxSk8Dm8pbns%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454693910", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '102'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:30 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '602'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJt
-        YW5kYXRvcnlfcGFja2FnZV9uYW1lcyI6IFsicGVuZ3VpbiJdLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAibmFtZSI6ICJiaXJkIiwgInVzZXJfdmlzaWJs
-        ZSI6IHRydWUsICJkZWZhdWx0IjogdHJ1ZSwgIl9sYXN0X3VwZGF0ZWQiOiAi
-        MjAxNi0wMi0wNVQxNzozNTozOFoiLCAiY2hpbGRyZW4iOiB7fSwgIm9wdGlv
-        bmFsX3BhY2thZ2VfbmFtZXMiOiBbXSwgInRyYW5zbGF0ZWRfbmFtZSI6IHt9
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcGFja2Fn
-        ZV9ncm91cC8zZWFkOGJkNS0yOTEzLTQ1YTQtYWVhNi0wZDYwYWFiY2UwZDkv
-        IiwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24iOiB7fSwgInB1bHBfdXNlcl9t
-        ZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNrYWdlX25hbWVzIjogW10sICJf
-        Y29udGVudF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAiaWQiOiAiYmly
-        ZCIsICJfaWQiOiAiM2VhZDhiZDUtMjkxMy00NWE0LWFlYTYtMGQ2MGFhYmNl
-        MGQ5IiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxfcGFj
-        a2FnZV9uYW1lcyI6IFtdfV0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:30 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/40685699-8705-4c05-ac3f-d12c23a35bf8/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="ZHwbPognj6MwprKEB555unrQURRXEIBfL6J8qK5DHo8",
-        oauth_signature="tAAhquTQ3QV3awwFkyLhPcSyQvg%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693911", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:31 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80MDY4NTY5OS04NzA1LTRjMDUtYWMzZi1kMTJjMjNhMzVi
-        ZjgvIiwgInRhc2tfaWQiOiAiNDA2ODU2OTktODcwNS00YzA1LWFjM2YtZDEy
-        YzIzYTM1YmY4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0ZGUx
-        NzhhZGE0MGRiMDRlZTExYmUifSwgImlkIjogIjU2YjRkZTE3OGFkYTQwZGIw
-        NGVlMTFiZSJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:31 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/40685699-8705-4c05-ac3f-d12c23a35bf8/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="mOhdFteZnyPR7Rhm4Cq23NDOFGkAzrNsUhxPQ1Qo",
-        oauth_signature="WZD9ly0Gbn1T%2Buz88FVGj6u%2FsXc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693911", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:31 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80MDY4NTY5OS04NzA1LTRjMDUtYWMzZi1kMTJjMjNhMzVi
-        ZjgvIiwgInRhc2tfaWQiOiAiNDA2ODU2OTktODcwNS00YzA1LWFjM2YtZDEy
-        YzIzYTM1YmY4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA1VDE3OjM4OjMxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE3OjM4OjMxWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        NGRlMTc4YWRhNDBkYjA0ZWUxMWJlIn0sICJpZCI6ICI1NmI0ZGUxNzhhZGE0
-        MGRiMDRlZTExYmUifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:31 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/64aa524d-eb26-47c2-91a7-c00e3847374e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="MLDTuZnWsTFaubLNVyiUcu1LwmMOt3W5Z3ooTHgpM",
-        oauth_signature="ImmwIfaa5B%2FUr8kk8LHME40Hams%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950272", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:51:12 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NGFhNTI0ZC1lYjI2LTQ3YzItOTFhNy1jMDBlMzg0NzM3
-        NGUvIiwgInRhc2tfaWQiOiAiNjRhYTUyNGQtZWIyNi00N2MyLTkxYTctYzAw
-        ZTM4NDczNzRlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiOGM3ODBj
-        MTlmZjUwNzk4MjNmNDdmIn0sICJpZCI6ICI1NmI4Yzc4MGMxOWZmNTA3OTgy
-        M2Y0N2YifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:51:12 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/64aa524d-eb26-47c2-91a7-c00e3847374e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="sIy1bpjUGRBPpSlTNX4gCN5D6hGEiXgi6Ek3oS7GgA",
-        oauth_signature="WkffZP95ZE%2BiH%2Ft8PF4iXyFjo3Y%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950272", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:51:12 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NGFhNTI0ZC1lYjI2LTQ3YzItOTFhNy1jMDBlMzg0NzM3
-        NGUvIiwgInRhc2tfaWQiOiAiNjRhYTUyNGQtZWIyNi00N2MyLTkxYTctYzAw
-        ZTM4NDczNzRlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo1MToxMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo1MToxMloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYjU0NDgxYzktMGNjMC00YjJjLWI0MWMtODg3MDljNDQx
-        MjhmLyIsICJ0YXNrX2lkIjogImI1NDQ4MWM5LTBjYzAtNGIyYy1iNDFjLTg4
-        NzA5YzQ0MTI4ZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjNzdmMTdmMjVlMGRhNDhiODQ5NyJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NTE6MTJaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo1MToxMloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjNzgwMTdmMjVlMTEyYWU4OGI3NiIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNzgwYzE5ZmY1
-        MDc5ODIzZjQ3ZiJ9LCAiaWQiOiAiNTZiOGM3ODBjMTlmZjUwNzk4MjNmNDdm
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:51:12 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/b54481c9-0cc0-4b2c-b41c-88709c44128f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="QJPGViEVNrKRf2dyCQlQOS06FekKWbjpLBzOrjWmtmM",
-        oauth_signature="lH%2Fbj9L4SawsF8SzkGC7XoGcAcY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950272", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:51:12 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3512'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9iNTQ0ODFjOS0wY2MwLTRiMmMtYjQxYy04ODcw
-        OWM0NDEyOGYvIiwgInRhc2tfaWQiOiAiYjU0NDgxYzktMGNjMC00YjJjLWI0
-        MWMtODg3MDljNDQxMjhmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wOFQxNjo1MToxMloiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyOTkx
-        OWFhMS0xMGFlLTRjODMtOTI3MC0zOGU1M2ZkNWEzZTYiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNWU0NTBjNTktYTc5
-        Yi00ODEzLWI4YzUtYWM4MDViMGRjY2YzIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiOTFjMDBmMWYtODE3Ni00OWQ0LWExMzktMWYzZmViZjI4MzBkIiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjdiY2Y5MzgtYjU2Ny00ZjZhLTk5
-        MWYtOWUyZDlmNWU1ZjBjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjY2
-        ZGQ5Y2Y2LWU3NmItNDZhYS05MzM4LTZjYTAzMjk0ZWMyOSIsICJudW1fcHJv
-        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIwZDY5ZTc0Mi1iMmE0LTRhOGUtYjM1ZC0w
-        NTJhNmQyN2U4ZTciLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEu
-        IiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJj
-        YjRmN2Y0OC1lMWU5LTRhYmMtYjJlNS01ZDAzNTJlMTczMTgiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9u
-        IjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xv
-        c2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0N2RmZDM3YS1m
-        ZTMwLTQyMmUtYTZhOS0yNzEzMjY0ZGQ1ZTYiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVy
-        YXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBz
-        cWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkYWM5MDQ3Yi1lOTc2LTQyM2MtODEz
-        MS1kMjEyMGE3YzBjYjYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMg
-        dG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJiNzE0MDNjZS0wYzBiLTQ4MGQtOWIxMS1jNTQw
-        OTMxZTBjMGIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIs
-        ICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImUyNTg3NTc5LWU4OGMtNDM0My05NGE2LWRjMmIz
-        Yzc3NzcwYSIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJl
-        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tY2VudG9zNy1kZXZl
-        bC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Y2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNzgwYzE5ZmY1
-        MDc5ODIzZjQ4ZiJ9LCAiaWQiOiAiNTZiOGM3ODBjMTlmZjUwNzk4MjNmNDhm
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:51:12 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/64aa524d-eb26-47c2-91a7-c00e3847374e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="pnvq9EKbAhT7IpRDHz5Hy3qaCYv9oo8cf4aseiTuzo",
-        oauth_signature="KaFzUlvYlvKpg%2B5ZQqNEu9%2BpNJ0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950273", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:51:13 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NGFhNTI0ZC1lYjI2LTQ3YzItOTFhNy1jMDBlMzg0NzM3
-        NGUvIiwgInRhc2tfaWQiOiAiNjRhYTUyNGQtZWIyNi00N2MyLTkxYTctYzAw
-        ZTM4NDczNzRlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo1MToxMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo1MToxMloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYjU0NDgxYzktMGNjMC00YjJjLWI0MWMtODg3MDljNDQx
-        MjhmLyIsICJ0YXNrX2lkIjogImI1NDQ4MWM5LTBjYzAtNGIyYy1iNDFjLTg4
-        NzA5YzQ0MTI4ZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjNzdmMTdmMjVlMGRhNDhiODQ5NyJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NTE6MTJaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo1MToxMloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjNzgwMTdmMjVlMTEyYWU4OGI3NiIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNzgwYzE5ZmY1
-        MDc5ODIzZjQ3ZiJ9LCAiaWQiOiAiNTZiOGM3ODBjMTlmZjUwNzk4MjNmNDdm
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:51:13 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/b54481c9-0cc0-4b2c-b41c-88709c44128f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="nPvepBCsYNpwKAVEIY5vFt8QGKG2cj0T7F5EX2q9M",
-        oauth_signature="es4lmw0cANaCibhbs5nJiY5sus0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950273", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:51:13 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6941'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9iNTQ0ODFjOS0wY2MwLTRiMmMtYjQxYy04ODcw
-        OWM0NDEyOGYvIiwgInRhc2tfaWQiOiAiYjU0NDgxYzktMGNjMC00YjJjLWI0
-        MWMtODg3MDljNDQxMjhmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wOFQxNjo1MToxMloiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo1MToxMloiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIyOTkxOWFhMS0xMGFlLTRjODMtOTI3MC0zOGU1M2Zk
-        NWEzZTYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNWU0NTBjNTktYTc5Yi00ODEzLWI4YzUtYWM4MDViMGRjY2YzIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiOTFjMDBmMWYtODE3Ni00OWQ0LWExMzkt
-        MWYzZmViZjI4MzBkIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjdi
-        Y2Y5MzgtYjU2Ny00ZjZhLTk5MWYtOWUyZDlmNWU1ZjBjIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjY2ZGQ5Y2Y2LWU3NmItNDZhYS05MzM4LTZjYTAz
-        Mjk0ZWMyOSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwZDY5ZTc0
-        Mi1iMmE0LTRhOGUtYjM1ZC0wNTJhNmQyN2U4ZTciLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJjYjRmN2Y0OC1lMWU5LTRhYmMtYjJlNS01ZDAz
-        NTJlMTczMTgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI0N2RmZDM3YS1mZTMwLTQyMmUtYTZhOS0yNzEzMjY0ZGQ1ZTYi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkYWM5
-        MDQ3Yi1lOTc2LTQyM2MtODEzMS1kMjEyMGE3YzBjYjYiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiNzE0MDNjZS0wYzBi
-        LTQ4MGQtOWIxMS1jNTQwOTMxZTBjMGIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUyNTg3NTc5LWU4OGMtNDM0
-        My05NGE2LWRjMmIzYzc3NzcwYSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Y2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAy
-        LTA4VDE2OjUxOjEyWiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMi
-        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMDhUMTY6NTE6MTJaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0
-        cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJ
-        UFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQi
-        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjog
-        IkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklO
-        SVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hf
-        ZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIs
-        ICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51
-        bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZi
-        OGM3ODAxN2YyNWUxMTJhZTg4Yjc3IiwgImRldGFpbHMiOiBbeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
-        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
-        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjI5OTE5YWExLTEwYWUtNGM4My05Mjcw
-        LTM4ZTUzZmQ1YTNlNiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
-        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI1ZTQ1MGM1OS1hNzliLTQ4MTMtYjhjNS1hYzgwNWIw
-        ZGNjZjMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        OCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
-        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5MWMwMGYxZi04MTc2LTQ5
-        ZDQtYTEzOS0xZjNmZWJmMjgzMGQiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7
-        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI2N2JjZjkzOC1iNTY3LTRmNmEtOTkxZi05ZTJkOWY1ZTVmMGMiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
-        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjZkZDljZjYtZTc2Yi00NmFhLTkz
-        MzgtNmNhMDMyOTRlYzI5IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBz
-        IGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjog
-        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjBkNjllNzQyLWIyYTQtNGE4ZS1iMzVkLTA1MmE2ZDI3ZThlNyIsICJudW1f
-        cHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNiNGY3ZjQ4LWUxZTktNGFiYy1i
-        MmU1LTVkMDM1MmUxNzMxOCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjQ3ZGZkMzdhLWZlMzAtNDIyZS1hNmE5LTI3MTMy
-        NjRkZDVlNiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMi
-        LCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImRhYzkwNDdiLWU5NzYtNDIzYy04MTMxLWQyMTIwYTdjMGNiNiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBl
-        IjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI3MTQw
-        M2NlLTBjMGItNDgwZC05YjExLWM1NDA5MzFlMGMwYiIsICJudW1fcHJvY2Vz
-        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
-        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTI1ODc1Nzkt
-        ZTg4Yy00MzQzLTk0YTYtZGMyYjNjNzc3NzBhIiwgIm51bV9wcm9jZXNzZWQi
-        OiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Yjhj
-        NzgwYzE5ZmY1MDc5ODIzZjQ4ZiJ9LCAiaWQiOiAiNTZiOGM3ODBjMTlmZjUw
-        Nzk4MjNmNDhmIn0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:51:13 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/89af994d-9faf-47e5-9db7-f369c45e0a6c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="gY7KKtncdMpAvcy7arLBjzMRBldkaa3w20p1pS1PIY",
-        oauth_signature="qeF24iaE6n%2FfyYOFENux8I6E6r8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950273", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:51:13 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '663'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84OWFmOTk0ZC05ZmFmLTQ3ZTUtOWRiNy1mMzY5YzQ1ZTBh
-        NmMvIiwgInRhc2tfaWQiOiAiODlhZjk5NGQtOWZhZi00N2U1LTlkYjctZjM2
-        OWM0NWUwYTZjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20u
-        ZHEiLCAic3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwu
-        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
-        Il9pZCI6IHsiJG9pZCI6ICI1NmI4Yzc4MWMxOWZmNTA3OTgyM2Y0OTAifSwg
-        ImlkIjogIjU2YjhjNzgxYzE5ZmY1MDc5ODIzZjQ5MCJ9
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:51:13 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/89af994d-9faf-47e5-9db7-f369c45e0a6c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="hNMTevrVpJyFQaL0M61VNX1TWgbGUIIr1Y6ubAKFoDY",
-        oauth_signature="eRNek4ZvuCJivznJnQC6CgzjsPA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950274", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:51:14 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '700'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84OWFmOTk0ZC05ZmFmLTQ3ZTUtOWRiNy1mMzY5YzQ1ZTBh
-        NmMvIiwgInRhc2tfaWQiOiAiODlhZjk5NGQtOWZhZi00N2U1LTlkYjctZjM2
-        OWM0NWUwYTZjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA4VDE2OjUxOjE0WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA4VDE2OjUxOjE0WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20uZHEiLCAic3Rh
-        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUu
-        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNTZiOGM3ODFjMTlmZjUwNzk4MjNmNDkwIn0sICJpZCI6ICI1
-        NmI4Yzc4MWMxOWZmNTA3OTgyM2Y0OTAifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:51:14 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/941a658d-f0cb-4bcb-9e78-db87557ca9aa/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="ZswGfGC3dKeoAIBeXdL9KjjduWvryn1wxwXAVPXQosA",
-        oauth_signature="gBEBhdk6Os9Lq7vL8MTg3aBxvng%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950275", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:51:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85NDFhNjU4ZC1mMGNiLTRiY2ItOWU3OC1kYjg3NTU3Y2E5
-        YWEvIiwgInRhc2tfaWQiOiAiOTQxYTY1OGQtZjBjYi00YmNiLTllNzgtZGI4
-        NzU1N2NhOWFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiOGM3ODNj
-        MTlmZjUwNzk4MjNmNDkxIn0sICJpZCI6ICI1NmI4Yzc4M2MxOWZmNTA3OTgy
-        M2Y0OTEifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:51:15 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/941a658d-f0cb-4bcb-9e78-db87557ca9aa/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="xbLI4o9NraIURLLnq6nxVa9oCjwSdL0OmeNE9a54A",
-        oauth_signature="%2FlPl6%2B9oEwo8Jdgyw5LY%2BB03nPs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950276", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:51:16 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85NDFhNjU4ZC1mMGNiLTRiY2ItOWU3OC1kYjg3NTU3Y2E5
-        YWEvIiwgInRhc2tfaWQiOiAiOTQxYTY1OGQtZjBjYi00YmNiLTllNzgtZGI4
-        NzU1N2NhOWFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo1MToxNloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo1MToxNVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvODM1Zjk1NDAtMzE2Zi00ZjRjLWJhOGUtYTdlNmJlYjRi
-        MzBhLyIsICJ0YXNrX2lkIjogIjgzNWY5NTQwLTMxNmYtNGY0Yy1iYThlLWE3
-        ZTZiZWI0YjMwYSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjNzgzMTdmMjVlMGRhNDhiODQ5ZiJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NTE6MTVaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo1MToxNloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjNzg0MTdmMjVlMTEyYWU4OGI3YiIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNzgzYzE5ZmY1
-        MDc5ODIzZjQ5MSJ9LCAiaWQiOiAiNTZiOGM3ODNjMTlmZjUwNzk4MjNmNDkx
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:51:16 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/835f9540-316f-4f4c-ba8e-a7e6beb4b30a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="t02EAstQ2RSXHjUA5wmR0kNjTAZAKKkbQqHKU08yxR4",
-        oauth_signature="R5LpfjReXHinus8YtwO0j8D%2BqMM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950276", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:51:16 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '670'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84MzVmOTU0MC0zMTZmLTRmNGMtYmE4ZS1hN2U2
-        YmViNGIzMGEvIiwgInRhc2tfaWQiOiAiODM1Zjk1NDAtMzE2Zi00ZjRjLWJh
-        OGUtYTdlNmJlYjRiMzBhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiBudWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBb
-        XSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRf
-        cmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1w
-        bGUuY29tLmRxIiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUi
-        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3
-        LWRldmVsLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiOGM3ODRjMTlmZjUwNzk4MjNm
-        NGExIn0sICJpZCI6ICI1NmI4Yzc4NGMxOWZmNTA3OTgyM2Y0YTEifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:51:16 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/941a658d-f0cb-4bcb-9e78-db87557ca9aa/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="cnxj3VOmsa9U7yRnvsHsxtm1OTk7H4PNZGgZeO1E",
-        oauth_signature="N3IjQ4JUEQORP6F1C%2F7ZYjx1SAU%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950276", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:51:16 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85NDFhNjU4ZC1mMGNiLTRiY2ItOWU3OC1kYjg3NTU3Y2E5
-        YWEvIiwgInRhc2tfaWQiOiAiOTQxYTY1OGQtZjBjYi00YmNiLTllNzgtZGI4
-        NzU1N2NhOWFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo1MToxNloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo1MToxNVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvODM1Zjk1NDAtMzE2Zi00ZjRjLWJhOGUtYTdlNmJlYjRi
-        MzBhLyIsICJ0YXNrX2lkIjogIjgzNWY5NTQwLTMxNmYtNGY0Yy1iYThlLWE3
-        ZTZiZWI0YjMwYSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjNzgzMTdmMjVlMGRhNDhiODQ5ZiJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NTE6MTVaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo1MToxNloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjNzg0MTdmMjVlMTEyYWU4OGI3YiIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNzgzYzE5ZmY1
-        MDc5ODIzZjQ5MSJ9LCAiaWQiOiAiNTZiOGM3ODNjMTlmZjUwNzk4MjNmNDkx
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:51:16 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/835f9540-316f-4f4c-ba8e-a7e6beb4b30a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="rw0fp4jxBAg93f4HAW5jYGgEs1jpx4JjAvjhUSloPI",
-        oauth_signature="gwxlUOOEaawlfgGy2c1JTqc49c0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950276", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:51:16 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6941'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84MzVmOTU0MC0zMTZmLTRmNGMtYmE4ZS1hN2U2
-        YmViNGIzMGEvIiwgInRhc2tfaWQiOiAiODM1Zjk1NDAtMzE2Zi00ZjRjLWJh
-        OGUtYTdlNmJlYjRiMzBhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wOFQxNjo1MToxNloiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo1MToxNloiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIyMDI2NmE5Zi1mMmIxLTQ4YjYtYTMwMi05ZGFkMDZi
-        ZTY3ZDQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMzg4M2IyMmYtZjViYS00NjZjLWEzYTEtNTQ3OTRjYjE2MDJlIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNmNkNGE0MjctODk5OS00NmUyLWFkMmIt
-        YTdmNWVmYTk0MjYyIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZWZl
-        NGRjOTItZDA2Ni00ZGY0LTg1NTAtYjA2Mjk4ZGZmYjE0IiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjMxMDdlOTk4LTkwY2EtNGNhMy1hOGRiLTgwYmI4
-        NGZmNmU5MCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3ODM3MTUy
-        Yi0wNDg3LTQ1Y2MtODg4MS1jYmEzZmM5Mzc5ODUiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI4MDhjY2QzYy04MDVlLTQ0Y2UtYjVjYy04ZjYx
-        YjFjMmQ1ZmYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJjNWJkZWQ0MS0xZGQ5LTQxODAtYWFjMi1iNDUyNTNlOGVmNzQi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2YjE4
-        MjhlNC00YWQ0LTQyY2ItYjlmNy00ODk3ZmRmZDAyMzciLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyNGFmYzU5Yy05MjE3
-        LTRkZDAtYTA0Yi04OTgxY2IwZDYyNWIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjU5MjNmOGU1LWY5ZDUtNGQ4
-        My05MWUyLTQ2OGFlMzU4Y2NkMiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Y2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAy
-        LTA4VDE2OjUxOjE2WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMi
-        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMDhUMTY6NTE6MTZaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0
-        cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJ
-        UFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQi
-        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjog
-        IkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklO
-        SVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hf
-        ZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIs
-        ICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51
-        bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZi
-        OGM3ODQxN2YyNWUxMTJhZTg4YjdjIiwgImRldGFpbHMiOiBbeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
-        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
-        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjIwMjY2YTlmLWYyYjEtNDhiNi1hMzAy
-        LTlkYWQwNmJlNjdkNCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
-        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIzODgzYjIyZi1mNWJhLTQ2NmMtYTNhMS01NDc5NGNi
-        MTYwMmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        OCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
-        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2Y2Q0YTQyNy04OTk5LTQ2
-        ZTItYWQyYi1hN2Y1ZWZhOTQyNjIiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7
-        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICJlZmU0ZGM5Mi1kMDY2LTRkZjQtODU1MC1iMDYyOThkZmZiMTQiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
-        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzEwN2U5OTgtOTBjYS00Y2EzLWE4
-        ZGItODBiYjg0ZmY2ZTkwIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBz
-        IGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjog
-        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        Ijc4MzcxNTJiLTA0ODctNDVjYy04ODgxLWNiYTNmYzkzNzk4NSIsICJudW1f
-        cHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjgwOGNjZDNjLTgwNWUtNDRjZS1i
-        NWNjLThmNjFiMWMyZDVmZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImM1YmRlZDQxLTFkZDktNDE4MC1hYWMyLWI0NTI1
-        M2U4ZWY3NCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMi
-        LCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjZiMTgyOGU0LTRhZDQtNDJjYi1iOWY3LTQ4OTdmZGZkMDIzNyIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBl
-        IjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI0YWZj
-        NTljLTkyMTctNGRkMC1hMDRiLTg5ODFjYjBkNjI1YiIsICJudW1fcHJvY2Vz
-        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
-        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTkyM2Y4ZTUt
-        ZjlkNS00ZDgzLTkxZTItNDY4YWUzNThjY2QyIiwgIm51bV9wcm9jZXNzZWQi
-        OiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Yjhj
-        Nzg0YzE5ZmY1MDc5ODIzZjRhMSJ9LCAiaWQiOiAiNTZiOGM3ODRjMTlmZjUw
-        Nzk4MjNmNGExIn0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:51:16 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/3b578a80-e01d-4753-8b51-702d92f5ae25/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="7L5dNlrHmDfiF2VEGraCxF42iVXYsn3rySYzog0YbQg",
-        oauth_signature="mv27YBYm3BDtWTSt31duNU1OPO4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950277", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:51:17 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zYjU3OGE4MC1lMDFkLTQ3NTMtOGI1MS03MDJkOTJmNWFl
-        MjUvIiwgInRhc2tfaWQiOiAiM2I1NzhhODAtZTAxZC00NzUzLThiNTEtNzAy
-        ZDkyZjVhZTI1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI4Yzc4
-        NWMxOWZmNTA3OTgyM2Y0YTIifSwgImlkIjogIjU2YjhjNzg1YzE5ZmY1MDc5
-        ODIzZjRhMiJ9
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:51:17 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/3b578a80-e01d-4753-8b51-702d92f5ae25/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="0Ukf8MWSzUrqpy6uo23NeoigtYX87EUYkAt62341o0",
-        oauth_signature="dYiI1UmorSr24Kfy4vYNHBpWmX4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950277", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:51:17 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '700'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zYjU3OGE4MC1lMDFkLTQ3NTMtOGI1MS03MDJkOTJmNWFl
-        MjUvIiwgInRhc2tfaWQiOiAiM2I1NzhhODAtZTAxZC00NzUzLThiNTEtNzAy
-        ZDkyZjVhZTI1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA4VDE2OjUxOjE3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA4VDE2OjUxOjE3WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20uZHEiLCAic3Rh
-        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUu
-        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNTZiOGM3ODVjMTlmZjUwNzk4MjNmNGEyIn0sICJpZCI6ICI1
-        NmI4Yzc4NWMxOWZmNTA3OTgyM2Y0YTIifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:51:17 GMT
-- request:
-    method: post
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
-        IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRp
-        c3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwi
-        OiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3Rl
-        Y3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJleHBvcnRfZGlzdHJpYnV0
-        b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBz
-        IjpmYWxzZSwicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIn0sImF1dG9fcHVi
-        bGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1
-        dG9yIn1dfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb",
-        oauth_nonce="8YKom1jhh10jilXg45pBXJegwRQus0ZdI053FtgY", oauth_signature="I8SUmhHVCQNzoNLgC4aeqFuFF9I%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454950278", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '817'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:51:18 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '320'
-      Location:
-      - https://katello-centos7-devel.example.com/pulp/api/v2/repositories/Fedora_17/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: US-ASCII
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiOGM3ODYxN2YyNWUwZGE2NzBkZDZhIn0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:51:18 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/542a6aeb-7c17-4ca9-855f-beaa8cc4e800/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="4829Sva7odZ7HTAlCFO7c18HIkLlIEwiwecMVw2oI2c",
-        oauth_signature="MuEkLUqQ9V53iT8k93NMuNGjSZg%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950278", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:51:18 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81NDJhNmFlYi03YzE3LTRjYTktODU1Zi1iZWFhOGNjNGU4
-        MDAvIiwgInRhc2tfaWQiOiAiNTQyYTZhZWItN2MxNy00Y2E5LTg1NWYtYmVh
-        YThjYzRlODAwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiOGM3ODZj
-        MTlmZjUwNzk4MjNmNGEzIn0sICJpZCI6ICI1NmI4Yzc4NmMxOWZmNTA3OTgy
-        M2Y0YTMifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:51:18 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/542a6aeb-7c17-4ca9-855f-beaa8cc4e800/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="LhesbXdKEOKf2Vde4QFfjfA5ZKV5W2pwGFGwemIzg",
-        oauth_signature="6n%2BZKPmTxJGd8eC9Vdrejv8aoLo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950279", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:51:19 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81NDJhNmFlYi03YzE3LTRjYTktODU1Zi1iZWFhOGNjNGU4
-        MDAvIiwgInRhc2tfaWQiOiAiNTQyYTZhZWItN2MxNy00Y2E5LTg1NWYtYmVh
-        YThjYzRlODAwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo1MToxOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo1MToxOVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYzRiYjBlNTctN2ZjMi00NmU3LWI3MTctOTMzYWQ4YTA4
-        OGY3LyIsICJ0YXNrX2lkIjogImM0YmIwZTU3LTdmYzItNDZlNy1iNzE3LTkz
-        M2FkOGEwODhmNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjNzg2MTdmMjVlMGRhNjcwZGQ2YiJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NTE6MTlaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo1MToxOVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjNzg3MTdmMjVlMTEyYWU4OGI4MCIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNzg2YzE5ZmY1
-        MDc5ODIzZjRhMyJ9LCAiaWQiOiAiNTZiOGM3ODZjMTlmZjUwNzk4MjNmNGEz
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:51:19 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/c4bb0e57-7fc2-46e7-b717-933ad8a088f7/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="qQuwhhJzXUPEiUJJj3lqrNvpqhUTIzunC8Xa3Vu6VQ8",
-        oauth_signature="CsEfsaE4HcteuwClOMi0Vx8Q3LM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950279", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:51:19 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '670'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9jNGJiMGU1Ny03ZmMyLTQ2ZTctYjcxNy05MzNh
-        ZDhhMDg4ZjcvIiwgInRhc2tfaWQiOiAiYzRiYjBlNTctN2ZjMi00NmU3LWI3
-        MTctOTMzYWQ4YTA4OGY3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiBudWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBb
-        XSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRf
-        cmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1w
-        bGUuY29tLmRxIiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUi
-        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3
-        LWRldmVsLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiOGM3ODdjMTlmZjUwNzk4MjNm
-        NGIzIn0sICJpZCI6ICI1NmI4Yzc4N2MxOWZmNTA3OTgyM2Y0YjMifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:51:19 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/542a6aeb-7c17-4ca9-855f-beaa8cc4e800/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="zzYAMSoPKsZROdOMIktfdZ34qOUcs9GwgPUNpXcKpU",
-        oauth_signature="8jaOG2G3oZL22X7zXFvQU31k7oY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950280", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:51:20 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81NDJhNmFlYi03YzE3LTRjYTktODU1Zi1iZWFhOGNjNGU4
-        MDAvIiwgInRhc2tfaWQiOiAiNTQyYTZhZWItN2MxNy00Y2E5LTg1NWYtYmVh
-        YThjYzRlODAwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo1MToxOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo1MToxOVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYzRiYjBlNTctN2ZjMi00NmU3LWI3MTctOTMzYWQ4YTA4
-        OGY3LyIsICJ0YXNrX2lkIjogImM0YmIwZTU3LTdmYzItNDZlNy1iNzE3LTkz
-        M2FkOGEwODhmNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjNzg2MTdmMjVlMGRhNjcwZGQ2YiJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NTE6MTlaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo1MToxOVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjNzg3MTdmMjVlMTEyYWU4OGI4MCIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjNzg2YzE5ZmY1
-        MDc5ODIzZjRhMyJ9LCAiaWQiOiAiNTZiOGM3ODZjMTlmZjUwNzk4MjNmNGEz
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:51:20 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/c4bb0e57-7fc2-46e7-b717-933ad8a088f7/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="uZsv0RHMH5eTdfcLgCDfxow6NxLIig3xKAb0kTyYo",
-        oauth_signature="wBO119WBeA7dfo9CC7luSw4r1DA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950280", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:51:20 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6941'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9jNGJiMGU1Ny03ZmMyLTQ2ZTctYjcxNy05MzNh
-        ZDhhMDg4ZjcvIiwgInRhc2tfaWQiOiAiYzRiYjBlNTctN2ZjMi00NmU3LWI3
-        MTctOTMzYWQ4YTA4OGY3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wOFQxNjo1MToxOVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo1MToxOVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIzOTQ4OGE4MC05MzRjLTRiYzEtYWVhYy04ZGE0ZTc0
-        NmIxMzEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZWRlOGQzNmUtYWU1NC00NjdjLTgwMjgtYmQ4ZDlhYTVlNmQ4Iiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZDY1Y2EwYjItZThiYi00NzQ2LThmM2Mt
-        MzlhZjcwYjdlMDMxIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiM2Y3
-        NzcxZjYtNjAzMS00NjUwLWEyOTEtMTBkZDJkMTJkZTk2IiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImY0OWMxMjg0LTlhMDgtNGYwMS1iMWVkLTIwYWMw
-        MTk1YzA2MSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmMzJhMWMw
-        MC1kOWEwLTRiYjAtYWRlMC00OTFlMzYxYjg2ZDkiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJhMGE0NzI0MC00MWY3LTQzZWMtOGRhYy1iMmUx
-        MDljNmY3Y2QiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIyODMzZjBmNy0zNjRiLTQ0NzUtYjUyZi1kMzgwNTVjZTY1MjQi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjYTAw
-        ZTZhMy05YzQyLTQ1NzAtOTdhOC03OGM0OWYzNjA0OTciLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3YWZmNzQyNy03NDcx
-        LTQ0Y2YtODAyNi0zZTRhNWNhNzVjNWMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ4ZWFmNDc4LTMzNjgtNGY4
-        My1hZmUzLTA4YjQ1M2E0ODliYSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Y2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAy
-        LTA4VDE2OjUxOjE5WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMi
-        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMDhUMTY6NTE6MTlaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0
-        cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJ
-        UFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQi
-        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjog
-        IkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklO
-        SVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hf
-        ZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIs
-        ICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51
-        bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZi
-        OGM3ODcxN2YyNWUxMTJhZTg4YjgxIiwgImRldGFpbHMiOiBbeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
-        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
-        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjM5NDg4YTgwLTkzNGMtNGJjMS1hZWFj
-        LThkYTRlNzQ2YjEzMSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
-        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJlZGU4ZDM2ZS1hZTU0LTQ2N2MtODAyOC1iZDhkOWFh
-        NWU2ZDgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        OCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
-        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkNjVjYTBiMi1lOGJiLTQ3
-        NDYtOGYzYy0zOWFmNzBiN2UwMzEiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7
-        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICIzZjc3NzFmNi02MDMxLTQ2NTAtYTI5MS0xMGRkMmQxMmRlOTYiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
-        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjQ5YzEyODQtOWEwOC00ZjAxLWIx
-        ZWQtMjBhYzAxOTVjMDYxIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBz
-        IGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjog
-        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImYzMmExYzAwLWQ5YTAtNGJiMC1hZGUwLTQ5MWUzNjFiODZkOSIsICJudW1f
-        cHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImEwYTQ3MjQwLTQxZjctNDNlYy04
-        ZGFjLWIyZTEwOWM2ZjdjZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjI4MzNmMGY3LTM2NGItNDQ3NS1iNTJmLWQzODA1
-        NWNlNjUyNCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMi
-        LCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImNhMDBlNmEzLTljNDItNDU3MC05N2E4LTc4YzQ5ZjM2MDQ5NyIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBl
-        IjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdhZmY3
-        NDI3LTc0NzEtNDRjZi04MDI2LTNlNGE1Y2E3NWM1YyIsICJudW1fcHJvY2Vz
-        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
-        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDhlYWY0Nzgt
-        MzM2OC00ZjgzLWFmZTMtMDhiNDUzYTQ4OWJhIiwgIm51bV9wcm9jZXNzZWQi
-        OiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Yjhj
-        Nzg3YzE5ZmY1MDc5ODIzZjRiMyJ9LCAiaWQiOiAiNTZiOGM3ODdjMTlmZjUw
-        Nzk4MjNmNGIzIn0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:51:20 GMT
-- request:
-    method: post
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/content/units/package_group/search/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMWQ0YTc5
-        MTgtZDBiMi00MGJhLTgzNTgtMjEzMzA3Y2VlNmNjIl19fX0sImluY2x1ZGVf
-        cmVwb3MiOnRydWV9
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb",
-        oauth_nonce="NGGYJIJrbDNAZy0FG7nXpFQqcZAec6Myq2wgqFhfv9g", oauth_signature="FUIaPseNr6a9hJ3rBoNINDKleZs%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454950280", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '102'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:51:20 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '602'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJt
-        YW5kYXRvcnlfcGFja2FnZV9uYW1lcyI6IFsicGVuZ3VpbiJdLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAibmFtZSI6ICJiaXJkIiwgInVzZXJfdmlzaWJs
-        ZSI6IHRydWUsICJkZWZhdWx0IjogdHJ1ZSwgIl9sYXN0X3VwZGF0ZWQiOiAi
-        MjAxNi0wMi0wOFQxNjo0Mzo0NFoiLCAiY2hpbGRyZW4iOiB7fSwgIm9wdGlv
-        bmFsX3BhY2thZ2VfbmFtZXMiOiBbXSwgInRyYW5zbGF0ZWRfbmFtZSI6IHt9
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcGFja2Fn
-        ZV9ncm91cC8xZDRhNzkxOC1kMGIyLTQwYmEtODM1OC0yMTMzMDdjZWU2Y2Mv
-        IiwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24iOiB7fSwgInB1bHBfdXNlcl9t
-        ZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNrYWdlX25hbWVzIjogW10sICJf
-        Y29udGVudF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAiaWQiOiAiYmly
-        ZCIsICJfaWQiOiAiMWQ0YTc5MTgtZDBiMi00MGJhLTgzNTgtMjEzMzA3Y2Vl
-        NmNjIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxfcGFj
-        a2FnZV9uYW1lcyI6IFtdfV0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:51:20 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/ca8505ee-e607-40b5-b6cf-d239baa3afaa/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="0GQuxk7lsZC48JOVMe6zWsQDw92SGon0oHcaiSLuQ",
-        oauth_signature="2pylJuypWUI5AF73RHEs8Z6oZso%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950280", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:51:20 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jYTg1MDVlZS1lNjA3LTQwYjUtYjZjZi1kMjM5YmFhM2Fm
-        YWEvIiwgInRhc2tfaWQiOiAiY2E4NTA1ZWUtZTYwNy00MGI1LWI2Y2YtZDIz
-        OWJhYTNhZmFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI4Yzc4
-        OGMxOWZmNTA3OTgyM2Y0YjQifSwgImlkIjogIjU2YjhjNzg4YzE5ZmY1MDc5
-        ODIzZjRiNCJ9
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:51:20 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/ca8505ee-e607-40b5-b6cf-d239baa3afaa/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="ypegK39kRcdBcvWoA0eimPrre0Jhx48XY3U9chlk",
-        oauth_signature="B%2F%2Bi2GHIVhlBr%2Bm68acpO%2BXpRFI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950281", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:51:21 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '700'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jYTg1MDVlZS1lNjA3LTQwYjUtYjZjZi1kMjM5YmFhM2Fm
-        YWEvIiwgInRhc2tfaWQiOiAiY2E4NTA1ZWUtZTYwNy00MGI1LWI2Y2YtZDIz
-        OWJhYTNhZmFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA4VDE2OjUxOjIwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA4VDE2OjUxOjIwWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20uZHEiLCAic3Rh
-        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUu
-        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNTZiOGM3ODhjMTlmZjUwNzk4MjNmNGI0In0sICJpZCI6ICI1
-        NmI4Yzc4OGMxOWZmNTA3OTgyM2Y0YjQifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:51:21 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/4c73697f-b0c7-4c6d-8d6a-2a324347da91/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:03:23 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80YzczNjk3Zi1iMGM3LTRjNmQtOGQ2YS0yYTMyNDM0N2Rh
-        OTEvIiwgInRhc2tfaWQiOiAiNGM3MzY5N2YtYjBjNy00YzZkLThkNmEtMmEz
-        MjQzNDdkYTkxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiZDA1MmIz
-        NDQ3MWU0MDA3MGIwYmIwIn0sICJpZCI6ICI1NmJkMDUyYjM0NDcxZTQwMDcw
-        YjBiYjAifQ==
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 22:03:23 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/4c73697f-b0c7-4c6d-8d6a-2a324347da91/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:03:24 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2324'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80YzczNjk3Zi1iMGM3LTRjNmQtOGQ2YS0yYTMyNDM0N2Rh
-        OTEvIiwgInRhc2tfaWQiOiAiNGM3MzY5N2YtYjBjNy00YzZkLThkNmEtMmEz
-        MjQzNDdkYTkxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMjowMzoyNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMjowMzoyM1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMWQ0MjZkMTctZjBjNi00NjI2LTk2NWMtODc0ZWQxOTJj
-        NDJiLyIsICJ0YXNrX2lkIjogIjFkNDI2ZDE3LWYwYzYtNDYyNi05NjVjLTg3
-        NGVkMTkyYzQyYiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDUy
-        YjY3N2M3NDJkMDQ5YjAxMDUifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIyOjAzOjIzWiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjI6MDM6MjRa
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA1MmM2NzdjNzQwODEyMzIyNDhlIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNTJiMzQ0NzFlNDAwNzBiMGJiMCJ9LCAiaWQi
-        OiAiNTZiZDA1MmIzNDQ3MWU0MDA3MGIwYmIwIn0=
-    http_version: 
-  recorded_at: Thu, 11 Feb 2016 22:03:24 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/1d426d17-f0c6-4626-965c-874ed192c42b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:03:24 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '658'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8xZDQyNmQxNy1mMGM2LTQ2MjYtOTY1Yy04NzRl
-        ZDE5MmM0MmIvIiwgInRhc2tfaWQiOiAiMWQ0MjZkMTctZjBjNi00NjI2LTk2
-        NWMtODc0ZWQxOTJjNDJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiBudWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBb
-        XSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRf
-        cmVzb3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29t
-        LmRxIiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVz
-        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQi
-        OiB7IiRvaWQiOiAiNTZiZDA1MmMzNDQ3MWU0MDA3MGIwYmMwIn0sICJpZCI6
-        ICI1NmJkMDUyYzM0NDcxZTQwMDcwYjBiYzAifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:03:24 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/4c73697f-b0c7-4c6d-8d6a-2a324347da91/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:03:24 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2324'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80YzczNjk3Zi1iMGM3LTRjNmQtOGQ2YS0yYTMyNDM0N2Rh
-        OTEvIiwgInRhc2tfaWQiOiAiNGM3MzY5N2YtYjBjNy00YzZkLThkNmEtMmEz
-        MjQzNDdkYTkxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMjowMzoyNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMjowMzoyM1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMWQ0MjZkMTctZjBjNi00NjI2LTk2NWMtODc0ZWQxOTJj
-        NDJiLyIsICJ0YXNrX2lkIjogIjFkNDI2ZDE3LWYwYzYtNDYyNi05NjVjLTg3
-        NGVkMTkyYzQyYiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDUy
-        YjY3N2M3NDJkMDQ5YjAxMDUifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIyOjAzOjIzWiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjI6MDM6MjRa
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA1MmM2NzdjNzQwODEyMzIyNDhlIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNTJiMzQ0NzFlNDAwNzBiMGJiMCJ9LCAiaWQi
-        OiAiNTZiZDA1MmIzNDQ3MWU0MDA3MGIwYmIwIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:03:24 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/1d426d17-f0c6-4626-965c-874ed192c42b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:03:24 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8xZDQyNmQxNy1mMGM2LTQ2MjYtOTY1Yy04NzRl
-        ZDE5MmM0MmIvIiwgInRhc2tfaWQiOiAiMWQ0MjZkMTctZjBjNi00NjI2LTk2
-        NWMtODc0ZWQxOTJjNDJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0xMVQyMjowMzoyNFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMjowMzoyNFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIzMGU5NzIxNS1iY2MyLTQ4OGItYTY0MC03MTBhNGUy
-        NjkyMTciLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZmQ5NTBhMTctZDYwYi00ZWEyLWJjOGQtYjY0YTAyYTUzOGU2Iiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZWEzMDJjYjItYTVjYS00OTVlLTg3NGMt
-        MmU5NGY1Yjg1Zjk2IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzFj
-        ODc5MTItZTQ0Yi00ZjFkLTllOGItMDA5NWM4NGE5ZTc2IiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjY1YjYyN2QwLWFjYWItNGMxNi1iNjdmLTZjZGU5
-        YzRjZTVkNiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1ODdmMzJi
-        ZS1iZDg2LTQ2ZjEtOWIwMC03M2E1M2ExMzA5NTUiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI4ZDU4ZTg2MC1jMjIzLTQ2NjctOGQyYy0zYTlj
-        Zjk0MmU2Y2MiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIyMzZmOGMyYy05YzYxLTQ1MDAtOWNiMS01NTgxNDZiZDBlYTIi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4ODhi
-        NmY1MS05NDMwLTRjZjMtOWM3ZS1jNzJmNGE4ODdkOTIiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4MGRmNjhiOC1iMGJk
-        LTQ1YjUtYWIwOC05ODY5M2EwMTdhYTkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImU1OTYxNGVmLWY1NmEtNGIz
-        Mi1iZGVhLWQzNmZmZGM3NTA2NiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8t
-        YnVycml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBr
-        YXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTExVDIyOjAzOjI0
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMTFUMjI6MDM6MjRaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiZDA1MmM2NzdjNzQw
-        ODEyMzIyNDhmIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjMwZTk3MjE1LWJjYzItNDg4Yi1hNjQwLTcxMGE0ZTI2OTIx
-        NyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJmZDk1MGExNy1kNjBiLTRlYTItYmM4ZC1iNjRhMDJhNTM4ZTYiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJlYTMwMmNiMi1hNWNhLTQ5NWUtODc0Yy0yZTk0
-        ZjViODVmOTYiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzMWM4Nzkx
-        Mi1lNDRiLTRmMWQtOWU4Yi0wMDk1Yzg0YTllNzYiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiNjViNjI3ZDAtYWNhYi00YzE2LWI2N2YtNmNkZTljNGNl
-        NWQ2IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjU4N2YzMmJlLWJk
-        ODYtNDZmMS05YjAwLTczYTUzYTEzMDk1NSIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjhkNThlODYwLWMyMjMtNDY2Ny04ZDJjLTNhOWNmOTQy
-        ZTZjYyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjIzNmY4YzJjLTljNjEtNDUwMC05Y2IxLTU1ODE0NmJkMGVhMiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjg4OGI2ZjUx
-        LTk0MzAtNGNmMy05YzdlLWM3MmY0YTg4N2Q5MiIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjgwZGY2OGI4LWIwYmQtNDVi
-        NS1hYjA4LTk4NjkzYTAxN2FhOSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTU5NjE0ZWYtZjU2YS00YjMyLWJk
-        ZWEtZDM2ZmZkYzc1MDY2IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmQwNTJjMzQ0NzFlNDAw
-        NzBiMGJjMCJ9LCAiaWQiOiAiNTZiZDA1MmMzNDQ3MWU0MDA3MGIwYmMwIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:03:24 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/7983464a-3f20-416c-84ed-8022b1aa1647/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:03:25 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '651'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83OTgzNDY0YS0zZjIwLTQxNmMtODRlZC04MDIyYjFhYTE2
-        NDcvIiwgInRhc2tfaWQiOiAiNzk4MzQ2NGEtM2YyMC00MTZjLTg0ZWQtODAy
-        MmIxYWExNjQ3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAi
-        c3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
-        ZXNvdXJjZV93b3JrZXItMEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20i
-        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmJkMDUyZDM0NDcxZTQwMDcwYjBiYzEifSwgImlkIjogIjU2YmQw
-        NTJkMzQ0NzFlNDAwNzBiMGJjMSJ9
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:03:25 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/7983464a-3f20-416c-84ed-8022b1aa1647/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:03:25 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83OTgzNDY0YS0zZjIwLTQxNmMtODRlZC04MDIyYjFhYTE2
-        NDcvIiwgInRhc2tfaWQiOiAiNzk4MzQ2NGEtM2YyMC00MTZjLTg0ZWQtODAy
-        MmIxYWExNjQ3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTExVDIyOjAzOjI1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTExVDIyOjAzOjI1WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZDA1MmQzNDQ3MWU0MDA3MGIwYmMxIn0sICJpZCI6ICI1NmJkMDUyZDM0NDcx
-        ZTQwMDcwYjBiYzEifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:03:25 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/c6d667b1-0f29-4ece-89ac-5ff2823ecddf/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:03:27 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jNmQ2NjdiMS0wZjI5LTRlY2UtODlhYy01ZmYyODIzZWNk
-        ZGYvIiwgInRhc2tfaWQiOiAiYzZkNjY3YjEtMGYyOS00ZWNlLTg5YWMtNWZm
-        MjgyM2VjZGRmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiZDA1MmYz
-        NDQ3MWU0MDA3MGIwYmMyIn0sICJpZCI6ICI1NmJkMDUyZjM0NDcxZTQwMDcw
-        YjBiYzIifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:03:27 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/c6d667b1-0f29-4ece-89ac-5ff2823ecddf/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:03:27 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1133'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jNmQ2NjdiMS0wZjI5LTRlY2UtODlhYy01ZmYyODIzZWNk
-        ZGYvIiwgInRhc2tfaWQiOiAiYzZkNjY3YjEtMGYyOS00ZWNlLTg5YWMtNWZm
-        MjgyM2VjZGRmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0xMVQyMjowMzoyN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJO
-        T1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        Tk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwi
-        OiAwLCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJO
-        T1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGth
-        dGVsbG8tYnVycml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5u
-        aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0wQGthdGVsbG8tYnVycml0by5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
-        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmQwNTJm
-        MzQ0NzFlNDAwNzBiMGJjMiJ9LCAiaWQiOiAiNTZiZDA1MmYzNDQ3MWU0MDA3
-        MGIwYmMyIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:03:27 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/c6d667b1-0f29-4ece-89ac-5ff2823ecddf/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:03:28 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2324'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jNmQ2NjdiMS0wZjI5LTRlY2UtODlhYy01ZmYyODIzZWNk
-        ZGYvIiwgInRhc2tfaWQiOiAiYzZkNjY3YjEtMGYyOS00ZWNlLTg5YWMtNWZm
-        MjgyM2VjZGRmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMjowMzoyN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMjowMzoyN1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNTNjN2QwOTktM2FlNy00ZjExLWFiMTAtN2MxNmFhOWQz
-        NTkxLyIsICJ0YXNrX2lkIjogIjUzYzdkMDk5LTNhZTctNGYxMS1hYjEwLTdj
-        MTZhYTlkMzU5MSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDUy
-        ZTY3N2M3NDJkMDZjY2NlNTYifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIyOjAzOjI3WiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjI6MDM6Mjda
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA1MmY2NzdjNzQwODEyMzIyNDkzIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNTJmMzQ0NzFlNDAwNzBiMGJjMiJ9LCAiaWQi
-        OiAiNTZiZDA1MmYzNDQ3MWU0MDA3MGIwYmMyIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:03:28 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/53c7d099-3ae7-4f11-ab10-7c16aa9d3591/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:03:28 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy81M2M3ZDA5OS0zYWU3LTRmMTEtYWIxMC03YzE2
-        YWE5ZDM1OTEvIiwgInRhc2tfaWQiOiAiNTNjN2QwOTktM2FlNy00ZjExLWFi
-        MTAtN2MxNmFhOWQzNTkxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0xMVQyMjowMzoyOFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMjowMzoyOFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIxZGRmYzMwMi03ODRlLTQ0ZGEtYjg2MS1hODMzNzMz
-        NWM5NGIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNjE3YmUxMWQtMzRmMS00ZDJjLTkxMzYtZDE2MTBmNjhiMjJkIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiOTNlMmYzZDMtODBjZi00ZTg5LWFjMDkt
-        YTRlY2I3NWRmYTc1IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiM2Q5
-        OGMwZjktYzBkMy00MWE3LWEzMDItMzJjNGJiNWQwMDg3IiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjMxMmFhNWQyLTI1MDMtNDQ2OS05YmE5LTQ5Yjg4
-        YzYyMDNkNCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0NmUxY2Q2
-        OC1kNThkLTRiNzItOWUxNS00MjFkOTVjMjVlNzYiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJkNDUzMzQzMi02OGE0LTRlNjYtYjMwOC1lYzE3
-        ZDk2YjUxZDgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIxYjU1ZjZjYy0xYjAzLTQyOTMtOTVlZS1hNzVlYjMzOTk3NWQi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2MjM1
-        ZDQyNC0zNzJiLTQ4NDUtYjk4Zi1iMzRlZjg4NjBhYzciLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3NTg2OGZkNi1mMWE5
-        LTQ2ZDMtOTJiYi1lNmE3OTgzOWVkYjEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImRkMDkwZTRlLWE2YTMtNDlm
-        Ni05NTdhLWI3N2U2NDAwYzEzOSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8t
-        YnVycml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBr
-        YXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTExVDIyOjAzOjI4
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMTFUMjI6MDM6MjhaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiZDA1MzA2NzdjNzQw
-        ODEyMzIyNDk0IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjFkZGZjMzAyLTc4NGUtNDRkYS1iODYxLWE4MzM3MzM1Yzk0
-        YiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI2MTdiZTExZC0zNGYxLTRkMmMtOTEzNi1kMTYxMGY2OGIyMmQiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI5M2UyZjNkMy04MGNmLTRlODktYWMwOS1hNGVj
-        Yjc1ZGZhNzUiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzZDk4YzBm
-        OS1jMGQzLTQxYTctYTMwMi0zMmM0YmI1ZDAwODciLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiMzEyYWE1ZDItMjUwMy00NDY5LTliYTktNDliODhjNjIw
-        M2Q0IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQ2ZTFjZDY4LWQ1
-        OGQtNGI3Mi05ZTE1LTQyMWQ5NWMyNWU3NiIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImQ0NTMzNDMyLTY4YTQtNGU2Ni1iMzA4LWVjMTdkOTZi
-        NTFkOCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjFiNTVmNmNjLTFiMDMtNDI5My05NWVlLWE3NWViMzM5OTc1ZCIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjYyMzVkNDI0
-        LTM3MmItNDg0NS1iOThmLWIzNGVmODg2MGFjNyIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc1ODY4ZmQ2LWYxYTktNDZk
-        My05MmJiLWU2YTc5ODM5ZWRiMSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZGQwOTBlNGUtYTZhMy00OWY2LTk1
-        N2EtYjc3ZTY0MDBjMTM5IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmQwNTJmMzQ0NzFlNDAw
-        NzBiMGJkMiJ9LCAiaWQiOiAiNTZiZDA1MmYzNDQ3MWU0MDA3MGIwYmQyIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:03:28 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/68d0dd5a-bb56-41cd-ad87-f2907fb60f86/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:03:28 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82OGQwZGQ1YS1iYjU2LTQxY2QtYWQ4Ny1mMjkwN2ZiNjBm
-        ODYvIiwgInRhc2tfaWQiOiAiNjhkMGRkNWEtYmI1Ni00MWNkLWFkODctZjI5
-        MDdmYjYwZjg2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJkMDUz
-        MDM0NDcxZTQwMDcwYjBiZDMifSwgImlkIjogIjU2YmQwNTMwMzQ0NzFlNDAw
-        NzBiMGJkMyJ9
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:03:28 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/68d0dd5a-bb56-41cd-ad87-f2907fb60f86/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:03:29 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82OGQwZGQ1YS1iYjU2LTQxY2QtYWQ4Ny1mMjkwN2ZiNjBm
-        ODYvIiwgInRhc2tfaWQiOiAiNjhkMGRkNWEtYmI1Ni00MWNkLWFkODctZjI5
-        MDdmYjYwZjg2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTExVDIyOjAzOjI5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTExVDIyOjAzOjI5WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZDA1MzAzNDQ3MWU0MDA3MGIwYmQzIn0sICJpZCI6ICI1NmJkMDUzMDM0NDcx
-        ZTQwMDcwYjBiZDMifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:03:29 GMT
-- request:
-    method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
-        IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRp
-        c3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwi
-        OiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3Rl
-        Y3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifV19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '636'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:03:30 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '320'
-      Location:
-      - https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiZDA1MzI2NzdjNzQyZDA1YWYzODNhIn0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:03:30 GMT
-- request:
-    method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -7852,7 +1019,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:03:30 GMT
+      - Tue, 23 Feb 2016 16:49:06 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -7865,14 +1032,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2E0Y2UwZWFiLTYxODctNDNiMC05NGJkLTQ0MTdmY2Q1YmUyZS8iLCAi
-        dGFza19pZCI6ICJhNGNlMGVhYi02MTg3LTQzYjAtOTRiZC00NDE3ZmNkNWJl
-        MmUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:03:30 GMT
+        c2tzLzkyZDM2ZWNlLTBmMDAtNDc4Yi1iN2UzLTgxZTNjZDdmMzE4YS8iLCAi
+        dGFza19pZCI6ICI5MmQzNmVjZS0wZjAwLTQ3OGItYjdlMy04MWUzY2Q3ZjMx
+        OGEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:49:06 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/a4ce0eab-6187-43b0-94bd-4417fcd5be2e/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/92d36ece-0f00-478b-b7e3-81e3cd7f318a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -7891,13 +1058,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:03:30 GMT
+      - Tue, 23 Feb 2016 16:49:06 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '643'
       Connection:
       - close
       Content-Type:
@@ -7907,22 +1074,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hNGNlMGVhYi02MTg3LTQzYjAtOTRiZC00NDE3ZmNkNWJl
-        MmUvIiwgInRhc2tfaWQiOiAiYTRjZTBlYWItNjE4Ny00M2IwLTk0YmQtNDQx
-        N2ZjZDViZTJlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy85MmQzNmVjZS0wZjAwLTQ3OGItYjdlMy04MWUzY2Q3ZjMx
+        OGEvIiwgInRhc2tfaWQiOiAiOTJkMzZlY2UtMGYwMC00NzhiLWI3ZTMtODFl
+        M2NkN2YzMThhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiZDA1MzIz
-        NDQ3MWU0MDA3MGIwYmQ0In0sICJpZCI6ICI1NmJkMDUzMjM0NDcxZTQwMDcw
-        YjBiZDQifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:03:30 GMT
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZj
+        YzhkODI5ODkwNTRmYzQ4YmEzMGEyIn0sICJpZCI6ICI1NmNjOGQ4Mjk4OTA1
+        NGZjNDhiYTMwYTIifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:49:06 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/a4ce0eab-6187-43b0-94bd-4417fcd5be2e/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/92d36ece-0f00-478b-b7e3-81e3cd7f318a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -7941,13 +1110,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:03:31 GMT
+      - Tue, 23 Feb 2016 16:49:06 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2324'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -7957,16 +1126,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hNGNlMGVhYi02MTg3LTQzYjAtOTRiZC00NDE3ZmNkNWJl
-        MmUvIiwgInRhc2tfaWQiOiAiYTRjZTBlYWItNjE4Ny00M2IwLTk0YmQtNDQx
-        N2ZjZDViZTJlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy85MmQzNmVjZS0wZjAwLTQ3OGItYjdlMy04MWUzY2Q3ZjMx
+        OGEvIiwgInRhc2tfaWQiOiAiOTJkMzZlY2UtMGYwMC00NzhiLWI3ZTMtODFl
+        M2NkN2YzMThhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMjowMzozMVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMjowMzozMFoiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0OTowNloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0OTowNloiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMTA1MjI0NWQtYjZjOS00YTRhLWE2ZWQtMjdkMGY5MTBh
-        YjlmLyIsICJ0YXNrX2lkIjogIjEwNTIyNDVkLWI2YzktNGE0YS1hNmVkLTI3
-        ZDBmOTEwYWI5ZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvMDU0YmU2NjMtODkxOS00YzE4LTgxMmYtZTBmNDk5YTJk
+        ZjhkLyIsICJ0YXNrX2lkIjogIjA1NGJlNjYzLTg5MTktNGMxOC04MTJmLWUw
+        ZjQ5OWEyZGY4ZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -7977,41 +1146,41 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDUz
-        MjY3N2M3NDJkMDVhZjM4M2IifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIyOjAzOjMwWiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjI6MDM6MzFa
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA1MzM2NzdjNzQwODEyMzIyNDk4IiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNTMyMzQ0NzFlNDAwNzBiMGJkNCJ9LCAiaWQi
-        OiAiNTZiZDA1MzIzNDQ3MWU0MDA3MGIwYmQ0In0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:03:31 GMT
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ4MWRlMDQw
+        MzNmNDM1MTRmYmYifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ5OjA2WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDk6MDZaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkODJk
+        ZTA0MDMwODk3NThhOTVkIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDgyOTg5MDU0ZmM0OGJhMzBhMiJ9LCAiaWQiOiAiNTZj
+        YzhkODI5ODkwNTRmYzQ4YmEzMGEyIn0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:49:06 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/1052245d-b6c9-4a4a-a6ed-27d0f910ab9f/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/054be663-8919-4c18-812f-e0f499a2df8d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -8030,13 +1199,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:03:31 GMT
+      - Tue, 23 Feb 2016 16:49:06 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '3513'
+      - '6923'
       Connection:
       - close
       Content-Type:
@@ -8046,368 +1215,163 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8xMDUyMjQ1ZC1iNmM5LTRhNGEtYTZlZC0yN2Qw
-        ZjkxMGFiOWYvIiwgInRhc2tfaWQiOiAiMTA1MjI0NWQtYjZjOS00YTRhLWE2
-        ZWQtMjdkMGY5MTBhYjlmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy8wNTRiZTY2My04OTE5LTRjMTgtODEyZi1lMGY0
+        OTlhMmRmOGQvIiwgInRhc2tfaWQiOiAiMDU0YmU2NjMtODkxOS00YzE4LTgx
+        MmYtZTBmNDk5YTJkZjhkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0xMVQyMjowMzozMVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3Y2I1
-        N2U4NS05MjBhLTRlNzktYTA5MC0yY2Q5MWNkZDI2ZDEiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzQ2MzA3M2EtODFj
-        NC00MDQ1LWE0ODgtOTI3N2ZiYWI3YzgwIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiMDIxYzM3NjEtOWExZS00Y2VjLWI3MWMtMTFkOGE2NzAxMTg2IiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzgxZTg3ZDgtMWM4Yi00MTY2LWI4
-        NmYtYjdiMjMyYTIwZGJjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNh
-        YmIwYmNlLTg0NjMtNDVlNy04MTI5LTQ2YWNhMzE5NzNmZSIsICJudW1fcHJv
-        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlYTVjMTFhYi05ZWI5LTQzZWUtYmE4
-        Zi1mYTYwOTQ3OGU3NGMiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
-        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRh
-        dGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICIxZDI3MjA4NC02NTRhLTQzNmQtODhmMS0wMjYzMGIzMjczYjYiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUi
-        OiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2
-        NzM4NTRlOC04ZGViLTQyYTctYWE3OS1jNGNiNWVkNmVjODIiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJn
-        ZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDQ3YzM2MmIt
-        OTBiYi00MjU3LWJjNmYtZWY3ZGZjODU5NGEyIiwgIm51bV9wcm9jZXNzZWQi
-        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJs
-        aXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9k
-        aXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
-        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTJhMzQ1ZWYtYWE4Ni00
-        MzJlLTljN2EtYmNlMjRjYjEyMmFkIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
-        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExp
-        c3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19t
-        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RB
-        UlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjNDdjNjFkZi05MzFlLTRl
-        OWEtYTBmZS01ZDljNDA5ZjExNmMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0s
-        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRlbGxv
-        LWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBr
-        YXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwg
-        ImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJkMDUzMzM0NDcx
-        ZTQwMDcwYjBiZTQifSwgImlkIjogIjU2YmQwNTMzMzQ0NzFlNDAwNzBiMGJl
-        NCJ9
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:03:31 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/a4ce0eab-6187-43b0-94bd-4417fcd5be2e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:03:31 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2324'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hNGNlMGVhYi02MTg3LTQzYjAtOTRiZC00NDE3ZmNkNWJl
-        MmUvIiwgInRhc2tfaWQiOiAiYTRjZTBlYWItNjE4Ny00M2IwLTk0YmQtNDQx
-        N2ZjZDViZTJlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMjowMzozMVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMjowMzozMFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMTA1MjI0NWQtYjZjOS00YTRhLWE2ZWQtMjdkMGY5MTBh
-        YjlmLyIsICJ0YXNrX2lkIjogIjEwNTIyNDVkLWI2YzktNGE0YS1hNmVkLTI3
-        ZDBmOTEwYWI5ZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDUz
-        MjY3N2M3NDJkMDVhZjM4M2IifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIyOjAzOjMwWiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjI6MDM6MzFa
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA1MzM2NzdjNzQwODEyMzIyNDk4IiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNTMyMzQ0NzFlNDAwNzBiMGJkNCJ9LCAiaWQi
-        OiAiNTZiZDA1MzIzNDQ3MWU0MDA3MGIwYmQ0In0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:03:31 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/1052245d-b6c9-4a4a-a6ed-27d0f910ab9f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:03:31 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8xMDUyMjQ1ZC1iNmM5LTRhNGEtYTZlZC0yN2Qw
-        ZjkxMGFiOWYvIiwgInRhc2tfaWQiOiAiMTA1MjI0NWQtYjZjOS00YTRhLWE2
-        ZWQtMjdkMGY5MTBhYjlmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0xMVQyMjowMzozMVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMjowMzozMVoiLCAi
+        bWUiOiAiMjAxNi0wMi0yM1QxNjo0OTowNloiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0OTowNloiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI3Y2I1N2U4NS05MjBhLTRlNzktYTA5MC0yY2Q5MWNk
-        ZDI2ZDEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICI3OWZlMWQxYS1iZjE5LTQ2YTAtOTQyZS1iM2QxYjdm
+        NTc5ZmMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNzQ2MzA3M2EtODFjNC00MDQ1LWE0ODgtOTI3N2ZiYWI3YzgwIiwg
+        aWQiOiAiMDllYmVjNTMtNTI3OS00MDRjLWJkN2YtNTdmMjM2YzE4MDcxIiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
         bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMDIxYzM3NjEtOWExZS00Y2VjLWI3MWMt
-        MTFkOGE2NzAxMTg2IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiYTZkYjgwYTctNGZmMC00ZjFjLTk0ZmIt
+        MzRmNzg4ZDY0YTFhIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
         TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzgx
-        ZTg3ZDgtMWM4Yi00MTY2LWI4NmYtYjdiMjMyYTIwZGJjIiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTM2
+        OGE4OWEtNzgxYy00NTgzLWJjZmQtMDczZjRmNzQxZGRmIiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjNhYmIwYmNlLTg0NjMtNDVlNy04MTI5LTQ2YWNh
-        MzE5NzNmZSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        IDAsICJzdGVwX2lkIjogImYxNDdkMjZhLWNiMGUtNDgyMC1iNDY5LTFkOWRm
+        ZGI5YWM2NiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
         OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
         InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlYTVjMTFh
-        Yi05ZWI5LTQzZWUtYmE4Zi1mYTYwOTQ3OGU3NGMiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1ZDU1ZjAz
+        MC1mZGFlLTRkMTQtYWI3Mi0xYjVmOTI1MjBjYmQiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
         Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIxZDI3MjA4NC02NTRhLTQzNmQtODhmMS0wMjYz
-        MGIzMjczYjYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICI1ZjRhZjk0NS1jODlmLTQ5MDMtYTQzMS1mMTgw
+        MjgxNTI4NGQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
         ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI2NzM4NTRlOC04ZGViLTQyYTctYWE3OS1jNGNiNWVkNmVjODIi
+        cF9pZCI6ICIwMjA2OWUyYi04N2JjLTQzZGQtYjU1Mi1kNjYzN2Q3ZjYzOGUi
         LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
         dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
         c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkNDdj
-        MzYyYi05MGJiLTQyNTctYmM2Zi1lZjdkZmM4NTk0YTIiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2Y2Y2
+        ZmYzMC1lZTI3LTRlYmQtODQ2ZS02YzlhMjcxMTY2MGYiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
         aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxMmEzNDVlZi1hYTg2
-        LTQzMmUtOWM3YS1iY2UyNGNiMTIyYWQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiYWJhZWVmMC01YzQ4
+        LTRlOWEtOWM0Mi1hMjgwMjA3OTFhOTIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
         TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
         X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM0N2M2MWRmLTkzMWUtNGU5
-        YS1hMGZlLTVkOWM0MDlmMTE2YyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8t
-        YnVycml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBr
-        YXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTExVDIyOjAzOjMx
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMTFUMjI6MDM6MzFaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiZDA1MzM2NzdjNzQw
-        ODEyMzIyNDk5IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjdjYjU3ZTg1LTkyMGEtNGU3OS1hMDkwLTJjZDkxY2RkMjZk
-        MSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI3NDYzMDczYS04MWM0LTQwNDUtYTQ4OC05Mjc3ZmJhYjdjODAiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIwMjFjMzc2MS05YTFlLTRjZWMtYjcxYy0xMWQ4
-        YTY3MDExODYiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3ODFlODdk
-        OC0xYzhiLTQxNjYtYjg2Zi1iN2IyMzJhMjBkYmMiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiM2FiYjBiY2UtODQ2My00NWU3LTgxMjktNDZhY2EzMTk3
-        M2ZlIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVhNWMxMWFiLTll
-        YjktNDNlZS1iYThmLWZhNjA5NDc4ZTc0YyIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjFkMjcyMDg0LTY1NGEtNDM2ZC04OGYxLTAyNjMwYjMy
-        NzNiNiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjYzYmI4YjljLTIxZjgtNGI5
+        YS05YWY5LTM4ZGQzNTY0ZmU0MyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
+        c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
+        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ5OjA2WiIsICJf
+        bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
+        MTYtMDItMjNUMTY6NDk6MDZaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
+        cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
+        IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
+        X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
+        RCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1z
+        IjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0
+        aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
+        SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
+        U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
+        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZjYzhkODJkZTA0MDMwODk3NThh
+        OTVlIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
         IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjY3Mzg1NGU4LThkZWItNDJhNy1hYTc5LWM0Y2I1ZWQ2ZWM4MiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ0N2MzNjJi
-        LTkwYmItNDI1Ny1iYzZmLWVmN2RmYzg1OTRhMiIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        IjogIjc5ZmUxZDFhLWJmMTktNDZhMC05NDJlLWIzZDFiN2Y1NzlmYyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwOWVi
+        ZWM1My01Mjc5LTQwNGMtYmQ3Zi01N2YyMzZjMTgwNzEiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICJhNmRiODBhNy00ZmYwLTRmMWMtOTRmYi0zNGY3ODhkNjRh
+        MWEiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5MzY4YTg5YS03ODFj
+        LTQ1ODMtYmNmZC0wNzNmNGY3NDFkZGYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiZjE0N2QyNmEtY2IwZS00ODIwLWI0NjktMWQ5ZGZkYjlhYzY2Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
+        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjEyYTM0NWVmLWFhODYtNDMy
-        ZS05YzdhLWJjZTI0Y2IxMjJhZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzQ3YzYxZGYtOTMxZS00ZTlhLWEw
-        ZmUtNWQ5YzQwOWYxMTZjIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmQwNTMzMzQ0NzFlNDAw
-        NzBiMGJlNCJ9LCAiaWQiOiAiNTZiZDA1MzMzNDQ3MWU0MDA3MGIwYmU0In0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:03:31 GMT
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjVkNTVmMDMwLWZkYWUtNGQx
+        NC1hYjcyLTFiNWY5MjUyMGNiZCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
+        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjVmNGFmOTQ1LWM4OWYtNDkwMy1hNDMxLWYxODAyODE1Mjg0ZCIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjAy
+        MDY5ZTJiLTg3YmMtNDNkZC1iNTUyLWQ2NjM3ZDdmNjM4ZSIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
+        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
+        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjZjZjZmZjMwLWVlMjct
+        NGViZC04NDZlLTZjOWEyNzExNjYwZiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
+        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImJhYmFlZWYwLTVjNDgtNGU5YS05YzQy
+        LWEyODAyMDc5MWE5MiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
+        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiNjNiYjhiOWMtMjFmOC00YjlhLTlhZjktMzhk
+        ZDM1NjRmZTQzIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDgyOTg5MDU0ZmM0OGJhMzBi
+        MiJ9LCAiaWQiOiAiNTZjYzhkODI5ODkwNTRmYzQ4YmEzMGIyIn0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:49:06 GMT
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -8429,7 +1393,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:03:32 GMT
+      - Tue, 23 Feb 2016 16:49:06 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -8443,45 +1407,45 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Im1hbmRhdG9yeV9wYWNrYWdlX25hbWVzIjogWyJw
-        ZW5ndWluIl0sICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogImJp
-        cmQiLCAidXNlcl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVlLCAi
-        X25zIjogInVuaXRzX3BhY2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRlZCI6
-        IDE0NTUyMjgwMjYsICJvcHRpb25hbF9wYWNrYWdlX25hbWVzIjogW10sICJ0
-        cmFuc2xhdGVkX25hbWUiOiB7fSwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24i
-        OiB7fSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNr
-        YWdlX25hbWVzIjogW10sICJfY29udGVudF90eXBlX2lkIjogInBhY2thZ2Vf
-        Z3JvdXAiLCAiaWQiOiAiYmlyZCIsICJfaWQiOiAiYmIyYzNjNzEtYzEwNS00
-        M2EwLWEyYTItMmI4MzNiZGM5NjJmIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0
-        LCAiY29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQi
-        OiAiMjAxNi0wMi0xMVQyMjowMzozMVoiLCAicmVwb19pZCI6ICJGZWRvcmFf
-        MTciLCAiY3JlYXRlZCI6ICIyMDE2LTAyLTExVDIyOjAzOjMxWiIsICJ1bml0
-        X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0X2lkIjogImJiMmMz
-        YzcxLWMxMDUtNDNhMC1hMmEyLTJiODMzYmRjOTYyZiIsICJfaWQiOiB7IiRv
-        aWQiOiAiNTZiZDA1MzMzNDQ3MWU0MDA3MGIwYmUxIn19LCB7Im1ldGFkYXRh
-        IjogeyJtYW5kYXRvcnlfcGFja2FnZV9uYW1lcyI6IFsiZWxlcGhhbnQsZ2ly
-        YWZmZSxjaGVldGFoLGxpb24sbW9ua2V5LHBlbmd1aW4sc3F1aXJyZWwsd2Fs
-        cnVzIiwgInBlbmd1aW4iXSwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5h
-        bWUiOiAibWFtbWFsIiwgInVzZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0
-        IjogdHJ1ZSwgIl9ucyI6ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0
-        X3VwZGF0ZWQiOiAxNDU1MjI4MDI2LCAib3B0aW9uYWxfcGFja2FnZV9uYW1l
-        cyI6IFtdLCAidHJhbnNsYXRlZF9uYW1lIjoge30sICJ0cmFuc2xhdGVkX2Rl
-        c2NyaXB0aW9uIjoge30sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImRl
-        ZmF1bHRfcGFja2FnZV9uYW1lcyI6IFtdLCAiX2NvbnRlbnRfdHlwZV9pZCI6
-        ICJwYWNrYWdlX2dyb3VwIiwgImlkIjogIm1hbW1hbCIsICJfaWQiOiAiZDJh
-        NTUyNTUtOGEzMC00ZjhkLThlMTAtNTMxYjcwYTQ1NWRkIiwgImRpc3BsYXlf
+        W3sibWV0YWRhdGEiOiB7Im1hbmRhdG9yeV9wYWNrYWdlX25hbWVzIjogWyJl
+        bGVwaGFudCxnaXJhZmZlLGNoZWV0YWgsbGlvbixtb25rZXkscGVuZ3Vpbixz
+        cXVpcnJlbCx3YWxydXMiLCAicGVuZ3VpbiJdLCAicmVwb19pZCI6ICJGZWRv
+        cmFfMTciLCAibmFtZSI6ICJtYW1tYWwiLCAidXNlcl92aXNpYmxlIjogdHJ1
+        ZSwgImRlZmF1bHQiOiB0cnVlLCAiX25zIjogInVuaXRzX3BhY2thZ2VfZ3Jv
+        dXAiLCAiX2xhc3RfdXBkYXRlZCI6IDE0NTYyNDYwNjgsICJvcHRpb25hbF9w
+        YWNrYWdlX25hbWVzIjogW10sICJ0cmFuc2xhdGVkX25hbWUiOiB7fSwgInRy
+        YW5zbGF0ZWRfZGVzY3JpcHRpb24iOiB7fSwgInB1bHBfdXNlcl9tZXRhZGF0
+        YSI6IHt9LCAiZGVmYXVsdF9wYWNrYWdlX25hbWVzIjogW10sICJfY29udGVu
+        dF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAiaWQiOiAibWFtbWFsIiwg
+        Il9pZCI6ICJlNTI3ZGM2Yy1kN2JlLTRlMWYtYTc4MS1iMWRlNTAzNzc4YWIi
+        LCAiZGlzcGxheV9vcmRlciI6IDEwMjQsICJjb25kaXRpb25hbF9wYWNrYWdl
+        X25hbWVzIjogW119LCAidXBkYXRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ5OjA2
+        WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTYt
+        MDItMjNUMTY6NDk6MDZaIiwgInVuaXRfdHlwZV9pZCI6ICJwYWNrYWdlX2dy
+        b3VwIiwgInVuaXRfaWQiOiAiZTUyN2RjNmMtZDdiZS00ZTFmLWE3ODEtYjFk
+        ZTUwMzc3OGFiIiwgIl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ4Mjk4OTA1NGZj
+        NDhiYTMwYjAifX0sIHsibWV0YWRhdGEiOiB7Im1hbmRhdG9yeV9wYWNrYWdl
+        X25hbWVzIjogWyJwZW5ndWluIl0sICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
+        ICJuYW1lIjogImJpcmQiLCAidXNlcl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1
+        bHQiOiB0cnVlLCAiX25zIjogInVuaXRzX3BhY2thZ2VfZ3JvdXAiLCAiX2xh
+        c3RfdXBkYXRlZCI6IDE0NTYyNDYwNjgsICJvcHRpb25hbF9wYWNrYWdlX25h
+        bWVzIjogW10sICJ0cmFuc2xhdGVkX25hbWUiOiB7fSwgInRyYW5zbGF0ZWRf
+        ZGVzY3JpcHRpb24iOiB7fSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAi
+        ZGVmYXVsdF9wYWNrYWdlX25hbWVzIjogW10sICJfY29udGVudF90eXBlX2lk
+        IjogInBhY2thZ2VfZ3JvdXAiLCAiaWQiOiAiYmlyZCIsICJfaWQiOiAiZmM4
+        ZjI4ZDEtMmVhZC00YjQ3LWFhOTgtYTM0NzBlNzIzYmJiIiwgImRpc3BsYXlf
         b3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtd
-        fSwgInVwZGF0ZWQiOiAiMjAxNi0wMi0xMVQyMjowMzozMVoiLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE2LTAyLTExVDIyOjAz
-        OjMxWiIsICJ1bml0X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0
-        X2lkIjogImQyYTU1MjU1LThhMzAtNGY4ZC04ZTEwLTUzMWI3MGE0NTVkZCIs
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiZDA1MzMzNDQ3MWU0MDA3MGIwYmUyIn19
+        fSwgInVwZGF0ZWQiOiAiMjAxNi0wMi0yM1QxNjo0OTowNloiLCAicmVwb19p
+        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ5
+        OjA2WiIsICJ1bml0X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0
+        X2lkIjogImZjOGYyOGQxLTJlYWQtNGI0Ny1hYTk4LWEzNDcwZTcyM2JiYiIs
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkODI5ODkwNTRmYzQ4YmEzMGFmIn19
         XQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:03:32 GMT
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:49:06 GMT
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -8503,7 +1467,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:03:32 GMT
+      - Tue, 23 Feb 2016 16:49:06 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -8517,50 +1481,50 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Im1hbmRhdG9yeV9wYWNrYWdlX25hbWVzIjogWyJw
-        ZW5ndWluIl0sICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogImJp
-        cmQiLCAidXNlcl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVlLCAi
-        X25zIjogInVuaXRzX3BhY2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRlZCI6
-        IDE0NTUyMjgwMjYsICJvcHRpb25hbF9wYWNrYWdlX25hbWVzIjogW10sICJ0
-        cmFuc2xhdGVkX25hbWUiOiB7fSwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24i
-        OiB7fSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNr
-        YWdlX25hbWVzIjogW10sICJfY29udGVudF90eXBlX2lkIjogInBhY2thZ2Vf
-        Z3JvdXAiLCAiaWQiOiAiYmlyZCIsICJfaWQiOiAiYmIyYzNjNzEtYzEwNS00
-        M2EwLWEyYTItMmI4MzNiZGM5NjJmIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0
-        LCAiY29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQi
-        OiAiMjAxNi0wMi0xMVQyMjowMzozMVoiLCAicmVwb19pZCI6ICJGZWRvcmFf
-        MTciLCAiY3JlYXRlZCI6ICIyMDE2LTAyLTExVDIyOjAzOjMxWiIsICJ1bml0
-        X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0X2lkIjogImJiMmMz
-        YzcxLWMxMDUtNDNhMC1hMmEyLTJiODMzYmRjOTYyZiIsICJfaWQiOiB7IiRv
-        aWQiOiAiNTZiZDA1MzMzNDQ3MWU0MDA3MGIwYmUxIn19LCB7Im1ldGFkYXRh
-        IjogeyJtYW5kYXRvcnlfcGFja2FnZV9uYW1lcyI6IFsiZWxlcGhhbnQsZ2ly
-        YWZmZSxjaGVldGFoLGxpb24sbW9ua2V5LHBlbmd1aW4sc3F1aXJyZWwsd2Fs
-        cnVzIiwgInBlbmd1aW4iXSwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5h
-        bWUiOiAibWFtbWFsIiwgInVzZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0
-        IjogdHJ1ZSwgIl9ucyI6ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0
-        X3VwZGF0ZWQiOiAxNDU1MjI4MDI2LCAib3B0aW9uYWxfcGFja2FnZV9uYW1l
-        cyI6IFtdLCAidHJhbnNsYXRlZF9uYW1lIjoge30sICJ0cmFuc2xhdGVkX2Rl
-        c2NyaXB0aW9uIjoge30sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImRl
-        ZmF1bHRfcGFja2FnZV9uYW1lcyI6IFtdLCAiX2NvbnRlbnRfdHlwZV9pZCI6
-        ICJwYWNrYWdlX2dyb3VwIiwgImlkIjogIm1hbW1hbCIsICJfaWQiOiAiZDJh
-        NTUyNTUtOGEzMC00ZjhkLThlMTAtNTMxYjcwYTQ1NWRkIiwgImRpc3BsYXlf
+        W3sibWV0YWRhdGEiOiB7Im1hbmRhdG9yeV9wYWNrYWdlX25hbWVzIjogWyJl
+        bGVwaGFudCxnaXJhZmZlLGNoZWV0YWgsbGlvbixtb25rZXkscGVuZ3Vpbixz
+        cXVpcnJlbCx3YWxydXMiLCAicGVuZ3VpbiJdLCAicmVwb19pZCI6ICJGZWRv
+        cmFfMTciLCAibmFtZSI6ICJtYW1tYWwiLCAidXNlcl92aXNpYmxlIjogdHJ1
+        ZSwgImRlZmF1bHQiOiB0cnVlLCAiX25zIjogInVuaXRzX3BhY2thZ2VfZ3Jv
+        dXAiLCAiX2xhc3RfdXBkYXRlZCI6IDE0NTYyNDYwNjgsICJvcHRpb25hbF9w
+        YWNrYWdlX25hbWVzIjogW10sICJ0cmFuc2xhdGVkX25hbWUiOiB7fSwgInRy
+        YW5zbGF0ZWRfZGVzY3JpcHRpb24iOiB7fSwgInB1bHBfdXNlcl9tZXRhZGF0
+        YSI6IHt9LCAiZGVmYXVsdF9wYWNrYWdlX25hbWVzIjogW10sICJfY29udGVu
+        dF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAiaWQiOiAibWFtbWFsIiwg
+        Il9pZCI6ICJlNTI3ZGM2Yy1kN2JlLTRlMWYtYTc4MS1iMWRlNTAzNzc4YWIi
+        LCAiZGlzcGxheV9vcmRlciI6IDEwMjQsICJjb25kaXRpb25hbF9wYWNrYWdl
+        X25hbWVzIjogW119LCAidXBkYXRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ5OjA2
+        WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTYt
+        MDItMjNUMTY6NDk6MDZaIiwgInVuaXRfdHlwZV9pZCI6ICJwYWNrYWdlX2dy
+        b3VwIiwgInVuaXRfaWQiOiAiZTUyN2RjNmMtZDdiZS00ZTFmLWE3ODEtYjFk
+        ZTUwMzc3OGFiIiwgIl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ4Mjk4OTA1NGZj
+        NDhiYTMwYjAifX0sIHsibWV0YWRhdGEiOiB7Im1hbmRhdG9yeV9wYWNrYWdl
+        X25hbWVzIjogWyJwZW5ndWluIl0sICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
+        ICJuYW1lIjogImJpcmQiLCAidXNlcl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1
+        bHQiOiB0cnVlLCAiX25zIjogInVuaXRzX3BhY2thZ2VfZ3JvdXAiLCAiX2xh
+        c3RfdXBkYXRlZCI6IDE0NTYyNDYwNjgsICJvcHRpb25hbF9wYWNrYWdlX25h
+        bWVzIjogW10sICJ0cmFuc2xhdGVkX25hbWUiOiB7fSwgInRyYW5zbGF0ZWRf
+        ZGVzY3JpcHRpb24iOiB7fSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAi
+        ZGVmYXVsdF9wYWNrYWdlX25hbWVzIjogW10sICJfY29udGVudF90eXBlX2lk
+        IjogInBhY2thZ2VfZ3JvdXAiLCAiaWQiOiAiYmlyZCIsICJfaWQiOiAiZmM4
+        ZjI4ZDEtMmVhZC00YjQ3LWFhOTgtYTM0NzBlNzIzYmJiIiwgImRpc3BsYXlf
         b3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtd
-        fSwgInVwZGF0ZWQiOiAiMjAxNi0wMi0xMVQyMjowMzozMVoiLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE2LTAyLTExVDIyOjAz
-        OjMxWiIsICJ1bml0X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0
-        X2lkIjogImQyYTU1MjU1LThhMzAtNGY4ZC04ZTEwLTUzMWI3MGE0NTVkZCIs
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiZDA1MzMzNDQ3MWU0MDA3MGIwYmUyIn19
+        fSwgInVwZGF0ZWQiOiAiMjAxNi0wMi0yM1QxNjo0OTowNloiLCAicmVwb19p
+        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ5
+        OjA2WiIsICJ1bml0X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0
+        X2lkIjogImZjOGYyOGQxLTJlYWQtNGI0Ny1hYTk4LWEzNDcwZTcyM2JiYiIs
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkODI5ODkwNTRmYzQ4YmEzMGFmIn19
         XQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:03:32 GMT
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:49:06 GMT
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/content/units/package_group/search/
+    uri: https://katello-yoda.example.com/pulp/api/v2/content/units/package_group/search/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiYmIyYzNj
-        NzEtYzEwNS00M2EwLWEyYTItMmI4MzNiZGM5NjJmIl19fX0sImluY2x1ZGVf
+        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiZTUyN2Rj
+        NmMtZDdiZS00ZTFmLWE3ODEtYjFkZTUwMzc3OGFiIl19fX0sImluY2x1ZGVf
         cmVwb3MiOnRydWV9
     headers:
       Accept:
@@ -8579,13 +1543,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:03:32 GMT
+      - Tue, 23 Feb 2016 16:49:06 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '602'
+      - '670'
       Connection:
       - close
       Content-Type:
@@ -8594,24 +1558,25 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJt
-        YW5kYXRvcnlfcGFja2FnZV9uYW1lcyI6IFsicGVuZ3VpbiJdLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAibmFtZSI6ICJiaXJkIiwgInVzZXJfdmlzaWJs
-        ZSI6IHRydWUsICJkZWZhdWx0IjogdHJ1ZSwgIl9sYXN0X3VwZGF0ZWQiOiAi
-        MjAxNi0wMi0xMVQyMjowMDoyNloiLCAiY2hpbGRyZW4iOiB7fSwgIm9wdGlv
-        bmFsX3BhY2thZ2VfbmFtZXMiOiBbXSwgInRyYW5zbGF0ZWRfbmFtZSI6IHt9
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcGFja2Fn
-        ZV9ncm91cC9iYjJjM2M3MS1jMTA1LTQzYTAtYTJhMi0yYjgzM2JkYzk2MmYv
-        IiwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24iOiB7fSwgInB1bHBfdXNlcl9t
-        ZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNrYWdlX25hbWVzIjogW10sICJf
-        Y29udGVudF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAiaWQiOiAiYmly
-        ZCIsICJfaWQiOiAiYmIyYzNjNzEtYzEwNS00M2EwLWEyYTItMmI4MzNiZGM5
-        NjJmIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxfcGFj
-        a2FnZV9uYW1lcyI6IFtdfV0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:03:32 GMT
+        YW5kYXRvcnlfcGFja2FnZV9uYW1lcyI6IFsiZWxlcGhhbnQsZ2lyYWZmZSxj
+        aGVldGFoLGxpb24sbW9ua2V5LHBlbmd1aW4sc3F1aXJyZWwsd2FscnVzIiwg
+        InBlbmd1aW4iXSwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5hbWUiOiAi
+        bWFtbWFsIiwgInVzZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0IjogdHJ1
+        ZSwgIl9sYXN0X3VwZGF0ZWQiOiAiMjAxNi0wMi0yM1QxNjo0Nzo0OFoiLCAi
+        Y2hpbGRyZW4iOiB7fSwgIm9wdGlvbmFsX3BhY2thZ2VfbmFtZXMiOiBbXSwg
+        InRyYW5zbGF0ZWRfbmFtZSI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L2NvbnRlbnQvdW5pdHMvcGFja2FnZV9ncm91cC9lNTI3ZGM2Yy1kN2JlLTRl
+        MWYtYTc4MS1iMWRlNTAzNzc4YWIvIiwgInRyYW5zbGF0ZWRfZGVzY3JpcHRp
+        b24iOiB7fSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9w
+        YWNrYWdlX25hbWVzIjogW10sICJfY29udGVudF90eXBlX2lkIjogInBhY2th
+        Z2VfZ3JvdXAiLCAiaWQiOiAibWFtbWFsIiwgIl9pZCI6ICJlNTI3ZGM2Yy1k
+        N2JlLTRlMWYtYTc4MS1iMWRlNTAzNzc4YWIiLCAiZGlzcGxheV9vcmRlciI6
+        IDEwMjQsICJjb25kaXRpb25hbF9wYWNrYWdlX25hbWVzIjogW119XQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:49:07 GMT
 - request:
     method: delete
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -8630,7 +1595,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:03:32 GMT
+      - Tue, 23 Feb 2016 16:49:07 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -8643,14 +1608,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzgwOGI3NjI2LTAxYzQtNDE0MC1hYWExLTZjNjUxMzc2NDM5My8iLCAi
-        dGFza19pZCI6ICI4MDhiNzYyNi0wMWM0LTQxNDAtYWFhMS02YzY1MTM3NjQz
-        OTMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:03:32 GMT
+        c2tzLzU4MmRkZDQ4LTJlYzAtNDBiOC1iMzlhLWNkNTFmMTU5MzJjYS8iLCAi
+        dGFza19pZCI6ICI1ODJkZGQ0OC0yZWMwLTQwYjgtYjM5YS1jZDUxZjE1OTMy
+        Y2EifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:49:07 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/808b7626-01c4-4140-aaa1-6c6513764393/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/582ddd48-2ec0-40b8-b39a-cd51f15932ca/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -8669,7 +1634,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:03:32 GMT
+      - Tue, 23 Feb 2016 16:49:07 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -8685,22 +1650,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84MDhiNzYyNi0wMWM0LTQxNDAtYWFhMS02YzY1MTM3NjQz
-        OTMvIiwgInRhc2tfaWQiOiAiODA4Yjc2MjYtMDFjNC00MTQwLWFhYTEtNmM2
-        NTEzNzY0MzkzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy81ODJkZGQ0OC0yZWMwLTQwYjgtYjM5YS1jZDUxZjE1OTMy
+        Y2EvIiwgInRhc2tfaWQiOiAiNTgyZGRkNDgtMmVjMC00MGI4LWIzOWEtY2Q1
+        MWYxNTkzMmNhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
         bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
         ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
         Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
         IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJkMDUz
-        NDM0NDcxZTQwMDcwYjBiZTUifSwgImlkIjogIjU2YmQwNTM0MzQ0NzFlNDAw
-        NzBiMGJlNSJ9
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:03:32 GMT
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ4
+        Mzk4OTA1NGZjNDhiYTMwYjMifSwgImlkIjogIjU2Y2M4ZDgzOTg5MDU0ZmM0
+        OGJhMzBiMyJ9
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:49:07 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/808b7626-01c4-4140-aaa1-6c6513764393/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/582ddd48-2ec0-40b8-b39a-cd51f15932ca/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -8719,13 +1684,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:03:33 GMT
+      - Tue, 23 Feb 2016 16:49:07 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '688'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -8735,20 +1700,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84MDhiNzYyNi0wMWM0LTQxNDAtYWFhMS02YzY1MTM3NjQz
-        OTMvIiwgInRhc2tfaWQiOiAiODA4Yjc2MjYtMDFjNC00MTQwLWFhYTEtNmM2
-        NTEzNzY0MzkzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy81ODJkZGQ0OC0yZWMwLTQwYjgtYjM5YS1jZDUxZjE1OTMy
+        Y2EvIiwgInRhc2tfaWQiOiAiNTgyZGRkNDgtMmVjMC00MGI4LWIzOWEtY2Q1
+        MWYxNTkzMmNhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTExVDIyOjAzOjMyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTExVDIyOjAzOjMyWiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ5OjA3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ5OjA3WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZDA1MzQzNDQ3MWU0MDA3MGIwYmU1In0sICJpZCI6ICI1NmJkMDUzNDM0NDcx
-        ZTQwMDcwYjBiZTUifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:03:33 GMT
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkODM5
+        ODkwNTRmYzQ4YmEzMGIzIn0sICJpZCI6ICI1NmNjOGQ4Mzk4OTA1NGZjNDhi
+        YTMwYjMifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:49:07 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/services/pulp/rpm.yml
+++ b/test/fixtures/vcr_cassettes/services/pulp/rpm.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/74815123-ab55-497f-aee4-f7209a653e93/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/ca84bc65-7236-4cd1-a5a4-aadba87cf0f9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -13,12 +13,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="Aic3DUKn21kJqf2fn5f3ejP5Q462c57SeGDtXPSt4",
-        oauth_signature="xhPjQYaVHhKDKQhkta%2FmO0g4RF8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292127", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -27,13 +21,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:02:07 GMT
+      - Tue, 23 Feb 2016 16:49:08 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '661'
       Connection:
       - close
       Content-Type:
@@ -43,22 +37,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83NDgxNTEyMy1hYjU1LTQ5N2YtYWVlNC1mNzIwOWE2NTNl
-        OTMvIiwgInRhc2tfaWQiOiAiNzQ4MTUxMjMtYWI1NS00OTdmLWFlZTQtZjcy
-        MDlhNjUzZTkzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9jYTg0YmM2NS03MjM2LTRjZDEtYTVhNC1hYWRiYTg3Y2Yw
+        ZjkvIiwgInRhc2tfaWQiOiAiY2E4NGJjNjUtNzIzNi00Y2QxLWE1YTQtYWFk
+        YmE4N2NmMGY5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjOWZl
-        NTQ5NzVmNzFhNmE2NmRhIn0sICJpZCI6ICI1NmFlYmM5ZmU1NDk3NWY3MWE2
-        YTY2ZGEifQ==
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0OTowOFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4
+        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNTZjYzhkODQ5ODkwNTRmYzQ4YmEzMGI0In0sICJp
+        ZCI6ICI1NmNjOGQ4NDk4OTA1NGZjNDhiYTMwYjQifQ==
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:07 GMT
+  recorded_at: Tue, 23 Feb 2016 16:49:08 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/74815123-ab55-497f-aee4-f7209a653e93/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/ca84bc65-7236-4cd1-a5a4-aadba87cf0f9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -69,12 +65,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="6orH1uWaWxqSo1vCZE2UfEidCpC2iXhdaWikXJcsfU",
-        oauth_signature="6GmoPVEv7TJr2ipW9UBy3paqswA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292128", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -83,13 +73,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:02:08 GMT
+      - Tue, 23 Feb 2016 16:49:09 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2310'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -99,61 +89,61 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83NDgxNTEyMy1hYjU1LTQ5N2YtYWVlNC1mNzIwOWE2NTNl
-        OTMvIiwgInRhc2tfaWQiOiAiNzQ4MTUxMjMtYWI1NS00OTdmLWFlZTQtZjcy
-        MDlhNjUzZTkzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9jYTg0YmM2NS03MjM2LTRjZDEtYTVhNC1hYWRiYTg3Y2Yw
+        ZjkvIiwgInRhc2tfaWQiOiAiY2E4NGJjNjUtNzIzNi00Y2QxLWE1YTQtYWFk
+        YmE4N2NmMGY5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMjowMjowN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMjowN1oiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0OTowOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0OTowOFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvOGUzNjMwZTUtMDczMC00NzVjLWI5MGItNWQ3MDczNjIw
-        NWU5LyIsICJ0YXNrX2lkIjogIjhlMzYzMGU1LTA3MzAtNDc1Yy1iOTBiLTVk
-        NzA3MzYyMDVlOSJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82
-        Njg5MjA3MS02ZTQ0LTRlMWQtYmIxYy03YzdlNjhiZTliMWIvIiwgInRhc2tf
-        aWQiOiAiNjY4OTIwNzEtNmU0NC00ZTFkLWJiMWMtN2M3ZTY4YmU5YjFiIn1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjOWZkZTA0MDMzNDZjZjY0YTA0
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MjowMjowN1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAyOjAyOjA3WiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmM5ZmRlMDQwMzRjZDky
-        ZGM1ZGYiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmM5ZmU1NDk3NWY3MWE2YTY2ZGEifSwgImlkIjogIjU2YWViYzlmZTU0
-        OTc1ZjcxYTZhNjZkYSJ9
+        cGkvdjIvdGFza3MvZTE2Y2RlZTQtZWFmOC00NDAyLTkxZjktMjRlZjQwZDRm
+        YmQxLyIsICJ0YXNrX2lkIjogImUxNmNkZWU0LWVhZjgtNDQwMi05MWY5LTI0
+        ZWY0MGQ0ZmJkMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ4NGRlMDQw
+        MzNmNDI2MmNhZGEifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ5OjA4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDk6MDhaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkODRk
+        ZTA0MDMwODk3NThhOTYyIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDg0OTg5MDU0ZmM0OGJhMzBiNCJ9LCAiaWQiOiAiNTZj
+        YzhkODQ5ODkwNTRmYzQ4YmEzMGI0In0=
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:08 GMT
+  recorded_at: Tue, 23 Feb 2016 16:49:09 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/8e3630e5-0730-475c-b90b-5d70736205e9/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/e16cdee4-eaf8-4402-91f9-24ef40d4fbd1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -164,12 +154,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="IufF8gd6RZSeF93yEfXkZgwL5BQtDzabR3s3xu8Me4",
-        oauth_signature="TthnU3CpWhqwW3ncOSVwiPRnoSc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292128", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -178,358 +162,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:02:08 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84ZTM2MzBlNS0wNzMwLTQ3NWMtYjkwYi01ZDcw
-        NzM2MjA1ZTkvIiwgInRhc2tfaWQiOiAiOGUzNjMwZTUtMDczMC00NzVjLWI5
-        MGItNWQ3MDczNjIwNWU5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMjowMjowOFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMjowOFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDI6MDI6MDhaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMjowMjowOFoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmNhMGRlMDQwMzRjZDkyZGM1ZTAiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjOWZlNTQ5NzVmNzFhNmE2NmVhIn0s
-        ICJpZCI6ICI1NmFlYmM5ZmU1NDk3NWY3MWE2YTY2ZWEifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:08 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/66892071-6e44-4e1d-bb1c-7c7e68be9b1b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="x0HHwYe0HC5jC3QoTdyy2JbiLvdFNeHfEdn1eaEc",
-        oauth_signature="cA7Et7IBqdRMdGqnh9vQBxc5%2FRk%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292128", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:02:08 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3517'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82Njg5MjA3MS02ZTQ0LTRlMWQtYmIxYy03Yzdl
-        NjhiZTliMWIvIiwgInRhc2tfaWQiOiAiNjY4OTIwNzEtNmU0NC00ZTFkLWJi
-        MWMtN2M3ZTY4YmU5YjFiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wMVQwMjowMjowOFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3YTMy
-        NGQ3Zi02OTQyLTRjMDctYjgzMi03NWZlMjI5MGM0NzkiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjI4YTQ1MzktZDBk
-        Yi00NmI5LTkxOTQtMWIzYzdkOTg3ZmE2IiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYjkyZmE3MTUtNzFiYi00NDFlLWIwMDAtMTUwMjBiMjY3MzRmIiwg
-        Im51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
-        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
-        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjIzOWU5OTU3LTk2OWEt
-        NDc5OC1hNjFlLTQ3YTc4Y2Q1YjZhZiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
-        ZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIxZDVmODZjOC00OGVmLTQ3MzktOTlhMC01MzRiOTAyZDgxMDYi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5
-        cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
-        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTAwMzU5MTktN2Zl
-        Yy00MDc0LWE4OTQtYzJhMzEyM2I0MzVhIiwgIm51bV9wcm9jZXNzZWQiOiAw
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiNzRlNGVhOTUtMWFiMS00MzI3LTkwN2EtOThjOTVm
-        NTgyZjM1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
-        IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAi
-        c3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
-        ZXBfaWQiOiAiNjI4MWQ4ZmQtOWZlZi00M2Y4LTg0YmEtNjgyODQ5MjU4NzY1
-        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
-        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
-        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImM4ZTI3MDM3LTIxNmItNDFiZS05MmI1LWFjMWRmZGNmOGY2YyIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjog
-        InB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjY5OWI2
-        MDZjLTU0OGItNDFiNi05ZDZlLWUwOWE4OWNjMTIxOSIsICJudW1fcHJvY2Vz
-        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
-        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
-        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTViMGQ1
-        MWMtZjlhOS00MDUzLWI0NTktNTUzODMwZWY3ZDk3IiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1
-        bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjOWZl
-        NTQ5NzVmNzFhNmE2NmViIn0sICJpZCI6ICI1NmFlYmM5ZmU1NDk3NWY3MWE2
-        YTY2ZWIifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:08 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/74815123-ab55-497f-aee4-f7209a653e93/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="zZETDHwWhrk7Q7c1ns4UG15YGMAz00msbdAxZY36g2c",
-        oauth_signature="RSqM%2Fuv6TeWrijOYhKHD4rsQC1o%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292128", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:02:08 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2310'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83NDgxNTEyMy1hYjU1LTQ5N2YtYWVlNC1mNzIwOWE2NTNl
-        OTMvIiwgInRhc2tfaWQiOiAiNzQ4MTUxMjMtYWI1NS00OTdmLWFlZTQtZjcy
-        MDlhNjUzZTkzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMjowMjowN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMjowN1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvOGUzNjMwZTUtMDczMC00NzVjLWI5MGItNWQ3MDczNjIw
-        NWU5LyIsICJ0YXNrX2lkIjogIjhlMzYzMGU1LTA3MzAtNDc1Yy1iOTBiLTVk
-        NzA3MzYyMDVlOSJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82
-        Njg5MjA3MS02ZTQ0LTRlMWQtYmIxYy03YzdlNjhiZTliMWIvIiwgInRhc2tf
-        aWQiOiAiNjY4OTIwNzEtNmU0NC00ZTFkLWJiMWMtN2M3ZTY4YmU5YjFiIn1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjOWZkZTA0MDMzNDZjZjY0YTA0
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MjowMjowN1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAyOjAyOjA3WiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmM5ZmRlMDQwMzRjZDky
-        ZGM1ZGYiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmM5ZmU1NDk3NWY3MWE2YTY2ZGEifSwgImlkIjogIjU2YWViYzlmZTU0
-        OTc1ZjcxYTZhNjZkYSJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:08 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/8e3630e5-0730-475c-b90b-5d70736205e9/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="Gkb4A9m2CjQSDt6lfZp38hdxFUYFj8KMiFymkgrUJI",
-        oauth_signature="ZcEIVElbVQPglIvxrdsq3DzqiPk%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292128", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:02:08 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84ZTM2MzBlNS0wNzMwLTQ3NWMtYjkwYi01ZDcw
-        NzM2MjA1ZTkvIiwgInRhc2tfaWQiOiAiOGUzNjMwZTUtMDczMC00NzVjLWI5
-        MGItNWQ3MDczNjIwNWU5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMjowMjowOFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMjowOFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDI6MDI6MDhaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMjowMjowOFoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmNhMGRlMDQwMzRjZDkyZGM1ZTAiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjOWZlNTQ5NzVmNzFhNmE2NmVhIn0s
-        ICJpZCI6ICI1NmFlYmM5ZmU1NDk3NWY3MWE2YTY2ZWEifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:08 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/66892071-6e44-4e1d-bb1c-7c7e68be9b1b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="QQEIspkPcBpGbnv2jYxr74uWiWCH9TRPChFbRCoeD8",
-        oauth_signature="r9lus3cyoNlSmiCWFXN28sk8QCE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292128", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:02:08 GMT
+      - Tue, 23 Feb 2016 16:49:09 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -545,84 +178,84 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82Njg5MjA3MS02ZTQ0LTRlMWQtYmIxYy03Yzdl
-        NjhiZTliMWIvIiwgInRhc2tfaWQiOiAiNjY4OTIwNzEtNmU0NC00ZTFkLWJi
-        MWMtN2M3ZTY4YmU5YjFiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy9lMTZjZGVlNC1lYWY4LTQ0MDItOTFmOS0yNGVm
+        NDBkNGZiZDEvIiwgInRhc2tfaWQiOiAiZTE2Y2RlZTQtZWFmOC00NDAyLTkx
+        ZjktMjRlZjQwZDRmYmQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMjowMjowOFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMjowOFoiLCAi
+        bWUiOiAiMjAxNi0wMi0yM1QxNjo0OTowOVoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0OTowOVoiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI3YTMyNGQ3Zi02OTQyLTRjMDctYjgzMi03NWZlMjI5
-        MGM0NzkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICJlODFlYWM2Ni01ZjBlLTRkMGUtOTAyMy00NDNjN2U0
+        Y2RkYjEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYjI4YTQ1MzktZDBkYi00NmI5LTkxOTQtMWIzYzdkOTg3ZmE2Iiwg
+        aWQiOiAiZmMxZGIzZTMtNDJiZC00YjYxLWJjMzQtNjFlZjAwYjJhODIzIiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
         bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiYjkyZmE3MTUtNzFiYi00NDFlLWIwMDAt
-        MTUwMjBiMjY3MzRmIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMzg3N2Q0MGItZDc2NS00ODY0LWE2YmUt
+        MDczOGVmZGFmODdjIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
         TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjM5
-        ZTk5NTctOTY5YS00Nzk4LWE2MWUtNDdhNzhjZDViNmFmIiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWY2
+        NjdlNzEtN2ZmZi00YzhjLTkxM2YtMmUyNDU1NmU5YWI4IiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjFkNWY4NmM4LTQ4ZWYtNDczOS05OWEwLTUzNGI5
-        MDJkODEwNiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        IDAsICJzdGVwX2lkIjogIjc3Y2RlNDAyLTY1NzctNDIxOC05ZGRiLWQ5MGNk
+        ZDFiMTI3MiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
         OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
         InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5MDAzNTkx
-        OS03ZmVjLTQwNzQtYTg5NC1jMmEzMTIzYjQzNWEiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3MzEwN2Mz
+        NC1lNDJkLTQ2MjItYTM2YS04YWRmNGY2ZWY4YTEiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
         Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI3NGU0ZWE5NS0xYWIxLTQzMjctOTA3YS05OGM5
-        NWY1ODJmMzUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICIxOTExNWRlYS04YmUxLTQxZDQtOWIyMS0zNzll
+        NzAyOGZjMWMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
         ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI2MjgxZDhmZC05ZmVmLTQzZjgtODRiYS02ODI4NDkyNTg3NjUi
+        cF9pZCI6ICJkZTZlMWU2YS02N2Q1LTRmMGYtOGJjOS1mMGNkYzUwNzZkYjIi
         LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
         dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
         c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjOGUy
-        NzAzNy0yMTZiLTQxYmUtOTJiNS1hYzFkZmRjZjhmNmMiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5YmFk
+        MDlkYi1iN2U4LTQ5OTctYTVhNi1kOGUwYjlhNWFmYWYiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
         aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2OTliNjA2Yy01NDhi
-        LTQxYjYtOWQ2ZS1lMDlhODljYzEyMTkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzNjhmMzA4NC03OTIw
+        LTQ2MDktOGQ3NS1mN2U5MWU5ODlhZjIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
         TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
         X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjU1YjBkNTFjLWY5YTktNDA1
-        My1iNDU5LTU1MzgzMGVmN2Q5NyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImRjMzJjMjZjLTlkNjMtNDRm
+        Ni04YjRmLTBkNjc0NWY3YzkzOSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
         InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
         eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
         b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
         bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
         c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTAxVDAyOjAyOjA4WiIsICJf
+        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ5OjA5WiIsICJf
         bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
-        MTYtMDItMDFUMDI6MDI6MDhaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
+        MTYtMDItMjNUMTY6NDk6MDlaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
         cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
         IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
         X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
@@ -631,77 +264,77 @@ http_interactions:
         aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
         SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
         U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
-        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZhZWJjYTBkZTA0MDM0Y2Q5MmRj
-        NWUxIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZjYzhkODVkZTA0MDMwODk3NThh
+        OTYzIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
         dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
         cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
         IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjdhMzI0ZDdmLTY5NDItNGMwNy1iODMyLTc1ZmUyMjkwYzQ3OSIsICJu
+        IjogImU4MWVhYzY2LTVmMGUtNGQwZS05MDIzLTQ0M2M3ZTRjZGRiMSIsICJu
         dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
         cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
         cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMjhh
-        NDUzOS1kMGRiLTQ2YjktOTE5NC0xYjNjN2Q5ODdmYTYiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmYzFk
+        YjNlMy00MmJkLTRiNjEtYmMzNC02MWVmMDBiMmE4MjMiLCAibnVtX3Byb2Nl
         c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
         c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICJiOTJmYTcxNS03MWJiLTQ0MWUtYjAwMC0xNTAyMGIyNjcz
-        NGYiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICIzODc3ZDQwYi1kNzY1LTQ4NjQtYTZiZS0wNzM4ZWZkYWY4
+        N2MiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
         X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
         U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyMzllOTk1Ny05Njlh
-        LTQ3OTgtYTYxZS00N2E3OGNkNWI2YWYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZjY2N2U3MS03ZmZm
+        LTRjOGMtOTEzZi0yZTI0NTU2ZTlhYjgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
         LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
         bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
         YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMWQ1Zjg2YzgtNDhlZi00NzM5LTk5YTAtNTM0YjkwMmQ4MTA2Iiwg
+        aWQiOiAiNzdjZGU0MDItNjU3Ny00MjE4LTlkZGItZDkwY2RkMWIxMjcyIiwg
         Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
         IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjkwMDM1OTE5LTdmZWMtNDA3
-        NC1hODk0LWMyYTMxMjNiNDM1YSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjczMTA3YzM0LWU0MmQtNDYy
+        Mi1hMzZhLThhZGY0ZjZlZjhhMSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
         bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
         ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
         dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
         OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjc0ZTRlYTk1LTFhYjEtNDMyNy05MDdhLTk4Yzk1ZjU4MmYzNSIs
+        X2lkIjogIjE5MTE1ZGVhLThiZTEtNDFkNC05YjIxLTM3OWU3MDI4ZmMxYyIs
         ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
         Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
         ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjYy
-        ODFkOGZkLTlmZWYtNDNmOC04NGJhLTY4Mjg0OTI1ODc2NSIsICJudW1fcHJv
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImRl
+        NmUxZTZhLTY3ZDUtNGYwZi04YmM5LWYwY2RjNTA3NmRiMiIsICJudW1fcHJv
         Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
         OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
         bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
         S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM4ZTI3MDM3LTIxNmIt
-        NDFiZS05MmI1LWFjMWRmZGNmOGY2YyIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjliYWQwOWRiLWI3ZTgt
+        NDk5Ny1hNWE2LWQ4ZTBiOWE1YWZhZiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
         IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
         ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
         b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjY5OWI2MDZjLTU0OGItNDFiNi05ZDZl
-        LWUwOWE4OWNjMTIxOSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjM2OGYzMDg0LTc5MjAtNDYwOS04ZDc1
+        LWY3ZTkxZTk4OWFmMiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
         Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
         aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
         LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
         b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiNTViMGQ1MWMtZjlhOS00MDUzLWI0NTktNTUz
-        ODMwZWY3ZDk3IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YWViYzlmZTU0OTc1ZjcxYTZhNjZl
-        YiJ9LCAiaWQiOiAiNTZhZWJjOWZlNTQ5NzVmNzFhNmE2NmViIn0=
+        IjogMCwgInN0ZXBfaWQiOiAiZGMzMmMyNmMtOWQ2My00NGY2LThiNGYtMGQ2
+        NzQ1ZjdjOTM5IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDg0OTg5MDU0ZmM0OGJhMzBj
+        NCJ9LCAiaWQiOiAiNTZjYzhkODQ5ODkwNTRmYzQ4YmEzMGM0In0=
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:08 GMT
+  recorded_at: Tue, 23 Feb 2016 16:49:09 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/24c70e47-c58b-43a9-ae10-ec5bdd88b438/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/8e84eb56-84df-4e99-9b53-55d739023106/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -712,12 +345,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="hPy1BqBLNgCFDCf2FNafUNORnWU07FDQ4H19095OTw",
-        oauth_signature="khHElRYugnEqxEsRmqAHc4QXgzY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292129", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -726,13 +353,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:02:09 GMT
+      - Tue, 23 Feb 2016 16:49:09 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '663'
       Connection:
       - close
       Content-Type:
@@ -742,22 +369,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yNGM3MGU0Ny1jNThiLTQzYTktYWUxMC1lYzViZGQ4OGI0
-        MzgvIiwgInRhc2tfaWQiOiAiMjRjNzBlNDctYzU4Yi00M2E5LWFlMTAtZWM1
-        YmRkODhiNDM4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy84ZTg0ZWI1Ni04NGRmLTRlOTktOWI1My01NWQ3MzkwMjMx
+        MDYvIiwgInRhc2tfaWQiOiAiOGU4NGViNTYtODRkZi00ZTk5LTliNTMtNTVk
+        NzM5MDIzMTA2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmFlYmNh
-        MWU1NDk3NWY3MWE2YTY2ZWMifSwgImlkIjogIjU2YWViY2ExZTU0OTc1Zjcx
-        YTZhNjZlYyJ9
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTIzVDE2OjQ5OjA5WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhh
+        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ4NTk4OTA1NGZjNDhiYTMwYzUifSwg
+        ImlkIjogIjU2Y2M4ZDg1OTg5MDU0ZmM0OGJhMzBjNSJ9
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:09 GMT
+  recorded_at: Tue, 23 Feb 2016 16:49:09 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/24c70e47-c58b-43a9-ae10-ec5bdd88b438/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/8e84eb56-84df-4e99-9b53-55d739023106/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -768,12 +397,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="scpxVplpdo67jjuAtrpXf4IHR1z61ZwWwsbLbGrtYoU",
-        oauth_signature="WnVoMlMZvP46u%2FVW4HGx5m3NkvA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292129", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -782,7 +405,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:02:09 GMT
+      - Tue, 23 Feb 2016 16:49:10 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -798,25 +421,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yNGM3MGU0Ny1jNThiLTQzYTktYWUxMC1lYzViZGQ4OGI0
-        MzgvIiwgInRhc2tfaWQiOiAiMjRjNzBlNDctYzU4Yi00M2E5LWFlMTAtZWM1
-        YmRkODhiNDM4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy84ZTg0ZWI1Ni04NGRmLTRlOTktOWI1My01NWQ3MzkwMjMx
+        MDYvIiwgInRhc2tfaWQiOiAiOGU4NGViNTYtODRkZi00ZTk5LTliNTMtNTVk
+        NzM5MDIzMTA2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTAxVDAyOjAyOjA5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTAxVDAyOjAyOjA5WiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ5OjA5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ5OjA5WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
         MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
         aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
         a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjYTFl
-        NTQ5NzVmNzFhNmE2NmVjIn0sICJpZCI6ICI1NmFlYmNhMWU1NDk3NWY3MWE2
-        YTY2ZWMifQ==
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkODU5
+        ODkwNTRmYzQ4YmEzMGM1In0sICJpZCI6ICI1NmNjOGQ4NTk4OTA1NGZjNDhi
+        YTMwYzUifQ==
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:09 GMT
+  recorded_at: Tue, 23 Feb 2016 16:49:10 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/4f985e6c-13d3-48f0-92b7-d66954efe902/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/07ac402d-4102-4d53-ad90-3cd5d5091dd1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -827,12 +450,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="B8KOv2wM6k5xiVKwBXWQ5M473aTXY8ujUWHLDIgsk",
-        oauth_signature="MrCipl%2F8TF6raTNHgcHFJjlmzxM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292130", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -841,13 +458,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:02:10 GMT
+      - Tue, 23 Feb 2016 16:49:11 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '661'
       Connection:
       - close
       Content-Type:
@@ -857,22 +474,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80Zjk4NWU2Yy0xM2QzLTQ4ZjAtOTJiNy1kNjY5NTRlZmU5
-        MDIvIiwgInRhc2tfaWQiOiAiNGY5ODVlNmMtMTNkMy00OGYwLTkyYjctZDY2
-        OTU0ZWZlOTAyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8wN2FjNDAyZC00MTAyLTRkNTMtYWQ5MC0zY2Q1ZDUwOTFk
+        ZDEvIiwgInRhc2tfaWQiOiAiMDdhYzQwMmQtNDEwMi00ZDUzLWFkOTAtM2Nk
+        NWQ1MDkxZGQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjYTJl
-        NTQ5NzVmNzFhNmE2NmVkIn0sICJpZCI6ICI1NmFlYmNhMmU1NDk3NWY3MWE2
-        YTY2ZWQifQ==
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0OToxMVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4
+        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNTZjYzhkODc5ODkwNTRmYzQ4YmEzMGM2In0sICJp
+        ZCI6ICI1NmNjOGQ4Nzk4OTA1NGZjNDhiYTMwYzYifQ==
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:10 GMT
+  recorded_at: Tue, 23 Feb 2016 16:49:11 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/4f985e6c-13d3-48f0-92b7-d66954efe902/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/07ac402d-4102-4d53-ad90-3cd5d5091dd1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -883,12 +502,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="FBiNMTQRi0eM3bsUwrsAvG5yNxrkIg8gTW1JmA0AXPg",
-        oauth_signature="2aAzlB%2BRpS3lnmVry6WD%2B1eqFAA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292131", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -897,13 +510,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:02:11 GMT
+      - Tue, 23 Feb 2016 16:49:11 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2310'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -913,61 +526,61 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80Zjk4NWU2Yy0xM2QzLTQ4ZjAtOTJiNy1kNjY5NTRlZmU5
-        MDIvIiwgInRhc2tfaWQiOiAiNGY5ODVlNmMtMTNkMy00OGYwLTkyYjctZDY2
-        OTU0ZWZlOTAyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8wN2FjNDAyZC00MTAyLTRkNTMtYWQ5MC0zY2Q1ZDUwOTFk
+        ZDEvIiwgInRhc2tfaWQiOiAiMDdhYzQwMmQtNDEwMi00ZDUzLWFkOTAtM2Nk
+        NWQ1MDkxZGQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMjowMjoxMVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMjoxMFoiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0OToxMVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0OToxMVoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZGZjNzY5OGMtNmY3MC00Y2UyLTk0NjUtNDk0NjhjZjMy
-        YTY2LyIsICJ0YXNrX2lkIjogImRmYzc2OThjLTZmNzAtNGNlMi05NDY1LTQ5
-        NDY4Y2YzMmE2NiJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84
-        ZTkzNTBmNS1iNjZmLTRkMmEtOTcwNS02M2RlMGFlYmMyZTQvIiwgInRhc2tf
-        aWQiOiAiOGU5MzUwZjUtYjY2Zi00ZDJhLTk3MDUtNjNkZTBhZWJjMmU0In1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjYTJkZTA0MDMzNDZkMTg5MDVh
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MjowMjoxMFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAyOjAyOjExWiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmNhM2RlMDQwMzRjZDky
-        ZGM1ZTUiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmNhMmU1NDk3NWY3MWE2YTY2ZWQifSwgImlkIjogIjU2YWViY2EyZTU0
-        OTc1ZjcxYTZhNjZlZCJ9
+        cGkvdjIvdGFza3MvNzMxNzJhOGUtZjRhMy00YzQ3LWE0NmItYmRlNjU0Yzk3
+        MTBlLyIsICJ0YXNrX2lkIjogIjczMTcyYThlLWY0YTMtNGM0Ny1hNDZiLWJk
+        ZTY1NGM5NzEwZSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ4N2RlMDQw
+        MzNmNDM1MTRmYzQifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ5OjExWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDk6MTFaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkODdk
+        ZTA0MDMwODk3NThhOTY3IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDg3OTg5MDU0ZmM0OGJhMzBjNiJ9LCAiaWQiOiAiNTZj
+        YzhkODc5ODkwNTRmYzQ4YmEzMGM2In0=
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:11 GMT
+  recorded_at: Tue, 23 Feb 2016 16:49:11 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/dfc7698c-6f70-4ce2-9465-49468cf32a66/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/73172a8e-f4a3-4c47-a46b-bde654c9710e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -978,12 +591,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="uEFTSWpccPmGuiRkJGzgsG4HcRQ37Azt9vUTwib2Qk",
-        oauth_signature="wXkr4x4Q39QnOPfTFYh3ogEvdCk%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292131", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -992,294 +599,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:02:11 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9kZmM3Njk4Yy02ZjcwLTRjZTItOTQ2NS00OTQ2
-        OGNmMzJhNjYvIiwgInRhc2tfaWQiOiAiZGZjNzY5OGMtNmY3MC00Y2UyLTk0
-        NjUtNDk0NjhjZjMyYTY2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMjowMjoxMVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMjoxMVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDI6MDI6MTFaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMjowMjoxMVoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmNhM2RlMDQwMzRjZDkyZGM1ZTYiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjYTNlNTQ5NzVmNzFhNmE2NmZkIn0s
-        ICJpZCI6ICI1NmFlYmNhM2U1NDk3NWY3MWE2YTY2ZmQifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:11 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/8e9350f5-b66f-4d2a-9705-63de0aebc2e4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="qPcCYdo6Q4SASiztal7gvknImfPDbnSlWdN0pb7FQ",
-        oauth_signature="acCOq70XOHBhbudnwjDDwEuE5No%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292131", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:02:11 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '670'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84ZTkzNTBmNS1iNjZmLTRkMmEtOTcwNS02M2Rl
-        MGFlYmMyZTQvIiwgInRhc2tfaWQiOiAiOGU5MzUwZjUtYjY2Zi00ZDJhLTk3
-        MDUtNjNkZTBhZWJjMmU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wMVQwMjowMjoxMVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15
-        b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29y
-        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
-        by15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjYTNlNTQ5NzVmNzFhNmE2
-        NmZlIn0sICJpZCI6ICI1NmFlYmNhM2U1NDk3NWY3MWE2YTY2ZmUifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:11 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/4f985e6c-13d3-48f0-92b7-d66954efe902/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="zSgVYY8tjAGZ52D71FWijtzQzJB1d2K7d5G3yonM",
-        oauth_signature="Ig1ldLkOOTXDgnWDzo%2B4QJFT4Vc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292132", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:02:12 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2310'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80Zjk4NWU2Yy0xM2QzLTQ4ZjAtOTJiNy1kNjY5NTRlZmU5
-        MDIvIiwgInRhc2tfaWQiOiAiNGY5ODVlNmMtMTNkMy00OGYwLTkyYjctZDY2
-        OTU0ZWZlOTAyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMjowMjoxMVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMjoxMFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZGZjNzY5OGMtNmY3MC00Y2UyLTk0NjUtNDk0NjhjZjMy
-        YTY2LyIsICJ0YXNrX2lkIjogImRmYzc2OThjLTZmNzAtNGNlMi05NDY1LTQ5
-        NDY4Y2YzMmE2NiJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84
-        ZTkzNTBmNS1iNjZmLTRkMmEtOTcwNS02M2RlMGFlYmMyZTQvIiwgInRhc2tf
-        aWQiOiAiOGU5MzUwZjUtYjY2Zi00ZDJhLTk3MDUtNjNkZTBhZWJjMmU0In1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjYTJkZTA0MDMzNDZkMTg5MDVh
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MjowMjoxMFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAyOjAyOjExWiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmNhM2RlMDQwMzRjZDky
-        ZGM1ZTUiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmNhMmU1NDk3NWY3MWE2YTY2ZWQifSwgImlkIjogIjU2YWViY2EyZTU0
-        OTc1ZjcxYTZhNjZlZCJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:12 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/dfc7698c-6f70-4ce2-9465-49468cf32a66/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="ikx697h6uqJ9AcP8kInAdUamggLq4rFVxjF0U0As",
-        oauth_signature="S8iGEgaLwn63UXJVH5kRxO1sVf0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292132", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:02:12 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9kZmM3Njk4Yy02ZjcwLTRjZTItOTQ2NS00OTQ2
-        OGNmMzJhNjYvIiwgInRhc2tfaWQiOiAiZGZjNzY5OGMtNmY3MC00Y2UyLTk0
-        NjUtNDk0NjhjZjMyYTY2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMjowMjoxMVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMjoxMVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDI6MDI6MTFaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMjowMjoxMVoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmNhM2RlMDQwMzRjZDkyZGM1ZTYiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjYTNlNTQ5NzVmNzFhNmE2NmZkIn0s
-        ICJpZCI6ICI1NmFlYmNhM2U1NDk3NWY3MWE2YTY2ZmQifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:12 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/8e9350f5-b66f-4d2a-9705-63de0aebc2e4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="ZYVRfMKe7orw93hKIVOmEWOnLQzzfK4K1wZ5sJ7WEw",
-        oauth_signature="3HMLRpnGV7%2BBIbMwzp70TRSitw4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292132", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:02:12 GMT
+      - Tue, 23 Feb 2016 16:49:11 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -1295,84 +615,84 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84ZTkzNTBmNS1iNjZmLTRkMmEtOTcwNS02M2Rl
-        MGFlYmMyZTQvIiwgInRhc2tfaWQiOiAiOGU5MzUwZjUtYjY2Zi00ZDJhLTk3
-        MDUtNjNkZTBhZWJjMmU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy83MzE3MmE4ZS1mNGEzLTRjNDctYTQ2Yi1iZGU2
+        NTRjOTcxMGUvIiwgInRhc2tfaWQiOiAiNzMxNzJhOGUtZjRhMy00YzQ3LWE0
+        NmItYmRlNjU0Yzk3MTBlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMjowMjoxMVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMjoxMVoiLCAi
+        bWUiOiAiMjAxNi0wMi0yM1QxNjo0OToxMVoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0OToxMVoiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI5OGEyZDQyNi0wZDYyLTQyZGUtOGJkZS02YTNhYzE1
-        MzI0Y2IiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICJjZDU5NzUyYy01NjQyLTRmYzItODhhZi1mODc2ZmU0
+        MmE5MTkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMjhkZDZkMWItYzA1ZC00ZTVjLTlkYWItZTRhZDc5NmRkODdlIiwg
+        aWQiOiAiMjY3NDg2ODAtYzVhNy00YmMyLWJjOTQtM2YxN2ZmYjdlZDFiIiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
         bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMjQ2MzliNTUtZmZmZC00OGNiLWFiYTUt
-        MmJjNzAwY2FiODcyIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMWU5MzdjMGQtZTRlYS00ZTk5LWFjMDkt
+        NjdkZWVlYzI1YzFlIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
         TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTlm
-        YWQyZjUtZWQ2YS00NmIzLWJjOTUtM2UzNTEzOWFkZDZiIiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYmQ4
+        MTY0ZDEtY2YxMi00Y2EwLThiYzctNGE3YmFlYTJkODg4IiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjg3NWM4MWIwLThiYjItNGNkYy05ZGUzLTc5ZTFh
-        ZTQ5NDEwNiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        IDAsICJzdGVwX2lkIjogIjJhYTdlZTgyLWRjMDItNDI5NS1iZjU2LTg5MDRl
+        ZDY2YzA5MSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
         OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
         InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhYjg0N2Jm
-        Yy05ZDlhLTQ5N2QtOTJkMi1iODgxMDI3NTM4NjYiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNDhlNDMw
+        YS0xZmVlLTRlNTgtYTEwNy02MTdlZTA2ZDY2MjYiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
         Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIxNjRjMzU1My1lOTMzLTQ4MzQtODdhMi1hNzlh
-        N2VhMjJiMmEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICI2YmZjMGEyNS1hYmRjLTRjOTItOWIyNi1hMDU3
+        YjMxODM1N2MiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
         ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJjZWQ5MGRhNC01YTllLTRmYTMtYmZkMC00NTJmZDkyM2I2Zjki
+        cF9pZCI6ICI1NDE4ZWY4ZC02MTUzLTQ5NGYtYmRiNS0wODg4YTMxYTI0Njki
         LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
         dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
         c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwZTJk
-        ZGMzYi01NDdiLTQ5M2UtOTUzZi1lMWRjZmZlYmZjZWQiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0MTcy
+        MmVkOS1kMjE3LTQ5NjYtOTAyOS0wODJhZTQ4OTY3NmQiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
         aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlMmEzZmJiMi1hY2Ni
-        LTRhMjEtOWJjYi1lNTliODlhNDBiYjciLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlZDM0ZGJiMi0wZjA5
+        LTRhY2ItYTJjMy1lNDk1NzY1MjczZTUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
         TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
         X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNlNzhiNjEwLWQwMmYtNGUw
-        NC1hOTE4LTQ5MWVmOGU0YTFiMiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQzOWJjZWUzLTZhODItNGM3
+        Mi1hYTg5LTUzNzM2MzMyMGM2ZSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
         InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
         eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
         b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
         bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
         c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTAxVDAyOjAyOjExWiIsICJf
+        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ5OjExWiIsICJf
         bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
-        MTYtMDItMDFUMDI6MDI6MTFaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
+        MTYtMDItMjNUMTY6NDk6MTFaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
         cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
         IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
         X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
@@ -1381,77 +701,77 @@ http_interactions:
         aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
         SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
         U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
-        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZhZWJjYTNkZTA0MDM0Y2Q5MmRj
-        NWU3IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZjYzhkODdkZTA0MDMwODk3NThh
+        OTY4IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
         dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
         cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
         IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjk4YTJkNDI2LTBkNjItNDJkZS04YmRlLTZhM2FjMTUzMjRjYiIsICJu
+        IjogImNkNTk3NTJjLTU2NDItNGZjMi04OGFmLWY4NzZmZTQyYTkxOSIsICJu
         dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
         cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
         cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyOGRk
-        NmQxYi1jMDVkLTRlNWMtOWRhYi1lNGFkNzk2ZGQ4N2UiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyNjc0
+        ODY4MC1jNWE3LTRiYzItYmM5NC0zZjE3ZmZiN2VkMWIiLCAibnVtX3Byb2Nl
         c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
         c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICIyNDYzOWI1NS1mZmZkLTQ4Y2ItYWJhNS0yYmM3MDBjYWI4
-        NzIiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICIxZTkzN2MwZC1lNGVhLTRlOTktYWMwOS02N2RlZWVjMjVj
+        MWUiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
         X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
         U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1OWZhZDJmNS1lZDZh
-        LTQ2YjMtYmM5NS0zZTM1MTM5YWRkNmIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiZDgxNjRkMS1jZjEy
+        LTRjYTAtOGJjNy00YTdiYWVhMmQ4ODgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
         LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
         bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
         YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiODc1YzgxYjAtOGJiMi00Y2RjLTlkZTMtNzllMWFlNDk0MTA2Iiwg
+        aWQiOiAiMmFhN2VlODItZGMwMi00Mjk1LWJmNTYtODkwNGVkNjZjMDkxIiwg
         Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
         IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFiODQ3YmZjLTlkOWEtNDk3
-        ZC05MmQyLWI4ODEwMjc1Mzg2NiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE0OGU0MzBhLTFmZWUtNGU1
+        OC1hMTA3LTYxN2VlMDZkNjYyNiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
         bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
         ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
         dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
         OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjE2NGMzNTUzLWU5MzMtNDgzNC04N2EyLWE3OWE3ZWEyMmIyYSIs
+        X2lkIjogIjZiZmMwYTI1LWFiZGMtNGM5Mi05YjI2LWEwNTdiMzE4MzU3YyIs
         ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
         Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
         ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNl
-        ZDkwZGE0LTVhOWUtNGZhMy1iZmQwLTQ1MmZkOTIzYjZmOSIsICJudW1fcHJv
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjU0
+        MThlZjhkLTYxNTMtNDk0Zi1iZGI1LTA4ODhhMzFhMjQ2OSIsICJudW1fcHJv
         Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
         OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
         bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
         S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBlMmRkYzNiLTU0N2It
-        NDkzZS05NTNmLWUxZGNmZmViZmNlZCIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQxNzIyZWQ5LWQyMTct
+        NDk2Ni05MDI5LTA4MmFlNDg5Njc2ZCIsICJudW1fcHJvY2Vzc2VkIjogMH0s
         IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
         ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
         b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImUyYTNmYmIyLWFjY2ItNGEyMS05YmNi
-        LWU1OWI4OWE0MGJiNyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImVkMzRkYmIyLTBmMDktNGFjYi1hMmMz
+        LWU0OTU3NjUyNzNlNSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
         Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
         aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
         LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
         b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiY2U3OGI2MTAtZDAyZi00ZTA0LWE5MTgtNDkx
-        ZWY4ZTRhMWIyIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YWViY2EzZTU0OTc1ZjcxYTZhNjZm
-        ZSJ9LCAiaWQiOiAiNTZhZWJjYTNlNTQ5NzVmNzFhNmE2NmZlIn0=
+        IjogMCwgInN0ZXBfaWQiOiAiNDM5YmNlZTMtNmE4Mi00YzcyLWFhODktNTM3
+        MzYzMzIwYzZlIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDg3OTg5MDU0ZmM0OGJhMzBk
+        NiJ9LCAiaWQiOiAiNTZjYzhkODc5ODkwNTRmYzQ4YmEzMGQ2In0=
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:12 GMT
+  recorded_at: Tue, 23 Feb 2016 16:49:11 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/eb13eb2f-0ed3-4b2b-8107-8b701684d95e/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/c37a5cd0-359a-4f89-8ac5-ee455202689d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1462,12 +782,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="fqR1NqjDpWjAjWo6U69otcHSPqLApImpvqQaihptI",
-        oauth_signature="jPvvSkQ8ItmbPy%2BHj2G992BArL8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292132", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -1476,7 +790,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:02:12 GMT
+      - Tue, 23 Feb 2016 16:49:12 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -1492,22 +806,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lYjEzZWIyZi0wZWQzLTRiMmItODEwNy04YjcwMTY4NGQ5
-        NWUvIiwgInRhc2tfaWQiOiAiZWIxM2ViMmYtMGVkMy00YjJiLTgxMDctOGI3
-        MDE2ODRkOTVlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9jMzdhNWNkMC0zNTlhLTRmODktOGFjNS1lZTQ1NTIwMjY4
+        OWQvIiwgInRhc2tfaWQiOiAiYzM3YTVjZDAtMzU5YS00Zjg5LThhYzUtZWU0
+        NTUyMDI2ODlkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
         bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
         ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
         Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
         IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmFlYmNh
-        NGU1NDk3NWY3MWE2YTY2ZmYifSwgImlkIjogIjU2YWViY2E0ZTU0OTc1Zjcx
-        YTZhNjZmZiJ9
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ4
+        ODk4OTA1NGZjNDhiYTMwZDcifSwgImlkIjogIjU2Y2M4ZDg4OTg5MDU0ZmM0
+        OGJhMzBkNyJ9
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:12 GMT
+  recorded_at: Tue, 23 Feb 2016 16:49:12 GMT
 - request:
     method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/eb13eb2f-0ed3-4b2b-8107-8b701684d95e/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/c37a5cd0-359a-4f89-8ac5-ee455202689d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1518,12 +832,6 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="56WmtQ54okZIBHEyEeyGpjmDnpZZIdaeFS7J5fdG8",
-        oauth_signature="G8O43WCRMf775P08UsAOIEfT5gM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292133", oauth_version="1.0"
-      Pulp-User:
-      - admin
       User-Agent:
       - Ruby
   response:
@@ -1532,7 +840,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:02:13 GMT
+      - Tue, 23 Feb 2016 16:49:13 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -1548,22 +856,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lYjEzZWIyZi0wZWQzLTRiMmItODEwNy04YjcwMTY4NGQ5
-        NWUvIiwgInRhc2tfaWQiOiAiZWIxM2ViMmYtMGVkMy00YjJiLTgxMDctOGI3
-        MDE2ODRkOTVlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9jMzdhNWNkMC0zNTlhLTRmODktOGFjNS1lZTQ1NTIwMjY4
+        OWQvIiwgInRhc2tfaWQiOiAiYzM3YTVjZDAtMzU5YS00Zjg5LThhYzUtZWU0
+        NTUyMDI2ODlkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTAxVDAyOjAyOjEyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTAxVDAyOjAyOjEyWiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ5OjEyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ5OjEyWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
         MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
         aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
         a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjYTRl
-        NTQ5NzVmNzFhNmE2NmZmIn0sICJpZCI6ICI1NmFlYmNhNGU1NDk3NWY3MWE2
-        YTY2ZmYifQ==
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkODg5
+        ODkwNTRmYzQ4YmEzMGQ3In0sICJpZCI6ICI1NmNjOGQ4ODk4OTA1NGZjNDhi
+        YTMwZDcifQ==
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:13 GMT
+  recorded_at: Tue, 23 Feb 2016 16:49:13 GMT
 - request:
     method: post
     uri: https://katello-yoda.example.com/pulp/api/v2/repositories/
@@ -1574,7 +882,8 @@ http_interactions:
         ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
         b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
         ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
+        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
+        IjpudWxsLCJyZW1vdmVfbWlzc2luZyI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
         LXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1
         dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9j
         b25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIiwiaHR0cCI6ZmFs
@@ -1584,12 +893,10 @@ http_interactions:
         dHJpYnV0b3JfY29uZmlnIjp7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lk
         IjoiRmVkb3JhXzE3In0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1
         dG9yX2lkIjoiRmVkb3JhXzE3X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBl
-        X2lkIjoibm9kZXNfaHR0cF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2Nv
-        bmZpZyI6e30sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3JfaWQi
-        OiJGZWRvcmFfMTdfbm9kZXMifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJl
-        eHBvcnRfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0
-        cCI6ZmFsc2UsImh0dHBzIjpmYWxzZX0sImF1dG9fcHVibGlzaCI6ZmFsc2Us
-        ImRpc3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
+        X2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmln
+        Ijp7Imh0dHAiOmZhbHNlLCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6
+        InRlc3RfcGF0aCJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRv
+        cl9pZCI6ImV4cG9ydF9kaXN0cmlidXRvciJ9XX0=
     headers:
       Accept:
       - application/json
@@ -1597,14 +904,8 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4",
-        oauth_nonce="JMhC0GV5mkDZc5OD3tVVxKS7nEnJScNciKNto1Dfo", oauth_signature="mfLc0rUFUb8DtJcLG7TvoT6WQmg%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454292133", oauth_version="1.0"
-      Pulp-User:
-      - admin
       Content-Length:
-      - '895'
+      - '839'
       User-Agent:
       - Ruby
   response:
@@ -1613,7 +914,7 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Mon, 01 Feb 2016 02:02:13 GMT
+      - Tue, 23 Feb 2016 16:49:13 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -1632,7139 +933,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZhZWJjYTVkZTA0MDMzNDZkMTg5MDYzIn0sICJpZCI6ICJGZWRvcmFfMTci
+        NTZjYzhkODlkZTA0MDMzZjQyNjJjYWUyIn0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:13 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/77c59958-20ab-47ec-80ef-4deb08041460/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="2Cp4qsejCo8n8uEoeMOf2gAMg1zVsvgMMqucGu92dQ",
-        oauth_signature="mVCG3U6nnEinjsQQyqsGfjnGBfw%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292134", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:02:14 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83N2M1OTk1OC0yMGFiLTQ3ZWMtODBlZi00ZGViMDgwNDE0
-        NjAvIiwgInRhc2tfaWQiOiAiNzdjNTk5NTgtMjBhYi00N2VjLTgwZWYtNGRl
-        YjA4MDQxNDYwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjYTZl
-        NTQ5NzVmNzFhNmE2NzAwIn0sICJpZCI6ICI1NmFlYmNhNmU1NDk3NWY3MWE2
-        YTY3MDAifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:14 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/77c59958-20ab-47ec-80ef-4deb08041460/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="TV4GwxE3mdRaXvAf4RwRNTXr9nFfU5RwOsPvA1OdKQ",
-        oauth_signature="p132sTu5s3VYXV7l5Y9hhXV76jk%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292134", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:02:14 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2310'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83N2M1OTk1OC0yMGFiLTQ3ZWMtODBlZi00ZGViMDgwNDE0
-        NjAvIiwgInRhc2tfaWQiOiAiNzdjNTk5NTgtMjBhYi00N2VjLTgwZWYtNGRl
-        YjA4MDQxNDYwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMjowMjoxNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMjoxNFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNGNmNjUwNTUtYWUyMi00M2RhLTg2YTYtNmI1YjQ3N2U1
-        OGQ5LyIsICJ0YXNrX2lkIjogIjRjZjY1MDU1LWFlMjItNDNkYS04NmE2LTZi
-        NWI0NzdlNThkOSJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84
-        NTFjYmMyOC01MTFhLTQ2YjItYTA2Mi1hNTBjNjA2OWVlMjEvIiwgInRhc2tf
-        aWQiOiAiODUxY2JjMjgtNTExYS00NmIyLWEwNjItYTUwYzYwNjllZTIxIn1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjYTVkZTA0MDMzNDZkMTg5MDY0
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MjowMjoxNFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAyOjAyOjE0WiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmNhNmRlMDQwMzRjZDky
-        ZGM1ZWIiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmNhNmU1NDk3NWY3MWE2YTY3MDAifSwgImlkIjogIjU2YWViY2E2ZTU0
-        OTc1ZjcxYTZhNjcwMCJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:14 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/4cf65055-ae22-43da-86a6-6b5b477e58d9/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="yjHnH8Gtg0sd9sMv79AUAlF5z4c4Zcu5xxpQhKNBYU0",
-        oauth_signature="hwlCxzWqlxF1xBe7cX%2BAuvr8m78%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292134", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:02:14 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80Y2Y2NTA1NS1hZTIyLTQzZGEtODZhNi02YjVi
-        NDc3ZTU4ZDkvIiwgInRhc2tfaWQiOiAiNGNmNjUwNTUtYWUyMi00M2RhLTg2
-        YTYtNmI1YjQ3N2U1OGQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMjowMjoxNFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMjoxNFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDI6MDI6MTRaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMjowMjoxNFoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmNhNmRlMDQwMzRjZDkyZGM1ZWMiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjYTZlNTQ5NzVmNzFhNmE2NzEwIn0s
-        ICJpZCI6ICI1NmFlYmNhNmU1NDk3NWY3MWE2YTY3MTAifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:14 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/851cbc28-511a-46b2-a062-a50c6069ee21/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="I1W3KJtpTeD5IR1d7O2FpAP9zavo8cxyksee4yVj1eg",
-        oauth_signature="Ye9CqQbqnuOe8St62VzHY8%2FwQwo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292134", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:02:14 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3491'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84NTFjYmMyOC01MTFhLTQ2YjItYTA2Mi1hNTBj
-        NjA2OWVlMjEvIiwgInRhc2tfaWQiOiAiODUxY2JjMjgtNTExYS00NmIyLWEw
-        NjItYTUwYzYwNjllZTIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wMVQwMjowMjoxNFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMTRi
-        MWRkMS1mOGQ1LTRkYmItOTAwOC01NmM1Mjg1Mjc3MDkiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjUyMDBlNGUtNTk3
-        OS00NWY3LTliZjktNzI1ZWViZmQ0MzcxIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiZDE3NDRhMjctYmNlOS00ZjdiLWJmYzAtNmUxM2FlNDllN2JkIiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOGI0ZTFkYmQtYWMyZi00MDM2LWJl
-        ZTctNmJiNDBiNjljNmUyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQ4
-        MzJjNTlhLTFiMzEtNDBlMC04YTM4LWMyODMwN2RlMjFiYiIsICJudW1fcHJv
-        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIwMTU4NmQxOC1hMDVkLTRiOTMtOGIzNy0z
-        ZmMxMjc5NTIyN2YiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEu
-        IiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIy
-        NDhiZWM3NS05Mjk4LTQ0YmEtYTAyZi1jNzJjYWE0ZGMwZGIiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9u
-        IjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xv
-        c2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5NmQ2MGFmMy00
-        MmY1LTRkZDEtOTRkZC04NGNlZmIzM2E1ZWUiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVy
-        YXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBz
-        cWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMTRmODEzYS1iMzg5LTQ4ZWEtYTBk
-        Ny1mMGVkOGRmZTE3NDMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMg
-        dG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIxYzg2ZDM2MS0yYWQ2LTRiZjQtYmFmNi1hMDRkZjM0
-        NjE1ZDQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImZjZGRhYTljLWMzMmEtNDZhZC1iN2NhLWMzZWUyM2Ri
-        M2Y1YiIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNv
-        bS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJl
-        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjU2YWViY2E2ZTU0OTc1ZjcxYTZhNjcxMSJ9LCAiaWQiOiAi
-        NTZhZWJjYTZlNTQ5NzVmNzFhNmE2NzExIn0=
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:14 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/77c59958-20ab-47ec-80ef-4deb08041460/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="385qwgikbzw918zQllF9NLe9VSrabkqSU1EsWDkvM",
-        oauth_signature="Vsx9am2EkJnB1eKxDQt7uEeSQcQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292135", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:02:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2310'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy83N2M1OTk1OC0yMGFiLTQ3ZWMtODBlZi00ZGViMDgwNDE0
-        NjAvIiwgInRhc2tfaWQiOiAiNzdjNTk5NTgtMjBhYi00N2VjLTgwZWYtNGRl
-        YjA4MDQxNDYwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wMVQwMjowMjoxNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMjoxNFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNGNmNjUwNTUtYWUyMi00M2RhLTg2YTYtNmI1YjQ3N2U1
-        OGQ5LyIsICJ0YXNrX2lkIjogIjRjZjY1MDU1LWFlMjItNDNkYS04NmE2LTZi
-        NWI0NzdlNThkOSJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84
-        NTFjYmMyOC01MTFhLTQ2YjItYTA2Mi1hNTBjNjA2OWVlMjEvIiwgInRhc2tf
-        aWQiOiAiODUxY2JjMjgtNTExYS00NmIyLWEwNjItYTUwYzYwNjllZTIxIn1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1w
-        b3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjYTVkZTA0MDMzNDZkMTg5MDY0
-        In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wMVQw
-        MjowMjoxNFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTAxVDAyOjAyOjE0WiIsICJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        dXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmFlYmNhNmRlMDQwMzRjZDky
-        ZGM1ZWIiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmFlYmNhNmU1NDk3NWY3MWE2YTY3MDAifSwgImlkIjogIjU2YWViY2E2ZTU0
-        OTc1ZjcxYTZhNjcwMCJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:15 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/4cf65055-ae22-43da-86a6-6b5b477e58d9/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="jNRx9SGZk3Uernzdb7gnHsuMGDzXgGaPwzVCoswsGH4",
-        oauth_signature="SxP8TmjQprfakaz34OHXTgnJNPk%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292135", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:02:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1069'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80Y2Y2NTA1NS1hZTIyLTQzZGEtODZhNi02YjVi
-        NDc3ZTU4ZDkvIiwgInRhc2tfaWQiOiAiNGNmNjUwNTUtYWUyMi00M2RhLTg2
-        YTYtNmI1YjQ3N2U1OGQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMjowMjoxNFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMjoxNFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGthdGVsbG8teW9kYS5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDFUMDI6MDI6MTRaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIs
-        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wMVQwMjowMjoxNFoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0
-        cF9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2NlZWRlZCIsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIkZlZG9yYV8x
-        N19ub2RlcyIsICJpZCI6ICI1NmFlYmNhNmRlMDQwMzRjZDkyZGM1ZWMiLCAi
-        ZGV0YWlscyI6IHsidW5pdF9jb3VudCI6IDE1fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjYTZlNTQ5NzVmNzFhNmE2NzEwIn0s
-        ICJpZCI6ICI1NmFlYmNhNmU1NDk3NWY3MWE2YTY3MTAifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:15 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/851cbc28-511a-46b2-a062-a50c6069ee21/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="MrbFkpgaJDS51nfKLusJfSAOgTzSYOpBP7RAi37U",
-        oauth_signature="HV0YvijH3YB5638WyqX1%2BVEAm1A%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292135", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:02:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6923'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84NTFjYmMyOC01MTFhLTQ2YjItYTA2Mi1hNTBj
-        NjA2OWVlMjEvIiwgInRhc2tfaWQiOiAiODUxY2JjMjgtNTExYS00NmIyLWEw
-        NjItYTUwYzYwNjllZTIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wMVQwMjowMjoxNFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wMVQwMjowMjoxNFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJiMTRiMWRkMS1mOGQ1LTRkYmItOTAwOC01NmM1Mjg1
-        Mjc3MDkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYjUyMDBlNGUtNTk3OS00NWY3LTliZjktNzI1ZWViZmQ0MzcxIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZDE3NDRhMjctYmNlOS00ZjdiLWJmYzAt
-        NmUxM2FlNDllN2JkIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOGI0
-        ZTFkYmQtYWMyZi00MDM2LWJlZTctNmJiNDBiNjljNmUyIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjQ4MzJjNTlhLTFiMzEtNDBlMC04YTM4LWMyODMw
-        N2RlMjFiYiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwMTU4NmQx
-        OC1hMDVkLTRiOTMtOGIzNy0zZmMxMjc5NTIyN2YiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIyNDhiZWM3NS05Mjk4LTQ0YmEtYTAyZi1jNzJj
-        YWE0ZGMwZGIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI5NmQ2MGFmMy00MmY1LTRkZDEtOTRkZC04NGNlZmIzM2E1ZWUi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMTRm
-        ODEzYS1iMzg5LTQ4ZWEtYTBkNy1mMGVkOGRmZTE3NDMiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxYzg2ZDM2MS0yYWQ2
-        LTRiZjQtYmFmNi1hMDRkZjM0NjE1ZDQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZjZGRhYTljLWMzMmEtNDZh
-        ZC1iN2NhLWMzZWUyM2RiM2Y1YiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
-        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
-        c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTAxVDAyOjAyOjE0WiIsICJf
-        bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
-        MTYtMDItMDFUMDI6MDI6MTRaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
-        cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
-        IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
-        X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
-        RCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1z
-        IjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0
-        aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
-        SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
-        U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
-        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZhZWJjYTZkZTA0MDM0Y2Q5MmRj
-        NWVkIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImIxNGIxZGQxLWY4ZDUtNGRiYi05MDA4LTU2YzUyODUyNzcwOSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
-        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiNTIw
-        MGU0ZS01OTc5LTQ1ZjctOWJmOS03MjVlZWJmZDQzNzEiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
-        c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICJkMTc0NGEyNy1iY2U5LTRmN2ItYmZjMC02ZTEzYWU0OWU3
-        YmQiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
-        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4YjRlMWRiZC1hYzJm
-        LTQwMzYtYmVlNy02YmI0MGI2OWM2ZTIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
-        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNDgzMmM1OWEtMWIzMS00MGUwLThhMzgtYzI4MzA3ZGUyMWJiIiwg
-        Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
-        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjAxNTg2ZDE4LWEwNWQtNGI5
-        My04YjM3LTNmYzEyNzk1MjI3ZiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
-        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
-        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjI0OGJlYzc1LTkyOTgtNDRiYS1hMDJmLWM3MmNhYTRkYzBkYiIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
-        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
-        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjk2
-        ZDYwYWYzLTQyZjUtNGRkMS05NGRkLTg0Y2VmYjMzYTVlZSIsICJudW1fcHJv
-        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
-        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
-        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImIxNGY4MTNhLWIzODkt
-        NDhlYS1hMGQ3LWYwZWQ4ZGZlMTc0MyIsICJudW1fcHJvY2Vzc2VkIjogMH0s
-        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
-        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
-        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjFjODZkMzYxLTJhZDYtNGJmNC1iYWY2
-        LWEwNGRmMzQ2MTVkNCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
-        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiZmNkZGFhOWMtYzMyYS00NmFkLWI3Y2EtYzNl
-        ZTIzZGIzZjViIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YWViY2E2ZTU0OTc1ZjcxYTZhNjcx
-        MSJ9LCAiaWQiOiAiNTZhZWJjYTZlNTQ5NzVmNzFhNmE2NzExIn0=
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:15 GMT
+  recorded_at: Tue, 23 Feb 2016 16:49:13 GMT
 - request:
     method: post
-    uri: https://katello-yoda.example.com/pulp/api/v2/content/units/rpm/search/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMzI4NGVh
-        NGYtZTc2ZS00MGRiLTlmYWEtOTg4YjE3MTExYTZjIiwiM2VmYzBlN2UtZGYz
-        MC00YjA1LWIzMDEtNzYwMWNiNjdlOWZmIiwiNTAwZTAyNjItZWE1NC00ZGQ5
-        LTkyZDMtYzRiZDRkNWM1NTExIiwiNzBkNzc5MTYtMzYwZS00OTJiLWJiYjgt
-        MmEyMDViNWJiMzdjIiwiYTZkNjUwOGYtMjlmMS00NDVmLWI4M2ItNDgwMDc0
-        OTJjMTczIiwiYjBjMjI4N2EtN2ZhZS00ZTlkLTgyZmYtOGZiYjdiMmIwMDEy
-        IiwiZTE4ODU2MTAtNzg2Mi00ZGYyLTg5MmYtMjU2ZjExZGRiYzEyIiwiZWYz
-        YmFlMmUtMGFiZS00MjMxLWIyMDMtNGNhOWVjNTdmNTFkIl19fSwiZmllbGRz
-        IjpbIm5hbWUiLCJ2ZXJzaW9uIiwicmVsZWFzZSIsImFyY2giLCJlcG9jaCIs
-        InN1bW1hcnkiLCJzb3VyY2VycG0iLCJjaGVja3N1bSIsImZpbGVuYW1lIiwi
-        X2lkIl19LCJpbmNsdWRlX3JlcG9zIjp0cnVlfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4",
-        oauth_nonce="j5ngzlPd1iNP1oSf4qnA7f420GO19xorAyZbQ0VA", oauth_signature="tCymEeCsaMlRTz3V8a5HgR4YQf0%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454292135", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '478'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:02:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3804'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJz
-        b3VyY2VycG0iOiAiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6
-        ICJnaXJhZmZlIiwgImNoZWNrc3VtIjogImYyNWQ2N2QxZDlkYTA0ZjEyZTU3
-        Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQi
-        LCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsICJm
-        aWxlbmFtZSI6ICJnaXJhZmZlLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9j
-        aCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44Iiwg
-        Il9pZCI6ICIzMjg0ZWE0Zi1lNzZlLTQwZGItOWZhYS05ODhiMTcxMTFhNmMi
-        LCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjog
-        Ii9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS8zMjg0ZWE0Zi1lNzZl
-        LTQwZGItOWZhYS05ODhiMTcxMTFhNmMvIn0sIHsicmVwb3NpdG9yeV9tZW1i
-        ZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJzb3VyY2VycG0iOiAid2FscnVz
-        LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1cyIsICJjaGVja3N1
-        bSI6ICI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3
-        MWJiYTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwgInN1bW1hcnkiOiAiQSBkdW1t
-        eSBwYWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6ICJ3YWxydXMtMC4z
-        LTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIw
-        LjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjNlZmMwZTdlLWRmMzAt
-        NGIwNS1iMzAxLTc2MDFjYjY3ZTlmZiIsICJhcmNoIjogIm5vYXJjaCIsICJj
-        aGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQv
-        dW5pdHMvcnBtLzNlZmMwZTdlLWRmMzAtNGIwNS1iMzAxLTc2MDFjYjY3ZTlm
-        Zi8ifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJGZWRvcmFfMTci
-        XSwgInNvdXJjZXJwbSI6ICJsaW9uLTAuMy0wLjguc3JjLnJwbSIsICJuYW1l
-        IjogImxpb24iLCAiY2hlY2tzdW0iOiAiMTI0MDBkYzk1YzIzYTRjMTYwNzI1
-        YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2MmVmYTNlNGFlNCIs
-        ICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBsaW9uIiwgImZpbGVu
-        YW1lIjogImxpb24tMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAi
-        LCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjog
-        IjUwMGUwMjYyLWVhNTQtNGRkOS05MmQzLWM0YmQ0ZDVjNTUxMSIsICJhcmNo
-        IjogIm5vYXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAv
-        YXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBtLzUwMGUwMjYyLWVhNTQtNGRkOS05
-        MmQzLWM0YmQ0ZDVjNTUxMS8ifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBz
-        IjogWyJGZWRvcmFfMTciXSwgInNvdXJjZXJwbSI6ICJwZW5ndWluLTAuMy0w
-        Ljguc3JjLnJwbSIsICJuYW1lIjogInBlbmd1aW4iLCAiY2hlY2tzdW0iOiAi
-        M2ZjYjJjOTI3ZGU5ZTEzYmY2ODQ2OTAzMmEyOGIxMzlkM2U1YWQyZTU4NTY0
-        ZmMyMTBmZDZlNDg2MzViZTY5NCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFj
-        a2FnZSBvZiBwZW5ndWluIiwgImZpbGVuYW1lIjogInBlbmd1aW4tMC4zLTAu
-        OC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMi
-        LCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjcwZDc3OTE2LTM2MGUtNDky
-        Yi1iYmI4LTJhMjA1YjViYjM3YyIsICJhcmNoIjogIm5vYXJjaCIsICJjaGls
-        ZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5p
-        dHMvcnBtLzcwZDc3OTE2LTM2MGUtNDkyYi1iYmI4LTJhMjA1YjViYjM3Yy8i
-        fSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJGZWRvcmFfMTciXSwg
-        InNvdXJjZXJwbSI6ICJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUi
-        OiAibW9ua2V5IiwgImNoZWNrc3VtIjogIjBlOGZhNTBkMDEyOGZiYWJjN2Nj
-        YzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1MDFkYjEi
-        LCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgbW9ua2V5IiwgImZp
-        bGVuYW1lIjogIm1vbmtleS0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2gi
-        OiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJf
-        aWQiOiAiYTZkNjUwOGYtMjlmMS00NDVmLWI4M2ItNDgwMDc0OTJjMTczIiwg
-        ImFyY2giOiAibm9hcmNoIiwgImNoaWxkcmVuIjoge30sICJfaHJlZiI6ICIv
-        cHVscC9hcGkvdjIvY29udGVudC91bml0cy9ycG0vYTZkNjUwOGYtMjlmMS00
-        NDVmLWI4M2ItNDgwMDc0OTJjMTczLyJ9LCB7InJlcG9zaXRvcnlfbWVtYmVy
-        c2hpcHMiOiBbIkZlZG9yYV8xNyJdLCAic291cmNlcnBtIjogImNoZWV0YWgt
-        MC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAiY2hlZXRhaCIsICJjaGVja3N1
-        bSI6ICI0MjJkMGJhYTBjZDlkNzcxM2FlNzk2ZTg4NmEyM2UxN2Y1NzhmOTI0
-        Zjc0ODgwZGViZGJiN2Q2NWZiMzY4ZGFlIiwgInN1bW1hcnkiOiAiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGNoZWV0YWgiLCAiZmlsZW5hbWUiOiAiY2hlZXRhaC0w
-        LjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjog
-        IjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiYjBjMjI4N2EtN2Zh
-        ZS00ZTlkLTgyZmYtOGZiYjdiMmIwMDEyIiwgImFyY2giOiAibm9hcmNoIiwg
-        ImNoaWxkcmVuIjoge30sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVu
-        dC91bml0cy9ycG0vYjBjMjI4N2EtN2ZhZS00ZTlkLTgyZmYtOGZiYjdiMmIw
-        MDEyLyJ9LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBbIkZlZG9yYV8x
-        NyJdLCAic291cmNlcnBtIjogImVsZXBoYW50LTAuMy0wLjguc3JjLnJwbSIs
-        ICJuYW1lIjogImVsZXBoYW50IiwgImNoZWNrc3VtIjogIjNlMWM3MGNkMWI0
-        MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcy
-        YTBhNzAxZjMiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgZWxl
-        cGhhbnQiLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gu
-        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFz
-        ZSI6ICIwLjgiLCAiX2lkIjogImUxODg1NjEwLTc4NjItNGRmMi04OTJmLTI1
-        NmYxMWRkYmMxMiIsICJhcmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6IHt9
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBtL2Ux
-        ODg1NjEwLTc4NjItNGRmMi04OTJmLTI1NmYxMWRkYmMxMi8ifSwgeyJyZXBv
-        c2l0b3J5X21lbWJlcnNoaXBzIjogWyJGZWRvcmFfMTciXSwgInNvdXJjZXJw
-        bSI6ICJzcXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJzcXVp
-        cnJlbCIsICJjaGVja3N1bSI6ICIyNTE3NjhiZGQxNWYxM2Q3ODQ4N2MyNzYz
-        OGFhNmFlY2QwMTU1MWUyNTM3NTYwOTNjZGUxYzBhZTg3OGExN2QyIiwgInN1
-        bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwgImZpbGVu
-        YW1lIjogInNxdWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6
-        ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgIl9p
-        ZCI6ICJlZjNiYWUyZS0wYWJlLTQyMzEtYjIwMy00Y2E5ZWM1N2Y1MWQiLCAi
-        YXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS9lZjNiYWUyZS0wYWJlLTQy
-        MzEtYjIwMy00Y2E5ZWM1N2Y1MWQvIn1d
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:15 GMT
-- request:
-    method: post
-    uri: https://katello-yoda.example.com/pulp/api/v2/content/units/rpm/search/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMzI4NGVh
-        NGYtZTc2ZS00MGRiLTlmYWEtOTg4YjE3MTExYTZjIl19fX0sImluY2x1ZGVf
-        cmVwb3MiOnRydWV9
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4",
-        oauth_nonce="h12rRX6FLp4S6U7YX2419PsC17sFzvtgqktm1mblI", oauth_signature="C%2FfpZlHsU%2Ffr%2BYZIZZ3ta8GasB4%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454292135", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '102'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:02:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2992'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJf
-        aHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9ycG0vMzI4NGVh
-        NGYtZTc2ZS00MGRiLTlmYWEtOTg4YjE3MTExYTZjLyIsICJidWlsZF90aW1l
-        IjogMTMwODI1NzQxNCwgImJ1aWxkaG9zdCI6ICJkaGNwLTI2LTExOC5icnEu
-        cmVkaGF0LmNvbSIsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250
-        ZW50X3R5cGVfaWQiOiAicnBtIiwgImNoaWxkcmVuIjoge30sICJzaXplIjog
-        MjIzNiwgImxpY2Vuc2UiOiAiR1BMdjIiLCAiZ3JvdXAiOiAiSW50ZXJuZXQv
-        QXBwbGljYXRpb25zIiwgImZpbGVuYW1lIjogImdpcmFmZmUtMC4zLTAuOC5u
-        b2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAi
-        dmVyc2lvbl9zb3J0X2luZGV4IjogIjAxLTAuMDEtMyIsICJwcm92aWRlcyI6
-        IFt7InJlbGVhc2UiOiAiMC44IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
-        ICIwLjMiLCAiZmxhZ3MiOiAiRVEiLCAibmFtZSI6ICJnaXJhZmZlIn1dLCAi
-        ZmlsZXMiOiB7ImRpciI6IFtdLCAiZmlsZSI6IFsiLy9naXJhZmZlLnR4dCJd
-        fSwgInJlcG9kYXRhIjogeyJmaWxlbGlzdHMiOiAiPHBhY2thZ2UgYXJjaD1c
-        Im5vYXJjaFwiIG5hbWU9XCJnaXJhZmZlXCIgcGtnaWQ9XCJmMjVkNjdkMWQ5
-        ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTViODJkZTZkMTky
-        MjAwOWY5ZjE0XCI+XG4gICAgPHZlcnNpb24gZXBvY2g9XCIwXCIgcmVsPVwi
-        MC44XCIgdmVyPVwiMC4zXCIgLz5cblxuICAgIDxmaWxlPi8vZ2lyYWZmZS50
-        eHQ8L2ZpbGU+XG48L3BhY2thZ2U+XG5cbiIsICJvdGhlciI6ICI8cGFja2Fn
-        ZSBhcmNoPVwibm9hcmNoXCIgbmFtZT1cImdpcmFmZmVcIiBwa2dpZD1cImYy
-        NWQ2N2QxZDlkYTA0ZjEyZTU3Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4
-        MmRlNmQxOTIyMDA5ZjlmMTRcIj5cbiAgICA8dmVyc2lvbiBlcG9jaD1cIjBc
-        IiByZWw9XCIwLjhcIiB2ZXI9XCIwLjNcIiAvPlxuXG48L3BhY2thZ2U+XG5c
-        biIsICJwcmltYXJ5IjogIjxwYWNrYWdlIHR5cGU9XCJycG1cIj5cbiAgPG5h
-        bWU+Z2lyYWZmZTwvbmFtZT5cbiAgPGFyY2g+bm9hcmNoPC9hcmNoPlxuICA8
-        dmVyc2lvbiBlcG9jaD1cIjBcIiByZWw9XCIwLjhcIiB2ZXI9XCIwLjNcIiAv
-        PlxuICA8Y2hlY2tzdW0gcGtnaWQ9XCJZRVNcIiB0eXBlPVwic2hhMjU2XCI+
-        ZjI1ZDY3ZDFkOWRhMDRmMTJlNTdjYTMyMzI0N2I0Mzg5MWFjNDY1MzNlMzU1
-        YjgyZGU2ZDE5MjIwMDlmOWYxNDwvY2hlY2tzdW0+XG4gIDxzdW1tYXJ5PkEg
-        ZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlPC9zdW1tYXJ5PlxuICA8ZGVzY3Jp
-        cHRpb24+QSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmU8L2Rlc2NyaXB0aW9u
-        PlxuICA8cGFja2FnZXIgLz5cbiAgPHVybD5odHRwOi8vdHN0cmFjaG90YS5m
-        ZWRvcmFwZW9wbGUub3JnPC91cmw+XG4gIDx0aW1lIGJ1aWxkPVwiMTMwODI1
-        NzQxNFwiIGZpbGU9XCIxMzIxODkxMDI3XCIgLz5cbiAgPHNpemUgYXJjaGl2
-        ZT1cIjI5MlwiIGluc3RhbGxlZD1cIjQyXCIgcGFja2FnZT1cIjIyMzZcIiAv
-        PlxuPGxvY2F0aW9uIGhyZWY9XCJnaXJhZmZlLTAuMy0wLjgubm9hcmNoLnJw
-        bVwiLz5cbiAgPGZvcm1hdD5cbiAgICA8cnBtOmxpY2Vuc2U+R1BMdjI8L3Jw
-        bTpsaWNlbnNlPlxuICAgIDxycG06dmVuZG9yIC8+XG4gICAgPHJwbTpncm91
-        cD5JbnRlcm5ldC9BcHBsaWNhdGlvbnM8L3JwbTpncm91cD5cbiAgICA8cnBt
-        OmJ1aWxkaG9zdD5kaGNwLTI2LTExOC5icnEucmVkaGF0LmNvbTwvcnBtOmJ1
-        aWxkaG9zdD5cbiAgICA8cnBtOnNvdXJjZXJwbT5naXJhZmZlLTAuMy0wLjgu
-        c3JjLnJwbTwvcnBtOnNvdXJjZXJwbT5cbiAgICA8cnBtOmhlYWRlci1yYW5n
-        ZSBlbmQ9XCIyMDE2XCIgc3RhcnQ9XCIyODBcIiAvPlxuICAgIDxycG06cHJv
-        dmlkZXM+XG4gICAgICA8cnBtOmVudHJ5IGVwb2NoPVwiMFwiIGZsYWdzPVwi
-        RVFcIiBuYW1lPVwiZ2lyYWZmZVwiIHJlbD1cIjAuOFwiIHZlcj1cIjAuM1wi
-        IC8+XG4gICAgPC9ycG06cHJvdmlkZXM+XG4gICAgPHJwbTpyZXF1aXJlcz5c
-        biAgICAgIDxycG06ZW50cnkgbmFtZT1cIi9iaW4vc2hcIiBwcmU9XCIxXCIg
-        Lz5cbiAgICA8L3JwbTpyZXF1aXJlcz5cbiAgPC9mb3JtYXQ+XG48L3BhY2th
-        Z2U+XG4ifSwgImRlc2NyaXB0aW9uIjogIkEgZHVtbXkgcGFja2FnZSBvZiBn
-        aXJhZmZlIiwgIl9sYXN0X3VwZGF0ZWQiOiAiMjAxNi0wMi0wMVQwMTo1OTo1
-        NVoiLCAidGltZSI6IDEzMjE4OTEwMjcsICJkb3dubG9hZGVkIjogdHJ1ZSwg
-        ImhlYWRlcl9yYW5nZSI6IHsic3RhcnQiOiAyODAsICJlbmQiOiAyMDE2fSwg
-        ImFyY2giOiAibm9hcmNoIiwgIm5hbWUiOiAiZ2lyYWZmZSIsICJfc3RvcmFn
-        ZV9wYXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0cy9ycG0vMzI4
-        NC8zMjg0ZWE0Zi1lNzZlLTQwZGItOWZhYS05ODhiMTcxMTFhNmMvZ2lyYWZm
-        ZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCAic291cmNlcnBtIjogImdpcmFmZmUt
-        MC4zLTAuOC5zcmMucnBtIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYiLCAi
-        cmVsZWFzZV9zb3J0X2luZGV4IjogIjAxLTAuMDEtOCIsICJjaGFuZ2Vsb2ci
-        OiBbXSwgInVybCI6ICJodHRwOi8vdHN0cmFjaG90YS5mZWRvcmFwZW9wbGUu
-        b3JnIiwgImNoZWNrc3VtIjogImYyNWQ2N2QxZDlkYTA0ZjEyZTU3Y2EzMjMy
-        NDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQiLCAic3Vt
-        bWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsICJyZWxhdGl2
-        ZXBhdGgiOiAiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCAicmVsZWFz
-        ZSI6ICIwLjgiLCAiX2lkIjogIjMyODRlYTRmLWU3NmUtNDBkYi05ZmFhLTk4
-        OGIxNzExMWE2YyIsICJyZXF1aXJlcyI6IFt7InJlbGVhc2UiOiBudWxsLCAi
-        ZXBvY2giOiBudWxsLCAidmVyc2lvbiI6IG51bGwsICJmbGFncyI6IG51bGws
-        ICJuYW1lIjogIi9iaW4vc2gifV19XQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:15 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/c153baa7-5d55-4dd1-abdd-e48016b55b24/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="K4ANY301IuR5dSIiX43z5kYxcc8EulhtN6dRr1q424",
-        oauth_signature="J5rdMrehxpbpu8Ejofr5HUgpwos%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292135", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:02:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jMTUzYmFhNy01ZDU1LTRkZDEtYWJkZC1lNDgwMTZiNTVi
-        MjQvIiwgInRhc2tfaWQiOiAiYzE1M2JhYTctNWQ1NS00ZGQxLWFiZGQtZTQ4
-        MDE2YjU1YjI0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmFlYmNh
-        N2U1NDk3NWY3MWE2YTY3MTIifSwgImlkIjogIjU2YWViY2E3ZTU0OTc1Zjcx
-        YTZhNjcxMiJ9
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:15 GMT
-- request:
-    method: get
-    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/c153baa7-5d55-4dd1-abdd-e48016b55b24/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="5N52BJQuADMGfHKMhzRV8NUfKUZvePw4", oauth_nonce="KN1098tLrgefYKeBMWRs1g7Po5h5B81nCcKWoMPA",
-        oauth_signature="eDpslDZ26Gy0mD%2BzuSW8p7Yf6G4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454292136", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 01 Feb 2016 02:02:16 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '682'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jMTUzYmFhNy01ZDU1LTRkZDEtYWJkZC1lNDgwMTZiNTVi
-        MjQvIiwgInRhc2tfaWQiOiAiYzE1M2JhYTctNWQ1NS00ZGQxLWFiZGQtZTQ4
-        MDE2YjU1YjI0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTAxVDAyOjAyOjE1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTAxVDAyOjAyOjE1WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
-        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZhZWJjYTdl
-        NTQ5NzVmNzFhNmE2NzEyIn0sICJpZCI6ICI1NmFlYmNhN2U1NDk3NWY3MWE2
-        YTY3MTIifQ==
-    http_version: 
-  recorded_at: Mon, 01 Feb 2016 02:02:16 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ac456f52-cfcc-46fd-bc10-27a38c103f95/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="rRySha7xaLldir8y9ZPJ35sCUERUeWfX0eBrQUDKQs",
-        oauth_signature="bZRcQJW5sItLGytwNm8exdM4tv0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693925", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:45 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hYzQ1NmY1Mi1jZmNjLTQ2ZmQtYmMxMC0yN2EzOGMxMDNm
-        OTUvIiwgInRhc2tfaWQiOiAiYWM0NTZmNTItY2ZjYy00NmZkLWJjMTAtMjdh
-        MzhjMTAzZjk1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMjU4
-        YWRhNDBkYjA0ZWUxMWM5In0sICJpZCI6ICI1NmI0ZGUyNThhZGE0MGRiMDRl
-        ZTExYzkifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:45 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ac456f52-cfcc-46fd-bc10-27a38c103f95/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="pfwsLrtx2DZZdgYyVqeoZ2rrp1WNFTOjo0q2a3eQ",
-        oauth_signature="Apj6O%2FwKXY2KY6Rq1y3Q5miHjrs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693926", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:46 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1081'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hYzQ1NmY1Mi1jZmNjLTQ2ZmQtYmMxMC0yN2EzOGMxMDNm
-        OTUvIiwgInRhc2tfaWQiOiAiYWM0NTZmNTItY2ZjYy00NmZkLWJjMTAtMjdh
-        MzhjMTAzZjk1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0wNVQxNzozODo0NVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJJ
-        Tl9QUk9HUkVTUyJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAi
-        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0
-        ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJl
-        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMjU4YWRhNDBk
-        YjA0ZWUxMWM5In0sICJpZCI6ICI1NmI0ZGUyNThhZGE0MGRiMDRlZTExYzki
-        fQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:46 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ac456f52-cfcc-46fd-bc10-27a38c103f95/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="UGew8zD61llv4aseETTaiHiv7I1GJlVO5sTjOwNTko",
-        oauth_signature="CIkHj79ecFvS6UqDp20JzGOLpjE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693926", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:46 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hYzQ1NmY1Mi1jZmNjLTQ2ZmQtYmMxMC0yN2EzOGMxMDNm
-        OTUvIiwgInRhc2tfaWQiOiAiYWM0NTZmNTItY2ZjYy00NmZkLWJjMTAtMjdh
-        MzhjMTAzZjk1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozODo0NloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODo0NVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZjZjYTg0YzUtNDg5Ny00ZDM1LThkNDMtMDRlZTU0YTlj
-        OTUzLyIsICJ0YXNrX2lkIjogImY2Y2E4NGM1LTQ4OTctNGQzNS04ZDQzLTA0
-        ZWU1NGE5Yzk1MyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZTI1Yzc4MjFiMzMwNWNlNTI4MyJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6Mzg6NDVaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozODo0
-        NloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRlMjZjNzgyMWIzNDQ0ZmNjNDk2IiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMjU4YWRhNDBkYjA0ZWUxMWM5In0s
-        ICJpZCI6ICI1NmI0ZGUyNThhZGE0MGRiMDRlZTExYzkifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:46 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f6ca84c5-4897-4d35-8d43-04ee54a9c953/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="iiNX7CfU6jVqJguJOSzk1ib6Ll3hmjUgTp8cABHHE",
-        oauth_signature="JoRz6YD%2FWPVnX2LjIZGT%2F0viejU%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693926", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:46 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3513'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9mNmNhODRjNS00ODk3LTRkMzUtOGQ0My0wNGVl
-        NTRhOWM5NTMvIiwgInRhc2tfaWQiOiAiZjZjYTg0YzUtNDg5Ny00ZDM1LThk
-        NDMtMDRlZTU0YTljOTUzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wNVQxNzozODo0NloiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiZDdj
-        ZmQ2Mi0wMDE1LTRjNTktODkyZC02YmQzNjQyMmFlMzkiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOWQwNDdkOWItMjU2
-        MC00ZWEyLTk3ODYtMGU0NWU3MjczOWJmIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiYTE4YWYwZGEtYzgzOC00ODQ3LTlhZTItNmI5NWZjNjg0OTg5IiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjNkYWQzZGEtYTA4NS00M2E5LTk0
-        OWYtYTQ1YTQ1NmU2ODc4IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVl
-        M2FiZTZkLWE2ZGItNDZjNC1hOWY2LWUyMzBjOTc4ZTE0MiIsICJudW1fcHJv
-        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZGQ4MWY2YS0zNmE2LTQ2NGUtYWM4
-        OC0yYzMzYzMxZWE3MTQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9z
-        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRh
-        dGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI3NmY1YjMxOC00ZjBlLTRjNjItYjRlNy1jZDc5Y2RjMzQzMTYiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUi
-        OiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJl
-        MWNiYjIzNS1hYTk2LTQxNDUtYTVkMS01ZWNkN2FhNDA3ODkiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJn
-        ZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzdiZTNlZjIt
-        MGY2My00NTdiLTk3NTUtNzM4MTZmYmRlZTYwIiwgIm51bV9wcm9jZXNzZWQi
-        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJs
-        aXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9k
-        aXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
-        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzQ5OTNhYzctODlkMy00
-        MDg5LTlkNWEtYzIwN2E1ODRhNmQ1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
-        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExp
-        c3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19t
-        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RB
-        UlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4MjRkOWZkMC0yMWQ1LTQ0
-        NTgtYjY1OC0wZmMzYTM0MDU5YzAiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0s
-        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
-        LTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
-        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwg
-        ImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0ZGUyNjhhZGE0
-        MGRiMDRlZTExZDkifSwgImlkIjogIjU2YjRkZTI2OGFkYTQwZGIwNGVlMTFk
-        OSJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:46 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ac456f52-cfcc-46fd-bc10-27a38c103f95/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="xyqHuL2el4rQyLFVEDnKjqaehNfYhtFu8OyFOJkU8",
-        oauth_signature="DPGwWQnfSHgBnTPewxPzQqSFmD0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693927", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:47 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hYzQ1NmY1Mi1jZmNjLTQ2ZmQtYmMxMC0yN2EzOGMxMDNm
-        OTUvIiwgInRhc2tfaWQiOiAiYWM0NTZmNTItY2ZjYy00NmZkLWJjMTAtMjdh
-        MzhjMTAzZjk1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozODo0NloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODo0NVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZjZjYTg0YzUtNDg5Ny00ZDM1LThkNDMtMDRlZTU0YTlj
-        OTUzLyIsICJ0YXNrX2lkIjogImY2Y2E4NGM1LTQ4OTctNGQzNS04ZDQzLTA0
-        ZWU1NGE5Yzk1MyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZTI1Yzc4MjFiMzMwNWNlNTI4MyJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6Mzg6NDVaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozODo0
-        NloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRlMjZjNzgyMWIzNDQ0ZmNjNDk2IiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMjU4YWRhNDBkYjA0ZWUxMWM5In0s
-        ICJpZCI6ICI1NmI0ZGUyNThhZGE0MGRiMDRlZTExYzkifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:47 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f6ca84c5-4897-4d35-8d43-04ee54a9c953/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="G2nlUBO7jnZ7A85F7nkyaLu9AXv6TofDYkRQEMB3p4",
-        oauth_signature="ghElFSUG98F%2FpVVd2gqIp7uKz08%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693927", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:47 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9mNmNhODRjNS00ODk3LTRkMzUtOGQ0My0wNGVl
-        NTRhOWM5NTMvIiwgInRhc2tfaWQiOiAiZjZjYTg0YzUtNDg5Ny00ZDM1LThk
-        NDMtMDRlZTU0YTljOTUzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wNVQxNzozODo0NloiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODo0NloiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJiZDdjZmQ2Mi0wMDE1LTRjNTktODkyZC02YmQzNjQy
-        MmFlMzkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiOWQwNDdkOWItMjU2MC00ZWEyLTk3ODYtMGU0NWU3MjczOWJmIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiYTE4YWYwZGEtYzgzOC00ODQ3LTlhZTIt
-        NmI5NWZjNjg0OTg5IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjNk
-        YWQzZGEtYTA4NS00M2E5LTk0OWYtYTQ1YTQ1NmU2ODc4IiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImVlM2FiZTZkLWE2ZGItNDZjNC1hOWY2LWUyMzBj
-        OTc4ZTE0MiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZGQ4MWY2
-        YS0zNmE2LTQ2NGUtYWM4OC0yYzMzYzMxZWE3MTQiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI3NmY1YjMxOC00ZjBlLTRjNjItYjRlNy1jZDc5
-        Y2RjMzQzMTYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJlMWNiYjIzNS1hYTk2LTQxNDUtYTVkMS01ZWNkN2FhNDA3ODki
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzN2Jl
-        M2VmMi0wZjYzLTQ1N2ItOTc1NS03MzgxNmZiZGVlNjAiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzNDk5M2FjNy04OWQz
-        LTQwODktOWQ1YS1jMjA3YTU4NGE2ZDUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjgyNGQ5ZmQwLTIxZDUtNDQ1
-        OC1iNjU4LTBmYzNhMzQwNTljMCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
-        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE3OjM4OjQ2
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMDVUMTc6Mzg6NDZaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGRlMjZjNzgyMWIz
-        NDQ0ZmNjNDk3IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImJkN2NmZDYyLTAwMTUtNGM1OS04OTJkLTZiZDM2NDIyYWUz
-        OSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI5ZDA0N2Q5Yi0yNTYwLTRlYTItOTc4Ni0wZTQ1ZTcyNzM5YmYiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJhMThhZjBkYS1jODM4LTQ4NDctOWFlMi02Yjk1
-        ZmM2ODQ5ODkiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiM2RhZDNk
-        YS1hMDg1LTQzYTktOTQ5Zi1hNDVhNDU2ZTY4NzgiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiZWUzYWJlNmQtYTZkYi00NmM0LWE5ZjYtZTIzMGM5Nzhl
-        MTQyIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFkZDgxZjZhLTM2
-        YTYtNDY0ZS1hYzg4LTJjMzNjMzFlYTcxNCIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjc2ZjViMzE4LTRmMGUtNGM2Mi1iNGU3LWNkNzljZGMz
-        NDMxNiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImUxY2JiMjM1LWFhOTYtNDE0NS1hNWQxLTVlY2Q3YWE0MDc4OSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM3YmUzZWYy
-        LTBmNjMtNDU3Yi05NzU1LTczODE2ZmJkZWU2MCIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM0OTkzYWM3LTg5ZDMtNDA4
-        OS05ZDVhLWMyMDdhNTg0YTZkNSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODI0ZDlmZDAtMjFkNS00NDU4LWI2
-        NTgtMGZjM2EzNDA1OWMwIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRkZTI2OGFkYTQwZGIw
-        NGVlMTFkOSJ9LCAiaWQiOiAiNTZiNGRlMjY4YWRhNDBkYjA0ZWUxMWQ5In0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:47 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f6ef4a06-3bda-40e7-8d3e-18e9b4836eca/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="zcmlhWN9f65h6GGM3iQPJDQZ8X7sZWCE00Dk3ThQ",
-        oauth_signature="NL9dU7tGH%2BeYg5WyHAvcziWIPJM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693927", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:48 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '651'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mNmVmNGEwNi0zYmRhLTQwZTctOGQzZS0xOGU5YjQ4MzZl
-        Y2EvIiwgInRhc2tfaWQiOiAiZjZlZjRhMDYtM2JkYS00MGU3LThkM2UtMThl
-        OWI0ODM2ZWNhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAi
-        c3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
-        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20i
-        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmI0ZGUyNzhhZGE0MGRiMDRlZTExZGEifSwgImlkIjogIjU2YjRk
-        ZTI3OGFkYTQwZGIwNGVlMTFkYSJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:48 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f6ef4a06-3bda-40e7-8d3e-18e9b4836eca/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="F0iKu44g1dMuSPtvDP8QXsLbQEZle68dqcGEFtBY8",
-        oauth_signature="EdEzxR78J%2FO0tJVH4wHm45akndI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693928", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:48 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mNmVmNGEwNi0zYmRhLTQwZTctOGQzZS0xOGU5YjQ4MzZl
-        Y2EvIiwgInRhc2tfaWQiOiAiZjZlZjRhMDYtM2JkYS00MGU3LThkM2UtMThl
-        OWI0ODM2ZWNhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA1VDE3OjM4OjQ4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE3OjM4OjQ4WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        NGRlMjc4YWRhNDBkYjA0ZWUxMWRhIn0sICJpZCI6ICI1NmI0ZGUyNzhhZGE0
-        MGRiMDRlZTExZGEifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:48 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/4609566a-ceb4-43ba-8b66-fadf914d4bf4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="twvjXx1d16a6LaG9IMDInyDxcFITAMVlVmjU5ypPR2s",
-        oauth_signature="G3lIMKkmy4EZ1dViIv4hsgMsxhE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693930", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:50 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NjA5NTY2YS1jZWI0LTQzYmEtOGI2Ni1mYWRmOTE0ZDRi
-        ZjQvIiwgInRhc2tfaWQiOiAiNDYwOTU2NmEtY2ViNC00M2JhLThiNjYtZmFk
-        ZjkxNGQ0YmY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMmE4
-        YWRhNDBkYjA0ZWUxMWRiIn0sICJpZCI6ICI1NmI0ZGUyYThhZGE0MGRiMDRl
-        ZTExZGIifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:50 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/4609566a-ceb4-43ba-8b66-fadf914d4bf4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="IcutxKWmBMY7ssRWtDlkffuyr6r3nnCqavOEyfbrKw8",
-        oauth_signature="hub%2F1nuf4eNyOugXVLWC35vdMXI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693930", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:50 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1093'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NjA5NTY2YS1jZWI0LTQzYmEtOGI2Ni1mYWRmOTE0ZDRi
-        ZjQvIiwgInRhc2tfaWQiOiAiNDYwOTU2NmEtY2ViNC00M2JhLThiNjYtZmFk
-        ZjkxNGQ0YmY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0wNVQxNzozODo1MFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
-        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJOT1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
-        bCI6IDAsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiSU5fUFJP
-        R1JFU1MifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjog
-        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        NGRlMmE4YWRhNDBkYjA0ZWUxMWRiIn0sICJpZCI6ICI1NmI0ZGUyYThhZGE0
-        MGRiMDRlZTExZGIifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:50 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/4609566a-ceb4-43ba-8b66-fadf914d4bf4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Qp8RxjuXkQWBemjozOzK0BK2xuWJme73shBMObtEGs",
-        oauth_signature="kjTE2iD5AFLqHhEDJbcLTWgDnSs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693931", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:51 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NjA5NTY2YS1jZWI0LTQzYmEtOGI2Ni1mYWRmOTE0ZDRi
-        ZjQvIiwgInRhc2tfaWQiOiAiNDYwOTU2NmEtY2ViNC00M2JhLThiNjYtZmFk
-        ZjkxNGQ0YmY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozODo1MVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODo1MFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZmU5NjUxOTMtNjg2My00Njg1LTg1ZmYtNmJmNmY3ZjZi
-        YjMxLyIsICJ0YXNrX2lkIjogImZlOTY1MTkzLTY4NjMtNDY4NS04NWZmLTZi
-        ZjZmN2Y2YmIzMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZTI5Yzc4MjFiMzMwNDJkOWY3MyJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6Mzg6NTBaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozODo1
-        MFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRlMmFjNzgyMWIzNDQ0ZmNjNDliIiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMmE4YWRhNDBkYjA0ZWUxMWRiIn0s
-        ICJpZCI6ICI1NmI0ZGUyYThhZGE0MGRiMDRlZTExZGIifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:51 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/fe965193-6863-4685-85ff-6bf6f7f6bb31/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="S75yEAShbN7sgSJVODAs4JvAJgVLOFt9elgHfnxzdk",
-        oauth_signature="J8NVBK0DwMtXDjbOs34ojAUA3Gw%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693931", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:51 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3523'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9mZTk2NTE5My02ODYzLTQ2ODUtODVmZi02YmY2
-        ZjdmNmJiMzEvIiwgInRhc2tfaWQiOiAiZmU5NjUxOTMtNjg2My00Njg1LTg1
-        ZmYtNmJmNmY3ZjZiYjMxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wNVQxNzozODo1MVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkNjc3
-        MWE4NC1jODA5LTQ1NGItYmFjYS1mM2JkMDE2NDEwZDgiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzZkYjIzZDQtNmY4
-        Ny00N2Q3LWE0MTMtNGQzNjA2MjFiOTNjIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDQsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYzEzZDY0NzMtMGI5Ny00ZmE3LWE0Y2ItNjhlZTViZDdkMWZkIiwg
-        Im51bV9wcm9jZXNzZWQiOiA0fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
-        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
-        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImEwNWFlNzNhLWQ5MTgt
-        NDdjYy1iNTE1LTExMTAzNThmMThmYiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
-        ZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIyZTUyODdmZi0xOWRhLTQ4MDItYjQ5ZS04NDNiYTg5Y2NlODMi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5
-        cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
-        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiY2RmMzU2MWQtNzA3
-        OC00YTk0LWE4OGYtYTU3OWNkZTJmMzQ5IiwgIm51bV9wcm9jZXNzZWQiOiAw
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiMzljYTk0OTEtM2MyZS00NzFhLWIyZmEtY2Q5NjVm
-        YjkwZDQ5IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
-        IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAi
-        c3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
-        ZXBfaWQiOiAiOWFkNzQ1ZjMtMWMxMS00MjJhLThkNjAtNTJlYTM5NDYwNDJi
-        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
-        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
-        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImQxMzRiNTg4LTQxMTUtNDY5MS1hOWI4LTBlNjM0YWFkMjBiYyIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjog
-        InB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNiNmUx
-        MDBjLWFiMGYtNDIzNy05MTE1LWIzMTRmNjVlYmM0ZSIsICJudW1fcHJvY2Vz
-        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
-        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
-        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjAwNzBi
-        MzgtZTkwNS00MTE5LWFlZTYtM2Y2OTg0NzQyNTdlIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjog
-        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        NGRlMmE4YWRhNDBkYjA0ZWUxMWViIn0sICJpZCI6ICI1NmI0ZGUyYThhZGE0
-        MGRiMDRlZTExZWIifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:51 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/4609566a-ceb4-43ba-8b66-fadf914d4bf4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="aox6I17Re3t85jcgl69rVcsbMKVbH0PXtszmvSVwt4",
-        oauth_signature="l8XGUXGFmRwu%2FO2pGbqCqWUbdBo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693931", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:51 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NjA5NTY2YS1jZWI0LTQzYmEtOGI2Ni1mYWRmOTE0ZDRi
-        ZjQvIiwgInRhc2tfaWQiOiAiNDYwOTU2NmEtY2ViNC00M2JhLThiNjYtZmFk
-        ZjkxNGQ0YmY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozODo1MVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODo1MFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZmU5NjUxOTMtNjg2My00Njg1LTg1ZmYtNmJmNmY3ZjZi
-        YjMxLyIsICJ0YXNrX2lkIjogImZlOTY1MTkzLTY4NjMtNDY4NS04NWZmLTZi
-        ZjZmN2Y2YmIzMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZTI5Yzc4MjFiMzMwNDJkOWY3MyJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6Mzg6NTBaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozODo1
-        MFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRlMmFjNzgyMWIzNDQ0ZmNjNDliIiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMmE4YWRhNDBkYjA0ZWUxMWRiIn0s
-        ICJpZCI6ICI1NmI0ZGUyYThhZGE0MGRiMDRlZTExZGIifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:51 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/fe965193-6863-4685-85ff-6bf6f7f6bb31/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="SeDenKiJ7IGQH99OYgWmLLd5smOqWFJ9H1GQ4vCNapU",
-        oauth_signature="oOV2XoJPuwyhcbf35gqqhDiZUF4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693931", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:51 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9mZTk2NTE5My02ODYzLTQ2ODUtODVmZi02YmY2
-        ZjdmNmJiMzEvIiwgInRhc2tfaWQiOiAiZmU5NjUxOTMtNjg2My00Njg1LTg1
-        ZmYtNmJmNmY3ZjZiYjMxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wNVQxNzozODo1MVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODo1MVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJkNjc3MWE4NC1jODA5LTQ1NGItYmFjYS1mM2JkMDE2
-        NDEwZDgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYzZkYjIzZDQtNmY4Ny00N2Q3LWE0MTMtNGQzNjA2MjFiOTNjIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiYzEzZDY0NzMtMGI5Ny00ZmE3LWE0Y2It
-        NjhlZTViZDdkMWZkIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTA1
-        YWU3M2EtZDkxOC00N2NjLWI1MTUtMTExMDM1OGYxOGZiIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjJlNTI4N2ZmLTE5ZGEtNDgwMi1iNDllLTg0M2Jh
-        ODljY2U4MyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjZGYzNTYx
-        ZC03MDc4LTRhOTQtYTg4Zi1hNTc5Y2RlMmYzNDkiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIzOWNhOTQ5MS0zYzJlLTQ3MWEtYjJmYS1jZDk2
-        NWZiOTBkNDkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI5YWQ3NDVmMy0xYzExLTQyMmEtOGQ2MC01MmVhMzk0NjA0MmIi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkMTM0
-        YjU4OC00MTE1LTQ2OTEtYTliOC0wZTYzNGFhZDIwYmMiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzYjZlMTAwYy1hYjBm
-        LTQyMzctOTExNS1iMzE0ZjY1ZWJjNGUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImYwMDcwYjM4LWU5MDUtNDEx
-        OS1hZWU2LTNmNjk4NDc0MjU3ZSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
-        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE3OjM4OjUx
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMDVUMTc6Mzg6NTFaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGRlMmJjNzgyMWIz
-        NDQ0ZmNjNDljIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImQ2NzcxYTg0LWM4MDktNDU0Yi1iYWNhLWYzYmQwMTY0MTBk
-        OCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJjNmRiMjNkNC02Zjg3LTQ3ZDctYTQxMy00ZDM2MDYyMWI5M2MiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJjMTNkNjQ3My0wYjk3LTRmYTctYTRjYi02OGVl
-        NWJkN2QxZmQiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhMDVhZTcz
-        YS1kOTE4LTQ3Y2MtYjUxNS0xMTEwMzU4ZjE4ZmIiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiMmU1Mjg3ZmYtMTlkYS00ODAyLWI0OWUtODQzYmE4OWNj
-        ZTgzIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNkZjM1NjFkLTcw
-        NzgtNGE5NC1hODhmLWE1NzljZGUyZjM0OSIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjM5Y2E5NDkxLTNjMmUtNDcxYS1iMmZhLWNkOTY1ZmI5
-        MGQ0OSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjlhZDc0NWYzLTFjMTEtNDIyYS04ZDYwLTUyZWEzOTQ2MDQyYiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQxMzRiNTg4
-        LTQxMTUtNDY5MS1hOWI4LTBlNjM0YWFkMjBiYyIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNiNmUxMDBjLWFiMGYtNDIz
-        Ny05MTE1LWIzMTRmNjVlYmM0ZSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjAwNzBiMzgtZTkwNS00MTE5LWFl
-        ZTYtM2Y2OTg0NzQyNTdlIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRkZTJhOGFkYTQwZGIw
-        NGVlMTFlYiJ9LCAiaWQiOiAiNTZiNGRlMmE4YWRhNDBkYjA0ZWUxMWViIn0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:52 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/e4e7bbb3-071f-4828-a2f5-f2f6293f2144/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="VAQrISmVuVmJF97kEEs1c4tUObq05I7tteqKKFwU",
-        oauth_signature="dzvYwbksHGuDGd1QUMCEYIsHeqE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693932", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:52 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lNGU3YmJiMy0wNzFmLTQ4MjgtYTJmNS1mMmY2MjkzZjIx
-        NDQvIiwgInRhc2tfaWQiOiAiZTRlN2JiYjMtMDcxZi00ODI4LWEyZjUtZjJm
-        NjI5M2YyMTQ0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0ZGUy
-        YzhhZGE0MGRiMDRlZTExZWMifSwgImlkIjogIjU2YjRkZTJjOGFkYTQwZGIw
-        NGVlMTFlYyJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:52 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/e4e7bbb3-071f-4828-a2f5-f2f6293f2144/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="NvIXyYCW8pLvZkQeqO4RMwytdMXz2M5g3NHMJw7Njc8",
-        oauth_signature="7P5j7Zp7N46COLxOEH5cEflq9es%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693933", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:53 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lNGU3YmJiMy0wNzFmLTQ4MjgtYTJmNS1mMmY2MjkzZjIx
-        NDQvIiwgInRhc2tfaWQiOiAiZTRlN2JiYjMtMDcxZi00ODI4LWEyZjUtZjJm
-        NjI5M2YyMTQ0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA1VDE3OjM4OjUyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE3OjM4OjUyWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        NGRlMmM4YWRhNDBkYjA0ZWUxMWVjIn0sICJpZCI6ICI1NmI0ZGUyYzhhZGE0
-        MGRiMDRlZTExZWMifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:53 GMT
-- request:
-    method: post
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
-        IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRp
-        c3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwi
-        OiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3Rl
-        Y3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJleHBvcnRfZGlzdHJpYnV0
-        b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBz
-        IjpmYWxzZSwicmVsYXRpdmVfdXJsIjpudWxsfSwiYXV0b19wdWJsaXNoIjpm
-        YWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJleHBvcnRfZGlzdHJpYnV0b3IifV19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
-        oauth_nonce="Rf31NQLnnYM2diVIlPQrErOmpm9xhHrl4s0Vt68", oauth_signature="hyUQrE7hyq%2BnKgvgYnP0ONcUbQI%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454693934", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '810'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:54 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '320'
-      Location:
-      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiNGRlMmVjNzgyMWIzMzAzNGJhZmRkIn0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:54 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/bd2515a5-6c0f-4440-af6c-8a462b02b74f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="7dpa4cv0AaW5Q6IDp3rKmTQARkz3DDO170HSHnVVlTo",
-        oauth_signature="F2YbeciM1eHOixaCO3xEorg%2Bzxk%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693934", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:54 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iZDI1MTVhNS02YzBmLTQ0NDAtYWY2Yy04YTQ2MmIwMmI3
-        NGYvIiwgInRhc2tfaWQiOiAiYmQyNTE1YTUtNmMwZi00NDQwLWFmNmMtOGE0
-        NjJiMDJiNzRmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMmU4
-        YWRhNDBkYjA0ZWUxMWVkIn0sICJpZCI6ICI1NmI0ZGUyZThhZGE0MGRiMDRl
-        ZTExZWQifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:54 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/bd2515a5-6c0f-4440-af6c-8a462b02b74f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="H1nuKtC8SggYYafxUhtmjBfLTdbJTxQbOsJMOLAMUVA",
-        oauth_signature="5QVkPn%2BGIwtHvPoDaZipG%2B8npGc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693935", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:55 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1090'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iZDI1MTVhNS02YzBmLTQ0NDAtYWY2Yy04YTQ2MmIwMmI3
-        NGYvIiwgInRhc2tfaWQiOiAiYmQyNTE1YTUtNmMwZi00NDQwLWFmNmMtOGE0
-        NjJiMDJiNzRmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0wNVQxNzozODo1NFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
-        Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJOT1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
-        bCI6IDAsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        a2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1
-        bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
-        IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRl
-        MmU4YWRhNDBkYjA0ZWUxMWVkIn0sICJpZCI6ICI1NmI0ZGUyZThhZGE0MGRi
-        MDRlZTExZWQifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:55 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/bd2515a5-6c0f-4440-af6c-8a462b02b74f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Sy66rVLAWOxJwi0ujlXSScD515lMq9ARGr41dogSQ",
-        oauth_signature="OGpFqyKsUadJia8gqWDOIPq2FUs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693935", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:55 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iZDI1MTVhNS02YzBmLTQ0NDAtYWY2Yy04YTQ2MmIwMmI3
-        NGYvIiwgInRhc2tfaWQiOiAiYmQyNTE1YTUtNmMwZi00NDQwLWFmNmMtOGE0
-        NjJiMDJiNzRmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozODo1NVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODo1NFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMDhmMzUyM2YtYmQxMS00NDg0LWFhOGUtZmJmNzM0YzYw
-        ODVhLyIsICJ0YXNrX2lkIjogIjA4ZjM1MjNmLWJkMTEtNDQ4NC1hYThlLWZi
-        ZjczNGM2MDg1YSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZTJlYzc4MjFiMzMwMzRiYWZkZSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6Mzg6NTRaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozODo1
-        NVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRlMmZjNzgyMWIzNDQ0ZmNjNGEwIiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMmU4YWRhNDBkYjA0ZWUxMWVkIn0s
-        ICJpZCI6ICI1NmI0ZGUyZThhZGE0MGRiMDRlZTExZWQifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:55 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/08f3523f-bd11-4484-aa8e-fbf734c6085a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="B2NadH2Njpu1bxirc2V50T5vAngqwE4tidi4ASL4bLw",
-        oauth_signature="njpn3xOg%2FFbnsBT7QJNrpoU%2FDCI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693935", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:55 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3516'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8wOGYzNTIzZi1iZDExLTQ0ODQtYWE4ZS1mYmY3
-        MzRjNjA4NWEvIiwgInRhc2tfaWQiOiAiMDhmMzUyM2YtYmQxMS00NDg0LWFh
-        OGUtZmJmNzM0YzYwODVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wNVQxNzozODo1NVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlYjdj
-        MGI1Yi01NmE5LTRlYWUtYmQ1NS0wNTAxNDBjMGI2YzAiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTFmYzMxZDktYmNh
-        YS00YzkzLWJhNWYtOGNhZmEyYjlkNTNhIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiNDJkODMwMWEtN2VhOS00ZTc0LTg2ZTgtOGE5MmIxZjBiYjJjIiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTEwYmEwMzctNjViMy00NTk2LWEx
-        ZjQtYzMwYTA0NTA0ODVlIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjViMjFjN2U1LTY4ZmQtNGM5Mi04MWFkLTIyMGM2MjM1MjA0ZCIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJj
-        b21wcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhODAyYmIyZS0xZjdhLTQxMGMt
-        YTNiMS0wNWM1NWI0ODYwMjkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
-        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0
-        YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIzOTU0YjFhZi0yNDU5LTRkNzMtYWNiNC0wNDFiMGU2NDAyYmQi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJmZmE1ZjNjNC0wODhhLTQ3M2MtYTVkNS05NjdiNzVmMmEzOTYiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
-        aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTc3ZWEx
-        MjEtMmZiMC00MjIxLWFiYjQtOWU1ODYwOWY0MDczIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
-        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
-        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzlmM2M4ZjMtOTFj
-        NS00MTYwLTljMmEtMTcyZmVkOWNhZGQ5IiwgIm51bV9wcm9jZXNzZWQiOiAw
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5n
-        IExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVw
-        b19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
-        U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmOGI1OTE5OC02YzEz
-        LTQ2OGYtYmVmMy02ZmM2MWIxMTUzN2IiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
-        bGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmlu
-        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVs
-        bCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0ZGUyZjhh
-        ZGE0MGRiMDRlZTExZmQifSwgImlkIjogIjU2YjRkZTJmOGFkYTQwZGIwNGVl
-        MTFmZCJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:55 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/bd2515a5-6c0f-4440-af6c-8a462b02b74f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="TNOSnHrjzqoMEknSNQXAggm4MXRxAqIxGCl37GGLfg",
-        oauth_signature="jWmtMzHILr3d%2BwsRKS%2FVHvprrTg%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693936", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:56 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2194'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iZDI1MTVhNS02YzBmLTQ0NDAtYWY2Yy04YTQ2MmIwMmI3
-        NGYvIiwgInRhc2tfaWQiOiAiYmQyNTE1YTUtNmMwZi00NDQwLWFmNmMtOGE0
-        NjJiMDJiNzRmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNVQxNzozODo1NVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODo1NFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMDhmMzUyM2YtYmQxMS00NDg0LWFhOGUtZmJmNzM0YzYw
-        ODVhLyIsICJ0YXNrX2lkIjogIjA4ZjM1MjNmLWJkMTEtNDQ4NC1hYThlLWZi
-        ZjczNGM2MDg1YSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
-        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
-        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
-        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRk
-        ZTJlYzc4MjFiMzMwMzRiYWZkZSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDVUMTc6Mzg6NTRaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNzozODo1
-        NVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
-        NTZiNGRlMmZjNzgyMWIzNDQ0ZmNjNGEwIiwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGRlMmU4YWRhNDBkYjA0ZWUxMWVkIn0s
-        ICJpZCI6ICI1NmI0ZGUyZThhZGE0MGRiMDRlZTExZWQifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:56 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/08f3523f-bd11-4484-aa8e-fbf734c6085a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="fxsi7EXUNTfZ7TuShY8SGcTbYJKqkVabkhttD0x6oI",
-        oauth_signature="WFoRi57zYsTzbVjZKeP6YNXKvEw%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693936", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:56 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8wOGYzNTIzZi1iZDExLTQ0ODQtYWE4ZS1mYmY3
-        MzRjNjA4NWEvIiwgInRhc2tfaWQiOiAiMDhmMzUyM2YtYmQxMS00NDg0LWFh
-        OGUtZmJmNzM0YzYwODVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wNVQxNzozODo1NloiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNzozODo1NVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJlYjdjMGI1Yi01NmE5LTRlYWUtYmQ1NS0wNTAxNDBj
-        MGI2YzAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMTFmYzMxZDktYmNhYS00YzkzLWJhNWYtOGNhZmEyYjlkNTNhIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNDJkODMwMWEtN2VhOS00ZTc0LTg2ZTgt
-        OGE5MmIxZjBiYjJjIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTEw
-        YmEwMzctNjViMy00NTk2LWExZjQtYzMwYTA0NTA0ODVlIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjViMjFjN2U1LTY4ZmQtNGM5Mi04MWFkLTIyMGM2
-        MjM1MjA0ZCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhODAyYmIy
-        ZS0xZjdhLTQxMGMtYTNiMS0wNWM1NWI0ODYwMjkiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIzOTU0YjFhZi0yNDU5LTRkNzMtYWNiNC0wNDFi
-        MGU2NDAyYmQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJmZmE1ZjNjNC0wODhhLTQ3M2MtYTVkNS05NjdiNzVmMmEzOTYi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNzdl
-        YTEyMS0yZmIwLTQyMjEtYWJiNC05ZTU4NjA5ZjQwNzMiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzOWYzYzhmMy05MWM1
-        LTQxNjAtOWMyYS0xNzJmZWQ5Y2FkZDkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImY4YjU5MTk4LTZjMTMtNDY4
-        Zi1iZWYzLTZmYzYxYjExNTM3YiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
-        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE3OjM4OjU1
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMDVUMTc6Mzg6NTZaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGRlMzBjNzgyMWIz
-        NDQ0ZmNjNGExIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImViN2MwYjViLTU2YTktNGVhZS1iZDU1LTA1MDE0MGMwYjZj
-        MCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICIxMWZjMzFkOS1iY2FhLTRjOTMtYmE1Zi04Y2FmYTJiOWQ1M2EiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI0MmQ4MzAxYS03ZWE5LTRlNzQtODZlOC04YTky
-        YjFmMGJiMmMiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1MTBiYTAz
-        Ny02NWIzLTQ1OTYtYTFmNC1jMzBhMDQ1MDQ4NWUiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiNWIyMWM3ZTUtNjhmZC00YzkyLTgxYWQtMjIwYzYyMzUy
-        MDRkIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE4MDJiYjJlLTFm
-        N2EtNDEwYy1hM2IxLTA1YzU1YjQ4NjAyOSIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjM5NTRiMWFmLTI0NTktNGQ3My1hY2I0LTA0MWIwZTY0
-        MDJiZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImZmYTVmM2M0LTA4OGEtNDczYy1hNWQ1LTk2N2I3NWYyYTM5NiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE3N2VhMTIx
-        LTJmYjAtNDIyMS1hYmI0LTllNTg2MDlmNDA3MyIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM5ZjNjOGYzLTkxYzUtNDE2
-        MC05YzJhLTE3MmZlZDljYWRkOSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjhiNTkxOTgtNmMxMy00NjhmLWJl
-        ZjMtNmZjNjFiMTE1MzdiIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRkZTJmOGFkYTQwZGIw
-        NGVlMTFmZCJ9LCAiaWQiOiAiNTZiNGRlMmY4YWRhNDBkYjA0ZWUxMWZkIn0=
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:56 GMT
-- request:
-    method: post
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/content/units/rpm/search/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMGE5Y2M5
-        YjYtMzRhNC00NTczLTg2NWMtMDA4MmRiMzcxMmIxIiwiMTU5ZDgyYjgtNTUy
-        NC00NzI5LWI4OTAtMTU5YjIyMzU4NTIwIiwiNTFiNGQwNjItMTNiMy00NTJl
-        LTkyOWMtNGU0NmM1ZGZmZThhIiwiNjYyNjI0NjQtNjhlMS00Mzc3LWIwODIt
-        OTE0ZTg1MzU2NGQyIiwiNzc3ODk3NDMtNTE5Mi00NWJhLWE5MTEtZWRjOTVm
-        ODM3ZmUyIiwiN2M0NDc3NjEtYTczYy00OGYwLWFjMzMtNWQ0YjM0ZDhhNWQ4
-        IiwiODVhNGY2YzItMDBmYy00NDNmLTgxM2QtMjk4MzQ2N2RkZWYyIiwiZmI5
-        Nzg4ZWItODIyOS00NTFkLWIzMTUtMTcyZmFlMjkzN2ZmIl19fSwiZmllbGRz
-        IjpbIm5hbWUiLCJ2ZXJzaW9uIiwicmVsZWFzZSIsImFyY2giLCJlcG9jaCIs
-        InN1bW1hcnkiLCJzb3VyY2VycG0iLCJjaGVja3N1bSIsImZpbGVuYW1lIiwi
-        X2lkIl19LCJpbmNsdWRlX3JlcG9zIjp0cnVlfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
-        oauth_nonce="sfhqX7AtjgnMEQJ41ESgKiBdAD08yhg2682SjDFv3fg", oauth_signature="Yz7SaBLs9wIe%2BPcHAdZUksZdqnQ%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454693936", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '478'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:56 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3804'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJz
-        b3VyY2VycG0iOiAiZWxlcGhhbnQtMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUi
-        OiAiZWxlcGhhbnQiLCAiY2hlY2tzdW0iOiAiM2UxYzcwY2QxYjQyMTMyOGFj
-        YWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFm
-        MyIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBlbGVwaGFudCIs
-        ICJmaWxlbmFtZSI6ICJlbGVwaGFudC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAi
-        ZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAu
-        OCIsICJfaWQiOiAiMGE5Y2M5YjYtMzRhNC00NTczLTg2NWMtMDA4MmRiMzcx
-        MmIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoaWxkcmVuIjoge30sICJfaHJl
-        ZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9ycG0vMGE5Y2M5YjYt
-        MzRhNC00NTczLTg2NWMtMDA4MmRiMzcxMmIxLyJ9LCB7InJlcG9zaXRvcnlf
-        bWVtYmVyc2hpcHMiOiBbIkZlZG9yYV8xNyJdLCAic291cmNlcnBtIjogImNo
-        ZWV0YWgtMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAiY2hlZXRhaCIsICJj
-        aGVja3N1bSI6ICI0MjJkMGJhYTBjZDlkNzcxM2FlNzk2ZTg4NmEyM2UxN2Y1
-        NzhmOTI0Zjc0ODgwZGViZGJiN2Q2NWZiMzY4ZGFlIiwgInN1bW1hcnkiOiAi
-        QSBkdW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCAiZmlsZW5hbWUiOiAiY2hl
-        ZXRhaC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJz
-        aW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiMTU5ZDgy
-        YjgtNTUyNC00NzI5LWI4OTAtMTU5YjIyMzU4NTIwIiwgImFyY2giOiAibm9h
-        cmNoIiwgImNoaWxkcmVuIjoge30sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIv
-        Y29udGVudC91bml0cy9ycG0vMTU5ZDgyYjgtNTUyNC00NzI5LWI4OTAtMTU5
-        YjIyMzU4NTIwLyJ9LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBbIkZl
-        ZG9yYV8xNyJdLCAic291cmNlcnBtIjogIm1vbmtleS0wLjMtMC44LnNyYy5y
-        cG0iLCAibmFtZSI6ICJtb25rZXkiLCAiY2hlY2tzdW0iOiAiMGU4ZmE1MGQw
-        MTI4ZmJhYmM3Y2NjNTYzMmUzZmEyNWQzOWIwMjgwMTY5ZjYxNjZjYjhlMmM4
-        NGRlODUwMWRiMSIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBt
-        b25rZXkiLCAiZmlsZW5hbWUiOiAibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJw
-        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2Ui
-        OiAiMC44IiwgIl9pZCI6ICI1MWI0ZDA2Mi0xM2IzLTQ1MmUtOTI5Yy00ZTQ2
-        YzVkZmZlOGEiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwg
-        Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS81MWI0
-        ZDA2Mi0xM2IzLTQ1MmUtOTI5Yy00ZTQ2YzVkZmZlOGEvIn0sIHsicmVwb3Np
-        dG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJzb3VyY2VycG0i
-        OiAid2FscnVzLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1cyIs
-        ICJjaGVja3N1bSI6ICI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3Yjdm
-        ODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwgInN1bW1hcnki
-        OiAiQSBkdW1teSBwYWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6ICJ3
-        YWxydXMtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVy
-        c2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjY2MjYy
-        NDY0LTY4ZTEtNDM3Ny1iMDgyLTkxNGU4NTM1NjRkMiIsICJhcmNoIjogIm5v
-        YXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
-        L2NvbnRlbnQvdW5pdHMvcnBtLzY2MjYyNDY0LTY4ZTEtNDM3Ny1iMDgyLTkx
-        NGU4NTM1NjRkMi8ifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJG
-        ZWRvcmFfMTciXSwgInNvdXJjZXJwbSI6ICJzcXVpcnJlbC0wLjMtMC44LnNy
-        Yy5ycG0iLCAibmFtZSI6ICJzcXVpcnJlbCIsICJjaGVja3N1bSI6ICIyNTE3
-        NjhiZGQxNWYxM2Q3ODQ4N2MyNzYzOGFhNmFlY2QwMTU1MWUyNTM3NTYwOTNj
-        ZGUxYzBhZTg3OGExN2QyIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdl
-        IG9mIHNxdWlycmVsIiwgImZpbGVuYW1lIjogInNxdWlycmVsLTAuMy0wLjgu
-        bm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwg
-        InJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICI3Nzc4OTc0My01MTkyLTQ1YmEt
-        YTkxMS1lZGM5NWY4MzdmZTIiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRy
-        ZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRz
-        L3JwbS83Nzc4OTc0My01MTkyLTQ1YmEtYTkxMS1lZGM5NWY4MzdmZTIvIn0s
-        IHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJz
-        b3VyY2VycG0iOiAibGlvbi0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJs
-        aW9uIiwgImNoZWNrc3VtIjogIjEyNDAwZGM5NWMyM2E0YzE2MDcyNWE5MDg3
-        MTZjZDNmY2RkN2E4OTgxNTg1NDM3YWI2NGNkNjJlZmEzZTRhZTQiLCAic3Vt
-        bWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgbGlvbiIsICJmaWxlbmFtZSI6
-        ICJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZl
-        cnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICI3YzQ0
-        Nzc2MS1hNzNjLTQ4ZjAtYWMzMy01ZDRiMzRkOGE1ZDgiLCAiYXJjaCI6ICJu
-        b2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92
-        Mi9jb250ZW50L3VuaXRzL3JwbS83YzQ0Nzc2MS1hNzNjLTQ4ZjAtYWMzMy01
-        ZDRiMzRkOGE1ZDgvIn0sIHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsi
-        RmVkb3JhXzE3Il0sICJzb3VyY2VycG0iOiAiZ2lyYWZmZS0wLjMtMC44LnNy
-        Yy5ycG0iLCAibmFtZSI6ICJnaXJhZmZlIiwgImNoZWNrc3VtIjogImYyNWQ2
-        N2QxZDlkYTA0ZjEyZTU3Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRl
-        NmQxOTIyMDA5ZjlmMTQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ug
-        b2YgZ2lyYWZmZSIsICJmaWxlbmFtZSI6ICJnaXJhZmZlLTAuMy0wLjgubm9h
-        cmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJl
-        bGVhc2UiOiAiMC44IiwgIl9pZCI6ICI4NWE0ZjZjMi0wMGZjLTQ0M2YtODEz
-        ZC0yOTgzNDY3ZGRlZjIiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4i
-        OiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3Jw
-        bS84NWE0ZjZjMi0wMGZjLTQ0M2YtODEzZC0yOTgzNDY3ZGRlZjIvIn0sIHsi
-        cmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJzb3Vy
-        Y2VycG0iOiAicGVuZ3Vpbi0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJw
-        ZW5ndWluIiwgImNoZWNrc3VtIjogIjNmY2IyYzkyN2RlOWUxM2JmNjg0Njkw
-        MzJhMjhiMTM5ZDNlNWFkMmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCAi
-        c3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsICJmaWxl
-        bmFtZSI6ICJwZW5ndWluLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6
-        ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgIl9p
-        ZCI6ICJmYjk3ODhlYi04MjI5LTQ1MWQtYjMxNS0xNzJmYWUyOTM3ZmYiLCAi
-        YXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS9mYjk3ODhlYi04MjI5LTQ1
-        MWQtYjMxNS0xNzJmYWUyOTM3ZmYvIn1d
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:56 GMT
-- request:
-    method: post
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/content/units/rpm/search/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMGE5Y2M5
-        YjYtMzRhNC00NTczLTg2NWMtMDA4MmRiMzcxMmIxIl19fX0sImluY2x1ZGVf
-        cmVwb3MiOnRydWV9
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
-        oauth_nonce="K6w8gvqFcSHSIx9ZHJk446w6Cuio42d22Ea3qYy5B8E", oauth_signature="hajXyenOwOcfnBbMjE3W%2B6D3tBA%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454693936", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '102'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:56 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3010'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJf
-        aHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9ycG0vMGE5Y2M5
-        YjYtMzRhNC00NTczLTg2NWMtMDA4MmRiMzcxMmIxLyIsICJidWlsZF90aW1l
-        IjogMTMwODI1NzQ2NiwgImJ1aWxkaG9zdCI6ICJkaGNwLTI2LTExOC5icnEu
-        cmVkaGF0LmNvbSIsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250
-        ZW50X3R5cGVfaWQiOiAicnBtIiwgImNoaWxkcmVuIjoge30sICJzaXplIjog
-        MjI0NCwgImxpY2Vuc2UiOiAiR1BMdjIiLCAiZ3JvdXAiOiAiSW50ZXJuZXQv
-        QXBwbGljYXRpb25zIiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgu
-        bm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwg
-        InZlcnNpb25fc29ydF9pbmRleCI6ICIwMS0wLjAxLTMiLCAicHJvdmlkZXMi
-        OiBbeyJyZWxlYXNlIjogIjAuOCIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24i
-        OiAiMC4zIiwgImZsYWdzIjogIkVRIiwgIm5hbWUiOiAiZWxlcGhhbnQifV0s
-        ICJmaWxlcyI6IHsiZGlyIjogW10sICJmaWxlIjogWyIvL2VsZXBoYW50LnR4
-        dCJdfSwgInJlcG9kYXRhIjogeyJmaWxlbGlzdHMiOiAiPHBhY2thZ2UgYXJj
-        aD1cIm5vYXJjaFwiIG5hbWU9XCJlbGVwaGFudFwiIHBrZ2lkPVwiM2UxYzcw
-        Y2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5NWY2NWQxYjA5NWZj
-        MzEzNzJhMGE3MDFmM1wiPlxuICAgIDx2ZXJzaW9uIGVwb2NoPVwiMFwiIHJl
-        bD1cIjAuOFwiIHZlcj1cIjAuM1wiIC8+XG5cbiAgICA8ZmlsZT4vL2VsZXBo
-        YW50LnR4dDwvZmlsZT5cbjwvcGFja2FnZT5cblxuIiwgIm90aGVyIjogIjxw
-        YWNrYWdlIGFyY2g9XCJub2FyY2hcIiBuYW1lPVwiZWxlcGhhbnRcIiBwa2dp
-        ZD1cIjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVm
-        NjVkMWIwOTVmYzMxMzcyYTBhNzAxZjNcIj5cbiAgICA8dmVyc2lvbiBlcG9j
-        aD1cIjBcIiByZWw9XCIwLjhcIiB2ZXI9XCIwLjNcIiAvPlxuXG48L3BhY2th
-        Z2U+XG5cbiIsICJwcmltYXJ5IjogIjxwYWNrYWdlIHR5cGU9XCJycG1cIj5c
-        biAgPG5hbWU+ZWxlcGhhbnQ8L25hbWU+XG4gIDxhcmNoPm5vYXJjaDwvYXJj
-        aD5cbiAgPHZlcnNpb24gZXBvY2g9XCIwXCIgcmVsPVwiMC44XCIgdmVyPVwi
-        MC4zXCIgLz5cbiAgPGNoZWNrc3VtIHBrZ2lkPVwiWUVTXCIgdHlwZT1cInNo
-        YTI1NlwiPjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJi
-        OTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjM8L2NoZWNrc3VtPlxuICA8c3Vt
-        bWFyeT5BIGR1bW15IHBhY2thZ2Ugb2YgZWxlcGhhbnQ8L3N1bW1hcnk+XG4g
-        IDxkZXNjcmlwdGlvbj5BIGR1bW15IHBhY2thZ2Ugb2YgZWxlcGhhbnQ8L2Rl
-        c2NyaXB0aW9uPlxuICA8cGFja2FnZXIgLz5cbiAgPHVybD5odHRwOi8vdHN0
-        cmFjaG90YS5mZWRvcmFwZW9wbGUub3JnPC91cmw+XG4gIDx0aW1lIGJ1aWxk
-        PVwiMTMwODI1NzQ2NlwiIGZpbGU9XCIxMzIxODkxMDI3XCIgLz5cbiAgPHNp
-        emUgYXJjaGl2ZT1cIjI5NlwiIGluc3RhbGxlZD1cIjQyXCIgcGFja2FnZT1c
-        IjIyNDRcIiAvPlxuPGxvY2F0aW9uIGhyZWY9XCJlbGVwaGFudC0wLjMtMC44
-        Lm5vYXJjaC5ycG1cIi8+XG4gIDxmb3JtYXQ+XG4gICAgPHJwbTpsaWNlbnNl
-        PkdQTHYyPC9ycG06bGljZW5zZT5cbiAgICA8cnBtOnZlbmRvciAvPlxuICAg
-        IDxycG06Z3JvdXA+SW50ZXJuZXQvQXBwbGljYXRpb25zPC9ycG06Z3JvdXA+
-        XG4gICAgPHJwbTpidWlsZGhvc3Q+ZGhjcC0yNi0xMTguYnJxLnJlZGhhdC5j
-        b208L3JwbTpidWlsZGhvc3Q+XG4gICAgPHJwbTpzb3VyY2VycG0+ZWxlcGhh
-        bnQtMC4zLTAuOC5zcmMucnBtPC9ycG06c291cmNlcnBtPlxuICAgIDxycG06
-        aGVhZGVyLXJhbmdlIGVuZD1cIjIwMjhcIiBzdGFydD1cIjI4MFwiIC8+XG4g
-        ICAgPHJwbTpwcm92aWRlcz5cbiAgICAgIDxycG06ZW50cnkgZXBvY2g9XCIw
-        XCIgZmxhZ3M9XCJFUVwiIG5hbWU9XCJlbGVwaGFudFwiIHJlbD1cIjAuOFwi
-        IHZlcj1cIjAuM1wiIC8+XG4gICAgPC9ycG06cHJvdmlkZXM+XG4gICAgPHJw
-        bTpyZXF1aXJlcz5cbiAgICAgIDxycG06ZW50cnkgbmFtZT1cIi9iaW4vc2hc
-        IiBwcmU9XCIxXCIgLz5cbiAgICA8L3JwbTpyZXF1aXJlcz5cbiAgPC9mb3Jt
-        YXQ+XG48L3BhY2thZ2U+XG4ifSwgImRlc2NyaXB0aW9uIjogIkEgZHVtbXkg
-        cGFja2FnZSBvZiBlbGVwaGFudCIsICJfbGFzdF91cGRhdGVkIjogIjIwMTYt
-        MDItMDVUMTc6MzU6MzdaIiwgInRpbWUiOiAxMzIxODkxMDI3LCAiZG93bmxv
-        YWRlZCI6IHRydWUsICJoZWFkZXJfcmFuZ2UiOiB7InN0YXJ0IjogMjgwLCAi
-        ZW5kIjogMjAyOH0sICJhcmNoIjogIm5vYXJjaCIsICJuYW1lIjogImVsZXBo
-        YW50IiwgIl9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVscC9jb250ZW50
-        L3VuaXRzL3JwbS8wYTljLzBhOWNjOWI2LTM0YTQtNDU3My04NjVjLTAwODJk
-        YjM3MTJiMS9lbGVwaGFudC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAic291cmNl
-        cnBtIjogImVsZXBoYW50LTAuMy0wLjguc3JjLnJwbSIsICJjaGVja3N1bXR5
-        cGUiOiAic2hhMjU2IiwgInJlbGVhc2Vfc29ydF9pbmRleCI6ICIwMS0wLjAx
-        LTgiLCAiY2hhbmdlbG9nIjogW10sICJ1cmwiOiAiaHR0cDovL3RzdHJhY2hv
-        dGEuZmVkb3JhcGVvcGxlLm9yZyIsICJjaGVja3N1bSI6ICIzZTFjNzBjZDFi
-        NDIxMzI4YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3
-        MmEwYTcwMWYzIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGVs
-        ZXBoYW50IiwgInJlbGF0aXZlcGF0aCI6ICJlbGVwaGFudC0wLjMtMC44Lm5v
-        YXJjaC5ycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjBhOWNjOWI2
-        LTM0YTQtNDU3My04NjVjLTAwODJkYjM3MTJiMSIsICJyZXF1aXJlcyI6IFt7
-        InJlbGVhc2UiOiBudWxsLCAiZXBvY2giOiBudWxsLCAidmVyc2lvbiI6IG51
-        bGwsICJmbGFncyI6IG51bGwsICJuYW1lIjogIi9iaW4vc2gifV19XQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:56 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/6607dd28-d140-48e8-95a6-df9019e2e59e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="wC0Hc15Cr9JcXOGbVaUjk6eYgfj8HoyoJbSbV30p0Y",
-        oauth_signature="OKXPLJ2mkrnYEUlNM%2Fe%2Fz8MnTuo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693937", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:57 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '669'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NjA3ZGQyOC1kMTQwLTQ4ZTgtOTVhNi1kZjkwMTllMmU1
-        OWUvIiwgInRhc2tfaWQiOiAiNjYwN2RkMjgtZDE0MC00OGU4LTk1YTYtZGY5
-        MDE5ZTJlNTllIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
-        LTAyLTA1VDE3OjM4OjU3WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
-        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYu
-        ZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTIt
-        OC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjog
-        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0ZGUzMThhZGE0MGRiMDRlZTEx
-        ZmUifSwgImlkIjogIjU2YjRkZTMxOGFkYTQwZGIwNGVlMTFmZSJ9
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:57 GMT
-- request:
-    method: get
-    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/6607dd28-d140-48e8-95a6-df9019e2e59e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Zxnw2cp6EF4oz4BfheK24zTIiZeXuVfhG76Afinm8",
-        oauth_signature="DEpPxOBgW7ayRRqr8ZE7vy9ArhQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454693937", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 05 Feb 2016 17:38:57 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NjA3ZGQyOC1kMTQwLTQ4ZTgtOTVhNi1kZjkwMTllMmU1
-        OWUvIiwgInRhc2tfaWQiOiAiNjYwN2RkMjgtZDE0MC00OGU4LTk1YTYtZGY5
-        MDE5ZTJlNTllIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA1VDE3OjM4OjU3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE3OjM4OjU3WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        NGRlMzE4YWRhNDBkYjA0ZWUxMWZlIn0sICJpZCI6ICI1NmI0ZGUzMThhZGE0
-        MGRiMDRlZTExZmUifQ==
-    http_version: 
-  recorded_at: Fri, 05 Feb 2016 17:38:57 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/1d5da143-4072-4c93-9fe0-b5235821e7ee/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="uxVkk61f9iOzYOw3YjN57RDxmXwz3xPmmNETyQSIU",
-        oauth_signature="WVmq4lC6bpmIJnjYKYJaxHDKWm4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950349", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:52:29 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xZDVkYTE0My00MDcyLTRjOTMtOWZlMC1iNTIzNTgyMWU3
-        ZWUvIiwgInRhc2tfaWQiOiAiMWQ1ZGExNDMtNDA3Mi00YzkzLTlmZTAtYjUy
-        MzU4MjFlN2VlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiOGM3Y2Rj
-        MTlmZjUwNzk4MjNmNGI1In0sICJpZCI6ICI1NmI4YzdjZGMxOWZmNTA3OTgy
-        M2Y0YjUifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:52:29 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/1d5da143-4072-4c93-9fe0-b5235821e7ee/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="mi01FsinqPn6iE4B0B34MclMYuQMNxWotLMeP89OTh8",
-        oauth_signature="M5KzzF3nsK4RyeTDx847fHfOBmY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950350", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:52:30 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xZDVkYTE0My00MDcyLTRjOTMtOWZlMC1iNTIzNTgyMWU3
-        ZWUvIiwgInRhc2tfaWQiOiAiMWQ1ZGExNDMtNDA3Mi00YzkzLTlmZTAtYjUy
-        MzU4MjFlN2VlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo1MjozMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo1MjoyOVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZWQyNzA3NGMtNjYzZi00MWY3LTlmMGItNmExMmEwZmMy
-        MjdkLyIsICJ0YXNrX2lkIjogImVkMjcwNzRjLTY2M2YtNDFmNy05ZjBiLTZh
-        MTJhMGZjMjI3ZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjN2NkMTdmMjVlMGRhNWE3Yzg4YSJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NTI6MjlaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo1MjozMFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjN2NlMTdmMjVlMTEyYWU4OGI4NSIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjN2NkYzE5ZmY1
-        MDc5ODIzZjRiNSJ9LCAiaWQiOiAiNTZiOGM3Y2RjMTlmZjUwNzk4MjNmNGI1
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:52:30 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/ed27074c-663f-41f7-9f0b-6a12a0fc227d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="3WmhYCMJGTFBkssuTfKIpADMp0CLKflhlMH5i5enBhw",
-        oauth_signature="zR%2FAokckZWFyOt%2FYqzuc9y%2FwlB0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950350", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:52:30 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3525'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9lZDI3MDc0Yy02NjNmLTQxZjctOWYwYi02YTEy
-        YTBmYzIyN2QvIiwgInRhc2tfaWQiOiAiZWQyNzA3NGMtNjYzZi00MWY3LTlm
-        MGItNmExMmEwZmMyMjdkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wOFQxNjo1MjozMFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNTQ1
-        MDRmYS04ZTNkLTQ4ZjQtODM0Zi1mZjQwYjJkMDlmYzkiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOWEwYjFjYWItZDEz
-        Mi00MjNiLTg4ZDktMzM0YmU3YWU0YTJlIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiYThjM2JhM2QtY2Q3MC00MjM5LTg5OWQtMjllNzAzMDRhYzhhIiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjE0NzE0ZWUtOGJlNi00MjI3LWE1
-        ZTAtZDFmMjExYjJiOThhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjJl
-        NjY1NTA3LTU3NGEtNDYwYi1iNDJkLWFhNGE5YTE4MzE1NyIsICJudW1fcHJv
-        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzNDdiNGMxYS01MWFjLTRjZDctODU4
-        ZS0yMDUzYTQwMjk4NWMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRh
-        dGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICIwNTM0OTMwZi1mY2ZiLTRmM2UtODQzZi1jN2MzN2QzMGFiYzQiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUi
-        OiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIx
-        ZGQ2Y2Y4Zi02ZjVhLTRhMzMtOGMyNS05YmU3OTE5MTIxMDUiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJn
-        ZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODhhZjhiNjMt
-        NjU2OS00YzQ0LWEwYmEtZDI4ZTdmMmEyNjdiIiwgIm51bV9wcm9jZXNzZWQi
-        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJs
-        aXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9k
-        aXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
-        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOGY4ODZkNDctMjYzYy00
-        ZGI3LTgyM2YtM2I3NzZhN2IyMjFmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
-        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExp
-        c3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19t
-        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RB
-        UlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxZWRlMzM1ZC1mOGZhLTQw
-        N2MtOTc0OC05Mjc1MWEzOTEzMWUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0s
-        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
-        LWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVu
-        bmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmI4YzdjZWMxOWZmNTA3OTgyM2Y0YzUifSwgImlkIjogIjU2YjhjN2NlYzE5
-        ZmY1MDc5ODIzZjRjNSJ9
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:52:30 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/1d5da143-4072-4c93-9fe0-b5235821e7ee/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="X7enBs2FAlFI11ziud0y2CYHEgwF3VbJVT7qkuCYxY",
-        oauth_signature="IbeB%2BM3l0lfIOfjdWU4ei6H0PK4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950350", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:52:30 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xZDVkYTE0My00MDcyLTRjOTMtOWZlMC1iNTIzNTgyMWU3
-        ZWUvIiwgInRhc2tfaWQiOiAiMWQ1ZGExNDMtNDA3Mi00YzkzLTlmZTAtYjUy
-        MzU4MjFlN2VlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo1MjozMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo1MjoyOVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZWQyNzA3NGMtNjYzZi00MWY3LTlmMGItNmExMmEwZmMy
-        MjdkLyIsICJ0YXNrX2lkIjogImVkMjcwNzRjLTY2M2YtNDFmNy05ZjBiLTZh
-        MTJhMGZjMjI3ZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjN2NkMTdmMjVlMGRhNWE3Yzg4YSJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NTI6MjlaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo1MjozMFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjN2NlMTdmMjVlMTEyYWU4OGI4NSIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjN2NkYzE5ZmY1
-        MDc5ODIzZjRiNSJ9LCAiaWQiOiAiNTZiOGM3Y2RjMTlmZjUwNzk4MjNmNGI1
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:52:30 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/ed27074c-663f-41f7-9f0b-6a12a0fc227d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="dhhLyAYXr2SjHUfqhwAjNT4VtnnkIcGjBcyJkYXJo",
-        oauth_signature="ojwHPesIKjfK8TR7QKwx008EZDo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950350", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:52:30 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6941'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9lZDI3MDc0Yy02NjNmLTQxZjctOWYwYi02YTEy
-        YTBmYzIyN2QvIiwgInRhc2tfaWQiOiAiZWQyNzA3NGMtNjYzZi00MWY3LTlm
-        MGItNmExMmEwZmMyMjdkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wOFQxNjo1MjozMFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo1MjozMFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIwNTQ1MDRmYS04ZTNkLTQ4ZjQtODM0Zi1mZjQwYjJk
-        MDlmYzkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiOWEwYjFjYWItZDEzMi00MjNiLTg4ZDktMzM0YmU3YWU0YTJlIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiYThjM2JhM2QtY2Q3MC00MjM5LTg5OWQt
-        MjllNzAzMDRhYzhhIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjE0
-        NzE0ZWUtOGJlNi00MjI3LWE1ZTAtZDFmMjExYjJiOThhIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjJlNjY1NTA3LTU3NGEtNDYwYi1iNDJkLWFhNGE5
-        YTE4MzE1NyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzNDdiNGMx
-        YS01MWFjLTRjZDctODU4ZS0yMDUzYTQwMjk4NWMiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIwNTM0OTMwZi1mY2ZiLTRmM2UtODQzZi1jN2Mz
-        N2QzMGFiYzQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIxZGQ2Y2Y4Zi02ZjVhLTRhMzMtOGMyNS05YmU3OTE5MTIxMDUi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4OGFm
-        OGI2My02NTY5LTRjNDQtYTBiYS1kMjhlN2YyYTI2N2IiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4Zjg4NmQ0Ny0yNjNj
-        LTRkYjctODIzZi0zYjc3NmE3YjIyMWYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjFlZGUzMzVkLWY4ZmEtNDA3
-        Yy05NzQ4LTkyNzUxYTM5MTMxZSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Y2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAy
-        LTA4VDE2OjUyOjMwWiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMi
-        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMDhUMTY6NTI6MzBaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0
-        cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJ
-        UFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQi
-        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjog
-        IkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklO
-        SVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hf
-        ZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIs
-        ICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51
-        bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZi
-        OGM3Y2UxN2YyNWUxMTJhZTg4Yjg2IiwgImRldGFpbHMiOiBbeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
-        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
-        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjA1NDUwNGZhLThlM2QtNDhmNC04MzRm
-        LWZmNDBiMmQwOWZjOSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
-        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI5YTBiMWNhYi1kMTMyLTQyM2ItODhkOS0zMzRiZTdh
-        ZTRhMmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        OCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
-        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhOGMzYmEzZC1jZDcwLTQy
-        MzktODk5ZC0yOWU3MDMwNGFjOGEiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7
-        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICJmMTQ3MTRlZS04YmU2LTQyMjctYTVlMC1kMWYyMTFiMmI5OGEiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
-        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmU2NjU1MDctNTc0YS00NjBiLWI0
-        MmQtYWE0YTlhMTgzMTU3IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBz
-        IGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjog
-        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjM0N2I0YzFhLTUxYWMtNGNkNy04NThlLTIwNTNhNDAyOTg1YyIsICJudW1f
-        cHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA1MzQ5MzBmLWZjZmItNGYzZS04
-        NDNmLWM3YzM3ZDMwYWJjNCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjFkZDZjZjhmLTZmNWEtNGEzMy04YzI1LTliZTc5
-        MTkxMjEwNSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMi
-        LCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjg4YWY4YjYzLTY1NjktNGM0NC1hMGJhLWQyOGU3ZjJhMjY3YiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBl
-        IjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjhmODg2
-        ZDQ3LTI2M2MtNGRiNy04MjNmLTNiNzc2YTdiMjIxZiIsICJudW1fcHJvY2Vz
-        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
-        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMWVkZTMzNWQt
-        ZjhmYS00MDdjLTk3NDgtOTI3NTFhMzkxMzFlIiwgIm51bV9wcm9jZXNzZWQi
-        OiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Yjhj
-        N2NlYzE5ZmY1MDc5ODIzZjRjNSJ9LCAiaWQiOiAiNTZiOGM3Y2VjMTlmZjUw
-        Nzk4MjNmNGM1In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:52:30 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/99f2e1d2-ca78-4bdc-84ba-61e51864c4d5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="z2jnzZH8gi13GawBZe6i7U9SAWm2ZA9P1joW0WCFNA",
-        oauth_signature="E8GbfFZcIPM0Sd5ZY%2B7UqEVRxD8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950351", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:52:31 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85OWYyZTFkMi1jYTc4LTRiZGMtODRiYS02MWU1MTg2NGM0
-        ZDUvIiwgInRhc2tfaWQiOiAiOTlmMmUxZDItY2E3OC00YmRjLTg0YmEtNjFl
-        NTE4NjRjNGQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI4Yzdj
-        ZmMxOWZmNTA3OTgyM2Y0YzYifSwgImlkIjogIjU2YjhjN2NmYzE5ZmY1MDc5
-        ODIzZjRjNiJ9
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:52:31 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/99f2e1d2-ca78-4bdc-84ba-61e51864c4d5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="0afZYJZqka9WThiqHguX6ko8fBwRxPMHIDekmuLASg",
-        oauth_signature="pIlKhBKjuhx%2B5ZnYnF3RG8htI6w%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950352", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:52:32 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '700'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85OWYyZTFkMi1jYTc4LTRiZGMtODRiYS02MWU1MTg2NGM0
-        ZDUvIiwgInRhc2tfaWQiOiAiOTlmMmUxZDItY2E3OC00YmRjLTg0YmEtNjFl
-        NTE4NjRjNGQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA4VDE2OjUyOjMxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA4VDE2OjUyOjMxWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20uZHEiLCAic3Rh
-        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUu
-        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNTZiOGM3Y2ZjMTlmZjUwNzk4MjNmNGM2In0sICJpZCI6ICI1
-        NmI4YzdjZmMxOWZmNTA3OTgyM2Y0YzYifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:52:32 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/5f1ee007-efc6-4e43-95ea-bf4fc744f485/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="UVYByYfL1Kj7q5pU3SKopxsbVrNqxnh3s3gEeU1UeU",
-        oauth_signature="zwvTjACxKANXie0tM6Qm2P%2BReUY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950353", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:52:33 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81ZjFlZTAwNy1lZmM2LTRlNDMtOTVlYS1iZjRmYzc0NGY0
-        ODUvIiwgInRhc2tfaWQiOiAiNWYxZWUwMDctZWZjNi00ZTQzLTk1ZWEtYmY0
-        ZmM3NDRmNDg1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiOGM3ZDFj
-        MTlmZjUwNzk4MjNmNGM3In0sICJpZCI6ICI1NmI4YzdkMWMxOWZmNTA3OTgy
-        M2Y0YzcifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:52:33 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/5f1ee007-efc6-4e43-95ea-bf4fc744f485/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="C7FKVnHMmyxl5zFp23W7QDTKVtcB6gj8sQpoAkdzg3w",
-        oauth_signature="SYgxWm99LgE0cvoWTomO9ivo5k4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950353", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:52:33 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81ZjFlZTAwNy1lZmM2LTRlNDMtOTVlYS1iZjRmYzc0NGY0
-        ODUvIiwgInRhc2tfaWQiOiAiNWYxZWUwMDctZWZjNi00ZTQzLTk1ZWEtYmY0
-        ZmM3NDRmNDg1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo1MjozM1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo1MjozM1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZDI2ZjcyODUtMmIzMy00OWE5LThjMmItZWQ2YjE4MzA5
-        MzdjLyIsICJ0YXNrX2lkIjogImQyNmY3Mjg1LTJiMzMtNDlhOS04YzJiLWVk
-        NmIxODMwOTM3YyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjN2QwMTdmMjVlMGRhNjcwZGQ3MSJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NTI6MzNaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo1MjozM1oiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjN2QxMTdmMjVlMTEyYWU4OGI4YSIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjN2QxYzE5ZmY1
-        MDc5ODIzZjRjNyJ9LCAiaWQiOiAiNTZiOGM3ZDFjMTlmZjUwNzk4MjNmNGM3
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:52:33 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/d26f7285-2b33-49a9-8c2b-ed6b1830937c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="Lc9EN5Oq06ZEX9i0Ya2DM19IWLx8oEkcov33LFZLfg",
-        oauth_signature="0b5iUDH%2BgtWEGZfkNmHDHdkbXNE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950353", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:52:33 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3522'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9kMjZmNzI4NS0yYjMzLTQ5YTktOGMyYi1lZDZi
-        MTgzMDkzN2MvIiwgInRhc2tfaWQiOiAiZDI2ZjcyODUtMmIzMy00OWE5LThj
-        MmItZWQ2YjE4MzA5MzdjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wOFQxNjo1MjozM1oiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjYmYx
-        YzhlZi0wMWM1LTQxM2YtODFlNy01MmQ5Y2E0NmE5ODIiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOWNjYTA2ODMtZjEw
-        ZC00YzMxLWE5NzktZGE0ZTA2MTFlMmYwIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiMmU1YzJjNDYtMTRmOS00NjkwLWJkMTktOWFkZDZmNmNhMjc2IiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzA1ZmIwNjctYzJjNy00YThhLTg0
-        NTUtMDA0ZTcxYmQ1YTVjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ5
-        YzgwNGVmLWMxMDQtNDI3NS1hY2M3LTMzMDJjYTNmY2E5YyIsICJudW1fcHJv
-        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIwZDVmMmVkMy04OTJiLTQ4NWEtOTRiNC1h
-        MGMyZmYwZmY3YjEiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEu
-        IiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJmYmZhM2I0ZC0wMTA1LTRlZDgtYTUwNS1jNzQ0YTYzZTA3MTgiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
-        aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAi
-        Y2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4ZWRj
-        Yzk5OC01ZTIxLTRiY2EtODE3NS1hYjA5MmEyMzk4NTIiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
-        IkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5l
-        cmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
-        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTg1ZjRmNWMtODcy
-        MS00YjM2LWEyZmUtOWYxZTI3MzlmOWZjIiwgIm51bV9wcm9jZXNzZWQiOiAw
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJl
-        Y3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYmY0MTgwNGEtMGNhOC00M2Fh
-        LWEwNmYtOTlhYzBhNDg5YjMxIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
-        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3Rp
-        bmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRh
-        ZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxMWQxNjlmYS1lZDA4LTRiOWYt
-        YjkzNS05YWFhYmJkYzcxZWEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJx
-        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLWNl
-        bnRvczctZGV2ZWwuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmlu
-        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20iLCAicmVzdWx0
-        IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI4
-        YzdkMWMxOWZmNTA3OTgyM2Y0ZDcifSwgImlkIjogIjU2YjhjN2QxYzE5ZmY1
-        MDc5ODIzZjRkNyJ9
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:52:33 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/5f1ee007-efc6-4e43-95ea-bf4fc744f485/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="z8eJCmPcb8m5k2lWCrqxAWYIouIrCuQ11yG0Nb7c",
-        oauth_signature="7BY0rlbul6D%2FiUtQ9cT95q27sIo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950354", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:52:34 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81ZjFlZTAwNy1lZmM2LTRlNDMtOTVlYS1iZjRmYzc0NGY0
-        ODUvIiwgInRhc2tfaWQiOiAiNWYxZWUwMDctZWZjNi00ZTQzLTk1ZWEtYmY0
-        ZmM3NDRmNDg1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo1MjozM1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo1MjozM1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZDI2ZjcyODUtMmIzMy00OWE5LThjMmItZWQ2YjE4MzA5
-        MzdjLyIsICJ0YXNrX2lkIjogImQyNmY3Mjg1LTJiMzMtNDlhOS04YzJiLWVk
-        NmIxODMwOTM3YyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjN2QwMTdmMjVlMGRhNjcwZGQ3MSJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NTI6MzNaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo1MjozM1oiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjN2QxMTdmMjVlMTEyYWU4OGI4YSIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjN2QxYzE5ZmY1
-        MDc5ODIzZjRjNyJ9LCAiaWQiOiAiNTZiOGM3ZDFjMTlmZjUwNzk4MjNmNGM3
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:52:34 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/d26f7285-2b33-49a9-8c2b-ed6b1830937c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="6NYyctX7bPUleSrzL4rJqyTVGu1M62rfSZSjTg1Y",
-        oauth_signature="dXNwYSFCWTQO47oXOr4%2FPT0G%2FsM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950354", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:52:34 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6941'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9kMjZmNzI4NS0yYjMzLTQ5YTktOGMyYi1lZDZi
-        MTgzMDkzN2MvIiwgInRhc2tfaWQiOiAiZDI2ZjcyODUtMmIzMy00OWE5LThj
-        MmItZWQ2YjE4MzA5MzdjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wOFQxNjo1MjozNFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo1MjozM1oiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJjYmYxYzhlZi0wMWM1LTQxM2YtODFlNy01MmQ5Y2E0
-        NmE5ODIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiOWNjYTA2ODMtZjEwZC00YzMxLWE5NzktZGE0ZTA2MTFlMmYwIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMmU1YzJjNDYtMTRmOS00NjkwLWJkMTkt
-        OWFkZDZmNmNhMjc2IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzA1
-        ZmIwNjctYzJjNy00YThhLTg0NTUtMDA0ZTcxYmQ1YTVjIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImQ5YzgwNGVmLWMxMDQtNDI3NS1hY2M3LTMzMDJj
-        YTNmY2E5YyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwZDVmMmVk
-        My04OTJiLTQ4NWEtOTRiNC1hMGMyZmYwZmY3YjEiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJmYmZhM2I0ZC0wMTA1LTRlZDgtYTUwNS1jNzQ0
-        YTYzZTA3MTgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI4ZWRjYzk5OC01ZTIxLTRiY2EtODE3NS1hYjA5MmEyMzk4NTIi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1ODVm
-        NGY1Yy04NzIxLTRiMzYtYTJmZS05ZjFlMjczOWY5ZmMiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiZjQxODA0YS0wY2E4
-        LTQzYWEtYTA2Zi05OWFjMGE0ODliMzEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjExZDE2OWZhLWVkMDgtNGI5
-        Zi1iOTM1LTlhYWFiYmRjNzFlYSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Y2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAy
-        LTA4VDE2OjUyOjMzWiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMi
-        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMDhUMTY6NTI6MzRaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0
-        cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJ
-        UFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQi
-        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjog
-        IkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklO
-        SVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hf
-        ZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIs
-        ICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51
-        bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZi
-        OGM3ZDIxN2YyNWUxMTJhZTg4YjhiIiwgImRldGFpbHMiOiBbeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
-        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
-        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImNiZjFjOGVmLTAxYzUtNDEzZi04MWU3
-        LTUyZDljYTQ2YTk4MiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
-        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI5Y2NhMDY4My1mMTBkLTRjMzEtYTk3OS1kYTRlMDYx
-        MWUyZjAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        OCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
-        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyZTVjMmM0Ni0xNGY5LTQ2
-        OTAtYmQxOS05YWRkNmY2Y2EyNzYiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7
-        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICJjMDVmYjA2Ny1jMmM3LTRhOGEtODQ1NS0wMDRlNzFiZDVhNWMiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
-        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDljODA0ZWYtYzEwNC00Mjc1LWFj
-        YzctMzMwMmNhM2ZjYTljIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBz
-        IGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjog
-        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjBkNWYyZWQzLTg5MmItNDg1YS05NGI0LWEwYzJmZjBmZjdiMSIsICJudW1f
-        cHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZiZmEzYjRkLTAxMDUtNGVkOC1h
-        NTA1LWM3NDRhNjNlMDcxOCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjhlZGNjOTk4LTVlMjEtNGJjYS04MTc1LWFiMDky
-        YTIzOTg1MiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMi
-        LCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjU4NWY0ZjVjLTg3MjEtNGIzNi1hMmZlLTlmMWUyNzM5ZjlmYyIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBl
-        IjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJmNDE4
-        MDRhLTBjYTgtNDNhYS1hMDZmLTk5YWMwYTQ4OWIzMSIsICJudW1fcHJvY2Vz
-        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
-        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTFkMTY5ZmEt
-        ZWQwOC00YjlmLWI5MzUtOWFhYWJiZGM3MWVhIiwgIm51bV9wcm9jZXNzZWQi
-        OiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Yjhj
-        N2QxYzE5ZmY1MDc5ODIzZjRkNyJ9LCAiaWQiOiAiNTZiOGM3ZDFjMTlmZjUw
-        Nzk4MjNmNGQ3In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:52:34 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/25908ab6-0d07-4c39-971b-1adedc8f3524/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="lIpgPcguy2NUQiGTr4CMT5jaBs6e9zuDtGazjeuc",
-        oauth_signature="ghpXN%2F3b1My85ok0N%2BPbFiHqbpY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950355", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:52:35 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yNTkwOGFiNi0wZDA3LTRjMzktOTcxYi0xYWRlZGM4ZjM1
-        MjQvIiwgInRhc2tfaWQiOiAiMjU5MDhhYjYtMGQwNy00YzM5LTk3MWItMWFk
-        ZWRjOGYzNTI0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI4Yzdk
-        M2MxOWZmNTA3OTgyM2Y0ZDgifSwgImlkIjogIjU2YjhjN2QzYzE5ZmY1MDc5
-        ODIzZjRkOCJ9
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:52:35 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/25908ab6-0d07-4c39-971b-1adedc8f3524/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="RpRLwLYAPxPLuaNUTOSexcReSgWZbL2FsloctWPcY",
-        oauth_signature="ck5dLpnI%2FqZX%2BzShDXS2tbv0LUw%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950355", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:52:35 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '700'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yNTkwOGFiNi0wZDA3LTRjMzktOTcxYi0xYWRlZGM4ZjM1
-        MjQvIiwgInRhc2tfaWQiOiAiMjU5MDhhYjYtMGQwNy00YzM5LTk3MWItMWFk
-        ZWRjOGYzNTI0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA4VDE2OjUyOjM1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA4VDE2OjUyOjM1WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20uZHEiLCAic3Rh
-        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUu
-        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNTZiOGM3ZDNjMTlmZjUwNzk4MjNmNGQ4In0sICJpZCI6ICI1
-        NmI4YzdkM2MxOWZmNTA3OTgyM2Y0ZDgifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:52:35 GMT
-- request:
-    method: post
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
-        IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRp
-        c3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwi
-        OiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3Rl
-        Y3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJleHBvcnRfZGlzdHJpYnV0
-        b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBz
-        IjpmYWxzZSwicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIn0sImF1dG9fcHVi
-        bGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1
-        dG9yIn1dfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb",
-        oauth_nonce="EsvdWPPM94CnJG3D7Sl7NYQ1zrpXojsCK4AODhxh3HA", oauth_signature="6s34JcLJXK9AjCYJ2c8gvmfMQR0%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454950356", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '817'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:52:36 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '320'
-      Location:
-      - https://katello-centos7-devel.example.com/pulp/api/v2/repositories/Fedora_17/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: US-ASCII
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiOGM3ZDQxN2YyNWUwZGE0OGI4NGE4In0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:52:36 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/f01e5eea-6d2c-4e10-99ca-d3fd634c2a8a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="YgTsEiZtZocQaZzyXRi2kblZbtr7RhEtxzOoiuaUfY",
-        oauth_signature="XyZnXsEHkLY0EoWnHwDQbl41gG4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950356", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:52:36 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '679'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mMDFlNWVlYS02ZDJjLTRlMTAtOTljYS1kM2ZkNjM0YzJh
-        OGEvIiwgInRhc2tfaWQiOiAiZjAxZTVlZWEtNmQyYy00ZTEwLTk5Y2EtZDNm
-        ZDYzNGMyYThhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0wOFQxNjo1MjozNloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRl
-        dmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29y
-        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
-        by1jZW50b3M3LWRldmVsLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGws
-        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiOGM3ZDRjMTlm
-        ZjUwNzk4MjNmNGQ5In0sICJpZCI6ICI1NmI4YzdkNGMxOWZmNTA3OTgyM2Y0
-        ZDkifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:52:36 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/f01e5eea-6d2c-4e10-99ca-d3fd634c2a8a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="W9tybI43AO8C6UeRO8pNcZrbhyiGI9zcVj1OdDiFPBc",
-        oauth_signature="SufhuatjVqnMbah2I6%2Bz9%2FDttZo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950357", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:52:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mMDFlNWVlYS02ZDJjLTRlMTAtOTljYS1kM2ZkNjM0YzJh
-        OGEvIiwgInRhc2tfaWQiOiAiZjAxZTVlZWEtNmQyYy00ZTEwLTk5Y2EtZDNm
-        ZDYzNGMyYThhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo1MjozN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo1MjozNloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvODZhMDNmMGMtZjI2Zi00M2VjLWIzZGMtMzM0NWMwZWRl
-        OWI5LyIsICJ0YXNrX2lkIjogIjg2YTAzZjBjLWYyNmYtNDNlYy1iM2RjLTMz
-        NDVjMGVkZTliOSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjN2Q0MTdmMjVlMGRhNDhiODRhOSJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NTI6MzZaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo1MjozN1oiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjN2Q1MTdmMjVlMTEyYWU4OGI4ZiIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjN2Q0YzE5ZmY1
-        MDc5ODIzZjRkOSJ9LCAiaWQiOiAiNTZiOGM3ZDRjMTlmZjUwNzk4MjNmNGQ5
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:52:37 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/86a03f0c-f26f-43ec-b3dc-3345c0ede9b9/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="xKBMHtVW9tvP0j1nKLs5mmb5RMx6u67AaBIylGmB67o",
-        oauth_signature="0ElCk4BnsfbmBI09iO9GN%2BkFIqc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950357", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:52:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3525'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84NmEwM2YwYy1mMjZmLTQzZWMtYjNkYy0zMzQ1
-        YzBlZGU5YjkvIiwgInRhc2tfaWQiOiAiODZhMDNmMGMtZjI2Zi00M2VjLWIz
-        ZGMtMzM0NWMwZWRlOWI5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0wOFQxNjo1MjozN1oiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2ZjYx
-        ZjNkMC1jMmYzLTRkYzktODg4YS03NDAyYmJiOTFmZWIiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODE5MzI0YTctMzlm
-        MC00YTVhLThlNDAtNWQ3MDdhNTMzMWJjIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiY2M3NmE2NWUtOWEwNS00NTA1LWJiODYtNzIwM2VhZTUyNTRlIiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjc5YzY0ZWQtNzQ5NS00NTg3LThm
-        YjQtNTIwN2I1ZTcwNmY3IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjFm
-        MWYyM2I5LTM5M2UtNGY1MS1hOGMyLTYwMmFhMDY1OTJiZSIsICJudW1fcHJv
-        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4OGUzOTM0Mi1jZmE3LTQyODMtYmQ1
-        NS1iOTUwN2EzYjZlY2UiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
-        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRh
-        dGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI5NDQ0ZTg1NC02MmQ4LTRkNTItYTFmZi05M2QwM2U1YWExZDMiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUi
-        OiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3
-        OGUxODgwZS01ZmRhLTRmMmQtOTZhMC01NTk1ZGNjNDcyM2YiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJn
-        ZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiN2JjZjE1NTAt
-        Njk4MS00MzEyLTg5N2YtYTkxNWFkMzNjNmU1IiwgIm51bV9wcm9jZXNzZWQi
-        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJs
-        aXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9k
-        aXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
-        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYmU0ZDY2OTMtYzhmYS00
-        ZGI3LWE0M2QtM2VkMjk1MjQ5ZGI3IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
-        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExp
-        c3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19t
-        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RB
-        UlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5NWRhNmUxOC0wZjBlLTRk
-        NzUtYTdhZi1hNDg3ZWJkZTE2N2IiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0s
-        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
-        LWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVu
-        bmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmI4YzdkNWMxOWZmNTA3OTgyM2Y0ZTkifSwgImlkIjogIjU2YjhjN2Q1YzE5
-        ZmY1MDc5ODIzZjRlOSJ9
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:52:37 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/f01e5eea-6d2c-4e10-99ca-d3fd634c2a8a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="5Jwm8DLs64lqObZVF4dS8B8Vx2nb3rgHach6ctrPDGc",
-        oauth_signature="FWXy15iEJi16%2ByIUkkPlE5WiQMk%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950358", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:52:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2207'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mMDFlNWVlYS02ZDJjLTRlMTAtOTljYS1kM2ZkNjM0YzJh
-        OGEvIiwgInRhc2tfaWQiOiAiZjAxZTVlZWEtNmQyYy00ZTEwLTk5Y2EtZDNm
-        ZDYzNGMyYThhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wOFQxNjo1MjozN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo1MjozNloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvODZhMDNmMGMtZjI2Zi00M2VjLWIzZGMtMzM0NWMwZWRl
-        OWI5LyIsICJ0YXNrX2lkIjogIjg2YTAzZjBjLWYyNmYtNDNlYy1iM2RjLTMz
-        NDVjMGVkZTliOSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1j
-        ZW50b3M3LWRldmVsLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGthdGVsbG8tY2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
-        b2lkIjogIjU2YjhjN2Q0MTdmMjVlMGRhNDhiODRhOSJ9LCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDhUMTY6NTI6MzZaIiwgIl9u
-        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
-        Mi0wOFQxNjo1MjozN1oiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50
-        IjogMCwgImlkIjogIjU2YjhjN2Q1MTdmMjVlMTEyYWU4OGI4ZiIsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjhjN2Q0YzE5ZmY1
-        MDc5ODIzZjRkOSJ9LCAiaWQiOiAiNTZiOGM3ZDRjMTlmZjUwNzk4MjNmNGQ5
-        In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:52:38 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/86a03f0c-f26f-43ec-b3dc-3345c0ede9b9/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="2b8ScwgdccrAoIB7FgF1ztHMzW1f8V87MK1JE4paJc",
-        oauth_signature="RHmnnRkUy3c%2FiMUFygpnlt18aFg%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950358", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:52:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6941'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84NmEwM2YwYy1mMjZmLTQzZWMtYjNkYy0zMzQ1
-        YzBlZGU5YjkvIiwgInRhc2tfaWQiOiAiODZhMDNmMGMtZjI2Zi00M2VjLWIz
-        ZGMtMzM0NWMwZWRlOWI5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0wOFQxNjo1MjozN1oiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wOFQxNjo1MjozN1oiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI2ZjYxZjNkMC1jMmYzLTRkYzktODg4YS03NDAyYmJi
-        OTFmZWIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiODE5MzI0YTctMzlmMC00YTVhLThlNDAtNWQ3MDdhNTMzMWJjIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiY2M3NmE2NWUtOWEwNS00NTA1LWJiODYt
-        NzIwM2VhZTUyNTRlIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjc5
-        YzY0ZWQtNzQ5NS00NTg3LThmYjQtNTIwN2I1ZTcwNmY3IiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjFmMWYyM2I5LTM5M2UtNGY1MS1hOGMyLTYwMmFh
-        MDY1OTJiZSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4OGUzOTM0
-        Mi1jZmE3LTQyODMtYmQ1NS1iOTUwN2EzYjZlY2UiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI5NDQ0ZTg1NC02MmQ4LTRkNTItYTFmZi05M2Qw
-        M2U1YWExZDMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI3OGUxODgwZS01ZmRhLTRmMmQtOTZhMC01NTk1ZGNjNDcyM2Yi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3YmNm
-        MTU1MC02OTgxLTQzMTItODk3Zi1hOTE1YWQzM2M2ZTUiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiZTRkNjY5My1jOGZh
-        LTRkYjctYTQzZC0zZWQyOTUyNDlkYjciLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjk1ZGE2ZTE4LTBmMGUtNGQ3
-        NS1hN2FmLWE0ODdlYmRlMTY3YiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
-        Y2VudG9zNy1kZXZlbC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAy
-        LTA4VDE2OjUyOjM3WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMi
-        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMDhUMTY6NTI6MzdaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0
-        cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJ
-        UFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQi
-        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjog
-        IkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklO
-        SVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hf
-        ZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIs
-        ICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51
-        bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZi
-        OGM3ZDUxN2YyNWUxMTJhZTg4YjkwIiwgImRldGFpbHMiOiBbeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
-        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
-        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjZmNjFmM2QwLWMyZjMtNGRjOS04ODhh
-        LTc0MDJiYmI5MWZlYiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
-        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI4MTkzMjRhNy0zOWYwLTRhNWEtOGU0MC01ZDcwN2E1
-        MzMxYmMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        OCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
-        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjYzc2YTY1ZS05YTA1LTQ1
-        MDUtYmI4Ni03MjAzZWFlNTI1NGUiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7
-        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICIyNzljNjRlZC03NDk1LTQ1ODctOGZiNC01MjA3YjVlNzA2ZjciLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
-        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMWYxZjIzYjktMzkzZS00ZjUxLWE4
-        YzItNjAyYWEwNjU5MmJlIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBz
-        IGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjog
-        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        Ijg4ZTM5MzQyLWNmYTctNDI4My1iZDU1LWI5NTA3YTNiNmVjZSIsICJudW1f
-        cHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjk0NDRlODU0LTYyZDgtNGQ1Mi1h
-        MWZmLTkzZDAzZTVhYTFkMyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjc4ZTE4ODBlLTVmZGEtNGYyZC05NmEwLTU1OTVk
-        Y2M0NzIzZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMi
-        LCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjdiY2YxNTUwLTY5ODEtNDMxMi04OTdmLWE5MTVhZDMzYzZlNSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBl
-        IjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJlNGQ2
-        NjkzLWM4ZmEtNGRiNy1hNDNkLTNlZDI5NTI0OWRiNyIsICJudW1fcHJvY2Vz
-        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
-        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTVkYTZlMTgt
-        MGYwZS00ZDc1LWE3YWYtYTQ4N2ViZGUxNjdiIiwgIm51bV9wcm9jZXNzZWQi
-        OiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Yjhj
-        N2Q1YzE5ZmY1MDc5ODIzZjRlOSJ9LCAiaWQiOiAiNTZiOGM3ZDVjMTlmZjUw
-        Nzk4MjNmNGU5In0=
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:52:38 GMT
-- request:
-    method: post
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/content/units/rpm/search/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMTM4ZjFj
-        NjAtMzFlNy00YWFlLWEyMzYtMmU4ZDFhZDNkMmIwIiwiMzc4Mjc1M2ItYTM5
-        Yy00YTY1LThiNDctYWQwYzI0OGY1NDBkIiwiN2ZhOWI3ODMtZDZjZi00OTcx
-        LWI3OWUtZTJiYWQwODA1NTU2IiwiOGNkN2UxNWItYWQ0MC00Yjc3LTk2NWQt
-        YWMxNWY3ZDY3ODZmIiwiYWRkNGYyN2MtNWQ3NS00YzVlLTg4MDMtMTBhM2Mz
-        ZGY0ZGI5IiwiZDQ4NmRjYTYtZDc3Zi00M2I3LTg1Y2MtMmEwMjkzMTFiOGI5
-        IiwiZjIzYmE0OTYtYWI0Yy00Yjk2LTk1MDgtY2FlZjEzMDIzOGMyIiwiZmIw
-        OGNmMjAtMjFhMS00OGE3LTk2NTMtYzg3MmI0ZTVkMzMyIl19fSwiZmllbGRz
-        IjpbIm5hbWUiLCJ2ZXJzaW9uIiwicmVsZWFzZSIsImFyY2giLCJlcG9jaCIs
-        InN1bW1hcnkiLCJzb3VyY2VycG0iLCJjaGVja3N1bSIsImZpbGVuYW1lIiwi
-        X2lkIl19LCJpbmNsdWRlX3JlcG9zIjp0cnVlfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb",
-        oauth_nonce="iNo3RpKnhlJ5FlznGg3yYGLQMrWNZxUD4G9sbfF8", oauth_signature="DVpkWDkS0zXxeplKc8PXRfsvZ6Q%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454950358", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '478'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:52:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3804'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJz
-        b3VyY2VycG0iOiAid2FscnVzLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjog
-        IndhbHJ1cyIsICJjaGVja3N1bSI6ICI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBk
-        YzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwg
-        InN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxl
-        bmFtZSI6ICJ3YWxydXMtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjog
-        IjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lk
-        IjogIjEzOGYxYzYwLTMxZTctNGFhZS1hMjM2LTJlOGQxYWQzZDJiMCIsICJh
-        cmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBtLzEzOGYxYzYwLTMxZTctNGFh
-        ZS1hMjM2LTJlOGQxYWQzZDJiMC8ifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNo
-        aXBzIjogWyJGZWRvcmFfMTciXSwgInNvdXJjZXJwbSI6ICJtb25rZXktMC4z
-        LTAuOC5zcmMucnBtIiwgIm5hbWUiOiAibW9ua2V5IiwgImNoZWNrc3VtIjog
-        IjBlOGZhNTBkMDEyOGZiYWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2
-        MTY2Y2I4ZTJjODRkZTg1MDFkYjEiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBh
-        Y2thZ2Ugb2YgbW9ua2V5IiwgImZpbGVuYW1lIjogIm1vbmtleS0wLjMtMC44
-        Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIs
-        ICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiMzc4Mjc1M2ItYTM5Yy00YTY1
-        LThiNDctYWQwYzI0OGY1NDBkIiwgImFyY2giOiAibm9hcmNoIiwgImNoaWxk
-        cmVuIjoge30sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0
-        cy9ycG0vMzc4Mjc1M2ItYTM5Yy00YTY1LThiNDctYWQwYzI0OGY1NDBkLyJ9
-        LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBbIkZlZG9yYV8xNyJdLCAi
-        c291cmNlcnBtIjogImNoZWV0YWgtMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUi
-        OiAiY2hlZXRhaCIsICJjaGVja3N1bSI6ICI0MjJkMGJhYTBjZDlkNzcxM2Fl
-        Nzk2ZTg4NmEyM2UxN2Y1NzhmOTI0Zjc0ODgwZGViZGJiN2Q2NWZiMzY4ZGFl
-        IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCAi
-        ZmlsZW5hbWUiOiAiY2hlZXRhaC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBv
-        Y2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIs
-        ICJfaWQiOiAiN2ZhOWI3ODMtZDZjZi00OTcxLWI3OWUtZTJiYWQwODA1NTU2
-        IiwgImFyY2giOiAibm9hcmNoIiwgImNoaWxkcmVuIjoge30sICJfaHJlZiI6
-        ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9ycG0vN2ZhOWI3ODMtZDZj
-        Zi00OTcxLWI3OWUtZTJiYWQwODA1NTU2LyJ9LCB7InJlcG9zaXRvcnlfbWVt
-        YmVyc2hpcHMiOiBbIkZlZG9yYV8xNyJdLCAic291cmNlcnBtIjogInBlbmd1
-        aW4tMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAicGVuZ3VpbiIsICJjaGVj
-        a3N1bSI6ICIzZmNiMmM5MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVh
-        ZDJlNTg1NjRmYzIxMGZkNmU0ODYzNWJlNjk0IiwgInN1bW1hcnkiOiAiQSBk
-        dW1teSBwYWNrYWdlIG9mIHBlbmd1aW4iLCAiZmlsZW5hbWUiOiAicGVuZ3Vp
-        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9u
-        IjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiOGNkN2UxNWIt
-        YWQ0MC00Yjc3LTk2NWQtYWMxNWY3ZDY3ODZmIiwgImFyY2giOiAibm9hcmNo
-        IiwgImNoaWxkcmVuIjoge30sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29u
-        dGVudC91bml0cy9ycG0vOGNkN2UxNWItYWQ0MC00Yjc3LTk2NWQtYWMxNWY3
-        ZDY3ODZmLyJ9LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBbIkZlZG9y
-        YV8xNyJdLCAic291cmNlcnBtIjogImdpcmFmZmUtMC4zLTAuOC5zcmMucnBt
-        IiwgIm5hbWUiOiAiZ2lyYWZmZSIsICJjaGVja3N1bSI6ICJmMjVkNjdkMWQ5
-        ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTViODJkZTZkMTky
-        MjAwOWY5ZjE0IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGdp
-        cmFmZmUiLCAiZmlsZW5hbWUiOiAiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5y
-        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNl
-        IjogIjAuOCIsICJfaWQiOiAiYWRkNGYyN2MtNWQ3NS00YzVlLTg4MDMtMTBh
-        M2MzZGY0ZGI5IiwgImFyY2giOiAibm9hcmNoIiwgImNoaWxkcmVuIjoge30s
-        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9ycG0vYWRk
-        NGYyN2MtNWQ3NS00YzVlLTg4MDMtMTBhM2MzZGY0ZGI5LyJ9LCB7InJlcG9z
-        aXRvcnlfbWVtYmVyc2hpcHMiOiBbIkZlZG9yYV8xNyJdLCAic291cmNlcnBt
-        IjogImxpb24tMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAibGlvbiIsICJj
-        aGVja3N1bSI6ICIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNk
-        ZDdhODk4MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0IiwgInN1bW1hcnkiOiAi
-        QSBkdW1teSBwYWNrYWdlIG9mIGxpb24iLCAiZmlsZW5hbWUiOiAibGlvbi0w
-        LjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjog
-        IjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiZDQ4NmRjYTYtZDc3
-        Zi00M2I3LTg1Y2MtMmEwMjkzMTFiOGI5IiwgImFyY2giOiAibm9hcmNoIiwg
-        ImNoaWxkcmVuIjoge30sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVu
-        dC91bml0cy9ycG0vZDQ4NmRjYTYtZDc3Zi00M2I3LTg1Y2MtMmEwMjkzMTFi
-        OGI5LyJ9LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBbIkZlZG9yYV8x
-        NyJdLCAic291cmNlcnBtIjogImVsZXBoYW50LTAuMy0wLjguc3JjLnJwbSIs
-        ICJuYW1lIjogImVsZXBoYW50IiwgImNoZWNrc3VtIjogIjNlMWM3MGNkMWI0
-        MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcy
-        YTBhNzAxZjMiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgZWxl
-        cGhhbnQiLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gu
-        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFz
-        ZSI6ICIwLjgiLCAiX2lkIjogImYyM2JhNDk2LWFiNGMtNGI5Ni05NTA4LWNh
-        ZWYxMzAyMzhjMiIsICJhcmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6IHt9
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBtL2Yy
-        M2JhNDk2LWFiNGMtNGI5Ni05NTA4LWNhZWYxMzAyMzhjMi8ifSwgeyJyZXBv
-        c2l0b3J5X21lbWJlcnNoaXBzIjogWyJGZWRvcmFfMTciXSwgInNvdXJjZXJw
-        bSI6ICJzcXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJzcXVp
-        cnJlbCIsICJjaGVja3N1bSI6ICIyNTE3NjhiZGQxNWYxM2Q3ODQ4N2MyNzYz
-        OGFhNmFlY2QwMTU1MWUyNTM3NTYwOTNjZGUxYzBhZTg3OGExN2QyIiwgInN1
-        bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwgImZpbGVu
-        YW1lIjogInNxdWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6
-        ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgIl9p
-        ZCI6ICJmYjA4Y2YyMC0yMWExLTQ4YTctOTY1My1jODcyYjRlNWQzMzIiLCAi
-        YXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS9mYjA4Y2YyMC0yMWExLTQ4
-        YTctOTY1My1jODcyYjRlNWQzMzIvIn1d
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:52:38 GMT
-- request:
-    method: post
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/content/units/rpm/search/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMTM4ZjFj
-        NjAtMzFlNy00YWFlLWEyMzYtMmU4ZDFhZDNkMmIwIl19fX0sImluY2x1ZGVf
-        cmVwb3MiOnRydWV9
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb",
-        oauth_nonce="pXT9JwiLloAUgPoJaB8tRLdtHel74Ts1xkl2gP4G4Q", oauth_signature="zhLRqeCrsq9Myz5gH8THqUQTYiY%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454950358", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '102'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:52:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2974'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJf
-        aHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9ycG0vMTM4ZjFj
-        NjAtMzFlNy00YWFlLWEyMzYtMmU4ZDFhZDNkMmIwLyIsICJidWlsZF90aW1l
-        IjogMTMwODI1NzQ0OSwgImJ1aWxkaG9zdCI6ICJkaGNwLTI2LTExOC5icnEu
-        cmVkaGF0LmNvbSIsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250
-        ZW50X3R5cGVfaWQiOiAicnBtIiwgImNoaWxkcmVuIjoge30sICJzaXplIjog
-        MjIzNiwgImxpY2Vuc2UiOiAiR1BMdjIiLCAiZ3JvdXAiOiAiSW50ZXJuZXQv
-        QXBwbGljYXRpb25zIiwgImZpbGVuYW1lIjogIndhbHJ1cy0wLjMtMC44Lm5v
-        YXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJ2
-        ZXJzaW9uX3NvcnRfaW5kZXgiOiAiMDEtMC4wMS0zIiwgInByb3ZpZGVzIjog
-        W3sicmVsZWFzZSI6ICIwLjgiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjog
-        IjAuMyIsICJmbGFncyI6ICJFUSIsICJuYW1lIjogIndhbHJ1cyJ9XSwgImZp
-        bGVzIjogeyJkaXIiOiBbXSwgImZpbGUiOiBbIi8vd2FscnVzLnR4dCJdfSwg
-        InJlcG9kYXRhIjogeyJmaWxlbGlzdHMiOiAiPHBhY2thZ2UgYXJjaD1cIm5v
-        YXJjaFwiIG5hbWU9XCJ3YWxydXNcIiBwa2dpZD1cIjZlOGQ2ZGMwNTdlM2Uy
-        Yzk4MTlmMGRjN2U2YzdiN2Y4NmJmMmU4NTcxYmJhNDE0YWRlYzdmYjYyMWE0
-        NjFkZmRcIj5cbiAgICA8dmVyc2lvbiBlcG9jaD1cIjBcIiByZWw9XCIwLjhc
-        IiB2ZXI9XCIwLjNcIiAvPlxuXG4gICAgPGZpbGU+Ly93YWxydXMudHh0PC9m
-        aWxlPlxuPC9wYWNrYWdlPlxuXG4iLCAib3RoZXIiOiAiPHBhY2thZ2UgYXJj
-        aD1cIm5vYXJjaFwiIG5hbWU9XCJ3YWxydXNcIiBwa2dpZD1cIjZlOGQ2ZGMw
-        NTdlM2UyYzk4MTlmMGRjN2U2YzdiN2Y4NmJmMmU4NTcxYmJhNDE0YWRlYzdm
-        YjYyMWE0NjFkZmRcIj5cbiAgICA8dmVyc2lvbiBlcG9jaD1cIjBcIiByZWw9
-        XCIwLjhcIiB2ZXI9XCIwLjNcIiAvPlxuXG48L3BhY2thZ2U+XG5cbiIsICJw
-        cmltYXJ5IjogIjxwYWNrYWdlIHR5cGU9XCJycG1cIj5cbiAgPG5hbWU+d2Fs
-        cnVzPC9uYW1lPlxuICA8YXJjaD5ub2FyY2g8L2FyY2g+XG4gIDx2ZXJzaW9u
-        IGVwb2NoPVwiMFwiIHJlbD1cIjAuOFwiIHZlcj1cIjAuM1wiIC8+XG4gIDxj
-        aGVja3N1bSBwa2dpZD1cIllFU1wiIHR5cGU9XCJzaGEyNTZcIj42ZThkNmRj
-        MDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3
-        ZmI2MjFhNDYxZGZkPC9jaGVja3N1bT5cbiAgPHN1bW1hcnk+QSBkdW1teSBw
-        YWNrYWdlIG9mIHdhbHJ1czwvc3VtbWFyeT5cbiAgPGRlc2NyaXB0aW9uPkEg
-        ZHVtbXkgcGFja2FnZSBvZiB3YWxydXM8L2Rlc2NyaXB0aW9uPlxuICA8cGFj
-        a2FnZXIgLz5cbiAgPHVybD5odHRwOi8vdHN0cmFjaG90YS5mZWRvcmFwZW9w
-        bGUub3JnPC91cmw+XG4gIDx0aW1lIGJ1aWxkPVwiMTMwODI1NzQ0OVwiIGZp
-        bGU9XCIxMzIxODkxMDMwXCIgLz5cbiAgPHNpemUgYXJjaGl2ZT1cIjI5Mlwi
-        IGluc3RhbGxlZD1cIjQyXCIgcGFja2FnZT1cIjIyMzZcIiAvPlxuPGxvY2F0
-        aW9uIGhyZWY9XCJ3YWxydXMtMC4zLTAuOC5ub2FyY2gucnBtXCIvPlxuICA8
-        Zm9ybWF0PlxuICAgIDxycG06bGljZW5zZT5HUEx2MjwvcnBtOmxpY2Vuc2U+
-        XG4gICAgPHJwbTp2ZW5kb3IgLz5cbiAgICA8cnBtOmdyb3VwPkludGVybmV0
-        L0FwcGxpY2F0aW9uczwvcnBtOmdyb3VwPlxuICAgIDxycG06YnVpbGRob3N0
-        PmRoY3AtMjYtMTE4LmJycS5yZWRoYXQuY29tPC9ycG06YnVpbGRob3N0Plxu
-        ICAgIDxycG06c291cmNlcnBtPndhbHJ1cy0wLjMtMC44LnNyYy5ycG08L3Jw
-        bTpzb3VyY2VycG0+XG4gICAgPHJwbTpoZWFkZXItcmFuZ2UgZW5kPVwiMjAx
-        NlwiIHN0YXJ0PVwiMjgwXCIgLz5cbiAgICA8cnBtOnByb3ZpZGVzPlxuICAg
-        ICAgPHJwbTplbnRyeSBlcG9jaD1cIjBcIiBmbGFncz1cIkVRXCIgbmFtZT1c
-        IndhbHJ1c1wiIHJlbD1cIjAuOFwiIHZlcj1cIjAuM1wiIC8+XG4gICAgPC9y
-        cG06cHJvdmlkZXM+XG4gICAgPHJwbTpyZXF1aXJlcz5cbiAgICAgIDxycG06
-        ZW50cnkgbmFtZT1cIi9iaW4vc2hcIiBwcmU9XCIxXCIgLz5cbiAgICA8L3Jw
-        bTpyZXF1aXJlcz5cbiAgPC9mb3JtYXQ+XG48L3BhY2thZ2U+XG4ifSwgImRl
-        c2NyaXB0aW9uIjogIkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCAiX2xh
-        c3RfdXBkYXRlZCI6ICIyMDE2LTAyLTA4VDE2OjQzOjQ0WiIsICJ0aW1lIjog
-        MTMyMTg5MTAzMCwgImRvd25sb2FkZWQiOiB0cnVlLCAiaGVhZGVyX3Jhbmdl
-        IjogeyJzdGFydCI6IDI4MCwgImVuZCI6IDIwMTZ9LCAiYXJjaCI6ICJub2Fy
-        Y2giLCAibmFtZSI6ICJ3YWxydXMiLCAiX3N0b3JhZ2VfcGF0aCI6ICIvdmFy
-        L2xpYi9wdWxwL2NvbnRlbnQvdW5pdHMvcnBtLzEzOGYvMTM4ZjFjNjAtMzFl
-        Ny00YWFlLWEyMzYtMmU4ZDFhZDNkMmIwL3dhbHJ1cy0wLjMtMC44Lm5vYXJj
-        aC5ycG0iLCAic291cmNlcnBtIjogIndhbHJ1cy0wLjMtMC44LnNyYy5ycG0i
-        LCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiIsICJyZWxlYXNlX3NvcnRfaW5k
-        ZXgiOiAiMDEtMC4wMS04IiwgImNoYW5nZWxvZyI6IFtdLCAidXJsIjogImh0
-        dHA6Ly90c3RyYWNob3RhLmZlZG9yYXBlb3BsZS5vcmciLCAiY2hlY2tzdW0i
-        OiAiNmU4ZDZkYzA1N2UzZTJjOTgxOWYwZGM3ZTZjN2I3Zjg2YmYyZTg1NzFi
-        YmE0MTRhZGVjN2ZiNjIxYTQ2MWRmZCIsICJzdW1tYXJ5IjogIkEgZHVtbXkg
-        cGFja2FnZSBvZiB3YWxydXMiLCAicmVsYXRpdmVwYXRoIjogIndhbHJ1cy0w
-        LjMtMC44Lm5vYXJjaC5ycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjog
-        IjEzOGYxYzYwLTMxZTctNGFhZS1hMjM2LTJlOGQxYWQzZDJiMCIsICJyZXF1
-        aXJlcyI6IFt7InJlbGVhc2UiOiBudWxsLCAiZXBvY2giOiBudWxsLCAidmVy
-        c2lvbiI6IG51bGwsICJmbGFncyI6IG51bGwsICJuYW1lIjogIi9iaW4vc2gi
-        fV19XQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:52:38 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/46856212-4e7b-4458-b3cc-8b40a447895e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="ljQCcXAoQST0zOXc2cT0r4FtrRA7T0eSiIN2FPQ9E",
-        oauth_signature="BEERk0vHbrwhXr%2BXGvAMNTJYif8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950358", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:52:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80Njg1NjIxMi00ZTdiLTQ0NTgtYjNjYy04YjQwYTQ0Nzg5
-        NWUvIiwgInRhc2tfaWQiOiAiNDY4NTYyMTItNGU3Yi00NDU4LWIzY2MtOGI0
-        MGE0NDc4OTVlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI4Yzdk
-        NmMxOWZmNTA3OTgyM2Y0ZWEifSwgImlkIjogIjU2YjhjN2Q2YzE5ZmY1MDc5
-        ODIzZjRlYSJ9
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:52:38 GMT
-- request:
-    method: get
-    uri: https://katello-centos7-devel.example.com/pulp/api/v2/tasks/46856212-4e7b-4458-b3cc-8b40a447895e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="XaTTz4dYsTGyQRPuD3JNRF8eBHxgfZcb", oauth_nonce="4lLVaBpvIEqtbSTV2liABfRTSizL8U7v0eTNM",
-        oauth_signature="QmQXX4PLSybJeebtGK6V2tENWKE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454950359", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Feb 2016 16:52:39 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '700'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80Njg1NjIxMi00ZTdiLTQ0NTgtYjNjYy04YjQwYTQ0Nzg5
-        NWUvIiwgInRhc2tfaWQiOiAiNDY4NTYyMTItNGU3Yi00NDU4LWIzY2MtOGI0
-        MGE0NDc4OTVlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA4VDE2OjUyOjM4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA4VDE2OjUyOjM4WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBrYXRlbGxvLWNlbnRvczctZGV2ZWwuZXhhbXBsZS5jb20uZHEiLCAic3Rh
-        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby1jZW50b3M3LWRldmVsLmV4YW1wbGUu
-        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNTZiOGM3ZDZjMTlmZjUwNzk4MjNmNGVhIn0sICJpZCI6ICI1
-        NmI4YzdkNmMxOWZmNTA3OTgyM2Y0ZWEifQ==
-    http_version: 
-  recorded_at: Mon, 08 Feb 2016 16:52:39 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/b24cced9-31d1-4966-867b-c317a4a8ba87/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:04:10 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '649'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iMjRjY2VkOS0zMWQxLTQ5NjYtODY3Yi1jMzE3YTRhOGJh
-        ODcvIiwgInRhc2tfaWQiOiAiYjI0Y2NlZDktMzFkMS00OTY2LTg2N2ItYzMx
-        N2E0YThiYTg3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tLmRxIiwgInN0
-        YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwg
-        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNTZiZDA1NWEzNDQ3MWU0MDA3MGIwYmU2In0sICJpZCI6ICI1NmJkMDU1
-        YTM0NDcxZTQwMDcwYjBiZTYifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:10 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/b24cced9-31d1-4966-867b-c317a4a8ba87/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:04:11 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2324'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iMjRjY2VkOS0zMWQxLTQ5NjYtODY3Yi1jMzE3YTRhOGJh
-        ODcvIiwgInRhc2tfaWQiOiAiYjI0Y2NlZDktMzFkMS00OTY2LTg2N2ItYzMx
-        N2E0YThiYTg3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMjowNDoxMVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMjowNDoxMFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYTEzNTc2NTctZDk2Zi00NDcwLWJhNzQtNDYzZTY5MzVi
-        MjRmLyIsICJ0YXNrX2lkIjogImExMzU3NjU3LWQ5NmYtNDQ3MC1iYTc0LTQ2
-        M2U2OTM1YjI0ZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDU1
-        YTY3N2M3NDJkMDQ5YjAxMGEifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIyOjA0OjEwWiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjI6MDQ6MTFa
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA1NWI2NzdjNzQwODEyMzIyNDlkIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNTVhMzQ0NzFlNDAwNzBiMGJlNiJ9LCAiaWQi
-        OiAiNTZiZDA1NWEzNDQ3MWU0MDA3MGIwYmU2In0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:11 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/a1357657-d96f-4470-ba74-463e6935b24f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:04:11 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '676'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9hMTM1NzY1Ny1kOTZmLTQ0NzAtYmE3NC00NjNl
-        NjkzNWIyNGYvIiwgInRhc2tfaWQiOiAiYTEzNTc2NTctZDk2Zi00NDcwLWJh
-        NzQtNDYzZTY5MzViMjRmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0xMVQyMjowNDoxMVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1i
-        dXJyaXRvLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAi
-        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAa2F0
-        ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJl
-        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiZDA1NWIzNDQ3MWU0
-        MDA3MGIwYmY2In0sICJpZCI6ICI1NmJkMDU1YjM0NDcxZTQwMDcwYjBiZjYi
-        fQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:11 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/b24cced9-31d1-4966-867b-c317a4a8ba87/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:04:12 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2324'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iMjRjY2VkOS0zMWQxLTQ5NjYtODY3Yi1jMzE3YTRhOGJh
-        ODcvIiwgInRhc2tfaWQiOiAiYjI0Y2NlZDktMzFkMS00OTY2LTg2N2ItYzMx
-        N2E0YThiYTg3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMjowNDoxMVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMjowNDoxMFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYTEzNTc2NTctZDk2Zi00NDcwLWJhNzQtNDYzZTY5MzVi
-        MjRmLyIsICJ0YXNrX2lkIjogImExMzU3NjU3LWQ5NmYtNDQ3MC1iYTc0LTQ2
-        M2U2OTM1YjI0ZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDU1
-        YTY3N2M3NDJkMDQ5YjAxMGEifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIyOjA0OjEwWiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjI6MDQ6MTFa
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA1NWI2NzdjNzQwODEyMzIyNDlkIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNTVhMzQ0NzFlNDAwNzBiMGJlNiJ9LCAiaWQi
-        OiAiNTZiZDA1NWEzNDQ3MWU0MDA3MGIwYmU2In0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:12 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/a1357657-d96f-4470-ba74-463e6935b24f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:04:12 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9hMTM1NzY1Ny1kOTZmLTQ0NzAtYmE3NC00NjNl
-        NjkzNWIyNGYvIiwgInRhc2tfaWQiOiAiYTEzNTc2NTctZDk2Zi00NDcwLWJh
-        NzQtNDYzZTY5MzViMjRmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0xMVQyMjowNDoxMVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMjowNDoxMVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI4NmMxOGFmNC1hNGI1LTQ0NzItOWE3Ni1mNzQ0ZGNj
-        ODdlZDUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNWFmM2M4ZjUtOTNmYy00OTU4LTliY2EtODJkOTIwYzAzODYwIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNDM2MTFkY2MtZDBhZS00ZTIxLTljNGEt
-        OTM5NjQwZDBmZDMyIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWY2
-        NWU2YTMtZmNlMi00NDgxLTllZTEtZGMyOWY3N2YxYTU3IiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjQwOTFkYTkzLTM0ODktNDEwMC04ZGNjLTViNzA1
-        YzVmMjVmZSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkOTI5ZTQ2
-        Mi1jNDdjLTQwMDctOGE2Ny1kZWIwNTdiNzUzYTYiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI3OTEyMDEwNS0zNGQ3LTQ1YWItYjU3ZC01YzYx
-        OWE5YWQwNjAiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI0MWFhZTM2OS02ZDVmLTRkYmItODZlNy00ODgwZWZiMGE1OTki
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjZjZj
-        ZGFmNi1hODA0LTQzOWItYWI4OS05ZjRlYmMzMmViNTYiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyZTYyMTBkYi1kYTFj
-        LTRiMDUtOTA5My04YWM5NTA3N2JjYjQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFmMjg2ZjhkLTRjODgtNDgx
-        Ny05OWUzLWVhMTM1MGI0ZjIyOCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8t
-        YnVycml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBr
-        YXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTExVDIyOjA0OjEx
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMTFUMjI6MDQ6MTFaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiZDA1NWI2NzdjNzQw
-        ODEyMzIyNDllIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjg2YzE4YWY0LWE0YjUtNDQ3Mi05YTc2LWY3NDRkY2M4N2Vk
-        NSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI1YWYzYzhmNS05M2ZjLTQ5NTgtOWJjYS04MmQ5MjBjMDM4NjAiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI0MzYxMWRjYy1kMGFlLTRlMjEtOWM0YS05Mzk2
-        NDBkMGZkMzIiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZjY1ZTZh
-        My1mY2UyLTQ0ODEtOWVlMS1kYzI5Zjc3ZjFhNTciLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiNDA5MWRhOTMtMzQ4OS00MTAwLThkY2MtNWI3MDVjNWYy
-        NWZlIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ5MjllNDYyLWM0
-        N2MtNDAwNy04YTY3LWRlYjA1N2I3NTNhNiIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjc5MTIwMTA1LTM0ZDctNDVhYi1iNTdkLTVjNjE5YTlh
-        ZDA2MCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjQxYWFlMzY5LTZkNWYtNGRiYi04NmU3LTQ4ODBlZmIwYTU5OSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNmNmNkYWY2
-        LWE4MDQtNDM5Yi1hYjg5LTlmNGViYzMyZWI1NiIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjJlNjIxMGRiLWRhMWMtNGIw
-        NS05MDkzLThhYzk1MDc3YmNiNCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWYyODZmOGQtNGM4OC00ODE3LTk5
-        ZTMtZWExMzUwYjRmMjI4IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmQwNTViMzQ0NzFlNDAw
-        NzBiMGJmNiJ9LCAiaWQiOiAiNTZiZDA1NWIzNDQ3MWU0MDA3MGIwYmY2In0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:12 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/0749d1d6-145e-4262-a10c-bc72dc551681/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:04:12 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '549'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wNzQ5ZDFkNi0xNDVlLTQyNjItYTEwYy1iYzcyZGM1NTE2
-        ODEvIiwgInRhc2tfaWQiOiAiMDc0OWQxZDYtMTQ1ZS00MjYyLWExMGMtYmM3
-        MmRjNTUxNjgxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJkMDU1
-        YzM0NDcxZTQwMDcwYjBiZjcifSwgImlkIjogIjU2YmQwNTVjMzQ0NzFlNDAw
-        NzBiMGJmNyJ9
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:12 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/0749d1d6-145e-4262-a10c-bc72dc551681/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:04:13 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wNzQ5ZDFkNi0xNDVlLTQyNjItYTEwYy1iYzcyZGM1NTE2
-        ODEvIiwgInRhc2tfaWQiOiAiMDc0OWQxZDYtMTQ1ZS00MjYyLWExMGMtYmM3
-        MmRjNTUxNjgxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTExVDIyOjA0OjEyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTExVDIyOjA0OjEyWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZDA1NWMzNDQ3MWU0MDA3MGIwYmY3In0sICJpZCI6ICI1NmJkMDU1YzM0NDcx
-        ZTQwMDcwYjBiZjcifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:13 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/6ff77d0c-ebd2-449e-99fb-9129e7e183a5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:04:14 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '547'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82ZmY3N2QwYy1lYmQyLTQ0OWUtOTlmYi05MTI5ZTdlMTgz
-        YTUvIiwgInRhc2tfaWQiOiAiNmZmNzdkMGMtZWJkMi00NDllLTk5ZmItOTEy
-        OWU3ZTE4M2E1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiZDA1NWUz
-        NDQ3MWU0MDA3MGIwYmY4In0sICJpZCI6ICI1NmJkMDU1ZTM0NDcxZTQwMDcw
-        YjBiZjgifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:14 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/6ff77d0c-ebd2-449e-99fb-9129e7e183a5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:04:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1130'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82ZmY3N2QwYy1lYmQyLTQ0OWUtOTlmYi05MTI5ZTdlMTgz
-        YTUvIiwgInRhc2tfaWQiOiAiNmZmNzdkMGMtZWJkMi00NDllLTk5ZmItOTEy
-        OWU3ZTE4M2E1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0xMVQyMjowNDoxNFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJO
-        T1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        Tk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwi
-        OiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJJTl9Q
-        Uk9HUkVTUyJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19
-        fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVs
-        bG8tYnVycml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5n
-        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0w
-        QGthdGVsbG8tYnVycml0by5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmQwNTVlMzQ0
-        NzFlNDAwNzBiMGJmOCJ9LCAiaWQiOiAiNTZiZDA1NWUzNDQ3MWU0MDA3MGIw
-        YmY4In0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:15 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/6ff77d0c-ebd2-449e-99fb-9129e7e183a5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:04:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2324'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82ZmY3N2QwYy1lYmQyLTQ0OWUtOTlmYi05MTI5ZTdlMTgz
-        YTUvIiwgInRhc2tfaWQiOiAiNmZmNzdkMGMtZWJkMi00NDllLTk5ZmItOTEy
-        OWU3ZTE4M2E1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMjowNDoxNVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMjowNDoxNFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZDM0NjBjNmEtNWI3Mi00Y2M3LWE2YjYtYjA5M2ExYjQ2
-        MWNjLyIsICJ0YXNrX2lkIjogImQzNDYwYzZhLTViNzItNGNjNy1hNmI2LWIw
-        OTNhMWI0NjFjYyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDU1
-        ZTY3N2M3NDJkMDQ5YjAxMTEifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIyOjA0OjE0WiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjI6MDQ6MTVa
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA1NWY2NzdjNzQwODEyMzIyNGEyIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNTVlMzQ0NzFlNDAwNzBiMGJmOCJ9LCAiaWQi
-        OiAiNTZiZDA1NWUzNDQ3MWU0MDA3MGIwYmY4In0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:15 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/d3460c6a-5b72-4cc7-a6b6-b093a1b461cc/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:04:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9kMzQ2MGM2YS01YjcyLTRjYzctYTZiNi1iMDkz
-        YTFiNDYxY2MvIiwgInRhc2tfaWQiOiAiZDM0NjBjNmEtNWI3Mi00Y2M3LWE2
-        YjYtYjA5M2ExYjQ2MWNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0xMVQyMjowNDoxNVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMjowNDoxNVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI0YWQ5NzQxNy05YTIxLTRjZWYtOGE2Yy1kMjEwOWU0
-        NzQyZDciLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZTJiNDdjMDEtN2I4NC00NGNiLTliNzUtNDgxOWIyY2ZlZDE5Iiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNTQ5MWY4OGMtN2U2ZC00MzM3LTk0NDkt
-        ZDMyYTIwNmE5Yjg5IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzYx
-        ZmFlNGYtMjliYi00MzVhLWIxYzYtYWJkOGEzYTVhYmQ3IiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImI4MDc2Yzc2LWZhNGEtNGNjZC1iY2FmLWQ1ZTRh
-        NTkxZWQyZCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjZDI2Y2Vl
-        OS05ZDYzLTQ5ZjYtYTZhYS1iNmM2NjJhNzAxN2YiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJiMzVmNGY5MS02Njg0LTQwNjYtODA3Yy00ZTAw
-        NjgwMjcwZjIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI2NGQ5MmI2Zi0yMjAzLTRkMzQtOTIzNi0wNTQ5YzdjOTM3MzIi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMTYz
-        MjdkOC01MDBkLTQzMTQtYjkyYy02YjJmODMxMjM1ZDQiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2NTczNWYwZi0zMTY2
-        LTRlMmYtYWNkNS03OGRjMTI3N2MxOGIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUzMjM1YzI0LTI0YjQtNDQ2
-        OC05ZDdiLWQyNjllNGJiOGM2MSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8t
-        YnVycml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBr
-        YXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTExVDIyOjA0OjE1
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMTFUMjI6MDQ6MTVaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiZDA1NWY2NzdjNzQw
-        ODEyMzIyNGEzIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjRhZDk3NDE3LTlhMjEtNGNlZi04YTZjLWQyMTA5ZTQ3NDJk
-        NyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJlMmI0N2MwMS03Yjg0LTQ0Y2ItOWI3NS00ODE5YjJjZmVkMTkiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI1NDkxZjg4Yy03ZTZkLTQzMzctOTQ0OS1kMzJh
-        MjA2YTliODkiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3NjFmYWU0
-        Zi0yOWJiLTQzNWEtYjFjNi1hYmQ4YTNhNWFiZDciLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiYjgwNzZjNzYtZmE0YS00Y2NkLWJjYWYtZDVlNGE1OTFl
-        ZDJkIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNkMjZjZWU5LTlk
-        NjMtNDlmNi1hNmFhLWI2YzY2MmE3MDE3ZiIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImIzNWY0ZjkxLTY2ODQtNDA2Ni04MDdjLTRlMDA2ODAy
-        NzBmMiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjY0ZDkyYjZmLTIyMDMtNGQzNC05MjM2LTA1NDljN2M5MzczMiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImIxNjMyN2Q4
-        LTUwMGQtNDMxNC1iOTJjLTZiMmY4MzEyMzVkNCIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjY1NzM1ZjBmLTMxNjYtNGUy
-        Zi1hY2Q1LTc4ZGMxMjc3YzE4YiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTMyMzVjMjQtMjRiNC00NDY4LTlk
-        N2ItZDI2OWU0YmI4YzYxIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmQwNTVmMzQ0NzFlNDAw
-        NzBiMGMwOCJ9LCAiaWQiOiAiNTZiZDA1NWYzNDQ3MWU0MDA3MGIwYzA4In0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:15 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/cb0722b2-a050-483c-bbfc-30adb0d1e1a3/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:04:16 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '651'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jYjA3MjJiMi1hMDUwLTQ4M2MtYmJmYy0zMGFkYjBkMWUx
-        YTMvIiwgInRhc2tfaWQiOiAiY2IwNzIyYjItYTA1MC00ODNjLWJiZmMtMzBh
-        ZGIwZDFlMWEzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAi
-        c3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
-        ZXNvdXJjZV93b3JrZXItMEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20i
-        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmJkMDU2MDM0NDcxZTQwMDcwYjBjMDkifSwgImlkIjogIjU2YmQw
-        NTYwMzQ0NzFlNDAwNzBiMGMwOSJ9
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:16 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/cb0722b2-a050-483c-bbfc-30adb0d1e1a3/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:04:16 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '688'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jYjA3MjJiMi1hMDUwLTQ4M2MtYmJmYy0zMGFkYjBkMWUx
-        YTMvIiwgInRhc2tfaWQiOiAiY2IwNzIyYjItYTA1MC00ODNjLWJiZmMtMzBh
-        ZGIwZDFlMWEzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTExVDIyOjA0OjE2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTExVDIyOjA0OjE2WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZDA1NjAzNDQ3MWU0MDA3MGIwYzA5In0sICJpZCI6ICI1NmJkMDU2MDM0NDcx
-        ZTQwMDcwYjBjMDkifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:16 GMT
-- request:
-    method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwiZG93bmxvYWRfcG9saWN5
-        IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRp
-        c3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwi
-        OiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3Rl
-        Y3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3Jf
-        aWQiOiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifV19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '636'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:04:17 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '320'
-      Location:
-      - https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTZiZDA1NjE2NzdjNzQyZDA0OWIwMTE1In0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:17 GMT
-- request:
-    method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -8787,7 +963,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:04:17 GMT
+      - Tue, 23 Feb 2016 16:49:13 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -8800,14 +976,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzE3YTMwNjFmLTgzMTYtNDcxYy05M2VmLTJlMWU4NWIyYTBiZi8iLCAi
-        dGFza19pZCI6ICIxN2EzMDYxZi04MzE2LTQ3MWMtOTNlZi0yZTFlODViMmEw
-        YmYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:17 GMT
+        c2tzLzY0ZDk1MWU1LWQ4YTQtNGVjNi05NGRiLTc5ZmE2MGZlZWIwNC8iLCAi
+        dGFza19pZCI6ICI2NGQ5NTFlNS1kOGE0LTRlYzYtOTRkYi03OWZhNjBmZWVi
+        MDQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:49:13 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/17a3061f-8316-471c-93ef-2e1e85b2a0bf/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/64d951e5-d8a4-4ec6-94db-79fa60feeb04/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -8826,13 +1002,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:04:17 GMT
+      - Tue, 23 Feb 2016 16:49:13 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '547'
+      - '661'
       Connection:
       - close
       Content-Type:
@@ -8842,22 +1018,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xN2EzMDYxZi04MzE2LTQ3MWMtOTNlZi0yZTFlODViMmEw
-        YmYvIiwgInRhc2tfaWQiOiAiMTdhMzA2MWYtODMxNi00NzFjLTkzZWYtMmUx
-        ZTg1YjJhMGJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy82NGQ5NTFlNS1kOGE0LTRlYzYtOTRkYi03OWZhNjBmZWVi
+        MDQvIiwgInRhc2tfaWQiOiAiNjRkOTUxZTUtZDhhNC00ZWM2LTk0ZGItNzlm
+        YTYwZmVlYjA0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
-        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiZDA1NjEz
-        NDQ3MWU0MDA3MGIwYzBhIn0sICJpZCI6ICI1NmJkMDU2MTM0NDcxZTQwMDcw
-        YjBjMGEifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:17 GMT
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0yM1QxNjo0OToxM1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby15b2RhLmV4
+        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNTZjYzhkODk5ODkwNTRmYzQ4YmEzMGQ4In0sICJp
+        ZCI6ICI1NmNjOGQ4OTk4OTA1NGZjNDhiYTMwZDgifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:49:13 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/17a3061f-8316-471c-93ef-2e1e85b2a0bf/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/64d951e5-d8a4-4ec6-94db-79fa60feeb04/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -8876,13 +1054,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:04:18 GMT
+      - Tue, 23 Feb 2016 16:49:14 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2324'
+      - '2318'
       Connection:
       - close
       Content-Type:
@@ -8892,16 +1070,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xN2EzMDYxZi04MzE2LTQ3MWMtOTNlZi0yZTFlODViMmEw
-        YmYvIiwgInRhc2tfaWQiOiAiMTdhMzA2MWYtODMxNi00NzFjLTkzZWYtMmUx
-        ZTg1YjJhMGJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy82NGQ5NTFlNS1kOGE0LTRlYzYtOTRkYi03OWZhNjBmZWVi
+        MDQvIiwgInRhc2tfaWQiOiAiNjRkOTUxZTUtZDhhNC00ZWM2LTk0ZGItNzlm
+        YTYwZmVlYjA0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMjowNDoxOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMjowNDoxN1oiLCAidHJhY2ViYWNr
+        Ni0wMi0yM1QxNjo0OToxNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0OToxM1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvODE1YmM0ODQtNjBlNi00M2EzLWEyYWEtYmJlNzMzY2Y1
-        MmE1LyIsICJ0YXNrX2lkIjogIjgxNWJjNDg0LTYwZTYtNDNhMy1hMmFhLWJi
-        ZTczM2NmNTJhNSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNTc3YzQ3MTItMzE5NS00ODU1LTkzZTEtNzNlYWJjN2E4
+        ZDE2LyIsICJ0YXNrX2lkIjogIjU3N2M0NzEyLTMxOTUtNDg1NS05M2UxLTcz
+        ZWFiYzdhOGQxNiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -8912,41 +1090,41 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDU2
-        MTY3N2M3NDJkMDQ5YjAxMTYifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIyOjA0OjE3WiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjI6MDQ6MTha
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA1NjI2NzdjNzQwODEyMzIyNGE3IiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNTYxMzQ0NzFlNDAwNzBiMGMwYSJ9LCAiaWQi
-        OiAiNTZiZDA1NjEzNDQ3MWU0MDA3MGIwYzBhIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:18 GMT
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8teW9k
+        YS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
+        Y2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ4OWRlMDQw
+        MzNmNDI2MmNhZTMifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIy
+        MDE2LTAyLTIzVDE2OjQ5OjEzWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
+        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMjNUMTY6NDk6MTRaIiwgImlt
+        cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        cHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2Nv
+        dW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZjYzhkOGFk
+        ZTA0MDMwODk3NThhOTZjIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
+        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
+        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
+        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2Y2M4ZDg5OTg5MDU0ZmM0OGJhMzBkOCJ9LCAiaWQiOiAiNTZj
+        YzhkODk5ODkwNTRmYzQ4YmEzMGQ4In0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:49:14 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/815bc484-60e6-43a3-a2aa-bbe733cf52a5/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/577c4712-3195-4855-93e1-73eabc7a8d16/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -8965,13 +1143,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:04:18 GMT
+      - Tue, 23 Feb 2016 16:49:14 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '3497'
+      - '6923'
       Connection:
       - close
       Content-Type:
@@ -8981,367 +1159,163 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84MTViYzQ4NC02MGU2LTQzYTMtYTJhYS1iYmU3
-        MzNjZjUyYTUvIiwgInRhc2tfaWQiOiAiODE1YmM0ODQtNjBlNi00M2EzLWEy
-        YWEtYmJlNzMzY2Y1MmE1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy81NzdjNDcxMi0zMTk1LTQ4NTUtOTNlMS03M2Vh
+        YmM3YThkMTYvIiwgInRhc2tfaWQiOiAiNTc3YzQ3MTItMzE5NS00ODU1LTkz
+        ZTEtNzNlYWJjN2E4ZDE2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wMi0xMVQyMjowNDoxOFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNDVi
-        YzQ2Ny1kM2Q3LTQwMDQtOTA1MS0yZTgzNjM5MzEwOWMiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTRjNjJjZTktNzZj
-        Zi00OGE2LWIxMWUtOGIyMmZiNDcyZTcyIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiYmIzZTY0YmMtNDhmNi00YTAxLWI4ZTQtMmI5ZmZhODZkZTI1IiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYmQ5NTQwYTgtYTk0OS00NzAwLTg0
-        ZGItOGI3YzAxNzJmYTg2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjcw
-        N2I4NjFhLTcyMzUtNDk5Ny1iODkzLTY2ZTI0NTkwNjA4ZCIsICJudW1fcHJv
-        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIyMTk5NDMxMC1hN2ViLTRmMGQtODA5NS01
-        ZjNhOTFhYTljOTciLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEu
-        IiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5
-        YWI5ZThiNC0zMzFjLTRjYWMtYWVmYi1mZjk4MzBjM2E0MjciLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9u
-        IjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xv
-        c2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkYTIzNDQ1Yi03
-        MzVkLTQwMzMtOTNlNi1iNTk4NzZhYjhhOTgiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVy
-        YXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBz
-        cWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4Mzk3OGQ4OC00ZGUxLTQxODktYmZl
-        ZS0zMGFlM2U2ODA3ZmUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMg
-        dG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJhYzkwNGM4ZC1lMDhiLTQ5ZGMtODQ1NS0yNjFlNTBk
-        YmZhZWIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjNmZTkxZGY5LTE4YWQtNDZmYi04MWNkLTQxNDE0YWI3
-        ZGU5ZSIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVycml0by5leGFtcGxl
-        LmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVycml0by5l
-        eGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjU2YmQwNTYyMzQ0NzFlNDAwNzBiMGMxYSJ9LCAi
-        aWQiOiAiNTZiZDA1NjIzNDQ3MWU0MDA3MGIwYzFhIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:18 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/17a3061f-8316-471c-93ef-2e1e85b2a0bf/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:04:19 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2324'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xN2EzMDYxZi04MzE2LTQ3MWMtOTNlZi0yZTFlODViMmEw
-        YmYvIiwgInRhc2tfaWQiOiAiMTdhMzA2MWYtODMxNi00NzFjLTkzZWYtMmUx
-        ZTg1YjJhMGJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0xMVQyMjowNDoxOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMjowNDoxN1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvODE1YmM0ODQtNjBlNi00M2EzLWEyYWEtYmJlNzMzY2Y1
-        MmE1LyIsICJ0YXNrX2lkIjogIjgxNWJjNDg0LTYwZTYtNDNhMy1hMmFhLWJi
-        ZTczM2NmNTJhNSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tYnVy
-        cml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRl
-        bGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmJkMDU2
-        MTY3N2M3NDJkMDQ5YjAxMTYifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTExVDIyOjA0OjE3WiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMTFUMjI6MDQ6MTha
-        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
-        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
-        ZDA1NjI2NzdjNzQwODEyMzIyNGE3IiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJw
-        dXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YmQwNTYxMzQ0NzFlNDAwNzBiMGMwYSJ9LCAiaWQi
-        OiAiNTZiZDA1NjEzNDQ3MWU0MDA3MGIwYzBhIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:19 GMT
-- request:
-    method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/815bc484-60e6-43a3-a2aa-bbe733cf52a5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 Feb 2016 22:04:19 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6929'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84MTViYzQ4NC02MGU2LTQzYTMtYTJhYS1iYmU3
-        MzNjZjUyYTUvIiwgInRhc2tfaWQiOiAiODE1YmM0ODQtNjBlNi00M2EzLWEy
-        YWEtYmJlNzMzY2Y1MmE1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wMi0xMVQyMjowNDoxOFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0xMVQyMjowNDoxOFoiLCAi
+        bWUiOiAiMjAxNi0wMi0yM1QxNjo0OToxNFoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0yM1QxNjo0OToxNFoiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJhNDViYzQ2Ny1kM2Q3LTQwMDQtOTA1MS0yZTgzNjM5
-        MzEwOWMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICIzZTkyYTlhNy1hMGI1LTQyNTUtYjFkNy1hNmVmNTcz
+        NDE0NDAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYTRjNjJjZTktNzZjZi00OGE2LWIxMWUtOGIyMmZiNDcyZTcyIiwg
+        aWQiOiAiMThlZTE2YWQtMDc4MC00MjA3LWI5ZTktZTc5Njg2MzFlZDI1Iiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
         bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiYmIzZTY0YmMtNDhmNi00YTAxLWI4ZTQt
-        MmI5ZmZhODZkZTI1IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNDE4NWJlOGEtYjE2NS00YWY3LTllMmUt
+        Yjg3MDM3MTI1ODk0IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
         TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYmQ5
-        NTQwYTgtYTk0OS00NzAwLTg0ZGItOGI3YzAxNzJmYTg2IiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjc1
+        ZWFkNDUtMThiZi00MTQ2LWE4YTMtOWFlMDY4ODc0NjZlIiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjcwN2I4NjFhLTcyMzUtNDk5Ny1iODkzLTY2ZTI0
-        NTkwNjA4ZCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        IDAsICJzdGVwX2lkIjogImRjYjEyOTcxLTcyY2MtNDI2MS1hNWMyLWY4ODhl
+        YmQxY2IzMiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
         OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
         InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyMTk5NDMx
-        MC1hN2ViLTRmMGQtODA5NS01ZjNhOTFhYTljOTciLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzMWM4MTAx
+        Ni0yMDMzLTRkNzMtOWU1Ny01N2FjOGNhZmQ1ODQiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
         Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI5YWI5ZThiNC0zMzFjLTRjYWMtYWVmYi1mZjk4
-        MzBjM2E0MjciLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICIyOGQzNzVlZi0yMjg2LTQyNjAtOTVkOC0yZjA4
+        ZWQ4MGFlNGEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
         ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJkYTIzNDQ1Yi03MzVkLTQwMzMtOTNlNi1iNTk4NzZhYjhhOTgi
+        cF9pZCI6ICI3MDE3MzdlMi02ODg5LTQ0MDQtYmYxZC1kMGZlZTgyNTk4ZmQi
         LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
         dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
         c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4Mzk3
-        OGQ4OC00ZGUxLTQxODktYmZlZS0zMGFlM2U2ODA3ZmUiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4NmIy
+        MTdkZC0wMmE2LTRiOTktYWM4OC00ZGFiODg3Zjk3ZmYiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
         aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhYzkwNGM4ZC1lMDhi
-        LTQ5ZGMtODQ1NS0yNjFlNTBkYmZhZWIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3OTJiNTFmYS1jNzc0
+        LTQyNWItOWIwOC0yODFjZGIxNDhkYzQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
         TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
         X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNmZTkxZGY5LTE4YWQtNDZm
-        Yi04MWNkLTQxNDE0YWI3ZGU5ZSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8t
-        YnVycml0by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBr
-        YXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
-        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTExVDIyOjA0OjE4
-        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMTFUMjI6MDQ6MThaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
-        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
-        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
-        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
-        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiZDA1NjI2NzdjNzQw
-        ODEyMzIyNGE4IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
-        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImE0NWJjNDY3LWQzZDctNDAwNC05MDUxLTJlODM2MzkzMTA5
-        YyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
-        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJhNGM2MmNlOS03NmNmLTQ4YTYtYjExZS04YjIyZmI0NzJlNzIiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJiYjNlNjRiYy00OGY2LTRhMDEtYjhlNC0yYjlm
-        ZmE4NmRlMjUiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
-        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiZDk1NDBh
-        OC1hOTQ5LTQ3MDAtODRkYi04YjdjMDE3MmZhODYiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiNzA3Yjg2MWEtNzIzNS00OTk3LWI4OTMtNjZlMjQ1OTA2
-        MDhkIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjIxOTk0MzEwLWE3
-        ZWItNGYwZC04MDk1LTVmM2E5MWFhOWM5NyIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjlhYjllOGI0LTMzMWMtNGNhYy1hZWZiLWZmOTgzMGMz
-        YTQyNyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE4N2EwMWYyLTM3ZTYtNDAz
+        OS1hYjcwLWVhN2FmZDdjM2Q5MCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        eW9kYS5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
+        c3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
+        cmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTIzVDE2OjQ5OjE0WiIsICJf
+        bnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
+        MTYtMDItMjNUMTY6NDk6MTRaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0
+        cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5
+        IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXpl
+        X3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hF
+        RCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1z
+        IjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0
+        aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklT
+        SEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5J
+        U0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9p
+        ZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZjYzhkOGFkZTA0MDMwODk3NThh
+        OTZkIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
         IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImRhMjM0NDViLTczNWQtNDAzMy05M2U2LWI1OTg3NmFiOGE5OCIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
-        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjgzOTc4ZDg4
-        LTRkZTEtNDE4OS1iZmVlLTMwYWUzZTY4MDdmZSIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        IjogIjNlOTJhOWE3LWEwYjUtNDI1NS1iMWQ3LWE2ZWY1NzM0MTQ0MCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxOGVl
+        MTZhZC0wNzgwLTQyMDctYjllOS1lNzk2ODYzMWVkMjUiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI0MTg1YmU4YS1iMTY1LTRhZjctOWUyZS1iODcwMzcxMjU4
+        OTQiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2NzVlYWQ0NS0xOGJm
+        LTQxNDYtYThhMy05YWUwNjg4NzQ2NmUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiZGNiMTI5NzEtNzJjYy00MjYxLWE1YzItZjg4OGViZDFjYjMyIiwg
+        Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
+        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFjOTA0YzhkLWUwOGItNDlk
-        Yy04NDU1LTI2MWU1MGRiZmFlYiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiM2ZlOTFkZjktMThhZC00NmZiLTgx
-        Y2QtNDE0MTRhYjdkZTllIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YmQwNTYyMzQ0NzFlNDAw
-        NzBiMGMxYSJ9LCAiaWQiOiAiNTZiZDA1NjIzNDQ3MWU0MDA3MGIwYzFhIn0=
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:19 GMT
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjMxYzgxMDE2LTIwMzMtNGQ3
+        My05ZTU3LTU3YWM4Y2FmZDU4NCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
+        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjI4ZDM3NWVmLTIyODYtNDI2MC05NWQ4LTJmMDhlZDgwYWU0YSIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjcw
+        MTczN2UyLTY4ODktNDQwNC1iZjFkLWQwZmVlODI1OThmZCIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
+        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
+        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjg2YjIxN2RkLTAyYTYt
+        NGI5OS1hYzg4LTRkYWI4ODdmOTdmZiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
+        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjc5MmI1MWZhLWM3NzQtNDI1Yi05YjA4
+        LTI4MWNkYjE0OGRjNCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
+        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiYTg3YTAxZjItMzdlNi00MDM5LWFiNzAtZWE3
+        YWZkN2MzZDkwIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4ZDhhOTg5MDU0ZmM0OGJhMzBl
+        OCJ9LCAiaWQiOiAiNTZjYzhkOGE5ODkwNTRmYzQ4YmEzMGU4In0=
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:49:14 GMT
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -9364,7 +1338,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:04:19 GMT
+      - Tue, 23 Feb 2016 16:49:14 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -9378,60 +1352,60 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIwMTVhOGQyZC0zZDQzLTRmODMtODk3
-        YS0yODMyZWJjN2EyZWQiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
-        Il9pZCI6IHsiJG9pZCI6ICI1NmJkMDU2MjM0NDcxZTQwMDcwYjBjMTAifSwg
-        InVuaXRfaWQiOiAiMDE1YThkMmQtM2Q0My00ZjgzLTg5N2EtMjgzMmViYzdh
-        MmVkIiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogIjJmMmIzY2FlLTBmODktNDNjOC1hYzIxLWUzNTIyZjA2Mzk0OCIs
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIzMzYzODQ1NC01OGE4LTQxYjAtYjA2
+        Ni05YzkxMDVkYmYzOTUiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ4YTk4OTA1NGZjNDhiYTMwZTAifSwg
+        InVuaXRfaWQiOiAiMzM2Mzg0NTQtNThhOC00MWIwLWIwNjYtOWM5MTA1ZGJm
+        Mzk1IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
+        X2lkIjogIjU3NGRiNGM0LTQ5ZDEtNDk2OS1iZTZmLTYzYjExZDQ4NWVkZSIs
         ICJfY29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjog
-        IjU2YmQwNTYyMzQ0NzFlNDAwNzBiMGMwZCJ9LCAidW5pdF9pZCI6ICIyZjJi
-        M2NhZS0wZjg5LTQzYzgtYWMyMS1lMzUyMmYwNjM5NDgiLCAidW5pdF90eXBl
-        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNGI5NjgzNTUt
-        YjQ0Zi00ZmZjLThiMzktZjY1YTViZDBiOTc4IiwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiZDA1NjIzNDQ3MWU0
-        MDA3MGIwYzBjIn0sICJ1bml0X2lkIjogIjRiOTY4MzU1LWI0NGYtNGZmYy04
-        YjM5LWY2NWE1YmQwYjk3OCIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
-        bWV0YWRhdGEiOiB7Il9pZCI6ICJiNjRmNThkMy0xNGZiLTQ3OTAtYTVmNC04
-        YjVmN2JmMjkzYTciLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1NmJkMDU2MjM0NDcxZTQwMDcwYjBjMGIifSwgInVu
-        aXRfaWQiOiAiYjY0ZjU4ZDMtMTRmYi00NzkwLWE1ZjQtOGI1ZjdiZjI5M2E3
+        IjU2Y2M4ZDhhOTg5MDU0ZmM0OGJhMzBkYyJ9LCAidW5pdF9pZCI6ICI1NzRk
+        YjRjNC00OWQxLTQ5NjktYmU2Zi02M2IxMWQ0ODVlZGUiLCAidW5pdF90eXBl
+        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNmI0NTE5Yzgt
+        MjgxNi00YzU1LTkzNzctMmRhYWVmZTY0ZjgxIiwgIl9jb250ZW50X3R5cGVf
+        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkOGE5ODkwNTRm
+        YzQ4YmEzMGRmIn0sICJ1bml0X2lkIjogIjZiNDUxOWM4LTI4MTYtNGM1NS05
+        Mzc3LTJkYWFlZmU2NGY4MSIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
+        bWV0YWRhdGEiOiB7Il9pZCI6ICI4ODEyZjZjOC05ODU4LTRiZDYtOTM4Yi00
+        ZDk4MjM0MDBkYTQiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1NmNjOGQ4YTk4OTA1NGZjNDhiYTMwZGEifSwgInVu
+        aXRfaWQiOiAiODgxMmY2YzgtOTg1OC00YmQ2LTkzOGItNGQ5ODIzNDAwZGE0
         IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lk
-        IjogImI4MzVlZDNhLWEzNjgtNGIwNS1hODg4LWQ3NmIzNDY3MTdiZSIsICJf
+        IjogImM2OGUxNzE2LTM0YWItNDdlMS1iNThlLWRiZWU3NzlhZGZkZCIsICJf
         Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2
-        YmQwNTYyMzQ0NzFlNDAwNzBiMGMwZSJ9LCAidW5pdF9pZCI6ICJiODM1ZWQz
-        YS1hMzY4LTRiMDUtYTg4OC1kNzZiMzQ2NzE3YmUiLCAidW5pdF90eXBlX2lk
-        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiZTJmY2UwYzYtN2Nl
-        Ny00OTU2LTk2M2ItZmYwMDQ0NGI0ODc4IiwgIl9jb250ZW50X3R5cGVfaWQi
-        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiZDA1NjIzNDQ3MWU0MDA3
-        MGIwYzExIn0sICJ1bml0X2lkIjogImUyZmNlMGM2LTdjZTctNDk1Ni05NjNi
-        LWZmMDA0NDRiNDg3OCIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
-        YWRhdGEiOiB7Il9pZCI6ICJmZDIwZjA2NC03MDU2LTQ4M2YtOWEwYS00MmRj
-        YmVkYzIwNjkiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NmJkMDU2MjM0NDcxZTQwMDcwYjBjMTIifSwgInVuaXRf
-        aWQiOiAiZmQyMGYwNjQtNzA1Ni00ODNmLTlhMGEtNDJkY2JlZGMyMDY5Iiwg
+        Y2M4ZDhhOTg5MDU0ZmM0OGJhMzBkOSJ9LCAidW5pdF9pZCI6ICJjNjhlMTcx
+        Ni0zNGFiLTQ3ZTEtYjU4ZS1kYmVlNzc5YWRmZGQiLCAidW5pdF90eXBlX2lk
+        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiZDc3ZGVjOGQtM2Y0
+        NC00MzZmLThhYjQtMmI0N2QyOTI4Zjg2IiwgIl9jb250ZW50X3R5cGVfaWQi
+        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkOGE5ODkwNTRmYzQ4
+        YmEzMGRlIn0sICJ1bml0X2lkIjogImQ3N2RlYzhkLTNmNDQtNDM2Zi04YWI0
+        LTJiNDdkMjkyOGY4NiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
+        YWRhdGEiOiB7Il9pZCI6ICJlYTA4MTJhNC1iN2E1LTRlODMtOTYyOS01N2M3
+        MGJiOThkZTgiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
+        IHsiJG9pZCI6ICI1NmNjOGQ4YTk4OTA1NGZjNDhiYTMwZGIifSwgInVuaXRf
+        aWQiOiAiZWEwODEyYTQtYjdhNS00ZTgzLTk2MjktNTdjNzBiYjk4ZGU4Iiwg
         InVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjog
-        ImZkY2YzM2YyLTgwYWYtNDMxYS1hYWRhLWU0NDMxMDcxNzE5MiIsICJfY29u
-        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2YmQw
-        NTYyMzQ0NzFlNDAwNzBiMGMwZiJ9LCAidW5pdF9pZCI6ICJmZGNmMzNmMi04
-        MGFmLTQzMWEtYWFkYS1lNDQzMTA3MTcxOTIiLCAidW5pdF90eXBlX2lkIjog
+        ImVlODExMTk3LWVmYTAtNDc1ZC1hNjM3LWQzYzZjODQzNWViMCIsICJfY29u
+        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4
+        ZDhhOTg5MDU0ZmM0OGJhMzBkZCJ9LCAidW5pdF9pZCI6ICJlZTgxMTE5Ny1l
+        ZmEwLTQ3NWQtYTYzNy1kM2M2Yzg0MzVlYjAiLCAidW5pdF90eXBlX2lkIjog
         InJwbSJ9XQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:19 GMT
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:49:14 GMT
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/content/units/rpm/search/
+    uri: https://katello-yoda.example.com/pulp/api/v2/content/units/rpm/search/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMDE1YThk
-        MmQtM2Q0My00ZjgzLTg5N2EtMjgzMmViYzdhMmVkIiwiMmYyYjNjYWUtMGY4
-        OS00M2M4LWFjMjEtZTM1MjJmMDYzOTQ4IiwiNGI5NjgzNTUtYjQ0Zi00ZmZj
-        LThiMzktZjY1YTViZDBiOTc4IiwiYjY0ZjU4ZDMtMTRmYi00NzkwLWE1ZjQt
-        OGI1ZjdiZjI5M2E3IiwiYjgzNWVkM2EtYTM2OC00YjA1LWE4ODgtZDc2YjM0
-        NjcxN2JlIiwiZTJmY2UwYzYtN2NlNy00OTU2LTk2M2ItZmYwMDQ0NGI0ODc4
-        IiwiZmQyMGYwNjQtNzA1Ni00ODNmLTlhMGEtNDJkY2JlZGMyMDY5IiwiZmRj
-        ZjMzZjItODBhZi00MzFhLWFhZGEtZTQ0MzEwNzE3MTkyIl19fSwiZmllbGRz
+        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMzM2Mzg0
+        NTQtNThhOC00MWIwLWIwNjYtOWM5MTA1ZGJmMzk1IiwiNTc0ZGI0YzQtNDlk
+        MS00OTY5LWJlNmYtNjNiMTFkNDg1ZWRlIiwiNmI0NTE5YzgtMjgxNi00YzU1
+        LTkzNzctMmRhYWVmZTY0ZjgxIiwiODgxMmY2YzgtOTg1OC00YmQ2LTkzOGIt
+        NGQ5ODIzNDAwZGE0IiwiYzY4ZTE3MTYtMzRhYi00N2UxLWI1OGUtZGJlZTc3
+        OWFkZmRkIiwiZDc3ZGVjOGQtM2Y0NC00MzZmLThhYjQtMmI0N2QyOTI4Zjg2
+        IiwiZWEwODEyYTQtYjdhNS00ZTgzLTk2MjktNTdjNzBiYjk4ZGU4IiwiZWU4
+        MTExOTctZWZhMC00NzVkLWE2MzctZDNjNmM4NDM1ZWIwIl19fSwiZmllbGRz
         IjpbIm5hbWUiLCJ2ZXJzaW9uIiwicmVsZWFzZSIsImFyY2giLCJlcG9jaCIs
         InN1bW1hcnkiLCJzb3VyY2VycG0iLCJjaGVja3N1bSIsImZpbGVuYW1lIiwi
         X2lkIl19LCJpbmNsdWRlX3JlcG9zIjp0cnVlfQ==
@@ -9452,13 +1426,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:04:19 GMT
+      - Tue, 23 Feb 2016 16:49:14 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '3804'
+      - '3948'
       Connection:
       - close
       Content-Type:
@@ -9466,96 +1440,99 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJz
-        b3VyY2VycG0iOiAiZWxlcGhhbnQtMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUi
-        OiAiZWxlcGhhbnQiLCAiY2hlY2tzdW0iOiAiM2UxYzcwY2QxYjQyMTMyOGFj
-        YWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFm
-        MyIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBlbGVwaGFudCIs
-        ICJmaWxlbmFtZSI6ICJlbGVwaGFudC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAi
-        ZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAu
-        OCIsICJfaWQiOiAiMDE1YThkMmQtM2Q0My00ZjgzLTg5N2EtMjgzMmViYzdh
-        MmVkIiwgImFyY2giOiAibm9hcmNoIiwgImNoaWxkcmVuIjoge30sICJfaHJl
-        ZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9ycG0vMDE1YThkMmQt
-        M2Q0My00ZjgzLTg5N2EtMjgzMmViYzdhMmVkLyJ9LCB7InJlcG9zaXRvcnlf
-        bWVtYmVyc2hpcHMiOiBbIkZlZG9yYV8xNyJdLCAic291cmNlcnBtIjogInBl
-        bmd1aW4tMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAicGVuZ3VpbiIsICJj
-        aGVja3N1bSI6ICIzZmNiMmM5MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQz
-        ZTVhZDJlNTg1NjRmYzIxMGZkNmU0ODYzNWJlNjk0IiwgInN1bW1hcnkiOiAi
-        QSBkdW1teSBwYWNrYWdlIG9mIHBlbmd1aW4iLCAiZmlsZW5hbWUiOiAicGVu
-        Z3Vpbi0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJz
-        aW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiMmYyYjNj
-        YWUtMGY4OS00M2M4LWFjMjEtZTM1MjJmMDYzOTQ4IiwgImFyY2giOiAibm9h
-        cmNoIiwgImNoaWxkcmVuIjoge30sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIv
-        Y29udGVudC91bml0cy9ycG0vMmYyYjNjYWUtMGY4OS00M2M4LWFjMjEtZTM1
-        MjJmMDYzOTQ4LyJ9LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBbIkZl
-        ZG9yYV8xNyJdLCAic291cmNlcnBtIjogIndhbHJ1cy0wLjMtMC44LnNyYy5y
-        cG0iLCAibmFtZSI6ICJ3YWxydXMiLCAiY2hlY2tzdW0iOiAiNmU4ZDZkYzA1
-        N2UzZTJjOTgxOWYwZGM3ZTZjN2I3Zjg2YmYyZTg1NzFiYmE0MTRhZGVjN2Zi
-        NjIxYTQ2MWRmZCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiB3
-        YWxydXMiLCAiZmlsZW5hbWUiOiAid2FscnVzLTAuMy0wLjgubm9hcmNoLnJw
-        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2Ui
-        OiAiMC44IiwgIl9pZCI6ICI0Yjk2ODM1NS1iNDRmLTRmZmMtOGIzOS1mNjVh
-        NWJkMGI5NzgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwg
-        Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS80Yjk2
-        ODM1NS1iNDRmLTRmZmMtOGIzOS1mNjVhNWJkMGI5NzgvIn0sIHsicmVwb3Np
-        dG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJzb3VyY2VycG0i
-        OiAibW9ua2V5LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogIm1vbmtleSIs
-        ICJjaGVja3N1bSI6ICIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNmYTI1
-        ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwgInN1bW1hcnki
-        OiAiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIsICJmaWxlbmFtZSI6ICJt
-        b25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVy
-        c2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogImI2NGY1
-        OGQzLTE0ZmItNDc5MC1hNWY0LThiNWY3YmYyOTNhNyIsICJhcmNoIjogIm5v
-        YXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
-        L2NvbnRlbnQvdW5pdHMvcnBtL2I2NGY1OGQzLTE0ZmItNDc5MC1hNWY0LThi
-        NWY3YmYyOTNhNy8ifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJG
-        ZWRvcmFfMTciXSwgInNvdXJjZXJwbSI6ICJzcXVpcnJlbC0wLjMtMC44LnNy
-        Yy5ycG0iLCAibmFtZSI6ICJzcXVpcnJlbCIsICJjaGVja3N1bSI6ICIyNTE3
-        NjhiZGQxNWYxM2Q3ODQ4N2MyNzYzOGFhNmFlY2QwMTU1MWUyNTM3NTYwOTNj
-        ZGUxYzBhZTg3OGExN2QyIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdl
-        IG9mIHNxdWlycmVsIiwgImZpbGVuYW1lIjogInNxdWlycmVsLTAuMy0wLjgu
+        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsicmVpbnRlcm1lZGlhdGUi
+        LCAiRmVkb3JhXzE3Il0sICJzb3VyY2VycG0iOiAic3F1aXJyZWwtMC4zLTAu
+        OC5zcmMucnBtIiwgIm5hbWUiOiAic3F1aXJyZWwiLCAiY2hlY2tzdW0iOiAi
+        MjUxNzY4YmRkMTVmMTNkNzg0ODdjMjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2
+        MDkzY2RlMWMwYWU4NzhhMTdkMiIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFj
+        a2FnZSBvZiBzcXVpcnJlbCIsICJmaWxlbmFtZSI6ICJzcXVpcnJlbC0wLjMt
+        MC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAu
+        MyIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiMzM2Mzg0NTQtNThhOC00
+        MWIwLWIwNjYtOWM5MTA1ZGJmMzk1IiwgImFyY2giOiAibm9hcmNoIiwgImNo
+        aWxkcmVuIjoge30sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91
+        bml0cy9ycG0vMzM2Mzg0NTQtNThhOC00MWIwLWIwNjYtOWM5MTA1ZGJmMzk1
+        LyJ9LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBbInJlaW50ZXJtZWRp
+        YXRlIiwgIkZlZG9yYV8xNyJdLCAic291cmNlcnBtIjogIm1vbmtleS0wLjMt
+        MC44LnNyYy5ycG0iLCAibmFtZSI6ICJtb25rZXkiLCAiY2hlY2tzdW0iOiAi
+        MGU4ZmE1MGQwMTI4ZmJhYmM3Y2NjNTYzMmUzZmEyNWQzOWIwMjgwMTY5ZjYx
+        NjZjYjhlMmM4NGRlODUwMWRiMSIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFj
+        a2FnZSBvZiBtb25rZXkiLCAiZmlsZW5hbWUiOiAibW9ua2V5LTAuMy0wLjgu
         bm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwg
-        InJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICJiODM1ZWQzYS1hMzY4LTRiMDUt
-        YTg4OC1kNzZiMzQ2NzE3YmUiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRy
+        InJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICI1NzRkYjRjNC00OWQxLTQ5Njkt
+        YmU2Zi02M2IxMWQ0ODVlZGUiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRy
         ZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRz
-        L3JwbS9iODM1ZWQzYS1hMzY4LTRiMDUtYTg4OC1kNzZiMzQ2NzE3YmUvIn0s
-        IHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJz
-        b3VyY2VycG0iOiAibGlvbi0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJs
-        aW9uIiwgImNoZWNrc3VtIjogIjEyNDAwZGM5NWMyM2E0YzE2MDcyNWE5MDg3
-        MTZjZDNmY2RkN2E4OTgxNTg1NDM3YWI2NGNkNjJlZmEzZTRhZTQiLCAic3Vt
-        bWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgbGlvbiIsICJmaWxlbmFtZSI6
-        ICJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZl
-        cnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICJlMmZj
-        ZTBjNi03Y2U3LTQ5NTYtOTYzYi1mZjAwNDQ0YjQ4NzgiLCAiYXJjaCI6ICJu
-        b2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92
-        Mi9jb250ZW50L3VuaXRzL3JwbS9lMmZjZTBjNi03Y2U3LTQ5NTYtOTYzYi1m
-        ZjAwNDQ0YjQ4NzgvIn0sIHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsi
-        RmVkb3JhXzE3Il0sICJzb3VyY2VycG0iOiAiZ2lyYWZmZS0wLjMtMC44LnNy
-        Yy5ycG0iLCAibmFtZSI6ICJnaXJhZmZlIiwgImNoZWNrc3VtIjogImYyNWQ2
-        N2QxZDlkYTA0ZjEyZTU3Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRl
-        NmQxOTIyMDA5ZjlmMTQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ug
-        b2YgZ2lyYWZmZSIsICJmaWxlbmFtZSI6ICJnaXJhZmZlLTAuMy0wLjgubm9h
-        cmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJl
-        bGVhc2UiOiAiMC44IiwgIl9pZCI6ICJmZDIwZjA2NC03MDU2LTQ4M2YtOWEw
-        YS00MmRjYmVkYzIwNjkiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4i
-        OiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3Jw
-        bS9mZDIwZjA2NC03MDU2LTQ4M2YtOWEwYS00MmRjYmVkYzIwNjkvIn0sIHsi
-        cmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJzb3Vy
-        Y2VycG0iOiAiY2hlZXRhaC0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJj
-        aGVldGFoIiwgImNoZWNrc3VtIjogIjQyMmQwYmFhMGNkOWQ3NzEzYWU3OTZl
-        ODg2YTIzZTE3ZjU3OGY5MjRmNzQ4ODBkZWJkYmI3ZDY1ZmIzNjhkYWUiLCAi
-        c3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsICJmaWxl
-        bmFtZSI6ICJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6
-        ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgIl9p
-        ZCI6ICJmZGNmMzNmMi04MGFmLTQzMWEtYWFkYS1lNDQzMTA3MTcxOTIiLCAi
-        YXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS9mZGNmMzNmMi04MGFmLTQz
-        MWEtYWFkYS1lNDQzMTA3MTcxOTIvIn1d
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:19 GMT
+        L3JwbS81NzRkYjRjNC00OWQxLTQ5NjktYmU2Zi02M2IxMWQ0ODVlZGUvIn0s
+        IHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsicmVpbnRlcm1lZGlhdGUi
+        LCAiRmVkb3JhXzE3Il0sICJzb3VyY2VycG0iOiAid2FscnVzLTAuMy0wLjgu
+        c3JjLnJwbSIsICJuYW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6ICI2ZThk
+        NmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFk
+        ZWM3ZmI2MjFhNDYxZGZkIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdl
+        IG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6ICJ3YWxydXMtMC4zLTAuOC5ub2Fy
+        Y2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVs
+        ZWFzZSI6ICIwLjgiLCAiX2lkIjogIjZiNDUxOWM4LTI4MTYtNGM1NS05Mzc3
+        LTJkYWFlZmU2NGY4MSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6
+        IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBt
+        LzZiNDUxOWM4LTI4MTYtNGM1NS05Mzc3LTJkYWFlZmU2NGY4MS8ifSwgeyJy
+        ZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJyZWludGVybWVkaWF0ZSIsICJG
+        ZWRvcmFfMTciXSwgInNvdXJjZXJwbSI6ICJlbGVwaGFudC0wLjMtMC44LnNy
+        Yy5ycG0iLCAibmFtZSI6ICJlbGVwaGFudCIsICJjaGVja3N1bSI6ICIzZTFj
+        NzBjZDFiNDIxMzI4YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1
+        ZmMzMTM3MmEwYTcwMWYzIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdl
+        IG9mIGVsZXBoYW50IiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgu
+        bm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwg
+        InJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICI4ODEyZjZjOC05ODU4LTRiZDYt
+        OTM4Yi00ZDk4MjM0MDBkYTQiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRy
+        ZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRz
+        L3JwbS84ODEyZjZjOC05ODU4LTRiZDYtOTM4Yi00ZDk4MjM0MDBkYTQvIn0s
+        IHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsicmVpbnRlcm1lZGlhdGUi
+        LCAiRmVkb3JhXzE3Il0sICJzb3VyY2VycG0iOiAiZ2lyYWZmZS0wLjMtMC44
+        LnNyYy5ycG0iLCAibmFtZSI6ICJnaXJhZmZlIiwgImNoZWNrc3VtIjogImYy
+        NWQ2N2QxZDlkYTA0ZjEyZTU3Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4
+        MmRlNmQxOTIyMDA5ZjlmMTQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2th
+        Z2Ugb2YgZ2lyYWZmZSIsICJmaWxlbmFtZSI6ICJnaXJhZmZlLTAuMy0wLjgu
+        bm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwg
+        InJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICJjNjhlMTcxNi0zNGFiLTQ3ZTEt
+        YjU4ZS1kYmVlNzc5YWRmZGQiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRy
+        ZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRz
+        L3JwbS9jNjhlMTcxNi0zNGFiLTQ3ZTEtYjU4ZS1kYmVlNzc5YWRmZGQvIn0s
+        IHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsicmVpbnRlcm1lZGlhdGUi
+        LCAiRmVkb3JhXzE3Il0sICJzb3VyY2VycG0iOiAiY2hlZXRhaC0wLjMtMC44
+        LnNyYy5ycG0iLCAibmFtZSI6ICJjaGVldGFoIiwgImNoZWNrc3VtIjogIjQy
+        MmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIzZTE3ZjU3OGY5MjRmNzQ4ODBk
+        ZWJkYmI3ZDY1ZmIzNjhkYWUiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2th
+        Z2Ugb2YgY2hlZXRhaCIsICJmaWxlbmFtZSI6ICJjaGVldGFoLTAuMy0wLjgu
+        bm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwg
+        InJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICJkNzdkZWM4ZC0zZjQ0LTQzNmYt
+        OGFiNC0yYjQ3ZDI5MjhmODYiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRy
+        ZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRz
+        L3JwbS9kNzdkZWM4ZC0zZjQ0LTQzNmYtOGFiNC0yYjQ3ZDI5MjhmODYvIn0s
+        IHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsicmVpbnRlcm1lZGlhdGUi
+        LCAiRmVkb3JhXzE3Il0sICJzb3VyY2VycG0iOiAibGlvbi0wLjMtMC44LnNy
+        Yy5ycG0iLCAibmFtZSI6ICJsaW9uIiwgImNoZWNrc3VtIjogIjEyNDAwZGM5
+        NWMyM2E0YzE2MDcyNWE5MDg3MTZjZDNmY2RkN2E4OTgxNTg1NDM3YWI2NGNk
+        NjJlZmEzZTRhZTQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        bGlvbiIsICJmaWxlbmFtZSI6ICJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAi
+        MC44IiwgIl9pZCI6ICJlYTA4MTJhNC1iN2E1LTRlODMtOTYyOS01N2M3MGJi
+        OThkZTgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9o
+        cmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS9lYTA4MTJh
+        NC1iN2E1LTRlODMtOTYyOS01N2M3MGJiOThkZTgvIn0sIHsicmVwb3NpdG9y
+        eV9tZW1iZXJzaGlwcyI6IFsicmVpbnRlcm1lZGlhdGUiLCAiRmVkb3JhXzE3
+        Il0sICJzb3VyY2VycG0iOiAicGVuZ3Vpbi0wLjMtMC44LnNyYy5ycG0iLCAi
+        bmFtZSI6ICJwZW5ndWluIiwgImNoZWNrc3VtIjogIjNmY2IyYzkyN2RlOWUx
+        M2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFkMmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1
+        YmU2OTQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgcGVuZ3Vp
+        biIsICJmaWxlbmFtZSI6ICJwZW5ndWluLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAi
+        MC44IiwgIl9pZCI6ICJlZTgxMTE5Ny1lZmEwLTQ3NWQtYTYzNy1kM2M2Yzg0
+        MzVlYjAiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9o
+        cmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS9lZTgxMTE5
+        Ny1lZmEwLTQ3NWQtYTYzNy1kM2M2Yzg0MzVlYjAvIn1d
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:49:14 GMT
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -9578,7 +1555,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:04:19 GMT
+      - Tue, 23 Feb 2016 16:49:14 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -9592,54 +1569,54 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIwMTVhOGQyZC0zZDQzLTRmODMtODk3
-        YS0yODMyZWJjN2EyZWQiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
-        Il9pZCI6IHsiJG9pZCI6ICI1NmJkMDU2MjM0NDcxZTQwMDcwYjBjMTAifSwg
-        InVuaXRfaWQiOiAiMDE1YThkMmQtM2Q0My00ZjgzLTg5N2EtMjgzMmViYzdh
-        MmVkIiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogIjJmMmIzY2FlLTBmODktNDNjOC1hYzIxLWUzNTIyZjA2Mzk0OCIs
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIzMzYzODQ1NC01OGE4LTQxYjAtYjA2
+        Ni05YzkxMDVkYmYzOTUiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmNjOGQ4YTk4OTA1NGZjNDhiYTMwZTAifSwg
+        InVuaXRfaWQiOiAiMzM2Mzg0NTQtNThhOC00MWIwLWIwNjYtOWM5MTA1ZGJm
+        Mzk1IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
+        X2lkIjogIjU3NGRiNGM0LTQ5ZDEtNDk2OS1iZTZmLTYzYjExZDQ4NWVkZSIs
         ICJfY29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjog
-        IjU2YmQwNTYyMzQ0NzFlNDAwNzBiMGMwZCJ9LCAidW5pdF9pZCI6ICIyZjJi
-        M2NhZS0wZjg5LTQzYzgtYWMyMS1lMzUyMmYwNjM5NDgiLCAidW5pdF90eXBl
-        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNGI5NjgzNTUt
-        YjQ0Zi00ZmZjLThiMzktZjY1YTViZDBiOTc4IiwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiZDA1NjIzNDQ3MWU0
-        MDA3MGIwYzBjIn0sICJ1bml0X2lkIjogIjRiOTY4MzU1LWI0NGYtNGZmYy04
-        YjM5LWY2NWE1YmQwYjk3OCIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
-        bWV0YWRhdGEiOiB7Il9pZCI6ICJiNjRmNThkMy0xNGZiLTQ3OTAtYTVmNC04
-        YjVmN2JmMjkzYTciLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1NmJkMDU2MjM0NDcxZTQwMDcwYjBjMGIifSwgInVu
-        aXRfaWQiOiAiYjY0ZjU4ZDMtMTRmYi00NzkwLWE1ZjQtOGI1ZjdiZjI5M2E3
+        IjU2Y2M4ZDhhOTg5MDU0ZmM0OGJhMzBkYyJ9LCAidW5pdF9pZCI6ICI1NzRk
+        YjRjNC00OWQxLTQ5NjktYmU2Zi02M2IxMWQ0ODVlZGUiLCAidW5pdF90eXBl
+        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNmI0NTE5Yzgt
+        MjgxNi00YzU1LTkzNzctMmRhYWVmZTY0ZjgxIiwgIl9jb250ZW50X3R5cGVf
+        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkOGE5ODkwNTRm
+        YzQ4YmEzMGRmIn0sICJ1bml0X2lkIjogIjZiNDUxOWM4LTI4MTYtNGM1NS05
+        Mzc3LTJkYWFlZmU2NGY4MSIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
+        bWV0YWRhdGEiOiB7Il9pZCI6ICI4ODEyZjZjOC05ODU4LTRiZDYtOTM4Yi00
+        ZDk4MjM0MDBkYTQiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1NmNjOGQ4YTk4OTA1NGZjNDhiYTMwZGEifSwgInVu
+        aXRfaWQiOiAiODgxMmY2YzgtOTg1OC00YmQ2LTkzOGItNGQ5ODIzNDAwZGE0
         IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lk
-        IjogImI4MzVlZDNhLWEzNjgtNGIwNS1hODg4LWQ3NmIzNDY3MTdiZSIsICJf
+        IjogImM2OGUxNzE2LTM0YWItNDdlMS1iNThlLWRiZWU3NzlhZGZkZCIsICJf
         Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2
-        YmQwNTYyMzQ0NzFlNDAwNzBiMGMwZSJ9LCAidW5pdF9pZCI6ICJiODM1ZWQz
-        YS1hMzY4LTRiMDUtYTg4OC1kNzZiMzQ2NzE3YmUiLCAidW5pdF90eXBlX2lk
-        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiZTJmY2UwYzYtN2Nl
-        Ny00OTU2LTk2M2ItZmYwMDQ0NGI0ODc4IiwgIl9jb250ZW50X3R5cGVfaWQi
-        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiZDA1NjIzNDQ3MWU0MDA3
-        MGIwYzExIn0sICJ1bml0X2lkIjogImUyZmNlMGM2LTdjZTctNDk1Ni05NjNi
-        LWZmMDA0NDRiNDg3OCIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
-        YWRhdGEiOiB7Il9pZCI6ICJmZDIwZjA2NC03MDU2LTQ4M2YtOWEwYS00MmRj
-        YmVkYzIwNjkiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NmJkMDU2MjM0NDcxZTQwMDcwYjBjMTIifSwgInVuaXRf
-        aWQiOiAiZmQyMGYwNjQtNzA1Ni00ODNmLTlhMGEtNDJkY2JlZGMyMDY5Iiwg
+        Y2M4ZDhhOTg5MDU0ZmM0OGJhMzBkOSJ9LCAidW5pdF9pZCI6ICJjNjhlMTcx
+        Ni0zNGFiLTQ3ZTEtYjU4ZS1kYmVlNzc5YWRmZGQiLCAidW5pdF90eXBlX2lk
+        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiZDc3ZGVjOGQtM2Y0
+        NC00MzZmLThhYjQtMmI0N2QyOTI4Zjg2IiwgIl9jb250ZW50X3R5cGVfaWQi
+        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkOGE5ODkwNTRmYzQ4
+        YmEzMGRlIn0sICJ1bml0X2lkIjogImQ3N2RlYzhkLTNmNDQtNDM2Zi04YWI0
+        LTJiNDdkMjkyOGY4NiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
+        YWRhdGEiOiB7Il9pZCI6ICJlYTA4MTJhNC1iN2E1LTRlODMtOTYyOS01N2M3
+        MGJiOThkZTgiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
+        IHsiJG9pZCI6ICI1NmNjOGQ4YTk4OTA1NGZjNDhiYTMwZGIifSwgInVuaXRf
+        aWQiOiAiZWEwODEyYTQtYjdhNS00ZTgzLTk2MjktNTdjNzBiYjk4ZGU4Iiwg
         InVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjog
-        ImZkY2YzM2YyLTgwYWYtNDMxYS1hYWRhLWU0NDMxMDcxNzE5MiIsICJfY29u
-        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2YmQw
-        NTYyMzQ0NzFlNDAwNzBiMGMwZiJ9LCAidW5pdF9pZCI6ICJmZGNmMzNmMi04
-        MGFmLTQzMWEtYWFkYS1lNDQzMTA3MTcxOTIiLCAidW5pdF90eXBlX2lkIjog
+        ImVlODExMTk3LWVmYTAtNDc1ZC1hNjM3LWQzYzZjODQzNWViMCIsICJfY29u
+        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2Y2M4
+        ZDhhOTg5MDU0ZmM0OGJhMzBkZCJ9LCAidW5pdF9pZCI6ICJlZTgxMTE5Ny1l
+        ZmEwLTQ3NWQtYTYzNy1kM2M2Yzg0MzVlYjAiLCAidW5pdF90eXBlX2lkIjog
         InJwbSJ9XQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:19 GMT
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:49:14 GMT
 - request:
     method: post
-    uri: https://katello-burrito.example.com/pulp/api/v2/content/units/rpm/search/
+    uri: https://katello-yoda.example.com/pulp/api/v2/content/units/rpm/search/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMDE1YThk
-        MmQtM2Q0My00ZjgzLTg5N2EtMjgzMmViYzdhMmVkIl19fX0sImluY2x1ZGVf
+        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMzM2Mzg0
+        NTQtNThhOC00MWIwLWIwNjYtOWM5MTA1ZGJmMzk1Il19fX0sImluY2x1ZGVf
         cmVwb3MiOnRydWV9
     headers:
       Accept:
@@ -9658,13 +1635,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:04:19 GMT
+      - Tue, 23 Feb 2016 16:49:14 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '3010'
+      - '3052'
       Connection:
       - close
       Content-Type:
@@ -9672,78 +1649,79 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJf
-        aHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9ycG0vMDE1YThk
-        MmQtM2Q0My00ZjgzLTg5N2EtMjgzMmViYzdhMmVkLyIsICJidWlsZF90aW1l
-        IjogMTMwODI1NzQ2NiwgImJ1aWxkaG9zdCI6ICJkaGNwLTI2LTExOC5icnEu
-        cmVkaGF0LmNvbSIsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250
-        ZW50X3R5cGVfaWQiOiAicnBtIiwgImNoaWxkcmVuIjoge30sICJzaXplIjog
-        MjI0NCwgImxpY2Vuc2UiOiAiR1BMdjIiLCAiZ3JvdXAiOiAiSW50ZXJuZXQv
-        QXBwbGljYXRpb25zIiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgu
-        bm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwg
-        InZlcnNpb25fc29ydF9pbmRleCI6ICIwMS0wLjAxLTMiLCAicHJvdmlkZXMi
-        OiBbeyJyZWxlYXNlIjogIjAuOCIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24i
-        OiAiMC4zIiwgImZsYWdzIjogIkVRIiwgIm5hbWUiOiAiZWxlcGhhbnQifV0s
-        ICJmaWxlcyI6IHsiZGlyIjogW10sICJmaWxlIjogWyIvL2VsZXBoYW50LnR4
-        dCJdfSwgInJlcG9kYXRhIjogeyJmaWxlbGlzdHMiOiAiPHBhY2thZ2UgYXJj
-        aD1cIm5vYXJjaFwiIG5hbWU9XCJlbGVwaGFudFwiIHBrZ2lkPVwiM2UxYzcw
-        Y2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5NWY2NWQxYjA5NWZj
-        MzEzNzJhMGE3MDFmM1wiPlxuICAgIDx2ZXJzaW9uIGVwb2NoPVwiMFwiIHJl
-        bD1cIjAuOFwiIHZlcj1cIjAuM1wiIC8+XG5cbiAgICA8ZmlsZT4vL2VsZXBo
-        YW50LnR4dDwvZmlsZT5cbjwvcGFja2FnZT5cblxuIiwgIm90aGVyIjogIjxw
-        YWNrYWdlIGFyY2g9XCJub2FyY2hcIiBuYW1lPVwiZWxlcGhhbnRcIiBwa2dp
-        ZD1cIjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVm
-        NjVkMWIwOTVmYzMxMzcyYTBhNzAxZjNcIj5cbiAgICA8dmVyc2lvbiBlcG9j
-        aD1cIjBcIiByZWw9XCIwLjhcIiB2ZXI9XCIwLjNcIiAvPlxuXG48L3BhY2th
-        Z2U+XG5cbiIsICJwcmltYXJ5IjogIjxwYWNrYWdlIHR5cGU9XCJycG1cIj5c
-        biAgPG5hbWU+ZWxlcGhhbnQ8L25hbWU+XG4gIDxhcmNoPm5vYXJjaDwvYXJj
-        aD5cbiAgPHZlcnNpb24gZXBvY2g9XCIwXCIgcmVsPVwiMC44XCIgdmVyPVwi
-        MC4zXCIgLz5cbiAgPGNoZWNrc3VtIHBrZ2lkPVwiWUVTXCIgdHlwZT1cInNo
-        YTI1NlwiPjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJi
-        OTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjM8L2NoZWNrc3VtPlxuICA8c3Vt
-        bWFyeT5BIGR1bW15IHBhY2thZ2Ugb2YgZWxlcGhhbnQ8L3N1bW1hcnk+XG4g
-        IDxkZXNjcmlwdGlvbj5BIGR1bW15IHBhY2thZ2Ugb2YgZWxlcGhhbnQ8L2Rl
-        c2NyaXB0aW9uPlxuICA8cGFja2FnZXIgLz5cbiAgPHVybD5odHRwOi8vdHN0
-        cmFjaG90YS5mZWRvcmFwZW9wbGUub3JnPC91cmw+XG4gIDx0aW1lIGJ1aWxk
-        PVwiMTMwODI1NzQ2NlwiIGZpbGU9XCIxMzIxODkxMDI3XCIgLz5cbiAgPHNp
-        emUgYXJjaGl2ZT1cIjI5NlwiIGluc3RhbGxlZD1cIjQyXCIgcGFja2FnZT1c
-        IjIyNDRcIiAvPlxuPGxvY2F0aW9uIGhyZWY9XCJlbGVwaGFudC0wLjMtMC44
-        Lm5vYXJjaC5ycG1cIi8+XG4gIDxmb3JtYXQ+XG4gICAgPHJwbTpsaWNlbnNl
-        PkdQTHYyPC9ycG06bGljZW5zZT5cbiAgICA8cnBtOnZlbmRvciAvPlxuICAg
-        IDxycG06Z3JvdXA+SW50ZXJuZXQvQXBwbGljYXRpb25zPC9ycG06Z3JvdXA+
-        XG4gICAgPHJwbTpidWlsZGhvc3Q+ZGhjcC0yNi0xMTguYnJxLnJlZGhhdC5j
-        b208L3JwbTpidWlsZGhvc3Q+XG4gICAgPHJwbTpzb3VyY2VycG0+ZWxlcGhh
-        bnQtMC4zLTAuOC5zcmMucnBtPC9ycG06c291cmNlcnBtPlxuICAgIDxycG06
-        aGVhZGVyLXJhbmdlIGVuZD1cIjIwMjhcIiBzdGFydD1cIjI4MFwiIC8+XG4g
-        ICAgPHJwbTpwcm92aWRlcz5cbiAgICAgIDxycG06ZW50cnkgZXBvY2g9XCIw
-        XCIgZmxhZ3M9XCJFUVwiIG5hbWU9XCJlbGVwaGFudFwiIHJlbD1cIjAuOFwi
-        IHZlcj1cIjAuM1wiIC8+XG4gICAgPC9ycG06cHJvdmlkZXM+XG4gICAgPHJw
-        bTpyZXF1aXJlcz5cbiAgICAgIDxycG06ZW50cnkgbmFtZT1cIi9iaW4vc2hc
-        IiBwcmU9XCIxXCIgLz5cbiAgICA8L3JwbTpyZXF1aXJlcz5cbiAgPC9mb3Jt
-        YXQ+XG48L3BhY2thZ2U+XG4ifSwgImRlc2NyaXB0aW9uIjogIkEgZHVtbXkg
-        cGFja2FnZSBvZiBlbGVwaGFudCIsICJfbGFzdF91cGRhdGVkIjogIjIwMTYt
-        MDItMTFUMjI6MDA6MjZaIiwgInRpbWUiOiAxMzIxODkxMDI3LCAiZG93bmxv
-        YWRlZCI6IHRydWUsICJoZWFkZXJfcmFuZ2UiOiB7InN0YXJ0IjogMjgwLCAi
-        ZW5kIjogMjAyOH0sICJhcmNoIjogIm5vYXJjaCIsICJuYW1lIjogImVsZXBo
-        YW50IiwgIl9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVscC9jb250ZW50
-        L3VuaXRzL3JwbS8wMTVhLzAxNWE4ZDJkLTNkNDMtNGY4My04OTdhLTI4MzJl
-        YmM3YTJlZC9lbGVwaGFudC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAic291cmNl
-        cnBtIjogImVsZXBoYW50LTAuMy0wLjguc3JjLnJwbSIsICJjaGVja3N1bXR5
-        cGUiOiAic2hhMjU2IiwgInJlbGVhc2Vfc29ydF9pbmRleCI6ICIwMS0wLjAx
-        LTgiLCAiY2hhbmdlbG9nIjogW10sICJ1cmwiOiAiaHR0cDovL3RzdHJhY2hv
-        dGEuZmVkb3JhcGVvcGxlLm9yZyIsICJjaGVja3N1bSI6ICIzZTFjNzBjZDFi
-        NDIxMzI4YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3
-        MmEwYTcwMWYzIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGVs
-        ZXBoYW50IiwgInJlbGF0aXZlcGF0aCI6ICJlbGVwaGFudC0wLjMtMC44Lm5v
-        YXJjaC5ycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjAxNWE4ZDJk
-        LTNkNDMtNGY4My04OTdhLTI4MzJlYmM3YTJlZCIsICJyZXF1aXJlcyI6IFt7
-        InJlbGVhc2UiOiBudWxsLCAiZXBvY2giOiBudWxsLCAidmVyc2lvbiI6IG51
-        bGwsICJmbGFncyI6IG51bGwsICJuYW1lIjogIi9iaW4vc2gifV19XQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:19 GMT
+        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsicmVpbnRlcm1lZGlhdGUi
+        LCAiRmVkb3JhXzE3Il0sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVu
+        dC91bml0cy9ycG0vMzM2Mzg0NTQtNThhOC00MWIwLWIwNjYtOWM5MTA1ZGJm
+        Mzk1LyIsICJidWlsZF90aW1lIjogMTMwODI1NzUwMiwgImJ1aWxkaG9zdCI6
+        ICJkaGNwLTI2LTExOC5icnEucmVkaGF0LmNvbSIsICJwdWxwX3VzZXJfbWV0
+        YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgImNoaWxk
+        cmVuIjoge30sICJzaXplIjogMjI0OCwgImxpY2Vuc2UiOiAiR1BMdjIiLCAi
+        Z3JvdXAiOiAiSW50ZXJuZXQvQXBwbGljYXRpb25zIiwgImZpbGVuYW1lIjog
+        InNxdWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwg
+        InZlcnNpb24iOiAiMC4zIiwgInZlcnNpb25fc29ydF9pbmRleCI6ICIwMS0w
+        LjAxLTMiLCAicHJvdmlkZXMiOiBbeyJyZWxlYXNlIjogIjAuOCIsICJlcG9j
+        aCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImZsYWdzIjogIkVRIiwgIm5h
+        bWUiOiAic3F1aXJyZWwifV0sICJmaWxlcyI6IHsiZGlyIjogW10sICJmaWxl
+        IjogWyIvL3NxdWlycmVsLnR4dCJdfSwgInJlcG9kYXRhIjogeyJmaWxlbGlz
+        dHMiOiAiPHBhY2thZ2UgYXJjaD1cIm5vYXJjaFwiIG5hbWU9XCJzcXVpcnJl
+        bFwiIHBrZ2lkPVwiMjUxNzY4YmRkMTVmMTNkNzg0ODdjMjc2MzhhYTZhZWNk
+        MDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMlwiPlxuICAgIDx2ZXJz
+        aW9uIGVwb2NoPVwiMFwiIHJlbD1cIjAuOFwiIHZlcj1cIjAuM1wiIC8+XG5c
+        biAgICA8ZmlsZT4vL3NxdWlycmVsLnR4dDwvZmlsZT5cbjwvcGFja2FnZT5c
+        blxuIiwgIm90aGVyIjogIjxwYWNrYWdlIGFyY2g9XCJub2FyY2hcIiBuYW1l
+        PVwic3F1aXJyZWxcIiBwa2dpZD1cIjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3
+        NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDJcIj5c
+        biAgICA8dmVyc2lvbiBlcG9jaD1cIjBcIiByZWw9XCIwLjhcIiB2ZXI9XCIw
+        LjNcIiAvPlxuXG48L3BhY2thZ2U+XG5cbiIsICJwcmltYXJ5IjogIjxwYWNr
+        YWdlIHR5cGU9XCJycG1cIj5cbiAgPG5hbWU+c3F1aXJyZWw8L25hbWU+XG4g
+        IDxhcmNoPm5vYXJjaDwvYXJjaD5cbiAgPHZlcnNpb24gZXBvY2g9XCIwXCIg
+        cmVsPVwiMC44XCIgdmVyPVwiMC4zXCIgLz5cbiAgPGNoZWNrc3VtIHBrZ2lk
+        PVwiWUVTXCIgdHlwZT1cInNoYTI1NlwiPjI1MTc2OGJkZDE1ZjEzZDc4NDg3
+        YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDI8
+        L2NoZWNrc3VtPlxuICA8c3VtbWFyeT5BIGR1bW15IHBhY2thZ2Ugb2Ygc3F1
+        aXJyZWw8L3N1bW1hcnk+XG4gIDxkZXNjcmlwdGlvbj5BIGR1bW15IHBhY2th
+        Z2Ugb2Ygc3F1aXJyZWw8L2Rlc2NyaXB0aW9uPlxuICA8cGFja2FnZXIgLz5c
+        biAgPHVybD5odHRwOi8vdHN0cmFjaG90YS5mZWRvcmFwZW9wbGUub3JnPC91
+        cmw+XG4gIDx0aW1lIGJ1aWxkPVwiMTMwODI1NzUwMlwiIGZpbGU9XCIxMzIx
+        ODkxMDI5XCIgLz5cbiAgPHNpemUgYXJjaGl2ZT1cIjI5NlwiIGluc3RhbGxl
+        ZD1cIjQyXCIgcGFja2FnZT1cIjIyNDhcIiAvPlxuPGxvY2F0aW9uIGhyZWY9
+        XCJzcXVpcnJlbC0wLjMtMC44Lm5vYXJjaC5ycG1cIi8+XG4gIDxmb3JtYXQ+
+        XG4gICAgPHJwbTpsaWNlbnNlPkdQTHYyPC9ycG06bGljZW5zZT5cbiAgICA8
+        cnBtOnZlbmRvciAvPlxuICAgIDxycG06Z3JvdXA+SW50ZXJuZXQvQXBwbGlj
+        YXRpb25zPC9ycG06Z3JvdXA+XG4gICAgPHJwbTpidWlsZGhvc3Q+ZGhjcC0y
+        Ni0xMTguYnJxLnJlZGhhdC5jb208L3JwbTpidWlsZGhvc3Q+XG4gICAgPHJw
+        bTpzb3VyY2VycG0+c3F1aXJyZWwtMC4zLTAuOC5zcmMucnBtPC9ycG06c291
+        cmNlcnBtPlxuICAgIDxycG06aGVhZGVyLXJhbmdlIGVuZD1cIjIwMjhcIiBz
+        dGFydD1cIjI4MFwiIC8+XG4gICAgPHJwbTpwcm92aWRlcz5cbiAgICAgIDxy
+        cG06ZW50cnkgZXBvY2g9XCIwXCIgZmxhZ3M9XCJFUVwiIG5hbWU9XCJzcXVp
+        cnJlbFwiIHJlbD1cIjAuOFwiIHZlcj1cIjAuM1wiIC8+XG4gICAgPC9ycG06
+        cHJvdmlkZXM+XG4gICAgPHJwbTpyZXF1aXJlcz5cbiAgICAgIDxycG06ZW50
+        cnkgbmFtZT1cIi9iaW4vc2hcIiBwcmU9XCIxXCIgLz5cbiAgICA8L3JwbTpy
+        ZXF1aXJlcz5cbiAgPC9mb3JtYXQ+XG48L3BhY2thZ2U+XG4ifSwgImRlc2Ny
+        aXB0aW9uIjogIkEgZHVtbXkgcGFja2FnZSBvZiBzcXVpcnJlbCIsICJfbGFz
+        dF91cGRhdGVkIjogIjIwMTYtMDItMThUMjM6MjY6MTFaIiwgInRpbWUiOiAx
+        MzIxODkxMDI5LCAiZG93bmxvYWRlZCI6IHRydWUsICJoZWFkZXJfcmFuZ2Ui
+        OiB7InN0YXJ0IjogMjgwLCAiZW5kIjogMjAyOH0sICJhcmNoIjogIm5vYXJj
+        aCIsICJuYW1lIjogInNxdWlycmVsIiwgIl9zdG9yYWdlX3BhdGgiOiAiL3Zh
+        ci9saWIvcHVscC9jb250ZW50L3VuaXRzL3JwbS82YS81OTNiYmU1ZTE1MDVh
+        MmU3OWRlZjg2MTQ3MzE4M2ExY2ZkMWUwYzQ2YmQ0YTU4MDQ0NTM5Y2Q4Njll
+        MDAxZC9zcXVpcnJlbC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAic291cmNlcnBt
+        IjogInNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsICJjaGVja3N1bXR5cGUi
+        OiAic2hhMjU2IiwgInJlbGVhc2Vfc29ydF9pbmRleCI6ICIwMS0wLjAxLTgi
+        LCAiY2hhbmdlbG9nIjogW10sICJ1cmwiOiAiaHR0cDovL3RzdHJhY2hvdGEu
+        ZmVkb3JhcGVvcGxlLm9yZyIsICJjaGVja3N1bSI6ICIyNTE3NjhiZGQxNWYx
+        M2Q3ODQ4N2MyNzYzOGFhNmFlY2QwMTU1MWUyNTM3NTYwOTNjZGUxYzBhZTg3
+        OGExN2QyIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIHNxdWly
+        cmVsIiwgInJlbGF0aXZlcGF0aCI6ICJzcXVpcnJlbC0wLjMtMC44Lm5vYXJj
+        aC5ycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjMzNjM4NDU0LTU4
+        YTgtNDFiMC1iMDY2LTljOTEwNWRiZjM5NSIsICJyZXF1aXJlcyI6IFt7InJl
+        bGVhc2UiOiBudWxsLCAiZXBvY2giOiBudWxsLCAidmVyc2lvbiI6IG51bGws
+        ICJmbGFncyI6IG51bGwsICJuYW1lIjogIi9iaW4vc2gifV19XQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:49:14 GMT
 - request:
     method: delete
-    uri: https://katello-burrito.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://katello-yoda.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -9762,7 +1740,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:04:19 GMT
+      - Tue, 23 Feb 2016 16:49:15 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -9775,14 +1753,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzYxOWZiNDMyLTc1NTktNDY0ZS05YzBjLWY2ZjAzZGFjN2U4Ni8iLCAi
-        dGFza19pZCI6ICI2MTlmYjQzMi03NTU5LTQ2NGUtOWMwYy1mNmYwM2RhYzdl
-        ODYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:19 GMT
+        c2tzLzk2NjI0ODYzLWEwYWYtNDhhMS05NWYxLTlkMjY1NDMzODQyMy8iLCAi
+        dGFza19pZCI6ICI5NjYyNDg2My1hMGFmLTQ4YTEtOTVmMS05ZDI2NTQzMzg0
+        MjMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:49:15 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/619fb432-7559-464e-9c0c-f6f03dac7e86/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/96624863-a0af-48a1-95f1-9d2654338423/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -9801,13 +1779,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:04:19 GMT
+      - Tue, 23 Feb 2016 16:49:15 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '549'
+      - '645'
       Connection:
       - close
       Content-Type:
@@ -9817,22 +1795,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82MTlmYjQzMi03NTU5LTQ2NGUtOWMwYy1mNmYwM2RhYzdl
-        ODYvIiwgInRhc2tfaWQiOiAiNjE5ZmI0MzItNzU1OS00NjRlLTljMGMtZjZm
-        MDNkYWM3ZTg2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy85NjYyNDg2My1hMGFmLTQ4YTEtOTVmMS05ZDI2NTQzMzg0
+        MjMvIiwgInRhc2tfaWQiOiAiOTY2MjQ4NjMtYTBhZi00OGExLTk1ZjEtOWQy
+        NjU0MzM4NDIzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
         bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
         ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
-        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmJkMDU2
-        MzM0NDcxZTQwMDcwYjBjMWIifSwgImlkIjogIjU2YmQwNTYzMzQ0NzFlNDAw
-        NzBiMGMxYiJ9
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:19 GMT
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3Rh
+        dGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        NmNjOGQ4Yjk4OTA1NGZjNDhiYTMwZTkifSwgImlkIjogIjU2Y2M4ZDhiOTg5
+        MDU0ZmM0OGJhMzBlOSJ9
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:49:15 GMT
 - request:
     method: get
-    uri: https://katello-burrito.example.com/pulp/api/v2/tasks/619fb432-7559-464e-9c0c-f6f03dac7e86/
+    uri: https://katello-yoda.example.com/pulp/api/v2/tasks/96624863-a0af-48a1-95f1-9d2654338423/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -9851,13 +1831,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 11 Feb 2016 22:04:20 GMT
+      - Tue, 23 Feb 2016 16:49:15 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '688'
+      - '682'
       Connection:
       - close
       Content-Type:
@@ -9867,20 +1847,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82MTlmYjQzMi03NTU5LTQ2NGUtOWMwYy1mNmYwM2RhYzdl
-        ODYvIiwgInRhc2tfaWQiOiAiNjE5ZmI0MzItNzU1OS00NjRlLTljMGMtZjZm
-        MDNkYWM3ZTg2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy85NjYyNDg2My1hMGFmLTQ4YTEtOTVmMS05ZDI2NTQzMzg0
+        MjMvIiwgInRhc2tfaWQiOiAiOTY2MjQ4NjMtYTBhZi00OGExLTk1ZjEtOWQy
+        NjU0MzM4NDIzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTExVDIyOjA0OjE5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTExVDIyOjA0OjE5WiIsICJ0cmFjZWJh
+        MDE2LTAyLTIzVDE2OjQ5OjE1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTIzVDE2OjQ5OjE1WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBrYXRlbGxvLWJ1cnJpdG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1idXJyaXRvLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        ZDA1NjMzNDQ3MWU0MDA3MGIwYzFiIn0sICJpZCI6ICI1NmJkMDU2MzM0NDcx
-        ZTQwMDcwYjBjMWIifQ==
-    http_version:
-  recorded_at: Thu, 11 Feb 2016 22:04:20 GMT
+        MUBrYXRlbGxvLXlvZGEuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby15b2RhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZjYzhkOGI5
+        ODkwNTRmYzQ4YmEzMGU5In0sICJpZCI6ICI1NmNjOGQ4Yjk4OTA1NGZjNDhi
+        YTMwZTkifQ==
+    http_version: 
+  recorded_at: Tue, 23 Feb 2016 16:49:15 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
Added code to mirror the upstream feed repository by default.
Scenario:
If feed had packages A1, B1 at some point and the katello host repo synced this , it would have A1,B1
Now if the feed updated its repo and now has A2, B1 and the user resynced, the host repo would now have A1,A2, B1.

This commit adds the mirroring option and enables it by default