### PR TITLE
Fixes #12722 and #12723 - extending capsule show page with pulp content

### DIFF
--- a/app/controllers/katello/api/v2/capsule_content_controller.rb
+++ b/app/controllers/katello/api/v2/capsule_content_controller.rb
@@ -8,50 +8,67 @@ module Katello
     before_filter :find_environment, :only => [:add_lifecycle_environment, :remove_lifecycle_environment]
 
     def_param_group :lifecycle_environments do
-      param :id, Integer, :desc => 'Id of the capsule', :required => true
-      param :organization_id, Integer, :desc => 'Id of the organization to limit environments on'
+      param :id, Integer, :desc => N_('Id of the capsule'), :required => true
+      param :organization_id, Integer, :desc => N_('Id of the organization to limit environments on')
     end
 
     def_param_group :update_lifecycle_environments do
-      param :id, Integer, :desc => 'Id of the capsule', :required => true
-      param :environment_id, Integer, :desc => 'Id of the lifecycle environment', :required => true
+      param :id, Integer, :desc => N_('Id of the capsule'), :required => true
+      param :environment_id, Integer, :desc => N_('Id of the lifecycle environment'), :required => true
     end
 
-    api :GET, '/capsules/:id/content/lifecycle_environments', 'List the lifecycle environments attached to the capsule'
+    api :GET, '/capsules/:id/content/lifecycle_environments', N_('List the lifecycle environments attached to the capsule')
     param_group :lifecycle_environments
     def lifecycle_environments
       environments = capsule_content.lifecycle_environments(params[:organization_id]).readable
       respond_for_lifecycle_environments_index(environments)
     end
 
-    api :GET, '/capsules/:id/content/available_lifecycle_environments', 'List the lifecycle environments not attached to the capsule'
+    api :GET, '/capsules/:id/content/available_lifecycle_environments', N_('List the lifecycle environments not attached to the capsule')
     param_group :lifecycle_environments
     def available_lifecycle_environments
       environments = capsule_content.available_lifecycle_environments(params[:organization_id]).readable
       respond_for_lifecycle_environments_index(environments)
     end
 
-    api :POST, '/capsules/:id/content/lifecycle_environments', 'Add lifecycle environments to the capsule'
+    api :POST, '/capsules/:id/content/lifecycle_environments', N_('Add lifecycle environments to the capsule')
     param_group :update_lifecycle_environments
     def add_lifecycle_environment
       capsule_content.add_lifecycle_environment(@environment)
       respond_for_lifecycle_environments_index(capsule_content.lifecycle_environments)
     end
 
-    api :DELETE, '/capsules/:id/content/lifecycle_environments/:environment_id',  'Remove lifecycle environments from the capsule'
+    api :DELETE, '/capsules/:id/content/lifecycle_environments/:environment_id', N_('Remove lifecycle environments from the capsule')
     param_group :update_lifecycle_environments
     def remove_lifecycle_environment
       capsule_content.remove_lifecycle_environment(@environment)
       respond_for_lifecycle_environments_index(capsule_content.lifecycle_environments)
     end
 
-    api :POST, '/capsules/:id/content/sync',  'Synchronize the content to the capsule'
-    param :id, Integer, :desc => 'Id of the capsule', :required => true
-    param :environment_id, Integer, :desc => 'Id of the environment to limit the synchronization on'
+    api :POST, '/capsules/:id/content/sync', N_('Synchronize the content to the capsule')
+    param :id, Integer, :desc => N_('Id of the capsule'), :required => true
+    param :environment_id, Integer, :desc => N_('Id of the environment to limit the synchronization on')
     def sync
       find_environment if params[:environment_id]
       task = async_task(::Actions::Katello::CapsuleContent::Sync, capsule_content, :environment => @environment)
       respond_for_async :resource => task
+    end
+
+    api :GET, '/capsules/:id/content/sync', N_('Get current capsule synchronization status')
+    param :id, Integer, :desc => N_('Id of the capsule'), :required => true
+    def sync_status
+      @capsule_content = capsule_content
+    end
+
+    api :DELETE, '/capsules/:id/content/sync', N_('Cancel running capsule synchronization.')
+    param :id, Integer, :desc => N_('Id of the capsule'), :required => true
+    def cancel_sync
+      tasks = capsule_content.cancel_sync
+      if tasks.empty?
+        render_message _('There\'s no running synchronization for this capsule.')
+      else
+        render_message _('Trying to cancel the synchronization...')
+      end
     end
 
     protected

--- a/app/controllers/katello/api/v2/capsule_content_controller.rb
+++ b/app/controllers/katello/api/v2/capsule_content_controller.rb
@@ -6,6 +6,7 @@ module Katello
 
     before_filter :find_capsule
     before_filter :find_environment, :only => [:add_lifecycle_environment, :remove_lifecycle_environment]
+    before_filter :find_optional_organization, :only => [:sync_status]
 
     def_param_group :lifecycle_environments do
       param :id, Integer, :desc => N_('Id of the capsule'), :required => true
@@ -56,8 +57,10 @@ module Katello
 
     api :GET, '/capsules/:id/content/sync', N_('Get current capsule synchronization status')
     param :id, Integer, :desc => N_('Id of the capsule'), :required => true
+    param :organization_id, Integer, :desc => N_('Id of the organization to get the status for'), :required => false
     def sync_status
       @capsule_content = capsule_content
+      @lifecycle_environments = @capsule_content.lifecycle_environments(@organization)
     end
 
     api :DELETE, '/capsules/:id/content/sync', N_('Cancel running capsule synchronization.')

