### PR TITLE
fixes #13447 - docker v2 - disable v1 support & introduce docker_manifest unit

### DIFF
--- a/app/lib/actions/pulp/repository/create.rb
+++ b/app/lib/actions/pulp/repository/create.rb
@@ -52,6 +52,7 @@ module Actions
             when ::Katello::Repository::DOCKER_TYPE
               importer.upstream_name   = input[:docker_upstream_name] if input[:docker_upstream_name]
               importer.feed            = input[:feed]
+              importer.enable_v1       = false
             end
           end
           importer

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -143,6 +143,7 @@ module Katello
           options = {}
           options[:upstream_name] = self.docker_upstream_name
           options[:feed] = self.url if self.respond_to?(:url)
+          options[:enable_v1] = false if self.respond_to?(:enable_v1)
           Runcible::Models::DockerImporter.new(options)
         else
           fail _("Unexpected repo type %s") % self.content_type
@@ -662,7 +663,7 @@ module Katello
         when Repository::PUPPET_TYPE
           "puppet_module"
         when Repository::DOCKER_TYPE
-          "docker_image"
+          "docker_manifest"
         end
       end
 


### PR DESCRIPTION
NOTE: THIS CHANGE IS BASED ON PULP 2.8

At this time, as Katello moves towards supporting Docker v2,
it will no longer support v1.  This commit will update the
repository importer to disable v1.

The changes are being kept simple/minimal, as the plan is
to also remove v1 from Pulp in the not-so-distant future.

This commit also contains a very minimal change to introduce
the 'docker_manifest' unit type.  Additional changes will be
coming in separate commits to build out functionality to
use this type.