### PR TITLE
Fixes #13207 - converting to global_notifications

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-details.controller.js
@@ -14,8 +14,8 @@
  *   Provides the functionality for the activation key details action pane.
  */
 angular.module('Bastion.activation-keys').controller('ActivationKeyDetailsController',
-    ['$scope', '$state', '$q', 'translate', 'ActivationKey', 'Organization', 'CurrentOrganization',
-    function ($scope, $state, $q, translate, ActivationKey, Organization, CurrentOrganization) {
+    ['$scope', '$state', '$q', 'translate', 'ActivationKey', 'Organization', 'CurrentOrganization', 'GlobalNotification',
+    function ($scope, $state, $q, translate, ActivationKey, Organization, CurrentOrganization, GlobalNotification) {
         $scope.successMessages = [];
         $scope.errorMessages = [];
         $scope.copyErrorMessages = [];
@@ -65,9 +65,9 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyDetailsContro
             activationKey.$delete(function () {
                 $scope.removeRow(id);
                 $scope.transitionTo('activation-keys.index');
-                $scope.successMessages.push(translate('Activation Key removed.'));
+                GlobalNotification.setSuccessMessage(translate('Activation Key removed.'));
             }, function (response) {
-                $scope.errorMessages.push(translate("An error occurred removing the Activation Key: ") + response.data.displayMessage);
+                GlobalNotification.setErrorMessage(translate("An error occurred removing the Activation Key: ") + response.data.displayMessage);
             });
         };
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-action-subscriptions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-action-subscriptions.controller.js
@@ -16,9 +16,9 @@
  */
 angular.module('Bastion.content-hosts').controller('ContentHostsBulkActionSubscriptionsController',
     ['$scope', '$q', '$location', 'HostCollection', 'CurrentOrganization', 'translate',
-     'Organization', 'Task',
+     'Organization', 'Task', 'GlobalNotification',
     function ($scope, $q, $location, HostCollection, CurrentOrganization, translate,
-        Organization, Task) {
+        Organization, Task, GlobalNotification) {
 
         function watchRunningTasks() {
             var searchParams = { 'type': 'resource',
@@ -48,10 +48,10 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkActionSubscr
                 $scope.subscription.runningTask = Task.monitorTask(task);
                 promise = $scope.subscription.runningTask.promise;
                 promise.then(function () {
-                    $scope.state.successMessages.push(translate('Successfully Scheduled Auto-attach.'));
+                    GlobalNotification.setSuccessMessage(translate('Successfully Scheduled Auto-attach.'));
                 });
                 promise.catch(function (errors) {
-                    $scope.state.errorMessages.push(translate("An error occurred applying Subscriptions: ") + errors.join('; '));
+                    GlobalNotification.setErrorMessage(translate("An error occurred applying Subscriptions: ") + errors.join('; '));
                 });
                 promise.finally(function () {
                     if ($scope.subscription.runningTask.state === 'stopped') {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-action.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-action.controller.js
@@ -30,10 +30,10 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkActionContro
             working: false
         };
 
-        $scope.setState = function (working, success, errors) {
+        $scope.setState = function (working, success, error) {
             $scope.state.working = working;
             $scope.state.successMessages = success;
-            $scope.state.errorMessages = errors;
+            $scope.state.errorMessages = error;
         };
 
         $scope.showConfirmDialog = function () {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
@@ -26,8 +26,6 @@ angular.module('Bastion.errata').controller('ApplyErrataController',
                 $scope.applyingErrata = false;
             }
 
-            $scope.successMessages = [];
-            $scope.errorMessages = [];
             $scope.applyingErrata = false;
 
             $scope.hasComposites = function (updates) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/new/new-gpg-key.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/new/new-gpg-key.controller.js
@@ -10,8 +10,8 @@
  *   Controls the creation of an empty GPGKey object for use by sub-controllers.
  */
 angular.module('Bastion.gpg-keys').controller('NewGPGKeyController',
-    ['$scope', 'GPGKey', 'CurrentOrganization',
-    function ($scope, GPGKey, CurrentOrganization) {
+    ['$scope', 'GPGKey', 'CurrentOrganization', 'GlobalNotification',
+    function ($scope, GPGKey, CurrentOrganization, GlobalNotification) {
 
         $scope.panel = {loading: false};
         $scope.gpgKey = new GPGKey();
@@ -27,7 +27,7 @@ angular.module('Bastion.gpg-keys').controller('NewGPGKeyController',
                     $scope.uploadStatus = 'success';
                     $scope.transitionTo('gpgKeys.index');
                 } else {
-                    $scope.errorMessages = [content.displayMessage];
+                    GlobalNotification.setErrorMessage("An error occurred while creating the GPG key: " + content.displayMessage);
                     $scope.uploadStatus = 'error';
                 }
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/products-bulk-action-sync-plan.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/products-bulk-action-sync-plan.controller.js
@@ -11,24 +11,28 @@
  *   A controller for providing bulk sync plan functionality for products.
  */
 angular.module('Bastion.products').controller('ProductsBulkActionSyncPlanController',
-    ['$scope', 'Nutupane', 'SyncPlan', 'ProductBulkAction',
-    function ($scope, Nutupane, SyncPlan, ProductBulkAction) {
+    ['$scope', 'Nutupane', 'SyncPlan', 'ProductBulkAction', 'GlobalNotification',
+    function ($scope, Nutupane, SyncPlan, ProductBulkAction, GlobalNotification) {
         var syncPlanNutupane = new Nutupane(SyncPlan);
-
-        $scope.successMessages = [];
-        $scope.errorMessages = [];
 
         $scope.syncPlanTable = syncPlanNutupane.table;
         syncPlanNutupane.query();
 
         function success(response) {
-            $scope.$parent.successMessages = response.displayMessages.success;
-            $scope.$parent.errorMessages = response.displayMessages.error;
+            angular.forEach(response.displayMessages.success, function(message) {
+                GlobalNotification.setSuccessMessage(message);
+            });
+
+            angular.forEach(response.displayMessages.error, function(message) {
+                GlobalNotification.setErrorMessage(message);
+            });
             $scope.updatingSyncPlans = false;
         }
 
         function error(response) {
-            $scope.$parent.errorMessages = response.data.errors;
+            angular.forEach(response.data.errors, function(message) {
+                GlobalNotification.setErrorMessage("An error occurred updating the sync plan: " + message);
+            });
             $scope.updatingSyncPlans = false;
         }
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/products-bulk-action.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/products-bulk-action.controller.js
@@ -11,11 +11,8 @@
  *   A controller for providing bulk action functionality to the products page.
  */
 angular.module('Bastion.products').controller('ProductsBulkActionController',
-    ['$scope', 'translate', 'ProductBulkAction', 'CurrentOrganization',
-    function ($scope, translate, ProductBulkAction, CurrentOrganization) {
-
-        $scope.successMessages = [];
-        $scope.errorMessages = [];
+    ['$scope', 'translate', 'ProductBulkAction', 'CurrentOrganization', 'GlobalNotification',
+    function ($scope, translate, ProductBulkAction, CurrentOrganization, GlobalNotification) {
 
         $scope.removeProducts = {
             confirm: false,
@@ -42,15 +39,21 @@ angular.module('Bastion.products').controller('ProductsBulkActionController',
                 $scope.productsNutupane.refresh();
                 $scope.table.selectAll(false);
 
-                $scope.$parent.successMessages = data.displayMessages.success;
-                $scope.$parent.errorMessages = data.displayMessages.error;
+                angular.forEach(data.displayMessages.success, function(message) {
+                    GlobalNotification.setSuccessMessage(message);
+                });
+
+                angular.forEach(data.displayMessages.error, function(message) {
+                    GlobalNotification.setErrorMessage(message);
+                });
+
                 $scope.removingProducts = false;
                 $scope.transitionTo('products.index');
             };
 
             error = function (response) {
                 angular.forEach(response.data.errors, function (errorMessage) {
-                    $scope.errorMessages.push(translate("An error occurred removing the Products: ") + errorMessage);
+                    GlobalNotification.setErrorMessage(translate("An error occurred removing the Products: ") + errorMessage);
                 });
                 $scope.removingProducts = false;
             };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/new/product-form.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/new/product-form.controller.js
@@ -15,8 +15,8 @@
  *   within the table.
  */
 angular.module('Bastion.products').controller('ProductFormController',
-    ['$scope', '$q', 'Product', 'GPGKey', 'SyncPlan', 'FormUtils',
-    function ($scope, $q, Product, GPGKey, SyncPlan, FormUtils) {
+    ['$scope', '$q', 'Product', 'GPGKey', 'SyncPlan', 'FormUtils', 'GlobalNotification',
+    function ($scope, $q, Product, GPGKey, SyncPlan, FormUtils, GlobalNotification) {
 
         function fetchGpgKeys() {
             return GPGKey.queryUnpaged(function (gpgKeys) {
@@ -42,7 +42,7 @@ angular.module('Bastion.products').controller('ProductFormController',
                     $scope.productForm[field].$setValidity('server', false);
                     $scope.productForm[field].$error.messages = errors;
                 } else {
-                    $scope.$parent.errorMessages = [errors];
+                    GlobalNotification.setErrorMessage("An error occurred while saving the Product: " + field + " " + errors);
                 }
             });
         }
@@ -57,7 +57,6 @@ angular.module('Bastion.products').controller('ProductFormController',
         });
 
         $scope.save = function (product) {
-            $scope.$parent.errorMessages = [];
             product.$save(success, error);
         };
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.controller.js
@@ -14,8 +14,9 @@
  *   within the table.
  */
 angular.module('Bastion.products').controller('ProductsController',
-    ['$scope', '$location', 'Nutupane', 'Product', 'CurrentOrganization',
-    function ($scope, $location, Nutupane, Product, CurrentOrganization) {
+    ['$scope', '$sce', '$location', 'Nutupane', 'Product', 'CurrentOrganization', 'GlobalNotification',
+    function ($scope, $sce, $location, Nutupane, Product, CurrentOrganization, GlobalNotification) {
+        var taskUrl, taskLink;
 
         var params = {
             'organization_id': CurrentOrganization,
@@ -36,7 +37,9 @@ angular.module('Bastion.products').controller('ProductsController',
         };
 
         $scope.$on('productDelete', function (event, taskId) {
-            $scope.productDeletionTaskId = taskId;
+            taskUrl = $scope.taskUrl(taskId);
+            taskLink = $sce.trustAsHtml("<a href=" + taskUrl + ">here</a>");
+            GlobalNotification.setRenderedSuccessMessage("Product delete operation has been initiated in the background. Click " + taskLink + " click to monitor the progress.");
         });
 
         $scope.unsetProductDeletionTaskId = function () {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/products.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/products.html
@@ -6,16 +6,6 @@
     {{ 'Products' | translate }}
   </div>
 
-  <div data-block="messages">
-    <div bst-alerts success-messages="successMessages" error-messages="errorMessages"></div>
-    <div bst-alert="success" ng-hide="productDeletionTaskId === undefined">
-      <button type="button" class="close" ng-click="unsetProductDeletionTaskId()">&times;</button>
-      <p translate>
-        Product delete operation has been initiated in the background.  Click <a href="{{ taskUrl(productDeletionTaskId) }}">Here</a> to monitor the progress.
-      </p>
-    </div>
-  </div>
-
   <div data-block="actions">
     <button class="btn btn-default"
             ng-show="permitted('edit_products') || permitted('destroy_products')"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/new-repository.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/new-repository.controller.js
@@ -12,12 +12,12 @@
  *   Controls the creation of an empty Repository object for use by sub-controllers.
  */
 angular.module('Bastion.repositories').controller('NewRepositoryController',
-    ['$scope', 'Repository', 'GPGKey', 'FormUtils', 'translate',
-    function ($scope, Repository, GPGKey, FormUtils, translate) {
+    ['$scope', 'Repository', 'GPGKey', 'FormUtils', 'translate', 'GlobalNotification',
+    function ($scope, Repository, GPGKey, FormUtils, translate, GlobalNotification) {
 
         function success(response) {
             $scope.detailsTable.rows.push(response);
-            $scope.successMessages.push(translate('Repository %s successfully created.').replace('%s', $scope.repository.name));
+            GlobalNotification.setSuccessMessage(translate('Repository %s successfully created.').replace('%s', $scope.repository.name));
             $scope.transitionTo('products.details.repositories.index', {productId: $scope.$stateParams.productId});
         }
 
@@ -41,7 +41,7 @@ angular.module('Bastion.repositories').controller('NewRepositoryController',
             });
 
             if (!foundError) {
-                $scope.errorMessages = [response.data.displayMessage];
+                GlobalNotification.setErrorMessage(response.data.displayMessage);
             }
         }
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/manifest-import.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/manifest-import.controller.js
@@ -14,8 +14,8 @@
  *   Controls the import of a manifest.
  */
 angular.module('Bastion.subscriptions').controller('ManifestImportController',
-    ['$scope', '$q', 'translate', 'CurrentOrganization', 'Organization', 'Task', 'Subscription',
-    function ($scope, $q, translate, CurrentOrganization, Organization, Task, Subscription) {
+    ['$scope', '$q', 'translate', 'CurrentOrganization', 'Organization', 'Task', 'Subscription', 'GlobalNotification',
+    function ($scope, $q, translate, CurrentOrganization, Organization, Task, Subscription, GlobalNotification) {
 
         function buildManifestLink(upstream) {
             var url = upstream.webUrl,
@@ -68,7 +68,7 @@ angular.module('Bastion.subscriptions').controller('ManifestImportController',
                 if (task.humanized.output && task.humanized.output.length > 0) {
                     errorMessageWithDetails += ' ' + task.humanized.output;
                 }
-                $scope.errorMessages.push(errorMessageWithDetails);
+                GlobalNotification.setErrorMessage(errorMessageWithDetails);
                 $scope.histories = Subscription.manifestHistory();
             }
         };
@@ -80,7 +80,7 @@ angular.module('Bastion.subscriptions').controller('ManifestImportController',
                 $scope.unregisterSearch();
                 if ($scope.task.result === 'success') {
                     $scope.refreshOrganizationInfo();
-                    $scope.successMessages.push(translate("Manifest successfully imported."));
+                    GlobalNotification.setSuccessMessage(translate("Manifest successfully imported."));
                     $scope.refreshTable();
                 } else {
                     $scope.handleTaskErrors(task, translate("Error importing manifest."));
@@ -104,7 +104,7 @@ angular.module('Bastion.subscriptions').controller('ManifestImportController',
                 $scope.unregisterSearch();
                 if ($scope.deleteTask.result === 'success') {
                     $scope.saveSuccess = true;
-                    $scope.successMessages.push(translate("Manifest successfully deleted."));
+                    GlobalNotification.setSuccessMessage(translate("Manifest successfully deleted."));
                     $scope.refreshTable();
                     $scope.refreshOrganizationInfo();
                 } else {
@@ -137,7 +137,7 @@ angular.module('Bastion.subscriptions').controller('ManifestImportController',
                 $scope.unregisterSearch();
                 if ($scope.refreshTask.result === 'success') {
                     $scope.saveSuccess = true;
-                    $scope.successMessages.push(translate("Manifest successfully refreshed."));
+                    GlobalNotification.setSuccessMessage(translate("Manifest successfully refreshed."));
                     $scope.refreshTable();
                     $scope.refreshOrganizationInfo();
                 } else {
@@ -151,14 +151,12 @@ angular.module('Bastion.subscriptions').controller('ManifestImportController',
 
             organization.$update(function (response) {
                 deferred.resolve(response);
-                $scope.successMessages.push(translate('Repository URL updated'));
+                GlobalNotification.setSuccessMessage.push(translate('Repository URL updated'));
                 $scope.refreshTable();
                 $scope.refreshOrganizationInfo();
             }, function (response) {
                 deferred.reject(response);
-                angular.forEach(response.data.errors, function (errorMessage) {
-                    $scope.errorMessages.push(translate("An error occurred saving the URL: ") + errorMessage);
-                });
+                GlobalNotification.setErrorMessage(translate("An error occurred saving the URL: ") + response.data.error.message);
             });
 
             return deferred.promise;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/subscriptions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/subscriptions.controller.js
@@ -33,8 +33,6 @@ angular.module('Bastion.subscriptions').controller('SubscriptionsController',
         nutupane = new Nutupane(Subscription, params);
         $scope.table = nutupane.table;
         $scope.refreshTable = nutupane.refresh;
-        $scope.successMessages = [];
-        $scope.errorMessages = [];
         $scope.controllerName = 'katello_subscriptions';
 
         $scope.table.closeItem = function () {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/new/new-sync-plan.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/new/new-sync-plan.controller.js
@@ -10,49 +10,48 @@
  *   Controls the creation of an empty SyncPlan object for use by sub-controllers.
  */
 angular.module('Bastion.sync-plans').controller('NewSyncPlanController',
-    ['$scope', 'translate', 'SyncPlan', function ($scope, translate, SyncPlan) {
-        $scope.intervals = [
-            {id: 'hourly', value: translate('hourly')},
-            {id: 'daily', value: translate('daily')},
-            {id: 'weekly', value: translate('weekly')}
-        ];
+    ['$scope', 'translate', 'SyncPlan', 'GlobalNotification',
+        function ($scope, translate, SyncPlan, GlobalNotification) {
+            $scope.intervals = [
+                {id: 'hourly', value: translate('hourly')},
+                {id: 'daily', value: translate('daily')},
+                {id: 'weekly', value: translate('weekly')}
+            ];
 
-        $scope.successMessages = [];
+            $scope.syncPlan = new SyncPlan();
+            $scope.syncPlan.interval = $scope.intervals[0].id;
+            $scope.syncPlan.startDate = new Date();
 
-        $scope.syncPlan = new SyncPlan();
-        $scope.syncPlan.interval = $scope.intervals[0].id;
-        $scope.syncPlan.startDate = new Date();
-
-        function success(syncPlan) {
-            $scope.working = false;
-            $scope.successMessages = [translate('New sync plan successfully created.')];
-            if ($scope.product) {
-                $scope.product['sync_plan_id'] = syncPlan.id;
-                $scope.$state.go('products.details.info', {productId: $scope.product.id});
-            } else if ($scope.syncPlanTable) {
-                $scope.syncPlanTable.rows.unshift(syncPlan);
-                $scope.$state.go('sync-plans.details.info', {syncPlanId: syncPlan.id});
+            function success(syncPlan) {
+                $scope.working = false;
+                GlobalNotification.setSuccessMessage(translate('New sync plan successfully created.'));
+                if ($scope.product) {
+                    $scope.product['sync_plan_id'] = syncPlan.id;
+                    $scope.$state.go('products.details.info', {productId: $scope.product.id});
+                } else if ($scope.syncPlanTable) {
+                    $scope.syncPlanTable.rows.unshift(syncPlan);
+                    $scope.$state.go('sync-plans.details.info', {syncPlanId: syncPlan.id});
+                }
             }
-        }
 
-        function error(response) {
-            $scope.working = false;
-            angular.forEach(response.data.errors, function (errors, field) {
-                $scope.syncPlanForm[field].$setValidity('server', false);
-                $scope.syncPlanForm[field].$error.messages = errors;
-            });
-        }
+            function error(response) {
+                $scope.working = false;
+                angular.forEach(response.data.errors, function (errors, field) {
+                    $scope.syncPlanForm[field].$setValidity('server', false);
+                    $scope.syncPlanForm[field].$error.messages = errors;
+                });
+            }
 
-        $scope.createSyncPlan = function (syncPlan) {
-            var GMT_OFFSET_MILLISECONDS = syncPlan.startDate.getTimezoneOffset() * 60000,
-                syncDate = new Date(syncPlan.startDate.getTime() + GMT_OFFSET_MILLISECONDS),
-                syncTime = new Date(syncPlan.startTime || new Date());
-            syncDate.setHours(syncTime.getHours());
-            syncDate.setMinutes(syncTime.getMinutes());
-            syncDate.setSeconds(0);
+            $scope.createSyncPlan = function (syncPlan) {
+                var GMT_OFFSET_MILLISECONDS = syncPlan.startDate.getTimezoneOffset() * 60000,
+                    syncDate = new Date(syncPlan.startDate.getTime() + GMT_OFFSET_MILLISECONDS),
+                    syncTime = new Date(syncPlan.startTime || new Date());
+                syncDate.setHours(syncTime.getHours());
+                syncDate.setMinutes(syncTime.getMinutes());
+                syncDate.setSeconds(0);
 
-            syncPlan['sync_date'] = syncDate.toString();
-            syncPlan.$save(success, error);
-        };
-    }]
+                syncPlan['sync_date'] = syncDate.toString();
+                syncPlan.$save(success, error);
+            };
+        }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/sync-plans.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/sync-plans.controller.js
@@ -15,12 +15,9 @@
  *   within the table.
  */
 angular.module('Bastion.sync-plans').controller('SyncPlansController',
-    ['$scope', '$location', 'translate', 'Nutupane', 'SyncPlan', 'CurrentOrganization',
-        function ($scope, $location, translate, Nutupane, SyncPlan, CurrentOrganization) {
+    ['$scope', '$location', 'translate', 'Nutupane', 'SyncPlan', 'CurrentOrganization', 'GlobalNotification',
+        function ($scope, $location, translate, Nutupane, SyncPlan, CurrentOrganization, GlobalNotification) {
             var params, nutupane;
-
-            $scope.successMessages = [];
-            $scope.errorMessages = [];
 
             params = {
                 'organization_id': CurrentOrganization,
@@ -49,7 +46,7 @@ angular.module('Bastion.sync-plans').controller('SyncPlansController',
 
             $scope.removeSyncPlan = function (syncPlan) {
                 syncPlan.$remove(function () {
-                    $scope.successMessages.push(translate('Sync Plan %s has been deleted.').replace('%s', syncPlan.name));
+                    GlobalNotification.setSuccessMessage(translate('Sync Plan %s has been deleted.').replace('%s', syncPlan.name));
                     $scope.removeRow(syncPlan.id);
                     $scope.transitionTo('sync-plans.index');
                 });

--- a/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-action-subscriptions.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-action-subscriptions.controller.test.js
@@ -1,5 +1,5 @@
 describe('Controller: ContentHostsBulkActionSubscriptionsController', function() {
-    var $scope, $_q_, translate, ContentHostBulkAction, HostCollection, Organization, Task, CurrentOrganization;
+    var $scope, $_q_, translate, ContentHostBulkAction, HostCollection, Organization, Task, CurrentOrganization, GlobalNotification;
 
     beforeEach(module('Bastion.content-hosts', 'Bastion.test-mocks'));
 
@@ -28,9 +28,10 @@ describe('Controller: ContentHostsBulkActionSubscriptionsController', function()
         CurrentOrganization = 'foo';
     });
 
-    beforeEach(inject(function($controller, $rootScope, $q) {
+    beforeEach(inject(function(_GlobalNotification_, $controller, $rootScope, $q) {
         $_q_ = $q;
         $scope = $rootScope.$new();
+        GlobalNotification = _GlobalNotification_;
         $scope.getSelectedContentHostIds = function() {
             return [1,2,3]
         };
@@ -42,7 +43,8 @@ describe('Controller: ContentHostsBulkActionSubscriptionsController', function()
             translate: translate,
             Organization: Organization,
             CurrentOrganization: CurrentOrganization,
-            Task: Task});
+            Task: Task,
+            GlobalNotification: GlobalNotification});
     }));
 
     it("can auto-attach available subscriptions to all content hosts", function() {

--- a/engines/bastion_katello/test/errata/apply-errata.controller.test.js
+++ b/engines/bastion_katello/test/errata/apply-errata.controller.test.js
@@ -37,6 +37,8 @@ describe('Controller: ApplyErrataController', function() {
 
         $scope = $injector.get('$rootScope').$new();
         $scope.checkIfIncrementalUpdateRunning = function () {};
+        $scope.errorMessages = [];
+        $scope.successMessages = [];
 
         dependencies = {
             $scope: $scope,

--- a/engines/bastion_katello/test/gpg-keys/new/new-gpg-key-controller.test.js
+++ b/engines/bastion_katello/test/gpg-keys/new/new-gpg-key-controller.test.js
@@ -1,5 +1,5 @@
 describe('Controller: NewGPGKeyController', function() {
-    var $scope, translate;
+    var $scope, translate, GlobalNotification;
 
     beforeEach(module(
         'Bastion.gpg-keys',
@@ -13,6 +13,7 @@ describe('Controller: NewGPGKeyController', function() {
             CurrentOrganization = "Foo";
 
         $scope = $injector.get('$rootScope').$new();
+        GlobalNotification = $injector.get('GlobalNotification');
 
         $scope.table = {
             addRow: function() {},
@@ -23,6 +24,7 @@ describe('Controller: NewGPGKeyController', function() {
             $scope: $scope,
             GPGKey: GPGKey,
             CurrentOrganization:CurrentOrganization,
+            GlobalNotification: GlobalNotification,
         });
 
     }));
@@ -34,9 +36,10 @@ describe('Controller: NewGPGKeyController', function() {
     it('should save a new gpg key resource', function() {
         spyOn($scope.table, 'addRow');
         spyOn($scope, 'transitionTo');
+        spyOn(GlobalNotification, "setErrorMessage");
         $scope.uploadContent({"status": "success"});
 
-        expect($scope.errorMessages).not.toBeDefined();
+        expect(GlobalNotification.setErrorMessage).not.toHaveBeenCalled();
         expect($scope.uploadStatus).toBe('success');
 
         expect($scope.table.addRow).toHaveBeenCalled();
@@ -46,9 +49,11 @@ describe('Controller: NewGPGKeyController', function() {
     it('should error on a new gpg key resource', function() {
         spyOn($scope.table, 'addRow');
         spyOn($scope, 'transitionTo');
+        spyOn(GlobalNotification, "setErrorMessage");
         $scope.uploadContent({"errors": "....", "displayMessage":"......"});
 
-        expect($scope.errorMessages.length).toBe(1);
+        expect(GlobalNotification.setErrorMessage).toHaveBeenCalled();
+
         expect($scope.uploadStatus).toBe('error');
         expect($scope.table.addRow).not.toHaveBeenCalled();
     });

--- a/engines/bastion_katello/test/products/bulk/products-bulk-action-sync-plan.controller.test.js
+++ b/engines/bastion_katello/test/products/bulk/products-bulk-action-sync-plan.controller.test.js
@@ -1,5 +1,5 @@
 describe('Controller: ProductsBulkActionSyncPlanController', function() {
-    var $scope, $q, ProductBulkAction, SyncPlan, Nutupane, selected;
+    var $scope, $q, ProductBulkAction, SyncPlan, Nutupane, selected, GlobalNotification;
 
     beforeEach(module('Bastion.products', 'Bastion.test-mocks'));
 
@@ -17,19 +17,21 @@ describe('Controller: ProductsBulkActionSyncPlanController', function() {
         };
     });
 
-    beforeEach(inject(function($controller, $rootScope, _$q_, MockResource) {
+    beforeEach(inject(function(_GlobalNotification_, $controller, $rootScope, _$q_, MockResource) {
         $scope = $rootScope.$new();
         $q = _$q_;
 
         $scope.actionParams = {};
         $scope.getSelectedProductIds = function () { return selected; };
         SyncPlan = MockResource.$new();
+        GlobalNotification = _GlobalNotification_;
 
         $controller('ProductsBulkActionSyncPlanController', {
             $scope: $scope,
             Nutpane: Nutupane,
             SyncPlan: SyncPlan,
-            ProductBulkAction: ProductBulkAction
+            ProductBulkAction: ProductBulkAction,
+            GlobalNotification: GlobalNotification
         });
     }));
 

--- a/engines/bastion_katello/test/products/bulk/products-bulk-action.controller.test.js
+++ b/engines/bastion_katello/test/products/bulk/products-bulk-action.controller.test.js
@@ -1,5 +1,5 @@
 describe('Controller: ProductsBulkActionController', function() {
-    var $scope, $q, translate, ProductBulkAction, CurrentOrganization, selected;
+    var $scope, $q, translate, ProductBulkAction, CurrentOrganization, GlobalNotification, selected;
 
     beforeEach(module('Bastion.products'));
 
@@ -15,9 +15,10 @@ describe('Controller: ProductsBulkActionController', function() {
         CurrentOrganization = 'foo';
     });
 
-    beforeEach(inject(function($controller, $rootScope, _$q_) {
+    beforeEach(inject(function(_GlobalNotification_, $controller, $rootScope, _$q_) {
         $scope = $rootScope.$new();
         $q = _$q_;
+        GlobalNotification = _GlobalNotification_;
 
         $scope.productTable = {
             getSelected: function () { return selected; }
@@ -27,7 +28,8 @@ describe('Controller: ProductsBulkActionController', function() {
             $scope: $scope,
             translate: translate,
             ProductBulkAction: ProductBulkAction,
-            CurrentOrganization: CurrentOrganization
+            CurrentOrganization: CurrentOrganization,
+            GlobalNotification: GlobalNotification
         });
     }));
 

--- a/engines/bastion_katello/test/products/new/product-form.controller.test.js
+++ b/engines/bastion_katello/test/products/new/product-form.controller.test.js
@@ -1,6 +1,7 @@
 describe('Controller: ProductFormController', function() {
     var $scope,
         FormUtils,
+        GlobalNotification,
         $httpBackend;
 
     beforeEach(module('Bastion.products', 'Bastion.test-mocks'));
@@ -17,6 +18,7 @@ describe('Controller: ProductFormController', function() {
         $scope = $injector.get('$rootScope').$new();
         $httpBackend = $injector.get('$httpBackend');
         FormUtils = $injector.get('FormUtils');
+        GlobalNotification = $injector.get('GlobalNotification');
 
         $scope.productForm = $injector.get('MockForm');
         $scope.productTable = {
@@ -34,7 +36,8 @@ describe('Controller: ProductFormController', function() {
             Provider: Provider,
             GPGKey: GPGKey,
             SyncPlan: SyncPlan,
-            FormUtils: FormUtils
+            FormUtils: FormUtils,
+            GlobalNotification: GlobalNotification
         });
     }));
 

--- a/engines/bastion_katello/test/products/products.controller.test.js
+++ b/engines/bastion_katello/test/products/products.controller.test.js
@@ -1,5 +1,6 @@
 describe('Controller: ProductsController', function() {
     var $scope,
+        GlobalNotification,
         Nutupane;
 
     beforeEach(module('Bastion.products', 'Bastion.test-mocks'));
@@ -14,15 +15,17 @@ describe('Controller: ProductsController', function() {
         Product = {};
     });
 
-    beforeEach(inject(function($controller, $rootScope, $location) {
+    beforeEach(inject(function(_GlobalNotification_, $controller, $rootScope, $location) {
         $scope = $rootScope.$new();
+        GlobalNotification = _GlobalNotification_;
 
         $controller('ProductsController', {
             $scope: $scope,
             $location: $location,
             Nutupane: Nutupane,
             Product: Product,
-            CurrentOrganization: 'CurrentOrganization'
+            CurrentOrganization: 'CurrentOrganization',
+            GlobalNotification: GlobalNotification
         });
     }));
 

--- a/engines/bastion_katello/test/repositories/new/new-repository.controller.test.js
+++ b/engines/bastion_katello/test/repositories/new/new-repository.controller.test.js
@@ -1,6 +1,7 @@
 describe('Controller: NewRepositoryController', function() {
     var $scope,
         FormUtils,
+        GlobalNotification,
         $httpBackend;
 
     beforeEach(module('Bastion.repositories', 'Bastion.test-mocks'));
@@ -14,9 +15,9 @@ describe('Controller: NewRepositoryController', function() {
         $scope = $injector.get('$rootScope').$new();
         $httpBackend = $injector.get('$httpBackend');
         FormUtils = $injector.get('FormUtils');
+        GlobalNotification = $injector.get('GlobalNotification');
 
         $scope.detailsTable = {rows: []};
-        $scope.successMessages = [];
         $scope.$stateParams = {productId: 1};
         $scope.repositoryForm = $injector.get('MockForm');
 
@@ -29,7 +30,8 @@ describe('Controller: NewRepositoryController', function() {
             $scope: $scope,
             $http: $http,
             Repository: Repository,
-            GPGKey: GPGKey
+            GPGKey: GPGKey,
+            GlobalNotification: GlobalNotification
         });
     }));
 
@@ -51,9 +53,11 @@ describe('Controller: NewRepositoryController', function() {
 
         spyOn($scope, 'transitionTo');
         spyOn(repository, '$save').andCallThrough();
+        spyOn(GlobalNotification, "setSuccessMessage");
         $scope.save(repository);
 
         expect(repository.$save).toHaveBeenCalled();
+        expect(GlobalNotification.setSuccessMessage).toHaveBeenCalled();
         expect($scope.transitionTo).toHaveBeenCalledWith('products.details.repositories.index', {productId: 1});
     });
 

--- a/engines/bastion_katello/test/subscriptions/manifest/manifest-import.controller.test.js
+++ b/engines/bastion_katello/test/subscriptions/manifest/manifest-import.controller.test.js
@@ -35,6 +35,8 @@ describe('Controller: ManifestImportController', function() {
             translate;
         Organization = $injector.get('Organization');
         Subscription = $injector.get('Subscription');
+        GlobalNotification = $injector.get('GlobalNotification');
+
         $httpBackend.expectGET('/api/organization/ACME/subscriptions/manifest_history').respond([]);
         $httpBackend.expectGET('/api/v2/organizations/ACME/redhat_provider').respond({name: "Red Hat"});
         $httpBackend.expectGET('/api/organization/ACME').respond(organization);
@@ -44,6 +46,9 @@ describe('Controller: ManifestImportController', function() {
         $q = $injector.get('$q');
         $scope.redhatProvider = Organization.redhatProvider();
         $scope.histories = Subscription.manifestHistory();
+
+        spyOn(GlobalNotification, "setSuccessMessage");
+        spyOn(GlobalNotification, "setErrorMessage");
 
         Task = {registerSearch: function() {}};
 
@@ -56,7 +61,8 @@ describe('Controller: ManifestImportController', function() {
             CurrentOrganization: "ACME",
             Organization: Organization,
             Subscription: Subscription,
-            Task: Task
+            Task: Task,
+            GlobalNotification: GlobalNotification
         });
     }));
 
@@ -79,8 +85,8 @@ describe('Controller: ManifestImportController', function() {
         $httpBackend.expectPUT('/api/v2/organizations/ACME/');
         promise = $scope.saveCdnUrl($scope.organization);
         promise.then(function() {
-            expect($scope.successMessages.length).toBe(1);
-            expect($scope.errorMessages.length).toBe(0);
+            expect(GlobalNotification.setErrorMessage).not.toHaveBeenCalled();
+            expect(GlobalNotification.setSuccessMessage).toHaveBeenCalled();
         });
     });
 
@@ -89,8 +95,8 @@ describe('Controller: ManifestImportController', function() {
         spyOn(Subscription, 'deleteManifest').andCallThrough();
         $scope.deleteManifest($scope.organization);
         $q.all([$scope.organization.$promise]).then(function () {
-            expect($scope.successMessages.length).toBe(1);
-            expect($scope.errorMessages.length).toBe(0);
+            expect(GlobalNotification.setErrorMessage).not.toHaveBeenCalled();
+            expect(GlobalNotification.setSuccessMessage).toHaveBeenCalled();
         });
     });
 
@@ -99,8 +105,8 @@ describe('Controller: ManifestImportController', function() {
         spyOn(Subscription, 'refreshManifest').andCallThrough();
         $scope.refreshManifest($scope.organization);
         $q.all([$scope.organization.$promise]).then(function () {
-            expect($scope.successMessages.length).toBe(1);
-            expect($scope.errorMessages.length).toBe(0);
+            expect(GlobalNotification.setErrorMessage).not.toHaveBeenCalled();
+            expect(GlobalNotification.setSuccessMessage).toHaveBeenCalled();
         });
     });
 
@@ -108,7 +114,7 @@ describe('Controller: ManifestImportController', function() {
         $q.all([$scope.organization.$promise]).then(function () {
             $scope.uploadManifest('<pre>"There was an error"</pre>', true);
 
-            expect($scope.successMessages.length).toBe(0);
+            expect(GlobalNotification.setSuccessMessage).not.toHaveBeenCalled();
             expect($scope.uploadErrorMessages.length).toBe(1);
         });
     });
@@ -120,7 +126,7 @@ describe('Controller: ManifestImportController', function() {
 
             expect($scope.saveSuccess).toBe(true);
             expect($scope.uploadErrorMessages.length).toBe(0);
-            expect($scope.successMessages.length).toBe(1);
+            expect(GlobalNotification.setSuccessMessage).toHaveBeenCalled();
             expect($scope.refreshTable).toHaveBeenCalled();
         });
     });

--- a/engines/bastion_katello/test/sync-plans/new-sync-plan.controller.test.js
+++ b/engines/bastion_katello/test/sync-plans/new-sync-plan.controller.test.js
@@ -1,5 +1,5 @@
 describe('Controller: NewSyncPlanController', function() {
-    var $scope, translate, SyncPlan;
+    var $scope, translate, SyncPlan, GlobalNotification;
 
     beforeEach(module(
         'Bastion.sync-plans',
@@ -10,6 +10,7 @@ describe('Controller: NewSyncPlanController', function() {
         var $controller = $injector.get('$controller');
 
         SyncPlan = $injector.get('MockResource').$new()
+        GlobalNotification = $injector.get('GlobalNotification');
         $scope = $injector.get('$rootScope').$new();
         $scope.$state = {go: function () {}};
 
@@ -18,15 +19,15 @@ describe('Controller: NewSyncPlanController', function() {
         $scope.syncPlanTable = {
             rows: {
                 unshift: function () {}
-            }
-        };
+             }
+         };
 
         $controller('NewSyncPlanController', {
             $scope: $scope,
             translate: translate,
-            SyncPlan: SyncPlan
+            SyncPlan: SyncPlan,
+            GlobalNotification: GlobalNotification
         });
-
     }));
 
     it('should attach a sync plan resource on to the scope', function() {
@@ -83,11 +84,12 @@ describe('Controller: NewSyncPlanController', function() {
         spyOn($scope.$state, 'go');
         spyOn(syncPlan, '$save').andCallThrough();
         spyOn($scope.syncPlanTable.rows, 'unshift');
+        spyOn(GlobalNotification, "setSuccessMessage");
 
         $scope.createSyncPlan(syncPlan);
 
         expect($scope.working).toBe(false);
-        expect($scope.successMessages.length).toBe(1);
+        expect(GlobalNotification.setSuccessMessage).toHaveBeenCalled();
         expect($scope.syncPlanTable.rows.unshift).toHaveBeenCalledWith(syncPlan);
         expect($scope.$state.go).toHaveBeenCalledWith('sync-plans.details.info', {syncPlanId: syncPlan.id});
     });
@@ -99,12 +101,13 @@ describe('Controller: NewSyncPlanController', function() {
 
         spyOn($scope.$state, 'go');
         spyOn(syncPlan, '$save').andCallThrough();
+        spyOn(GlobalNotification, "setSuccessMessage");
 
         $scope.product = {id: 1};
         $scope.createSyncPlan(syncPlan);
 
         expect($scope.working).toBe(false);
-        expect($scope.successMessages.length).toBe(1);
+        expect(GlobalNotification.setSuccessMessage).toHaveBeenCalled();
         expect($scope.$state.go).toHaveBeenCalledWith('products.details.info', {productId: $scope.product.id});
     });
 });

--- a/engines/bastion_katello/test/test-mocks.module.js
+++ b/engines/bastion_katello/test/test-mocks.module.js
@@ -10,6 +10,12 @@ angular.module('Bastion.test-mocks').config(['$provide', function ($provide) {
         };
     });
 
+    $provide.service('GlobalNotification', function () {
+        return {
+            this.setSuccessMessage: function() {},
+            this.setErrorMessage: function() {},
+        }
+    });
 }]);
 
 angular.module('Bastion.test-mocks').run(['$state', '$stateParams', '$rootScope', '$window',


### PR DESCRIPTION
This converts Katello to using the global notification service introduced in https://github.com/Katello/bastion/pull/91 

All top level notification (ones near the page title) are converted to using global notifications.