--- a/app/controllers/katello/concerns/smart_proxies_controller_extensions.rb
+++ b/app/controllers/katello/concerns/smart_proxies_controller_extensions.rb
@@ -7,6 +7,7 @@ module Katello
         append_view_path('app/views/foreman')
         before_filter :find_resource_and_status, :only => [:pulp_storage, :pulp_status]
         alias_method_chain :action_permission, :katello
+        alias_method_chain :show, :content
 
         def pulp_storage
           pulp_connection = @proxy_status[:pulp] || @proxy_status[:pulpnode]
@@ -39,6 +40,11 @@ module Katello
             end
           end
         end
+      end
+
+      def show_with_content
+        @task_search_url = main_app.foreman_tasks_tasks_path(:search=>"resource_id = #{@smart_proxy.id} AND resource_type = #{@smart_proxy.class}")
+        render 'foreman/smart_proxies/show', :layout => 'katello/layouts/foreman_with_bastion'
       end
 
       private

--- a/app/lib/actions/katello/capsule_content/sync.rb
+++ b/app/lib/actions/katello/capsule_content/sync.rb
@@ -2,11 +2,17 @@ module Actions
   module Katello
     module CapsuleContent
       class Sync < ::Actions::EntryAction
+        def resource_locks
+          :link
+        end
+
         def humanized_name
           _("Synchronize capsule content")
         end
 
         def plan(capsule_content, options = {})
+          action_subject(capsule_content.capsule)
+
           environment = options.fetch(:environment, nil)
           repository = options.fetch(:repository, nil)
           content_view = options.fetch(:content_view, nil)

--- a/app/lib/katello/capsule_content.rb
+++ b/app/lib/katello/capsule_content.rb
@@ -74,6 +74,21 @@ module Katello
       last_sync_time.nil? || env.content_view_environments.where('updated_at > ?', last_sync_time).any?
     end
 
+    def pulp_repositories_data(environment = nil, content_view = nil)
+      @pulp_repositories ||= @capsule.pulp_repositories
+
+      repos = Katello::Repository
+      repos = repos.in_environment(environment) if environment
+      repos = repos.in_content_views([content_view]) if content_view
+      puppet_envs = Katello::ContentViewPuppetEnvironment
+      puppet_envs = puppet_envs.in_environment(environment) if environment
+      puppet_envs = puppet_envs.in_content_view(content_view) if content_view
+
+      repo_ids = repos.pluck(:pulp_id) + puppet_envs.pluck(:pulp_id)
+
+      @pulp_repositories.select { |r| repo_ids.include?(r['id']) }
+    end
+
     def cancel_sync
       active_sync_tasks.map(&:cancel)
     end

--- a/app/lib/katello/util/thread_session.rb
+++ b/app/lib/katello/util/thread_session.rb
@@ -54,9 +54,16 @@ module Katello
             end
 
             def self.pulp_config(user_remote_id, &_block)
-              uri = URI.parse(SETTINGS[:katello][:pulp][:url])
+              Katello.pulp_server = runcible_instance(SETTINGS[:katello][:pulp][:url], user_remote_id)
+              yield if block_given?
+            ensure
+              Katello.pulp_server = nil if block_given?
+            end
 
-              Katello.pulp_server = Runcible::Instance.new(
+            def self.runcible_instance(pulp_url, user_remote_id)
+              uri = URI.parse(pulp_url)
+
+              Runcible::Instance.new(
                 :url      => "#{uri.scheme}://#{uri.host.downcase}",
                 :api_path => uri.path,
                 :user     => user_remote_id,
@@ -69,9 +76,6 @@ module Katello
                               :info       => true,
                               :debug      => true }
               )
-              yield if block_given?
-            ensure
-              Katello.pulp_server = nil if block_given?
             end
 
             def self.cp_config(cp_oauth_header)

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -7,6 +7,8 @@ module Katello
       PULP_NODE_FEATURE = "Pulp Node"
 
       included do
+        include ForemanTasks::Concerns::ActionSubject
+
         before_create :associate_organizations
         before_create :associate_default_location
         before_create :associate_lifecycle_environments

--- a/app/overrides/disable_turbolinks_on_proxies_index.rb
+++ b/app/overrides/disable_turbolinks_on_proxies_index.rb
@@ -1,0 +1,5 @@
+Deface::Override.new(
+  :virtual_path => 'smart_proxies/index',
+  :name => 'disable_turbolinks_on_proxies_index',
+  :set_attributes => '.proxy-show',
+  :attributes => {'data-no-turbolink' => 'true'})

--- a/app/services/katello/pulp/content_counts_calculator.rb
+++ b/app/services/katello/pulp/content_counts_calculator.rb
@@ -1,0 +1,54 @@
+module Katello
+  module Pulp
+    class ContentCountsCalculator
+      def initialize(repos)
+        @repos = repos
+      end
+
+      def calculate
+        counts = {
+          :yum_repositories => 0,
+          :packages => 0,
+          :package_groups => 0,
+          :errata => 0,
+          :puppet_repositories => 0,
+          :puppet_modules => 0,
+          :docker_repositories => 0,
+          :docker_images => 0
+        }
+
+        @repos.each do |repo|
+          case
+          when repo_type?(repo, 'rpm')
+            counts[:yum_repositories] += 1
+            counts[:packages] += get_unit_count(repo, 'rpm')
+            counts[:package_groups] += get_unit_count(repo, 'package_group')
+            counts[:errata] += get_unit_count(repo, 'erratum')
+          when repo_type?(repo, 'docker')
+            counts[:docker_repositories] += 1
+            counts[:docker_images] += get_unit_count(repo, 'docker_image')
+          when repo_type?(repo, 'puppet')
+            counts[:puppet_repositories] += 1
+            counts[:puppet_modules] += get_unit_count(repo, 'puppet_module')
+          end
+        end
+
+        counts
+      end
+
+      protected
+
+      def repo_type?(repo, repo_type)
+        repo['notes'] && (repo['notes']['_repo-type'] == "#{repo_type}-repo")
+      end
+
+      def get_unit_count(repo, unit_type)
+        if repo['content_unit_counts']
+          repo['content_unit_counts'][unit_type] || 0
+        else
+          0
+        end
+      end
+    end
+  end
+end

