### PR TITLE
refs #13454 - rake task to remove docker v1 content...

### DIFF
--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -240,7 +240,8 @@ module Katello
       load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/2.4/import_distributions.rake"
       load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/2.4/import_puppet_modules.rake"
       load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/2.4/import_subscriptions.rake"
-      load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/2.5/add_export_distributor.rake"
+      load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/3.0/add_export_distributor.rake"
+      load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/3.0/delete_docker_v1_content.rake"
     end
   end
 end

--- a/lib/katello/tasks/upgrades/3.0/add_export_distributor.rake
+++ b/lib/katello/tasks/upgrades/3.0/add_export_distributor.rake
@@ -1,6 +1,6 @@
 namespace :katello do
   namespace :upgrades do
-    namespace '2.5' do
+    namespace '3.0' do
       task :add_export_distributor => ["environment"]  do
         User.current = User.anonymous_api_admin
         puts _("Refreshing existing repositories to add export distributor")

--- a/lib/katello/tasks/upgrades/3.0/delete_docker_v1_content.rake
+++ b/lib/katello/tasks/upgrades/3.0/delete_docker_v1_content.rake
@@ -1,0 +1,27 @@
+namespace :katello do
+  namespace :upgrades do
+    namespace '3.0' do
+      task :delete_docker_v1_content => ["environment"] do
+        print _("Deleting repositories that only contain Docker v1 content....")
+        User.current = User.anonymous_admin
+        docker_repositories = Katello::Repository.where(:content_type => Katello::Repository::DOCKER_TYPE, :library_instance_id => nil)
+
+        v1_repos = docker_repositories.select do |repo|
+          docker_images_count = Katello.pulp_server.extensions.repository.docker_images(repo.pulp_id).size
+          repo_units_count = Katello.pulp_server.extensions.repository.unit_search(repo.pulp_id).size
+          docker_images_count > 0 && docker_images_count == repo_units_count
+        end
+
+        v1_repos.each do |v1_repo|
+          v1_repo.clones.each do |clone|
+            ForemanTasks.sync_task(::Actions::Katello::Repository::Destroy, clone, :planned_destroy => true)
+          end
+          ForemanTasks.sync_task(::Actions::Katello::Repository::Destroy, v1_repo, :planned_destroy => true)
+        end
+
+        puts _("Done")
+        Rake::Task["katello:delete_orphaned_content"].invoke
+      end
+    end
+  end
+end


### PR DESCRIPTION
Docker v2 content will be removed with this rake task. Once Katello
switches to Pulp 2.8, it will no longer be able to support Docker v1
content.