### PR TITLE
Fixes #12898 - Adds content view and lifecycle environment to content…

### DIFF
--- a/app/lib/actions/katello/host/destroy.rb
+++ b/app/lib/actions/katello/host/destroy.rb
@@ -22,8 +22,7 @@ module Actions
             host.subscription_facet.try(:destroy!)
             host.content_facet.try(:destroy!)
           else
-            host.subscription_facet.update_attributes!(:uuid => nil) if host.subscription_facet
-            host.content_facet.update_attributes!(:uuid => nil) if host.content_facet
+            unregister_host(host)
           end
 
           if host.content_host
@@ -39,6 +38,17 @@ module Actions
           else
             host.get_status(::Katello::ErrataStatus).destroy
             host.get_status(::Katello::SubscriptionStatus).destroy
+          end
+        end
+
+        def unregister_host(host)
+          if host.subscription_facet
+            host.subscription_facet.uuid = nil
+            host.subscription_facet.save!
+          end
+          if host.content_facet
+            host.content_facet.uuid = nil
+            host.content_facet.save!
           end
         end
 

--- a/app/lib/actions/katello/host/register.rb
+++ b/app/lib/actions/katello/host/register.rb
@@ -46,8 +46,10 @@ module Actions
 
         def finalize
           host = ::Host.find(input[:host_id])
-          host.content_facet.update_attributes(:uuid => input[:uuid])
-          host.subscription_facet.update_attributes(:uuid => input[:uuid])
+          host.content_facet.uuid = input[:uuid]
+          host.subscription_facet.uuid = input[:uuid]
+          host.content_facet.save!
+          host.subscription_facet.save!
 
           system = ::Katello::System.find(input[:system_id])
           system.uuid = input[:uuid]

--- a/app/models/katello/concerns/content_facet_host_extensions.rb
+++ b/app/models/katello/concerns/content_facet_host_extensions.rb
@@ -25,6 +25,7 @@ module Katello
         scoped_search :in => :lifecycle_environment, :on => :name, :complete_value => true, :rename => :lifecycle_environment
 
         accepts_nested_attributes_for :content_facet, :reject_if => proc { |attributes| attributes['content_view_id'].blank? && attributes['lifecycle_environment_id'].blank? }
+        attr_accessible :content_facet_attributes
       end
     end
   end

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -24,6 +24,8 @@ module Katello
         scoped_search :in => :content_source, :on => :name, :complete_value => true, :rename => :content_source
         scoped_search :in => :host_collections, :on => :id, :complete_value => false, :rename => :host_collection_id
         scoped_search :in => :host_collections, :on => :name, :complete_value => true, :rename => :host_collection
+
+        attr_accessible :content_source_id
       end
 
       def validate_media_with_capsule?

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -18,6 +18,8 @@ module Katello
       validates :host, :presence => true, :allow_blank => false
       validates_with Validators::ContentViewEnvironmentValidator
 
+      attr_accessible :content_view_id, :lifecycle_environment_id, :host
+
       def update_repositories_by_paths(paths)
         paths = paths.map { |path| path.gsub('/pulp/repos/', '') }
         repos = Repository.where(:relative_path => paths)

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -41,8 +41,7 @@ module Katello
       assert_equal @foreman_host.info['parameters']['content_view'], nil
       assert_equal @foreman_host.info['parameters']['lifecycle_environment'], nil
 
-      @foreman_host.content_facet = Katello::Host::ContentFacet.new(:content_view => @view, :lifecycle_environment => @library)
-      @foreman_host.reload
+      Support::HostSupport.attach_content_facet(@foreman_host, @view, @library)
 
       assert_equal @foreman_host.info['parameters']['content_view'], @foreman_host.content_view.label
       assert_equal @foreman_host.info['parameters']['lifecycle_environment'], @foreman_host.lifecycle_environment.label
@@ -52,8 +51,7 @@ module Katello
       assert_equal @foreman_host.info['parameters']['kt_cv'], nil
       assert_equal @foreman_host.info['parameters']['kt_env'], nil
 
-      @foreman_host.content_facet = Katello::Host::ContentFacet.new(:content_view => @view, :lifecycle_environment => @library)
-      @foreman_host.reload
+      Support::HostSupport.attach_content_facet(@foreman_host, @view, @library)
 
       assert_equal @foreman_host.info['parameters']['kt_cv'], @foreman_host.content_view.label
       assert_equal @foreman_host.info['parameters']['kt_env'], @foreman_host.lifecycle_environment.label
@@ -80,17 +78,17 @@ module Katello
 
     def test_update_with_cv_env
       host = FactoryGirl.create(:host, :with_content, :content_view => @library_view, :lifecycle_environment => @library)
-      host.content_view = @library_view
-      host.lifecycle_environment = @library
-      assert host.save!
+      host.content_facet.content_view = @library_view
+      host.content_facet.lifecycle_environment = @library
+      assert host.content_facet.save!
     end
 
     def test_update_with_invalid_cv_env_combo
       host = FactoryGirl.create(:host, :with_content, :content_view => @library_view, :lifecycle_environment => @library)
-      host.content_view = @library_view
-      host.lifecycle_environment = @dev
+      host.content_facet.content_view = @library_view
+      host.content_facet.lifecycle_environment = @dev
       assert_raises(ActiveRecord::RecordInvalid) do
-        host.save!
+        host.content_facet.save!
       end
     end
   end

--- a/test/support/host_support.rb
+++ b/test/support/host_support.rb
@@ -2,6 +2,14 @@
 
 module Support
   class HostSupport
+    def self.attach_content_facet(host, view, environment)
+      content_facet = Katello::Host::ContentFacet.new
+      content_facet.content_view = view
+      content_facet.lifecycle_environment = environment
+      host.content_facet = content_facet
+      host.reload
+    end
+
     def self.setup_host_for_view(host, view, environment, assign_to_puppet)
       puppet_env = ::Environment.create!(:name => 'blahblah')
 
@@ -9,7 +17,8 @@ module Support
       cvpe.puppet_environment = puppet_env
       cvpe.save!
 
-      host.content_facet = Katello::Host::ContentFacet.new(:content_view => view, :lifecycle_environment => environment)
+      attach_content_facet(host, view, environment)
+
       host.update_column(:environment_id, cvpe.puppet_environment.id) if assign_to_puppet
       host.reload
     end


### PR DESCRIPTION
…_facet attr_accessible

This should allow the user to set the content_view_id and lifecycle_environment_id to a host (content_facet) but not other content_facet attributes like uuid

To test in the rails console
This should work:
```Host.new({:name => "hi", :content_facet_attributes => {:content_view_id => 1}})```

This should throw a mass assignment error:
```Host.new({:name => "hi", :content_facet_attributes => {:uuid => "hi"}})```