--- a/app/views/foreman/smart_proxies/_content_sync.html.erb
+++ b/app/views/foreman/smart_proxies/_content_sync.html.erb
@@ -1,0 +1,35 @@
+<div>
+  <h3><%= _('Content Sync') %></h3>
+
+  <div bst-alerts error-messages="syncErrorMessages"></div>
+
+  {{ syncStatusText(syncState, syncStatus) }}
+  <div ng-show="syncState.is(syncState.SYNCING, syncState.SYNC_TRIGGERED, syncState.CANCEL_TRIGGERED, syncState.FAILURE)">
+    {{syncTask.progressbar.value || 0}}%
+    <a href="<%= @task_search_url %>" target="_self">
+      <div ng-class="{ active: isTaskInProgress(syncTask) }" class="progress progress-striped">
+        <span progressbar
+          animate="false"
+          value="syncTask.progressbar.value || 0"
+          type="{{ progressbarType(syncTask) }}"></span>
+      </div>
+    </a>
+  </div>
+
+  <div>
+    <span translate>Last sync:</span> {{ syncStatus.last_sync_time }}
+  </div>
+
+  <br>
+
+  <div>
+    <a ng-show="syncState.is(syncState.SYNCING, syncState.SYNC_TRIGGERED, syncState.CANCEL_TRIGGERED)"
+      ng-click="cancelSync()" class="btn btn-default" ng-disabled="!syncState.is(syncState.SYNCING)">
+      <span translate>Cancel Sync</span>
+    </a>
+    <a ng-hide="syncState.is(syncState.SYNCING, syncState.SYNC_TRIGGERED, syncState.CANCEL_TRIGGERED)"
+      ng-click="syncCapsule()" class="btn btn-default">
+      <span translate>Synchronize</span>
+    </a>
+  </div>
+</div>

--- a/app/views/foreman/smart_proxies/_content_tab.html.erb
+++ b/app/views/foreman/smart_proxies/_content_tab.html.erb
@@ -1,0 +1,44 @@
+<br />
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th translate>Content View Name</th>
+      <th translate>Composite</th>
+      <th translate>Last Published</th>
+      <th translate>Hosts</th>
+      <th translate>Products</th>
+      <th translate>Yum repos</th>
+      <th translate>Docker repos</th>
+      <th translate>Packages</th>
+      <th translate>Errata</th>
+      <th translate>Puppet modules</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr ng-repeat-start="env in syncStatus.lifecycle_environments">
+      <td colspan="10"
+          ng-click="toggleExpandEnvironment(env)"
+          class="expander {{isEnvronmentExpanded(env) ? '' : 'collapsed'}}">
+        <span class="caret"></span>
+        {{ env.name }}
+      </td>
+    </tr>
+    <tr ng-repeat-end ng-repeat="cv in env.content_views" ng-show="isEnvronmentExpanded(env)">
+      <td>
+        <a href="/content_views/{{cv.id}}/versions" target="_self">
+          {{ cv.name }}
+        </a>
+      </td>
+      <td>{{ cv.composite | booleanToYesNo }}</td>
+      <td>{{ cv.last_published }}</td>
+      <td>{{ cv.counts.content_hosts }}</td>
+      <td>{{ cv.counts.products }}</td>
+      <td>{{ cv.counts.yum_repositories }}</td>
+      <td>{{ cv.counts.docker_repositories }}</td>
+      <td>{{ cv.counts.packages }}</td>
+      <td>{{ cv.counts.errata }}</td>
+      <td>{{ cv.counts.puppet_modules }}</td>
+    </td>
+  </tbody>
+</table>

--- a/app/views/foreman/smart_proxies/show.html.erb
+++ b/app/views/foreman/smart_proxies/show.html.erb
@@ -1,0 +1,7 @@
+<% if @smart_proxy.has_feature?(SmartProxy::PULP_NODE_FEATURE) -%>
+  <div ng-controller="CapsuleContentController">
+    <%= render :file => 'smart_proxies/show' %>
+  </div>
+<% else -%>
+  <%= render :file => 'smart_proxies/show' %>
+<% end -%>

--- a/app/views/katello/api/v2/capsule_content/sync_status.json.rabl
+++ b/app/views/katello/api/v2/capsule_content/sync_status.json.rabl
@@ -1,0 +1,20 @@
+object @capsule_content
+
+attribute :last_sync_time
+
+child :active_sync_tasks => :active_sync_tasks do
+  extends 'foreman_tasks/api/tasks/show'
+end
+child :last_failed_sync_tasks => :last_failed_sync_tasks do
+  extends 'foreman_tasks/api/tasks/show'
+end
+
+child :lifecycle_environments => :lifecycle_environments do
+  extends 'katello/api/v2/common/identifier'
+  extends 'katello/api/v2/common/org_reference'
+
+  attributes :library
+  node :syncable do |env|
+    @capsule_content.environment_syncable?(env)
+  end
+end

--- a/app/views/katello/api/v2/capsule_content/sync_status.json.rabl
+++ b/app/views/katello/api/v2/capsule_content/sync_status.json.rabl
@@ -9,12 +9,40 @@ child :last_failed_sync_tasks => :last_failed_sync_tasks do
   extends 'foreman_tasks/api/tasks/show'
 end
 
-child :lifecycle_environments => :lifecycle_environments do
+child @lifecycle_environments => :lifecycle_environments do
   extends 'katello/api/v2/common/identifier'
   extends 'katello/api/v2/common/org_reference'
 
   attributes :library
   node :syncable do |env|
     @capsule_content.environment_syncable?(env)
+  end
+  node :counts do |env|
+    counts = {
+      :content_hosts => env.systems.readable.count,
+      :content_views => env.content_views.non_default.count,
+      :products => env.products.enabled.count
+    }
+    repo_data = @capsule_content.pulp_repositories_data(env)
+    counts.merge!(Katello::Pulp::ContentCountsCalculator.new(repo_data).calculate)
+  end
+
+  node :content_views do |env|
+    env.content_views.map do |content_view|
+      attributes = {
+        :id => content_view.id,
+        :label => content_view.label,
+        :name => content_view.name,
+        :composite => content_view.composite,
+        :last_published => content_view.versions.empty? ? nil : content_view.versions.last.created_at,
+        :counts => {
+          :content_hosts => content_view.systems.readable.count,
+          :products => content_view.products.enabled.count
+        }
+      }
+      repo_data = @capsule_content.pulp_repositories_data(env, content_view)
+      attributes[:counts].merge!(Katello::Pulp::ContentCountsCalculator.new(repo_data).calculate)
+      attributes
+    end
   end
 end

--- a/app/views/katello/layouts/foreman_with_bastion.html.erb
+++ b/app/views/katello/layouts/foreman_with_bastion.html.erb
@@ -1,0 +1,5 @@
+<%= content_for(:content) do %>
+  <%= render :partial => 'layouts/application_content' %>
+<% end %>
+
+<%= render :file => 'bastion/layouts/assets' %>

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -21,6 +21,8 @@ Katello::Engine.routes.draw do
               get :lifecycle_environments
               get :available_lifecycle_environments
               post :sync
+              get :sync, :action => :sync_status
+              delete :sync, :action => :cancel_sync
               post '/lifecycle_environments' => 'capsule_content#add_lifecycle_environment'
               delete '/lifecycle_environments/:environment_id' => 'capsule_content#remove_lifecycle_environment'
             end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/bastion-katello-bootstrap.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/bastion-katello-bootstrap.js
@@ -1,4 +1,5 @@
 BASTION_MODULES.push(
+    'Bastion.capsule-content',
     'Bastion.activation-keys',
     'Bastion.content-views',
     'Bastion.content-views.versions',

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/bastion_katello.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/bastion_katello.js
@@ -31,6 +31,9 @@
 //= require "bastion_katello/capsules/capsules.module.js"
 //= require_tree "./capsules"
 
+//= require "bastion_katello/capsule-content/capsule-content.module.js"
+//= require_tree "./capsule-content"
+
 //= require "bastion_katello/organizations/organizations.module.js"
 //= require_tree "./organizations"
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.controller.js
@@ -1,0 +1,171 @@
+/**
+ * @ngdoc object
+ * @name  Bastion.capsule-content.controller:CapsuleContentController
+ *
+ * @requires $scope
+ * @requires $urlMatcherFactory
+ * @requires $location
+ * @requires translate
+ * @requires CapsuleContent
+ * @requires AggregateTask
+ *
+ * @description
+ *   Provides the functionality for the capsule-content page.
+ */
+angular.module('Bastion.capsule-content').controller('CapsuleContentController',
+    ['$scope', '$urlMatcherFactory', '$location', 'translate', 'CapsuleContent', 'AggregateTask', 'syncState',
+    function ($scope, $urlMatcherFactory, $location, translate, CapsuleContent, AggregateTask, syncState) {
+
+        var refreshSyncStatus;
+        var urlMatcher = $urlMatcherFactory.compile("/smart_proxies/:capsuleId");
+        var capsuleId = urlMatcher.exec($location.path()).capsuleId;
+
+
+        function processError(response) {
+            if (response.data && response.data.displayMessage) {
+                $scope.syncErrorMessages = [response.data.displayMessage];
+            }
+        }
+
+        function pickLastTask(tasks) {
+            var task = tasks.slice(-1)[0];
+            task.progressbar = {
+                value: task.progress * 100,
+                type: $scope.progressbarType(task)
+            };
+            return task;
+        }
+
+        function isTaskInProgress(task) {
+            return (task && (task.state === 'pending' || task.state === 'running'));
+        }
+
+        function stateFromTask(syncTask) {
+            var state;
+
+            if (isTaskInProgress(syncTask)) {
+                state = syncState.SYNCING;
+            }
+            if (syncTask && syncTask.result !== 'success') {
+                state = syncState.FAILURE;
+            } else {
+                state = syncState.DEFAULT;
+            }
+            return state;
+        }
+
+        function taskUpdated() {
+            if (!angular.isUndefined($scope.syncTask.result) && $scope.syncTask.result !== 'pending') {
+                $scope.syncTask.unregisterAll();
+                refreshSyncStatus();
+            }
+        }
+
+        function aggregateTasks(tasks) {
+            var taskIds = _.map(tasks, function (task) {
+                                return task.id;
+                            });
+            return AggregateTask.new(taskIds, taskUpdated);
+        }
+
+        refreshSyncStatus = function () {
+            CapsuleContent.syncStatus({id: capsuleId}).$promise.then(function (syncStatus) {
+                $scope.syncStatus = syncStatus;
+                if (syncStatus['last_sync_time'] === null) {
+                    $scope.syncStatus['last_sync_time'] = translate('Never');
+                }
+
+                if (syncStatus['active_sync_tasks'].length > 0) {
+                    $scope.syncTask = aggregateTasks(syncStatus['active_sync_tasks']);
+
+                } else if (syncStatus['last_failed_sync_tasks'].length > 0) {
+                    $scope.syncTask = pickLastTask(syncStatus['last_failed_sync_tasks']);
+                    $scope.syncErrorMessages = $scope.syncTask.humanized.errors;
+                }
+                $scope.syncState.set(stateFromTask($scope.syncTask));
+            }, function (response) {
+                $scope.syncStatus = {
+                    'active_sync_tasks': [],
+                    'last_failed_sync_tasks': []
+                };
+                processError(response);
+            });
+        };
+
+        $scope.syncState = syncState;
+
+        refreshSyncStatus();
+
+        $scope.$on('$destroy', function () {
+            if ($scope.syncTask) {
+                $scope.syncTask.unregisterAll();
+            }
+        });
+
+        $scope.isTaskInProgress = isTaskInProgress;
+
+        $scope.syncCapsule = function () {
+            if (!$scope.syncState.is(syncState.SYNCING)) {
+
+                $scope.syncErrorMessages = [];
+                $scope.syncState.set(syncState.SYNC_TRIGGERED);
+
+                CapsuleContent.sync({id: capsuleId}).$promise.then(function (task) {
+                    $scope.syncStatus['active_sync_tasks'].push(task);
+                    $scope.syncTask = aggregateTasks($scope.syncStatus['active_sync_tasks']);
+                    $scope.syncState.set(syncState.SYNCING);
+                }, function (response) {
+                    processError(response);
+                    $scope.syncState.set(syncState.DEFAULT);
+                });
+            }
+        };
+
+        $scope.cancelSync = function () {
+            if ($scope.syncState.is(syncState.SYNCING)) {
+
+                $scope.syncState.set(syncState.CANCEL_TRIGGERED);
+                CapsuleContent.cancelSync({id: capsuleId}).$promise.catch(processError);
+            }
+        };
+
+        $scope.syncStatusText = function (currentSyncState, syncStatus) {
+            var message, syncableEnvs, envNames;
+
+            if (angular.isUndefined(syncStatus)) {
+                return "";
+            }
+
+            if (currentSyncState.is(currentSyncState.SYNCING)) {
+                message = translate("Capsule currently syncing to your locations...");
+            } else if (currentSyncState.is(currentSyncState.SYNC_TRIGGERED)) {
+                message = translate("Synchronization is about to start...");
+            } else if (currentSyncState.is(currentSyncState.CANCEL_TRIGGERED)) {
+                message = translate("Synchronization is being cancelled...");
+            } else {
+                syncableEnvs = _.where(syncStatus['lifecycle_environments'], {syncable: true});
+                if (syncableEnvs.length > 0) {
+                    envNames = _.pluck(syncableEnvs, 'name').join(', ');
+                    message = translate("%count environment(s) can be synchronized: %envs")
+                                .replace('%count', syncableEnvs.length)
+                                .replace('%envs', envNames);
+                } else {
+                    message = translate("Capsule is synchronized");
+                }
+            }
+            return message;
+        };
+
+        $scope.progressbarType = function (syncTask) {
+            var type;
+
+            if (angular.isUndefined(syncTask) || syncTask.result === 'pending' || syncTask.result === 'success') {
+                type = 'success';
+            } else {
+                type = 'danger';
+            }
+            return type;
+        };
+
+    }]
+);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.factory.js
@@ -1,0 +1,20 @@
+/**
+ * @ngdoc service
+ * @name  Bastion.capsule-content.factory:CapsuleContent
+ *
+ * @requires BastionResource
+ *
+ * @description
+ *   Provides a BastionResource for capsule content.
+ */
+angular.module('Bastion.capsule-content').factory('CapsuleContent',
+    ['BastionResource', function (BastionResource) {
+
+        return BastionResource('/katello/api/capsules/:id/content/:action', {id: '@id'}, {
+          syncStatus: {method: 'GET', isArray: false, params: {action: 'sync'}},
+          sync: {method: 'post', isArray: false, params: {action: 'sync'}},
+          cancelSync: {method: 'delete', isArray: false, params: {action: 'sync'}}
+        });
+
+    }]
+);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.module.js
@@ -1,0 +1,12 @@
+/**
+ * @ngdoc module
+ * @name  Bastion.capsule-content
+ *
+ * @description
+ *   Module for Capsule content related functionality.
+ */
+angular.module('Bastion.capsule-content', [
+    'ngResource',
+    'ui.router',
+    'Bastion'
+]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.routes.js
@@ -1,0 +1,29 @@
+/**
+ * @ngdoc object
+ * @name Bastion.capsule-content.config
+ *
+ * @requires $stateProvider
+ *
+ * @description
+ *   Used for systems level configuration such as setting up the ui state machine.
+ */
+angular.module('Bastion.capsule-content').config(['$stateProvider', '$urlRouterProvider', function ($stateProvider, $urlRouterProvider) {
+
+    // Catch the url to prevent the router to perform redirect.
+    $urlRouterProvider.when('/smart_proxies/:proxyId', function ($match, $stateParams) {
+        $stateParams.pageName = 'smart_proxies/detail';
+        return true;
+    });
+
+    // Add rule to redirect links on the smart proxy detail page.
+    // Changing state doesn't work there since there's no <ui-view> element there
+    $urlRouterProvider.rule(function ($injector, $location) {
+        var $stateParams = $injector.get('$stateParams'),
+            $window = $injector.get('$window');
+
+        if ($stateParams.pageName === 'smart_proxies/detail') {
+            $window.location.href = $location.path();
+        }
+    });
+
+}]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/sync-state.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/sync-state.service.js
@@ -1,0 +1,25 @@
+/**
+ * @ngdoc service
+ * @name  Bastion.capsule-content.service:syncState
+ *
+ * @description
+ *   Provides a syncState that keeps capsule sync UI state.
+ */
+angular.module('Bastion.capsule-content').service('syncState', function () {
+
+    this.DEFAULT = 'DEFAULT';
+    this.SYNCING = 'SYNCING';
+    this.SYNC_TRIGGERED = 'SYNC_TRIGGERED';
+    this.CANCEL_TRIGGERED = 'CANCEL_TRIGGERED';
+    this.FAILURE = 'FAILURE';
+
+    this.set = function (state) {
+        this.state = state;
+        return this.state;
+    };
+
+    this.is = function () {
+        return _.contains(arguments, this.state || this.DEFAULT);
+    };
+
+});

--- a/engines/bastion_katello/test/capsules/capsule-content.controller.test.js
+++ b/engines/bastion_katello/test/capsules/capsule-content.controller.test.js
@@ -1,0 +1,135 @@
+describe('Controller: CapsuleContentController', function() {
+    var $scope,
+        translate,
+        CapsuleContent,
+        syncState,
+        deferred;
+
+
+    beforeEach(module(
+        'Bastion.capsule-content',
+        'Bastion.test-mocks'
+    ));
+
+    beforeEach(inject(function($injector, $q) {
+        var $controller = $injector.get('$controller'),
+            $urlMatcherFactory = $injector.get('$urlMatcherFactory'),
+            $location = { path: function(){ return '/smart_proxies/83' } },
+            AggregateTask = { new: function(){} }
+
+        deferred = $q.defer();
+
+        var syncStatusData = {
+            active_sync_tasks: [],
+            last_failed_sync_tasks: []
+        }
+
+        CapsuleContent = $injector.get('MockResource').$new();
+        CapsuleContent.syncStatus = function (params, callback) {
+            var statusDeferred = $q.defer();
+            statusDeferred.resolve(syncStatusData);
+            return { $promise: statusDeferred.promise };
+        }
+        CapsuleContent.cancelSync = function (params, callback) {
+            return { $promise: deferred.promise };
+        }
+        CapsuleContent.sync = function (params) {
+            return { $promise: deferred.promise };
+        }
+
+        translate = function (message) {
+            return message;
+        };
+
+        $scope = $injector.get('$rootScope').$new();
+
+        $controller('CapsuleContentController', {
+            $scope: $scope,
+            $urlMatcherFactory: $urlMatcherFactory,
+            $location: $location,
+            translate: translate,
+            CapsuleContent: CapsuleContent,
+            AggregateTask: AggregateTask
+        });
+        $scope.$apply();
+
+        syncState = $scope.syncState;
+        syncState.set(syncState.DEFAULT);
+    }));
+
+
+    describe('syncCapsule', function() {
+
+        it('has no effect when sync is in progress', function() {
+            spyOn(CapsuleContent, 'sync').andCallThrough();
+            syncState.set(syncState.SYNCING);
+            $scope.syncCapsule();
+            expect(CapsuleContent.sync).not.toHaveBeenCalled();
+        });
+
+        it('starts capsule synchronization', function() {
+            spyOn(CapsuleContent, 'sync').andCallThrough();
+            $scope.syncCapsule();
+            expect(CapsuleContent.sync).toHaveBeenCalledWith({ id: '83' });
+        });
+
+        it('sets state to SYNC_TRIGGERED', function() {
+            $scope.syncCapsule();
+            expect(syncState.is(syncState.SYNC_TRIGGERED)).toBeTruthy();
+        });
+
+        it('sets state to SYNCING when the response is successful', function() {
+            $scope.syncCapsule();
+            deferred.resolve({id: '1'});
+            $scope.$apply();
+
+            expect(syncState.is(syncState.SYNCING)).toBeTruthy();
+        });
+
+
+        it('adds task to active_sync_tasks when the response is successful', function() {
+            var taskCount = $scope.syncStatus['active_sync_tasks'].length;
+
+            $scope.syncCapsule();
+            deferred.resolve({id: '1'});
+            $scope.$apply();
+
+            expect($scope.syncStatus['active_sync_tasks'].length).toBe(taskCount + 1);
+        });
+
+        it('sets state to DEFAULT when there is some error', function() {
+            $scope.syncCapsule();
+            deferred.reject({});
+            $scope.$apply();
+
+            expect(syncState.is(syncState.DEFAULT)).toBeTruthy();
+        });
+
+    });
+
+    describe('cancelSync', function() {
+
+        it('has no effect when sync is not in progress', function() {
+            spyOn(CapsuleContent, 'cancelSync').andCallThrough();
+            $scope.cancelSync();
+            expect(CapsuleContent.cancelSync).not.toHaveBeenCalled();
+        });
+
+        it('tries to cancel the sync', function() {
+            spyOn(CapsuleContent, 'cancelSync').andCallThrough();
+            syncState.set(syncState.SYNCING);
+            $scope.cancelSync();
+            expect(CapsuleContent.cancelSync).toHaveBeenCalledWith({ id: '83' });
+        });
+
+        it('sets state to CANCEL_TRIGGERED', function() {
+            spyOn(CapsuleContent, 'cancelSync').andCallThrough();
+            syncState.set(syncState.SYNCING);
+            $scope.cancelSync();
+            expect(syncState.is(syncState.CANCEL_TRIGGERED)).toBeTruthy();
+        });
+
+    });
+
+
+});

--- a/engines/bastion_katello/test/capsules/capsule-content.factory.test.js
+++ b/engines/bastion_katello/test/capsules/capsule-content.factory.test.js
@@ -1,0 +1,31 @@
+describe('Factory: CapsuleContent', function () {
+    var $httpBackend, CapsuleContent;
+
+    beforeEach(module('Bastion.capsule-content', 'Bastion.test-mocks'));
+
+    beforeEach(inject(function($injector) {
+        $httpBackend = $injector.get('$httpBackend');
+        CapsuleContent = $injector.get('CapsuleContent');
+    }));
+
+    afterEach(function () {
+        $httpBackend.flush();
+        $httpBackend.verifyNoOutstandingExpectation();
+        $httpBackend.verifyNoOutstandingRequest();
+    });
+
+    it('provides a way to get synchronization status', function () {
+        $httpBackend.expectGET('/katello/api/capsules/1/content/sync').respond({});
+        CapsuleContent.syncStatus({ id: 1 });
+    });
+
+    it('provides a way to start synchronization', function () {
+        $httpBackend.expectPOST('/katello/api/capsules/1/content/sync').respond({});
+        CapsuleContent.sync({ id: 1 });
+    });
+
+    it('provides a way to cancel synchronization', function () {
+        $httpBackend.expectDELETE('/katello/api/capsules/1/content/sync').respond({});
+        CapsuleContent.cancelSync({ id: 1 });
+    });
+});

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |gem|
   # UI
   gem.add_dependency "deface", '>= 1.0.0', '< 2.0.0'
   gem.add_dependency "jquery-ui-rails"
-  gem.add_dependency "bastion", ">= 3.0.0", "< 4.0.0"
+  gem.add_dependency "bastion", ">= 3.0.1", "< 4.0.0"
 
   # Testing
   gem.add_development_dependency "factory_girl_rails"

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -161,6 +161,7 @@ module Katello
       #Controller extensions
       ::OperatingsystemsController.send :include, Katello::Concerns::OperatingsystemsControllerExtensions
       ::HostsController.send :include, Katello::Concerns::HostsControllerExtensions
+      ::SmartProxiesController.send :include, Katello::Concerns::SmartProxiesControllerExtensions
       ::Containers::StepsController.send :include, Katello::Concerns::Containers::StepsControllerExtensions
       ::SmartProxiesController.send :include, Katello::Concerns::SmartProxiesControllerExtensions
 

--- a/lib/katello/permissions/capsule_content_permissions.rb
+++ b/lib/katello/permissions/capsule_content_permissions.rb
@@ -3,7 +3,8 @@ require 'katello/plugin.rb'
 Foreman::Plugin.find(:katello).security_block :capsule_content do
   permission :manage_capsule_content,
              {
-               'katello/api/v2/capsule_content' => [:lifecycle_environments, :available_lifecycle_environments, :add_lifecycle_environment, :remove_lifecycle_environment, :sync]
+               'katello/api/v2/capsule_content' => [:lifecycle_environments, :available_lifecycle_environments, :add_lifecycle_environment, :remove_lifecycle_environment,
+                                                    :sync, :sync_status, :cancel_sync]
              },
              :resource_type => 'SmartProxy'
 end

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -163,6 +163,10 @@ Foreman::Plugin.register :katello do
   widget 'host_collection_widget', :name => 'Host Collection Widget', :sizey => 1, :sizex => 6
 
   extend_page("smart_proxies/show") do |context|
+    context.add_pagelet :main_tabs,
+      :name => _("Content"),
+      :partial => "foreman/smart_proxies/content_tab",
+      :onlyif => proc { |proxy| proxy.has_feature?(SmartProxy::PULP_NODE_FEATURE) }
     context.add_pagelet :details_content,
       :name => _("Content Sync"),
       :partial => "foreman/smart_proxies/content_sync",

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -162,6 +162,13 @@ Foreman::Plugin.register :katello do
   widget 'subscription_status_widget', :name => 'Subscription Status Widget', :sizey => 1, :sizex => 6
   widget 'host_collection_widget', :name => 'Host Collection Widget', :sizey => 1, :sizex => 6
 
+  extend_page("smart_proxies/show") do |context|
+    context.add_pagelet :details_content,
+      :name => _("Content Sync"),
+      :partial => "foreman/smart_proxies/content_sync",
+      :onlyif => proc { |proxy| proxy.has_feature?(SmartProxy::PULP_NODE_FEATURE) }
+  end
+
   register_custom_status(Katello::ErrataStatus)
   register_custom_status(Katello::SubscriptionStatus)
 

--- a/test/controllers/api/v2/capsule_content_controller_test.rb
+++ b/test/controllers/api/v2/capsule_content_controller_test.rb
@@ -85,5 +85,27 @@ module Katello
         post :sync, :id => proxy_with_pulp.id, :environment_id => environment.id
       end
     end
+
+    def test_sync_status
+      get :sync_status, :id => proxy_with_pulp.id
+      assert_response :success
+    end
+
+    def test_sync_status_protected
+      assert_protected_action(:sync, allowed_perms, denied_perms) do
+        get :sync_status, :id => proxy_with_pulp.id
+      end
+    end
+
+    def test_cancel_sync
+      get :cancel_sync, :id => proxy_with_pulp.id
+      assert_response :success
+    end
+
+    def test_cancel_sync_protected
+      assert_protected_action(:sync, allowed_perms, denied_perms) do
+        get :cancel_sync, :id => proxy_with_pulp.id
+      end
+    end
   end
 end

--- a/test/factories/foreman_task.rb
+++ b/test/factories/foreman_task.rb
@@ -1,0 +1,29 @@
+FactoryGirl.define do
+  factory :foreman_task, :class => ForemanTasks::Task do
+    sequence(:label) { |n| "task#{n}" }
+    sequence(:id) { |n| 'b8317062-c664-4792-9d9a-8167b23c%04d' % n }
+    type 'ForemanTasks::Task'
+    state 'stopped'
+    result 'success'
+    sequence(:started_at) { |n| "2016-#{(n/30)+1}-#{(n%30)+1} 11:15:00" }
+    after(:build) do |task|
+      task.ended_at = task.started_at.change(:sec => 32)
+    end
+
+    trait :running do
+      state 'running'
+      result 'pending'
+      ended_at nil
+    end
+
+    trait :failed do
+      state 'paused'
+      result 'error'
+      ended_at nil
+    end
+  end
+
+  factory :dynflow_task, :parent => :foreman_task, :class => ForemanTasks::Task::DynflowTask do
+    type 'ForemanTasks::Task::DynflowTask'
+  end
+end

--- a/test/lib/capsule_content_test.rb
+++ b/test/lib/capsule_content_test.rb
@@ -127,5 +127,65 @@ module Katello
         refute capsule_content.environment_syncable?(environment)
       end
     end
+
+    describe "pulp_repositories_data" do
+      let(:repo_lib_cv1) do
+        { "id" => FIXTURES['katello_repositories']['p_forge']['pulp_id'].to_s }
+      end
+
+      let(:repo_lib_cv2) do
+        { "id" => FIXTURES['katello_repositories']['lib_p_forge']['pulp_id'].to_s }
+      end
+
+      let(:repo_dev_cv2) do
+        { "id" => FIXTURES['katello_repositories']['dev_p_forge']['pulp_id'].to_s }
+      end
+
+      let(:lib) do
+        katello_environments(:library)
+      end
+
+      let(:cv1) do
+        katello_content_views(:acme_default)
+      end
+
+      before do
+        capsule_content.capsule.stubs(:pulp_repositories).returns([
+          repo_lib_cv1,
+          repo_lib_cv2,
+          repo_dev_cv2
+        ])
+      end
+
+      test "filters by environment" do
+        repo_ids = capsule_content.pulp_repositories_data(lib).map { |repo| repo['id'] }
+        expected_repo_ids = [
+          repo_lib_cv1['id'],
+          repo_lib_cv2['id']
+        ]
+
+        assert_equal expected_repo_ids, repo_ids
+      end
+
+      test "filters by environment and content view" do
+        repo_ids = capsule_content.pulp_repositories_data(lib, cv1).map { |repo| repo['id'] }
+        expected_repo_ids = [
+          repo_lib_cv1['id']
+        ]
+
+        assert_equal expected_repo_ids, repo_ids
+      end
+
+      test "returns all repositories" do
+        repo_ids = capsule_content.pulp_repositories_data.map { |repo| repo['id'] }
+        expected_repo_ids = [
+          repo_lib_cv1['id'],
+          repo_lib_cv2['id'],
+          repo_dev_cv2['id']
+        ]
+
+        assert_equal expected_repo_ids, repo_ids
+      end
+    end
   end
 end

--- a/test/models/content_counts_calculator_test.rb
+++ b/test/models/content_counts_calculator_test.rb
@@ -1,0 +1,80 @@
+require 'katello_test_helper'
+
+module Katello
+  class ContentCountsCalculator < ActiveSupport::TestCase
+    let(:repositories_data) do
+      [{
+        "display_name"=>"rpm repo 1",
+        "notes"=>{"_repo-type"=>"rpm-repo"},
+        "content_unit_counts"=>{
+          "package_group"=>2,
+          "rpm"=>32,
+          "erratum"=>4
+        },
+        "id"=>"rpm-repo-1"
+      }, {
+        "display_name"=>"rpm repo 2",
+        "notes"=>{"_repo-type"=>"rpm-repo"},
+        "content_unit_counts"=>{
+          "package_group"=>3,
+          "rpm"=>6,
+          "erratum"=>1
+        },
+        "id"=>"rpm-repo-2"
+      }, {
+        "display_name"=>"docker repo",
+        "notes"=>{"_repo-type"=>"docker-repo"},
+        "content_unit_counts"=>{
+          "docker_image" => 5
+        },
+        "id"=>"docker-repo"
+      }, {
+        "display_name"=>"puppet repo 1",
+        "notes"=>{"_repo-type"=>"puppet-repo"},
+        "content_unit_counts"=>{
+          "puppet_module" => 1
+        },
+        "id"=>"puppet-repo-1"
+      }, {
+        "display_name"=>"puppet repo 2",
+        "notes"=>{"_repo-type"=>"puppet-repo"},
+        "content_unit_counts"=>{
+          "puppet_module" => 2
+        },
+        "id"=>"puppet-repo-2"
+      }]
+    end
+
+    test 'count calculation' do
+      calculator = Katello::Pulp::ContentCountsCalculator.new(repositories_data)
+      expected_counts = {
+        :yum_repositories => 2,
+        :packages => 38,
+        :package_groups => 5,
+        :errata => 5,
+        :puppet_repositories => 2,
+        :puppet_modules => 3,
+        :docker_repositories => 1,
+        :docker_images => 5
+      }
+
+      assert_equal expected_counts, calculator.calculate
+    end
+
+    test 'return zero counts for empty repos' do
+      calculator = Katello::Pulp::ContentCountsCalculator.new([])
+      expected_counts = {
+        :yum_repositories => 0,
+        :packages => 0,
+        :package_groups => 0,
+        :errata => 0,
+        :puppet_repositories => 0,
+        :puppet_modules => 0,
+        :docker_repositories => 0,
+        :docker_images => 0
+      }
+
+      assert_equal expected_counts, calculator.calculate
+    end
+  end
+end


### PR DESCRIPTION
- extends capsule content api with actions to get sync status and
  cancelling synchronizations
- adds panel with sync progress
    - buttons for starting and cancelling synchronizations
    - progressbar for currently running synchroniations, links to proxy
      related foreman-tasks
    - displays last synchronization in case it failed
- adds tab with repository content details
    - repositories split by content view
    - grouped by lifecycle environment

**TODO:**
- [x] date and yes/no formatting in templates
- [x] tests for the UI js part
- [x] tests for the backend part

Please test with the latest Foreman develop.