### PR TITLE
Fixes #13568 - Don't create node distrbutors for yum repos

### DIFF
--- a/app/lib/actions/pulp/repository/create.rb
+++ b/app/lib/actions/pulp/repository/create.rb
@@ -61,7 +61,7 @@ module Actions
         def distributors
           case input[:content_type]
           when ::Katello::Repository::YUM_TYPE
-            [yum_distributor, yum_clone_distributor, nodes_distributor, export_distributor]
+            [yum_distributor, yum_clone_distributor, export_distributor]
           when ::Katello::Repository::FILE_TYPE
             [iso_distributor]
           when ::Katello::Repository::PUPPET_TYPE

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -162,7 +162,7 @@ module Katello
           clone_dist = Runcible::Models::YumCloneDistributor.new(:id => "#{self.pulp_id}_clone",
                                                                  :destination_distributor_id => yum_dist_id)
           export_dist = Runcible::Models::ExportDistributor.new(false, false)
-          [yum_dist, clone_dist, nodes_distributor, export_dist]
+          [yum_dist, clone_dist, export_dist]
         when Repository::FILE_TYPE
           dist = Runcible::Models::IsoDistributor.new(true, true)
           dist.auto_publish = true

--- a/test/fixtures/vcr_cassettes/actions/katello/capsule_content/manage_bound_repositories_add/0001_plans.yml
+++ b/test/fixtures/vcr_cassettes/actions/katello/capsule_content/manage_bound_repositories_add/0001_plans.yml
@@ -73,53 +73,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:33:35 GMT
 - request:
-    method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/2/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="bBdmwOCbTDYNmFFQDvCgFzeysmi6ph4CKfJ9Smed778",
-        oauth_signature="ZUrpaR9rrlLqTw%2FROt%2FnLMT2U%2FM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628815", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:33:35 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzQ3NDNiY2NlLTQ2NzYtNGVhOC1iZDM0LWU0ZmQ4MTEwNjVlZi8iLCAi
-        dGFza19pZCI6ICI0NzQzYmNjZS00Njc2LTRlYTgtYmQzNC1lNGZkODExMDY1
-        ZWYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:33:35 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/4743bcce-4676-4ea8-bd34-e4fd811065ef/
     body:
@@ -229,4 +182,233 @@ http_interactions:
         NCJ9
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:33:36 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjIiLCJkaXNwbGF5X25hbWUiOiJGZWRvcmEgMTcgeDg2XzY0IGRl
+        diIsImltcG9ydGVyX3R5cGVfaWQiOiJ5dW1faW1wb3J0ZXIiLCJpbXBvcnRl
+        cl9jb25maWciOnsiZmVlZCI6ImZpbGU6Ly8vdmFyL3d3dy90ZXN0X3JlcG9z
+        L3pvbyIsInNzbF9jYV9jZXJ0IjpudWxsLCJzc2xfY2xpZW50X2NlcnQiOm51
+        bGwsInNzbF9jbGllbnRfa2V5IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlw
+        ZSI6InJwbS1yZXBvIn0sImRpc3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3Jf
+        dHlwZV9pZCI6Inl1bV9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZp
+        ZyI6eyJyZWxhdGl2ZV91cmwiOiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwi
+        aHR0cHMiOnRydWUsInByb3RlY3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6
+        dHJ1ZSwiZGlzdHJpYnV0b3JfaWQiOiIyIn0seyJkaXN0cmlidXRvcl90eXBl
+        X2lkIjoieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29u
+        ZmlnIjp7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjoiMiJ9LCJhdXRv
+        X3B1Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRvcl9pZCI6IjJfY2xvbmUifSx7
+        ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJleHBvcnRfZGlzdHJpYnV0b3IiLCJk
+        aXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBzIjpmYWxz
+        ZSwicmVsYXRpdmVfdXJsIjpudWxsfSwiYXV0b19wdWJsaXNoIjpmYWxzZSwi
+        ZGlzdHJpYnV0b3JfaWQiOiJleHBvcnRfZGlzdHJpYnV0b3IifV19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="aCrMhq39OfwJuNakSU1neu8jesqyIQOU8JmXVm8WU8", oauth_signature="1k9RHmssbKqECTyMEerHfPuBErY%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681039", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '759'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:03:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '308'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/2/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCBkZXYiLCAiZGVzY3JpcHRpb24iOiBudWxsLCAibGFzdF91bml0
+        X2FkZGVkIjogbnVsbCwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
+        ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3Vu
+        aXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lkIjogeyIkb2lk
+        IjogIjU2YjRhYmNmYzc4MjFiMzMwMzRiYWRmZiJ9LCAiaWQiOiAiMiIsICJf
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzLzIvIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:03:59 GMT
+- request:
+    method: delete
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="gmZjikBodkiIe4zry1XaIj6iq3oI89OUUxxO4NueUo",
+        oauth_signature="haDbE1phy6wMka9Kd49wuqOb5uM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681040", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2YyN2EyZWEyLWIzZjctNGE3Ni04NWE2LTliNGQ5YmY3Y2IwNC8iLCAi
+        dGFza19pZCI6ICJmMjdhMmVhMi1iM2Y3LTRhNzYtODVhNi05YjRkOWJmN2Ni
+        MDQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:00 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f27a2ea2-b3f7-4a76-85a6-9b4d9bf7cb04/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="WUQRmGObz3UaNKXTjeiSTAIUjnCcgEqO2bOlTBVD0",
+        oauth_signature="RVppuwu5N5%2BolI6A47hvDpUUe8g%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681040", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '541'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mMjdhMmVhMi1iM2Y3LTRhNzYtODVhNi05YjRkOWJmN2Ni
+        MDQvIiwgInRhc2tfaWQiOiAiZjI3YTJlYTItYjNmNy00YTc2LTg1YTYtOWI0
+        ZDliZjdjYjA0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1
+        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiBudWxsLCAiX25z
+        IjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAidHJhY2Vi
+        YWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3Jl
+        cG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6ICJ3YWl0
+        aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51bGwsICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFiZDA4YWRhNDBk
+        YjA0ZWUwOTk1In0sICJpZCI6ICI1NmI0YWJkMDhhZGE0MGRiMDRlZTA5OTUi
+        fQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:00 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f27a2ea2-b3f7-4a76-85a6-9b4d9bf7cb04/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="rWdfD9kt4hyM4w2z21zJFxDzT7ihNcyMMyQbYkIKg",
+        oauth_signature="0SLhjmgzHbF8UXHjvASpZTP2fys%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681040", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '680'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mMjdhMmVhMi1iM2Y3LTRhNzYtODVhNi05YjRkOWJmN2Ni
+        MDQvIiwgInRhc2tfaWQiOiAiZjI3YTJlYTItYjNmNy00YTc2LTg1YTYtOWI0
+        ZDliZjdjYjA0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1
+        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0w
+        NVQxNDowNDowMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3Rp
+        bWUiOiAiMjAxNi0wMi0wNVQxNDowNDowMFoiLCAidHJhY2ViYWNrIjogbnVs
+        bCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9
+        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
+        by0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVk
+        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
+        QGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhYmQwOGFk
+        YTQwZGIwNGVlMDk5NSJ9LCAiaWQiOiAiNTZiNGFiZDA4YWRhNDBkYjA0ZWUw
+        OTk1In0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:00 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/actions/katello/capsule_content/manage_bound_repositories_remove/0001_plans.yml
+++ b/test/fixtures/vcr_cassettes/actions/katello/capsule_content/manage_bound_repositories_remove/0001_plans.yml
@@ -73,53 +73,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:33:36 GMT
 - request:
-    method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/2/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="lWQKKLjYZngHdeCsNV9ntsIV1T93wrliuvhZWsiCuUk",
-        oauth_signature="BbPZgg9ttShQGvbGmgauB8S3IpM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628817", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:33:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzg3ZmUxZjgyLTBkNmUtNGRlYi1hMGFmLTc5NDYxYTQyMTBmNC8iLCAi
-        dGFza19pZCI6ICI4N2ZlMWY4Mi0wZDZlLTRkZWItYTBhZi03OTQ2MWE0MjEw
-        ZjQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:33:37 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/87fe1f82-0d6e-4deb-a0af-79461a4210f4/
     body:
@@ -229,4 +182,233 @@ http_interactions:
         YiJ9
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:33:37 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjIiLCJkaXNwbGF5X25hbWUiOiJGZWRvcmEgMTcgeDg2XzY0IGRl
+        diIsImltcG9ydGVyX3R5cGVfaWQiOiJ5dW1faW1wb3J0ZXIiLCJpbXBvcnRl
+        cl9jb25maWciOnsiZmVlZCI6ImZpbGU6Ly8vdmFyL3d3dy90ZXN0X3JlcG9z
+        L3pvbyIsInNzbF9jYV9jZXJ0IjpudWxsLCJzc2xfY2xpZW50X2NlcnQiOm51
+        bGwsInNzbF9jbGllbnRfa2V5IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlw
+        ZSI6InJwbS1yZXBvIn0sImRpc3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3Jf
+        dHlwZV9pZCI6Inl1bV9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZp
+        ZyI6eyJyZWxhdGl2ZV91cmwiOiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwi
+        aHR0cHMiOnRydWUsInByb3RlY3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6
+        dHJ1ZSwiZGlzdHJpYnV0b3JfaWQiOiIyIn0seyJkaXN0cmlidXRvcl90eXBl
+        X2lkIjoieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29u
+        ZmlnIjp7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjoiMiJ9LCJhdXRv
+        X3B1Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRvcl9pZCI6IjJfY2xvbmUifSx7
+        ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJleHBvcnRfZGlzdHJpYnV0b3IiLCJk
+        aXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBzIjpmYWxz
+        ZSwicmVsYXRpdmVfdXJsIjpudWxsfSwiYXV0b19wdWJsaXNoIjpmYWxzZSwi
+        ZGlzdHJpYnV0b3JfaWQiOiJleHBvcnRfZGlzdHJpYnV0b3IifV19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="mpjy03WNnIYCGCG01GahhAR59nd3Y5Q0chrt6W5Iovw", oauth_signature="vubQZaSX0kSqYCXUV6NZIOcg6YQ%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681041", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '759'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:01 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '308'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/2/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCBkZXYiLCAiZGVzY3JpcHRpb24iOiBudWxsLCAibGFzdF91bml0
+        X2FkZGVkIjogbnVsbCwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
+        ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3Vu
+        aXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lkIjogeyIkb2lk
+        IjogIjU2YjRhYmQxYzc4MjFiMzMwNDJkOWRjMCJ9LCAiaWQiOiAiMiIsICJf
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzLzIvIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:01 GMT
+- request:
+    method: delete
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="iHW87Vk6Nj0FhCPHdvrM5T8BXEM3T8e6rQNwqJTJWhw",
+        oauth_signature="XKeYQdRvNhhbPk9TowwiEMuwmys%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681042", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:02 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzg4YmJhYTRjLTAzMWItNGM1Mi05MjIxLWZiN2U5YTljOTQxMS8iLCAi
+        dGFza19pZCI6ICI4OGJiYWE0Yy0wMzFiLTRjNTItOTIyMS1mYjdlOWE5Yzk0
+        MTEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:02 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/88bbaa4c-031b-4c52-9221-fb7e9a9c9411/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="CyZkrWWOlFw5ivNmbQPXm13LOMwZ2lNSjIyoqZQIg",
+        oauth_signature="%2BhlisRe9t3J9mU34fMwB7zjboNU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681042", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:02 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '541'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84OGJiYWE0Yy0wMzFiLTRjNTItOTIyMS1mYjdlOWE5Yzk0
+        MTEvIiwgInRhc2tfaWQiOiAiODhiYmFhNGMtMDMxYi00YzUyLTkyMjEtZmI3
+        ZTlhOWM5NDExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1
+        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiBudWxsLCAiX25z
+        IjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAidHJhY2Vi
+        YWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3Jl
+        cG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6ICJ3YWl0
+        aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51bGwsICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFiZDI4YWRhNDBk
+        YjA0ZWUwOTk2In0sICJpZCI6ICI1NmI0YWJkMjhhZGE0MGRiMDRlZTA5OTYi
+        fQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:02 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/88bbaa4c-031b-4c52-9221-fb7e9a9c9411/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="vnCVtI34c5pfpWcA2dPTqH0BPr6xmkQYd1kbVCP50",
+        oauth_signature="4U3vZcgbkq%2BHtJ3H%2FndroRhhNBg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681042", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:02 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '680'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84OGJiYWE0Yy0wMzFiLTRjNTItOTIyMS1mYjdlOWE5Yzk0
+        MTEvIiwgInRhc2tfaWQiOiAiODhiYmFhNGMtMDMxYi00YzUyLTkyMjEtZmI3
+        ZTlhOWM5NDExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1
+        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0w
+        NVQxNDowNDowMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3Rp
+        bWUiOiAiMjAxNi0wMi0wNVQxNDowNDowMloiLCAidHJhY2ViYWNrIjogbnVs
+        bCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9
+        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
+        by0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVk
+        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
+        QGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhYmQyOGFk
+        YTQwZGIwNGVlMDk5NiJ9LCAiaWQiOiAiNTZiNGFiZDI4YWRhNDBkYjA0ZWUw
+        OTk2In0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:02 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/actions/pulp/consumer/create.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp/consumer/create.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/
     body:
       encoding: UTF-8
       base64_string: |
@@ -15,9 +15,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="WDkGV7gkPgyXXhncQUwXgYbMyFPkgFPWIowt9dFX1U", oauth_signature="LY2psz9nBjzqcIh5SfTxGPybX1w%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628839", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="G8vOOhGB51nUbNft7YvOnyVfV76X4LfurhyroB5m1TI", oauth_signature="zm8yKnDznqasb5HCdDqH6T%2BlOGc%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681079", oauth_version="1.0"
       Pulp-User:
       - admin
       Content-Length:
@@ -27,77 +27,76 @@ http_interactions:
   response:
     status:
       code: 201
-      message: Created
+      message: CREATED
     headers:
       Date:
-      - Thu, 04 Feb 2016 23:33:59 GMT
+      - Fri, 05 Feb 2016 14:04:39 GMT
       Server:
       - Apache/2.4.6 (CentOS)
-      Location:
-      - "/pulp/api/v2/consumers/uuid/"
       Content-Length:
-      - '2169'
+      - '2158'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/consumers/uuid/
       Connection:
       - close
       Content-Type:
-      - application/json
+      - application/json; charset=utf-8
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25zdW1lciI6IHsiZGlzcGxheV9uYW1lIjogIm5hbWUiLCAiZGVzY3Jp
         cHRpb24iOiBudWxsLCAiX25zIjogImNvbnN1bWVycyIsICJub3RlcyI6IHt9
         LCAicnNhX3B1YiI6IG51bGwsICJjYXBhYmlsaXRpZXMiOiB7fSwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NmIzZGZlNzg0YTA5YzA3MDYzNDMxYTkifSwgImlkIjog
-        InV1aWQiLCAiX2hyZWYiOiB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb25z
-        dW1lcnMvdXVpZC8ifX0sICJjZXJ0aWZpY2F0ZSI6ICItLS0tLUJFR0lOIFJT
-        QSBQUklWQVRFIEtFWS0tLS0tXG5NSUlDWFFJQkFBS0JnUUROVjZGUTdNaDdC
-        cEdwVTliTlk4UCtodWpsL0R2WnAvY1kzYTRNYWNjVGhmS2tPY2d3XG5CcTNx
-        TzBGUksvM21RdjlneTV4cTBmNkNFd3NSODNCV2FoZ0pPRmxwZHlKV3h0Uitt
-        RGZ0VElnRlQvaklvamhtXG41RWpQbHplSUcvaEtaVnFuY01RUTYyT2pENFEx
-        UUZIWlcxeGZMN09WNzRycGJWYVZrOTc0YVdSM1R3SURBUUFCXG5Bb0dBUXhI
-        aVVPcG1PVGpXRHZhaGJJaXZsYzArK1EvQUJNSEdCY3N5ZEQrQWxMSGxwUnB5
-        ZHExWDFPL3h6NitNXG55TThOVnZKcWJzR1VYYXdXcTVCV0d3T2dRWnk0Z05x
-        Q2hSZXlTN09PSkVpenJCK3NXVkJnY0hQbWpVMGxGK05RXG5idk5oWEhmOHhJ
-        aXdaTFlQOVpVVGJYM3ZUNnlvdGtTWVhaZ0REZ3N0UzR5M2I1RUNRUUR4bi9i
-        VGJtRXNDY0ZuXG4rV2VHU2JBV25LaTYwTkUrK1FsbEpRUk1ZUEFkSHlCZFEv
-        akV6eUhNQzVaTHhXeGt4OUdjY3dOUjl6VzRvVDlvXG5IeXhPR3VVckFrRUEy
-        WThSdTcraTZteU9HRHRlQXY4LzkrT2luQ2p1bUQxMlQ3UGhmckhtS1BHQWFT
-        Tkl3bmhQXG42Z2dpNXNKbktKdTFsMXlSK2wrT3JPMVVSMCt1dGVpc2JRSkFL
-        RFZ3ZzdySW5PVjZzK3pERjR2SHE5dWlFSVNUXG5iYUZQdU84eUNldlB5V2pX
-        bis2aHhVNmExelBPYlFtTGdqSG1aZHlWM3R2K3FwemF5bDcxcG9HL1JRSkJB
-        TmRSXG5iNzJmbHIvb25HR0RNREpMS2FaUFZ2cXkwQ0ZBZ3oyeXpEUTJJWkxZ
-        SWJ6c3ZQQXJYdnhDL1RmaG8zTmZXRVByXG56RlkrQ05sQk1pNDV3TEl0QzZr
-        Q1FRQ3lYYklOK0x4WnZGS0VRSmIzZndvQVdiY0xHWjhBWWg1UHVEc2VWZWta
-        XG5zRUs1SFlHS0xRWFFrV2RxYVpWTm9hMzcwOFNvbHVObng1Q2ozNjY2NTBt
-        RlxuLS0tLS1FTkQgUlNBIFBSSVZBVEUgS0VZLS0tLS1cbi0tLS0tQkVHSU4g
-        Q0VSVElGSUNBVEUtLS0tLVxuTUlJQ3NEQ0NBWmdDQWdJVU1BMEdDU3FHU0li
-        M0RRRUJCUVVBTUlHRk1Rc3dDUVlEVlFRR0V3SlZVekVYTUJVR1xuQTFVRUNC
-        TU9UbTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9CZ05WQkFjVEIxSmhiR1ZwWjJn
-        eEVEQU9CZ05WQkFvVFxuQjB0aGRHVnNiRzh4RkRBU0JnTlZCQXNUQzFOdmJX
-        VlBjbWRWYm1sME1TTXdJUVlEVlFRREV4cHJZWFJsYkd4dlxuTFdSbGRtSnZl
-        QzVsZUdGdGNHeGxMbU52YlRBZUZ3MHhOakF5TURReU16TXpOVGxhRncweU5q
-        QXlNREV5TXpNelxuTlRsYU1Ea3hEVEFMQmdOVkJBTVRCSFYxYVdReEtEQW1C
-        Z29Ka2lhSmsvSXNaQUVCRXhnMU5tSXpaR1psTnpnMFxuWVRBNVl6QTNNRFl6
-        TkRNeFlUa3dnWjh3RFFZSktvWklodmNOQVFFQkJRQURnWTBBTUlHSkFvR0JB
-        TTFYb1ZEc1xueUhzR2thbFQxczFqdy82RzZPWDhPOW1uOXhqZHJneHB4eE9G
-        OHFRNXlEQUdyZW83UVZFci9lWkMvMkRMbkdyUlxuL29JVEN4SHpjRlpxR0Fr
-        NFdXbDNJbGJHMUg2WU4rMU1pQVZQK01paU9HYmtTTStYTjRnYitFcGxXcWR3
-        eEJEclxuWTZNUGhEVkFVZGxiWEY4dnM1WHZpdWx0VnBXVDN2aHBaSGRQQWdN
-        QkFBRXdEUVlKS29aSWh2Y05BUUVGQlFBRFxuZ2dFQkFBY2xwYWhKWWNtc0Q2
-        SEJSZWVJbFlzdDRRck51NGIxOWdGK0p3VjYwWEw1Uy9vdGRLLzVLV2ZBWEYy
-        QlxuOC9seFdlTEYrSFVXUXpLVlVQMXBLOENnTXhvaDhvSGlTV09EUXFhK2hm
-        RzU1dmxRZnI1MEV6SEdPTWRvY2xKRFxuRWdNa3B4eG9kRUVQcmtPd1dPNHh2
-        V2Zwem9ibHBjWTFCOUFDaVY3M0cxQzVxT25ERERTdmpOdW53SndlZnlvOFxu
-        ODJQeVVxSXVRTVBZUVNlbFFvMlczZEE2dE9mcWJrNlNjQjRJakw0U1JNZWh3
-        c1JKVkNlcTBMTDRuU3p0OE1CSVxuRTRkelpCVWtkRzB5aXhSY2kwSDhUWU9T
-        OXhqUk9TR1BTK3VQcHRLM2VPMTJHREpPWjVDeklRMnhsRktEa2N1TVxuV1NU
-        cXM1TFlyT3hKaGNjU2pPcHhtSDhFMEVvPVxuLS0tLS1FTkQgQ0VSVElGSUNB
-        VEUtLS0tLSJ9
+        IHsiJG9pZCI6ICI1NmI0YWJmN2M3ODIxYjMzMDVjZTUwY2UifSwgImlkIjog
+        InV1aWQiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnN1bWVycy91dWlk
+        LyJ9LCAiY2VydGlmaWNhdGUiOiAiLS0tLS1CRUdJTiBSU0EgUFJJVkFURSBL
+        RVktLS0tLVxuTUlJQ1hRSUJBQUtCZ1FEUTJFeVZZczF4di9TbGhnT3FhcmdE
+        L2hrTTF5Z2hESTIzMmVkRWFCYTN1R0tZWENBSFxuSnowSUg3eGQwNURMeHFH
+        eFlSbHJWd1ZuUUhiM2RBZzhzKzFla1BjTStxVkVkdzg3Qy8wYS9nOG9vYSts
+        S1FZalxubzJ2SmNTelN5MW5STUFRTkMxamtQRnVGY05YTCtsdjR4TnorMzVw
+        VkpJeno1aDQ2VHpGUll6d3N5d0lEQVFBQlxuQW9HQVRSTjIrQzhWdVdScHF1
+        a1IwMFE5azZPa3BSdUhBT044TGgwcWdCR1dTTW14QWFBR1pmMXlSZHhJamF3
+        MlxuSlM2eW9COUEzVitwYTlqYnp5bXduSTZmREhzK0NoY2gvNm9FQ3lYZjly
+        aEpZMkY1MEdIMnd2N3VzK3B0TzlTTlxucS9iVG5vakl6Z1ZSK0RlUHJhTi9z
+        N1lIK3Y3TkUrYjRaUTFjM0RBeDVuRWVabEVDUVFEOUtiN1lSTXFRSHJsaFxu
+        UGdCRDF1bmk0NE03dmZzL2tyTld5WmorSzllYzN5aUE4NHBDSEQvZW9ISm1t
+        SlpDWEtDOTNCeGQ1NXhWR200d1xuOU5xcWxJUmpBa0VBMHk5cXpoZ00rQ20r
+        ZnNkUHV2Mi83LzJkZW9RUWxDMjYwdFk3SUhOa0pFemExMW1hNWxFMFxuejR1
+        QXo1cEl2WFZzWVdWSk1RajdRTytMUHpubi9rSWVlUUpBSWFWWXJkbUdxbHpL
+        K25lSkJYc2Nub0RxUWhoZlxudWZVL1RIdUNqOVUzMUt0NzhKZHRlcGZTalQz
+        NXRsVDFNMkNvSkZPS21aaGNtSnJvcGkwRW1zTWVUUUpCQUxlUFxuUzRKL25T
+        WkhBbkVueE1GL3RjbGY0L1dOdk90UEpFZ0dOYlpyRmV3SGNXQWxYbUk2eTNC
+        cWpUZmxucnd1eUZtUFxudENLTzcvVHRRVmRmZWFxaXhlRUNRUUNRNVpKcjFi
+        dEFtWWpJNmlWdmRIcktUb3JaaWJCdVZDK2Qxb0Jva01zb1xuWEZuMGNMeE5n
+        YS9wOFRvUlJuT1hjZmszYnFnYVVEQVdOeWVOZVZHeGRHUzhcbi0tLS0tRU5E
+        IFJTQSBQUklWQVRFIEtFWS0tLS0tXG4tLS0tLUJFR0lOIENFUlRJRklDQVRF
+        LS0tLS1cbk1JSUNzRENDQVpnQ0FUOHdEUVlKS29aSWh2Y05BUUVGQlFBd2dZ
+        WXhDekFKQmdOVkJBWVRBbFZUTVJjd0ZRWURcblZRUUlFdzVPYjNKMGFDQkRZ
+        WEp2YkdsdVlURVFNQTRHQTFVRUJ4TUhVbUZzWldsbmFERVFNQTRHQTFVRUNo
+        TUhcblMyRjBaV3hzYnpFVU1CSUdBMVVFQ3hNTFUyOXRaVTl5WjFWdWFYUXhK
+        REFpQmdOVkJBTVRHMnRoZEdWc2JHOHRcbk1pMDRMV1JsZGk1bGVHRnRjR3hs
+        TG1OdmJUQWVGdzB4TmpBeU1EVXhOREEwTXpsYUZ3MHlOakF5TURJeE5EQTBc
+        bk16bGFNRGt4RFRBTEJnTlZCQU1UQkhWMWFXUXhLREFtQmdvSmtpYUprL0lz
+        WkFFQkV4ZzFObUkwWVdKbU4yTTNcbk9ESXhZak16TURWalpUVXdZMlV3Z1o4
+        d0RRWUpLb1pJaHZjTkFRRUJCUUFEZ1kwQU1JR0pBb0dCQU5EWVRKVmlcbnpY
+        Ry85S1dHQTZwcXVBUCtHUXpYS0NFTWpiZlo1MFJvRnJlNFlwaGNJQWNuUFFn
+        ZnZGM1RrTXZHb2JGaEdXdFhcbkJXZEFkdmQwQ0R5ejdWNlE5d3o2cFVSM0R6
+        c0wvUnIrRHlpaHI2VXBCaU9qYThseExOTExXZEV3QkEwTFdPUThcblc0Vncx
+        Y3Y2Vy9qRTNQN2ZtbFVralBQbUhqcFBNVkZqUEN6TEFnTUJBQUV3RFFZSktv
+        WklodmNOQVFFRkJRQURcbmdnRUJBT3l2K2RLdERpUWFUWnNVRmxneVVYN2RU
+        OW5hcHJSRTNCUFhSL3kwTkZydkpCQUtEd1dCNVlZMVBpMkxcbmIvOFZUdERr
+        T3V0K3owRVBUK3hBcFJpd25DNUVmWEM1akdqS21RdmhDSmRmNTliQzUzTHJV
+        alRrR3lKOTJNbEJcbkI3cE5aY3Q5bzEzQklIL3d0QnRLOUl2bnhzdW1iUzhS
+        NHpSb0RINEE1MHV4T01yV3JidkVHVlJ2RHZ5Qk1rQzRcbnU2K1JHa25TaDB3
+        ZEVOdHE5bWVGK1Nxc3lnK1gxajRkOTlKSGs2c1IvOW9UVjJjd2pNbXYzYTFQ
+        UktvQWZydURcblovUVhma1cyOStvcUMwdFlqQTVVdG0veDZGcnJzUHZyd1hS
+        V29mZSswOEtTWHdBMVpzKzB1Ri9RU3lld2s3bVRcblZjaGExVDgxU2dzMURH
+        ZXptNXkzck5mZzJWRT1cbi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0ifQ==
     http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:33:59 GMT
+  recorded_at: Fri, 05 Feb 2016 14:04:39 GMT
 - request:
     method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/uuid/
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/uuid/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -109,9 +108,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="JCcZgZgUigvgorHY2SExrivryMWtAqYby3hX4UmOmvA",
-        oauth_signature="kDkaE0IeCw%2FJ3x61SDqmsqR7BSA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628839", oauth_version="1.0"
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="IPVdgMqtKRvDJD8eL2V4cR5VWdfJQTqUVENiSKEbDE",
+        oauth_signature="iwKbl02lUnViZltUwz%2FKEkvCvy0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681079", oauth_version="1.0"
       Pulp-User:
       - admin
       User-Agent:
@@ -122,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 Feb 2016 23:33:59 GMT
+      - Fri, 05 Feb 2016 14:04:39 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -130,11 +129,11 @@ http_interactions:
       Connection:
       - close
       Content-Type:
-      - application/json
+      - application/json; charset=utf-8
     body:
       encoding: UTF-8
       base64_string: |
         bnVsbA==
     http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:00 GMT
+  recorded_at: Fri, 05 Feb 2016 14:04:39 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/actions/pulp/consumer/install_content.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp/consumer/install_content.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/
     body:
       encoding: UTF-8
       base64_string: |
@@ -15,9 +15,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="TSeGd3sHVxf38p9KvlDahQKo23VDFgPqxFLXFTEpuY", oauth_signature="I850CM0ZQQpzNHsDFVvkTwkXnJ8%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628840", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="ioSEz4FYYw1RE09Y8WrT2M2Vckg0SxAYdcJB8aiW3FE", oauth_signature="sZ3H8Bm3vKQMhyrYZJBhDRMDoLw%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681079", oauth_version="1.0"
       Pulp-User:
       - admin
       Content-Length:
@@ -27,77 +27,76 @@ http_interactions:
   response:
     status:
       code: 201
-      message: Created
+      message: CREATED
     headers:
       Date:
-      - Thu, 04 Feb 2016 23:34:00 GMT
+      - Fri, 05 Feb 2016 14:04:39 GMT
       Server:
       - Apache/2.4.6 (CentOS)
-      Location:
-      - "/pulp/api/v2/consumers/uuid/"
       Content-Length:
-      - '2169'
+      - '2158'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/consumers/uuid/
       Connection:
       - close
       Content-Type:
-      - application/json
+      - application/json; charset=utf-8
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25zdW1lciI6IHsiZGlzcGxheV9uYW1lIjogIm5hbWUiLCAiZGVzY3Jp
         cHRpb24iOiBudWxsLCAiX25zIjogImNvbnN1bWVycyIsICJub3RlcyI6IHt9
         LCAicnNhX3B1YiI6IG51bGwsICJjYXBhYmlsaXRpZXMiOiB7fSwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NmIzZGZlODg0YTA5YzA3MDYzNDMxYjIifSwgImlkIjog
-        InV1aWQiLCAiX2hyZWYiOiB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb25z
-        dW1lcnMvdXVpZC8ifX0sICJjZXJ0aWZpY2F0ZSI6ICItLS0tLUJFR0lOIFJT
-        QSBQUklWQVRFIEtFWS0tLS0tXG5NSUlDWEFJQkFBS0JnUURvUTkza0I0R2hM
-        a3EvM0laY1hLaFc4QWlRVzcwS2hCTSsyWnhpSVNJUjhRODNhVFFlXG5lb3hP
-        a2lUM0oxYkF0cFNISGEyaUJCMEJvbkcrbmxpNkk4VFNWOGxBTUV5Z2ZxZXpL
-        MGpsMStRQlZoRW93MHJPXG5Ia01NaGtWRnNVbTE1UFJWaDV4aVk0dU9EMVBy
-        T00rYUtmV3lpcXVIeVpkVVhnd1FyWG14QW9WUHJRSURBUUFCXG5Bb0dBUXNt
-        Skc1SGcvNVVOSDRCdERsQUNoQVUvb1NzUC85OGNuWno3YitneElOR2RXNFNm
-        M1FmR0lxMjVmV3hOXG5jTnJQZU03YTU5U2c5cUJjYnNDZnFONnlNSEZ6Wmxk
-        Sksra2N4KzBnZDQyNjRVYjJnaHNiYnY0N0RDTGJhMGNEXG5uM0paZzhsUzYz
-        ZmswRTZ6QS9mVk9vMm9lOEkwYjJYZDAwaC9ybkpqVnV2aUhzRUNRUUQvcERK
-        SjZYakZZQXZSXG40WGZZNENWVHFnNXJTZzBReHNtUlQyUUNaK2p1V0dwN3Np
-        T0lJRTBLYk4rd05rR1RkWTNvZzNZWWVsOFBwZzdhXG5KMWZ5MGJnUkFrRUE2
-        SmRHa0xCMlFIMmNYOHdHKzIrNzN0NWNQMWI1UGlVQTE2YXlGem5aWVVMempY
-        bDB5a1YvXG4rZkx6R04wZ29vVzRmYzAvbmZFOXd2ZXpvZEtZVWtQWjNRSkJB
-        TVExeFhkZllCZTEwVHlrM2pTeVRWUDZ1UmgxXG4vTE04c0NiOGxWa1hZZnZX
-        RnR5YjdKT2xueHY2Vm5ITUl1YklHa1EwNm1aOVBnc252RXlLV0FHQ0g5RUNR
-        SDVqXG4vZytRSktKRTM5M2F4QXlNR2g0dzNSWDZVRFNwN1B4QzlGSFV1TUMy
-        bmh6SjNHSXlSQ255RUpINVQ4dWhPTEQ4XG5BTTcyRWViSnJjNkkzd2NOSWUw
-        Q1FHZkVFZ2JuY2JJbHBBOU1UWTBPNVNRRFdUYmZtUzFoNlJtOStYVnBnTHh0
-        XG5yVEc5OVJtQTI5M3dIazhYcU1HTzRDZjdYeUpNSnloaHRpUkVzMnB6VTFN
-        PVxuLS0tLS1FTkQgUlNBIFBSSVZBVEUgS0VZLS0tLS1cbi0tLS0tQkVHSU4g
-        Q0VSVElGSUNBVEUtLS0tLVxuTUlJQ3NEQ0NBWmdDQWdJVk1BMEdDU3FHU0li
-        M0RRRUJCUVVBTUlHRk1Rc3dDUVlEVlFRR0V3SlZVekVYTUJVR1xuQTFVRUNC
-        TU9UbTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9CZ05WQkFjVEIxSmhiR1ZwWjJn
-        eEVEQU9CZ05WQkFvVFxuQjB0aGRHVnNiRzh4RkRBU0JnTlZCQXNUQzFOdmJX
-        VlBjbWRWYm1sME1TTXdJUVlEVlFRREV4cHJZWFJsYkd4dlxuTFdSbGRtSnZl
-        QzVsZUdGdGNHeGxMbU52YlRBZUZ3MHhOakF5TURReU16TTBNREJhRncweU5q
-        QXlNREV5TXpNMFxuTURCYU1Ea3hEVEFMQmdOVkJBTVRCSFYxYVdReEtEQW1C
-        Z29Ka2lhSmsvSXNaQUVCRXhnMU5tSXpaR1psT0RnMFxuWVRBNVl6QTNNRFl6
-        TkRNeFlqSXdnWjh3RFFZSktvWklodmNOQVFFQkJRQURnWTBBTUlHSkFvR0JB
-        T2hEM2VRSFxuZ2FFdVNyL2NobHhjcUZid0NKQmJ2UXFFRXo3Wm5HSWhJaEh4
-        RHpkcE5CNTZqRTZTSlBjblZzQzJsSWNkcmFJRVxuSFFHaWNiNmVXTG9qeE5K
-        WHlVQXdUS0IrcDdNclNPWFg1QUZXRVNqRFNzNGVRd3lHUlVXeFNiWGs5RldI
-        bkdKalxuaTQ0UFUrczR6NW9wOWJLS3E0ZkpsMVJlREJDdGViRUNoVSt0QWdN
-        QkFBRXdEUVlKS29aSWh2Y05BUUVGQlFBRFxuZ2dFQkFGN2ZQYXNIa25SWTd1
-        UUhZZEFDOVpFOE5UUmh4MnRORnN4dGo2eG4rMUt5S1pJVmhoeEl4aThpUFJI
-        WFxubi9XZ3hORWhHYmRab1BWVkpndjFwU213b2p3NVFSckp2a0NFdEIyK1ZZ
-        d3pOQ0hqK1VRRVpMcGZrNU9JMDRlYVxueW9PanVYeVlvcXpiODBnK2ZIenVl
-        ejk1UDdZRTZWQS92ZFgxYXAyVEF4VThpMHBKUGxsVnN3d0Ezc2prb3VDY1xu
-        eGJ3YlBuYmZoenJLMnptTHNqaGt1dTJuNTVja01kMlJFcW1RM3ZEaFZ0cUxm
-        VkhBWXB1OHZFZDdEeitlbE9KVFxuUExYcnZ3M1prNm1zOThoNDZ5cm1vRjJV
-        VlN4TW9aT012MGZub0RPYTZCMmRKQ281S0NDeHNvcXRZUC9GL0xBV1xuOVRp
-        Rld2MDRzcW1CRC9MOFF4d0RYRjEveTgwPVxuLS0tLS1FTkQgQ0VSVElGSUNB
-        VEUtLS0tLSJ9
+        IHsiJG9pZCI6ICI1NmI0YWJmN2M3ODIxYjMzMDVjZTUwZDIifSwgImlkIjog
+        InV1aWQiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnN1bWVycy91dWlk
+        LyJ9LCAiY2VydGlmaWNhdGUiOiAiLS0tLS1CRUdJTiBSU0EgUFJJVkFURSBL
+        RVktLS0tLVxuTUlJQ1d3SUJBQUtCZ1FETGZXVHc5Sm9Yc3NJSTk0YzVUQ0dn
+        a3UxbFF5ZFgrZy82em5qUVFUNi9VcFRkRjRURFxueEljejZ4eXQyNk4vQTEx
+        NW81VGYrTVhIZkN2WkVoSk1NT1FNMVptajdZdVdJTVljWXBGOHpsdHNLa20v
+        cDRXT1xuM3VHU2NyWnppYnV6QWxSa1FjbmtDUDcxaml4OTlveGlNT2V1ZTNR
+        eHpjLzY5c1dKWWJUeUNKbkpXUUlEQVFBQlxuQW9HQVZiZjV5SUxSVW9CTHVt
+        bEMva0R5dldpSE5pdm1xK203eDRRb1lsbkpxK0NHc3VmUVZvTTREUWZTYWU1
+        bVxuM2Y4MTVpS2hlUU9ibE4vYXZMTWZJQmRNU05kdXhOaXpFS1JCWlhON2hn
+        R2FkUnZYMzAwdGJCVjhnSnFYSHhJVlxua21OTnJLSERnT09JWVhhbGY1bE4v
+        SXJCVDIzWDRpYjl2MDF3WUtQTUt3VldHN0VDUVFEcFp2NkQ1MkpsdnYwUlxu
+        TlcwQ3pxOUk2cTdzQkdTOTltam9pNHQ1aDFUUFlFY3BiaUh3UHJUTHRFU3lO
+        UEJwZ0haZ3BJdjlwd3FtcVVxZFxuYXJCMnptRmRBa0VBM3pFQWtqK3Q4aVZ3
+        UTFiTW80aE1lRnJNWmkrbkFsSk9ISktMZUdzQUNzT0dEOExYRnlkTlxuME5m
+        WVBzcDM0Z2xpUkljS1FuRUJmbnpWQm1ZdHlSYWNMUUpBTzhyRHh0eSt5MXZy
+        RHI2R0I2TVZLblBjamQvdVxuUXUvZUhqeXBaVit5N1ZFM3liaEovM2JBOERK
+        bEt0WC9CTGdCRzI3cjRmWXA5MW9GSUdDVmhrb0dqUUpBUENZNlxubnk5bU00
+        SC9kVVpwTkJGQmVwWU55K1Evd0JKcVZxenZ4VzRndnNYZTFWU1BId0JLcW1Q
+        aE5WcmZZQjFqVEZDUVxuWlVPTFFZbG01NmlWNGtHanFRSkFDSEs1cGVUV2hL
+        c2lTQUt3SlZrWVdLeTJYMjBIK2FwY3Jac1FuaWtwY3VRWlxudTlnMWpVL2R4
+        dXRYVlp4eGRRSmhIYjNMUS8vNTZGVWNjdjBFVUZ6bkRnPT1cbi0tLS0tRU5E
+        IFJTQSBQUklWQVRFIEtFWS0tLS0tXG4tLS0tLUJFR0lOIENFUlRJRklDQVRF
+        LS0tLS1cbk1JSUNzRENDQVpnQ0FVQXdEUVlKS29aSWh2Y05BUUVGQlFBd2dZ
+        WXhDekFKQmdOVkJBWVRBbFZUTVJjd0ZRWURcblZRUUlFdzVPYjNKMGFDQkRZ
+        WEp2YkdsdVlURVFNQTRHQTFVRUJ4TUhVbUZzWldsbmFERVFNQTRHQTFVRUNo
+        TUhcblMyRjBaV3hzYnpFVU1CSUdBMVVFQ3hNTFUyOXRaVTl5WjFWdWFYUXhK
+        REFpQmdOVkJBTVRHMnRoZEdWc2JHOHRcbk1pMDRMV1JsZGk1bGVHRnRjR3hs
+        TG1OdmJUQWVGdzB4TmpBeU1EVXhOREEwTXpsYUZ3MHlOakF5TURJeE5EQTBc
+        bk16bGFNRGt4RFRBTEJnTlZCQU1UQkhWMWFXUXhLREFtQmdvSmtpYUprL0lz
+        WkFFQkV4ZzFObUkwWVdKbU4yTTNcbk9ESXhZak16TURWalpUVXdaREl3Z1o4
+        d0RRWUpLb1pJaHZjTkFRRUJCUUFEZ1kwQU1JR0pBb0dCQU10OVpQRDBcbm1o
+        ZXl3Z2ozaHpsTUlhQ1M3V1ZESjFmNkQvck9lTkJCUHI5U2xOMFhoTVBFaHpQ
+        ckhLM2JvMzhEWFhtamxOLzRcbnhjZDhLOWtTRWt3dzVBelZtYVB0aTVZZ3ho
+        eGlrWHpPVzJ3cVNiK25oWTdlNFpKeXRuT0p1N01DVkdSQnllUUlcbi92V09M
+        SDMyakdJdzU2NTdkREhOei9yMnhZbGh0UElJbWNsWkFnTUJBQUV3RFFZSktv
+        WklodmNOQVFFRkJRQURcbmdnRUJBRm5kMzZZUDF6WGU4Q05JR2J1Ujd0cWNo
+        YVZsQzFNb2RxUUhSQUJneklEaEJxLzVIVTBma2o5dlBYYzRcblZWTEJjS2hP
+        eWUzRW9qZEUrYzFYMjJVa3JXRnRoVHNoRWdreHBHbVU3aUE2VlNRcXRnc0Iz
+        a3BEUS9rZ2xOWG9cbjhOTXUzZUUwYjZzQzhLc2xuQU1pbW45SjdrcmQzNlNn
+        SFNhSFRveXF0LzdqQ2FMVnh0SjVMMHlnVW81MkMzRlVcbk9GR2dwM2FqTjZy
+        Q0NDeExGajFORkxzTVlKRnBKaVdlWURRZmdKZHUyOVkvQ1RVUkkxMGpqY2pU
+        U1oyNjk3U2Jcbm1xWCt3TXhPMzNwbUZleGJzditTQXBtT1N1bHU0V3hCN1BR
+        d3lSd04xYnpRSGVKRGtkNmtXdjdlZ3A1UEhmMHRcbit4VTRDK0MwaFhCS0Iw
+        aStQTVhvNmdxdVJkND1cbi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0ifQ==
     http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:00 GMT
+  recorded_at: Fri, 05 Feb 2016 14:04:39 GMT
 - request:
     method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/uuid/
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/uuid/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -109,9 +108,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="5MIoWiCWyIRuDn75gkDyj5dGJjRSmauUjoKajmZ96zo",
-        oauth_signature="LiDgbiinCdHDx8BXktXM6dGO094%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628840", oauth_version="1.0"
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="WB6V5epVISpcXEzYrBCFRlConZSVDxXtJqX0vab8g",
+        oauth_signature="41XsyWApppuUZIRSKM9CYlSXOFc%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681079", oauth_version="1.0"
       Pulp-User:
       - admin
       User-Agent:
@@ -122,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 Feb 2016 23:34:00 GMT
+      - Fri, 05 Feb 2016 14:04:39 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -130,11 +129,11 @@ http_interactions:
       Connection:
       - close
       Content-Type:
-      - application/json
+      - application/json; charset=utf-8
     body:
       encoding: UTF-8
       base64_string: |
         bnVsbA==
     http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:00 GMT
+  recorded_at: Fri, 05 Feb 2016 14:04:40 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/actions/pulp/consumer/sync_node.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp/consumer/sync_node.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/
     body:
       encoding: UTF-8
       base64_string: |
@@ -15,9 +15,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="ecrrHW0EYqIUMJna2xhs84XzhJKpOH8MWdn48mU8jwA", oauth_signature="kH9aKwD8OM4LQMmaiE3usYYdaJs%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628841", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="bPMwbcaQYZ2tmvyDWLCDM2pRCPCV6bpUaKuG8faCU", oauth_signature="KtRnoj5YrmuDxkd52FeFWyh%2FLHw%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681080", oauth_version="1.0"
       Pulp-User:
       - admin
       Content-Length:
@@ -27,77 +27,76 @@ http_interactions:
   response:
     status:
       code: 201
-      message: Created
+      message: CREATED
     headers:
       Date:
-      - Thu, 04 Feb 2016 23:34:01 GMT
+      - Fri, 05 Feb 2016 14:04:40 GMT
       Server:
       - Apache/2.4.6 (CentOS)
-      Location:
-      - "/pulp/api/v2/consumers/uuid/"
       Content-Length:
-      - '2169'
+      - '2158'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/consumers/uuid/
       Connection:
       - close
       Content-Type:
-      - application/json
+      - application/json; charset=utf-8
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25zdW1lciI6IHsiZGlzcGxheV9uYW1lIjogIm5hbWUiLCAiZGVzY3Jp
         cHRpb24iOiBudWxsLCAiX25zIjogImNvbnN1bWVycyIsICJub3RlcyI6IHt9
         LCAicnNhX3B1YiI6IG51bGwsICJjYXBhYmlsaXRpZXMiOiB7fSwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NmIzZGZlOTg0YTA5YzA3MDYzNDMxYmIifSwgImlkIjog
-        InV1aWQiLCAiX2hyZWYiOiB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb25z
-        dW1lcnMvdXVpZC8ifX0sICJjZXJ0aWZpY2F0ZSI6ICItLS0tLUJFR0lOIFJT
-        QSBQUklWQVRFIEtFWS0tLS0tXG5NSUlDWEFJQkFBS0JnUURKaGxaSWxDSDJX
-        b2pGVXZYay9DSFV3L0laT29nTzZrejY2Y2dhOTBSd2d6ckN4VmhYXG5PS0Ny
-        bnAzbUVkOVN2b2VvdmxoMjYwckgzQU1FalJsKytUMkQzaGw2dlhQQ3NwS3Ra
-        S2FkS1JSWDBkMmYwdmN1XG5mbk0zUnUrdzJSRFZCZldSaFh2bmIvV05ydXRF
-        VmNJWTlNY0NSMWd6MTN5ODZPdTExY2thKzhtOW93SURBUUFCXG5Bb0dBYk1D
-        eE9aT3ZURW9KT3l1TkJWakhUUkc5U2I0YmhLa09oKzIzamszWVFqdWZiMUtl
-        WE50ellZcEV2Yzd4XG5USzhEZUozWUViemlhejZnNWtqYTlIbStwc0N1dDhE
-        WUpHMFNXOEdXRE1NWnBCdnd2cFVnZWVUTEdVS2Y4K1B0XG4xN1R2UjNPNU1j
-        aVFvaU1FRzdidWVrQzdKbnh5bTZlZktwYU94R3lZQ3NoUGtZRUNRUUR2UFhu
-        RjRNSTZhbFRXXG43cFFyK0NJWG5UTFBFNDloWERMR1FhaFBHWm9ZaTBMSHBu
-        cnlKYXNIanJHNm83dmRtTGlnOTNXK1dhdzJMWFNaXG44c3doS2IxQkFrRUEx
-        NlI1bHptT0hhU2xESnYwYzh1TE5Xdk5QR25Nb2thNXRBTk9GK3R2S3g5ak1u
-        dWJNZnlvXG5MV2hTa1ZFQ1lLbDREdUMzYkRod1RDNFBIcW0rN0dLdDR3SkJB
-        T1V2MEh1SFVLcGplUGthUDJwTDRHVWMzRExTXG5lelg2L0UwL1V2ekwrdnB1
-        VnNBcXRYZEtMS2tsd3crWWtYMjlNNHBJNWt3L1hhSGRNK25UVmtpaTBzRUNR
-        RHNBXG4yZlF5MzF2bERQUWlTQVRYRU1RUk54cnNwLzFPOU1qNGpvbWs5Y29L
-        MEkyam5KZFUxbjkyS0FGeTlQK1YzeS9TXG45TjA3cEI1MEM5Y01BeDJTOHBr
-        Q1FBZGx1dkhCdndxSWZoT0JpU0JzTDZvTmJDWXlaVmo4djdub3k1UXBmWFJj
-        XG42cC9mWmpzV3lwYXB5Z2lSWlc1VDNrcjdjMTFnalR5cG9iU1dNeE5rUEhV
-        PVxuLS0tLS1FTkQgUlNBIFBSSVZBVEUgS0VZLS0tLS1cbi0tLS0tQkVHSU4g
-        Q0VSVElGSUNBVEUtLS0tLVxuTUlJQ3NEQ0NBWmdDQWdJV01BMEdDU3FHU0li
-        M0RRRUJCUVVBTUlHRk1Rc3dDUVlEVlFRR0V3SlZVekVYTUJVR1xuQTFVRUNC
-        TU9UbTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9CZ05WQkFjVEIxSmhiR1ZwWjJn
-        eEVEQU9CZ05WQkFvVFxuQjB0aGRHVnNiRzh4RkRBU0JnTlZCQXNUQzFOdmJX
-        VlBjbWRWYm1sME1TTXdJUVlEVlFRREV4cHJZWFJsYkd4dlxuTFdSbGRtSnZl
-        QzVsZUdGdGNHeGxMbU52YlRBZUZ3MHhOakF5TURReU16TTBNREZhRncweU5q
-        QXlNREV5TXpNMFxuTURGYU1Ea3hEVEFMQmdOVkJBTVRCSFYxYVdReEtEQW1C
-        Z29Ka2lhSmsvSXNaQUVCRXhnMU5tSXpaR1psT1RnMFxuWVRBNVl6QTNNRFl6
-        TkRNeFltSXdnWjh3RFFZSktvWklodmNOQVFFQkJRQURnWTBBTUlHSkFvR0JB
-        TW1HVmtpVVxuSWZaYWlNVlM5ZVQ4SWRURDhoazZpQTdxVFBycHlCcjNSSENE
-        T3NMRldGYzRvS3VlbmVZUjMxSytoNmkrV0hiclxuU3NmY0F3U05HWDc1UFlQ
-        ZUdYcTljOEt5a3Exa3BwMHBGRmZSM1ovUzl5NStjemRHNzdEWkVOVUY5WkdG
-        ZStkdlxuOVkydTYwUlZ3aGoweHdKSFdEUFhmTHpvNjdYVnlScjd5YjJqQWdN
-        QkFBRXdEUVlKS29aSWh2Y05BUUVGQlFBRFxuZ2dFQkFMSjQrVGhza1Q0STN2
-        ZVQwU2YwMmMzUHlSb0U5em9oMVYvT1VHNVprZEQ4cWdmcjdDcmtRRTNNSE5F
-        ZVxuVG95bkN0QlpvZmNzdjgwMHBaa0ViYjVCZkxTenVzNnVNdGRGbTFBTVNB
-        emRwQ3BqTWRwSFd1SGZXZ2NNcUlVRlxuRjFqUFRGZjZSWFFyWjVrUlp5S0Nq
-        eTZRc1ErL2Q5bm9KWXMxQVIyMXA0WjZuQVZWdC9RK05rZlZEcmQ2ZHhuNVxu
-        N3U4K3UrZVpROHFCZmdTTDZyUWJQYnhHcDlmOVBEaEhKU0VpdHNkRmora3lJ
-        Q1pHRE9uUXNmb0FuT2p2aVpaY1xuYmt2cjFJY1RVOEVYclVpK1ZwMUlwdHlv
-        dVlYdXNlZTA4UjhqRXg0SzNscWNOWnVMU24yMVJvZ2RMOGNlMVJLSFxuSzZX
-        cXFGbTl2MjlyUDRpblRTbnV5VzdPNkJVPVxuLS0tLS1FTkQgQ0VSVElGSUNB
-        VEUtLS0tLSJ9
+        IHsiJG9pZCI6ICI1NmI0YWJmOGM3ODIxYjMzMDVjZTUwZDYifSwgImlkIjog
+        InV1aWQiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnN1bWVycy91dWlk
+        LyJ9LCAiY2VydGlmaWNhdGUiOiAiLS0tLS1CRUdJTiBSU0EgUFJJVkFURSBL
+        RVktLS0tLVxuTUlJQ1hRSUJBQUtCZ1FDNTVObXRtWDBGK0N0d3lkeTlXVFpN
+        L25ZcE9Bd2RxZzlyUUNMdlVxakl2NVZWdjdlMFxuMUpoWWdTcmdrdzlYK0F4
+        KzVQTGlYOGczTmhNc1BtTzQyOE5lYTJXQTFxbGoxaE44M2RZZmYzMVNXVzFl
+        ZWhZb1xuamRyZk5XMk1mOVJ2enRTR2ZSdE9wNEIxMmlRNldUQVFrVkF6YmZS
+        SmxlQ3FiTGcxdWJKMk03WEl4UUlEQVFBQlxuQW9HQkFLZGNSU3BKSk1sS0Mv
+        b29reWFaK2d4SmtDSStCcEp5ZUIxTUNlZkRXSmdiL0J2T1ZsdGtoNkF1OG1a
+        clxub0FYSUdaL3BDazhLZ3R4S1ArcTJaTnVhWjRIQnF1RWZhL1U4dndPTDlw
+        UHR3ZW5lNmozOGpoaVdNZlVWYTlRMVxubnlEQzUzVkV0OWJoT1JLU2FYWG1U
+        SHZYdDc4QmlVSlpKS1VrZE1wYUZHV0tuOE9CQWtFQTZUVktGTnpKQ3Z3elxu
+        NnZ3RThZdFJRcEFyNVp2RWlCMHNWYUVWVDdyVU41Q2Z2WTlsMzNvcVZlallW
+        SU94TTI0SU5kN2F0dHVPVUtDaVxudnVwR0VLcExvUUpCQU13UHlvNUFBMHhN
+        VjZnNm95ZVU0eWxKTSt2cXRBdVlraHN5WE82ZEZvVlplMHN1TVp0eFxucXMr
+        ZUtZSEZiYUxVQkZqTkdpSW1PZkZQNnd0R1U0Q0d5cVVDUVFERmdNTVh2aEJw
+        eEVQMys2MzRIdVFYK2wraVxuMm5Qc1RzQ3dXSGJqQ2pnV1F0NTJQTTZySUJ4
+        Z200MHlya0ZSYkJ0NS9CM0JCVnFXd0NSMGlaWURJU1poQWtCMVxuVFVxSjFR
+        QlFWcjQ0NVdRdWQ2YlJiOVFaOUhRRkNuSktrZnZiNm84c25wQ0NXZzZJSmFJ
+        ajhPNDVPKzFYSVh0U1xuTkt5bUhzVkdFME93Mm45YnJhQkZBa0FVL1EyZ1ZU
+        bkdZNFliZnE4TWV6aEFwa0plZVB6clhuRW5Oa3diQXh2elxuL2plUmtIb2Y0
+        emxYUXVRR2Z5b05sYkFSL2hXbXd2bnl3RVcvSkV4Rjg2VXpcbi0tLS0tRU5E
+        IFJTQSBQUklWQVRFIEtFWS0tLS0tXG4tLS0tLUJFR0lOIENFUlRJRklDQVRF
+        LS0tLS1cbk1JSUNzRENDQVpnQ0FVRXdEUVlKS29aSWh2Y05BUUVGQlFBd2dZ
+        WXhDekFKQmdOVkJBWVRBbFZUTVJjd0ZRWURcblZRUUlFdzVPYjNKMGFDQkRZ
+        WEp2YkdsdVlURVFNQTRHQTFVRUJ4TUhVbUZzWldsbmFERVFNQTRHQTFVRUNo
+        TUhcblMyRjBaV3hzYnpFVU1CSUdBMVVFQ3hNTFUyOXRaVTl5WjFWdWFYUXhK
+        REFpQmdOVkJBTVRHMnRoZEdWc2JHOHRcbk1pMDRMV1JsZGk1bGVHRnRjR3hs
+        TG1OdmJUQWVGdzB4TmpBeU1EVXhOREEwTkRGYUZ3MHlOakF5TURJeE5EQTBc
+        bk5ERmFNRGt4RFRBTEJnTlZCQU1UQkhWMWFXUXhLREFtQmdvSmtpYUprL0lz
+        WkFFQkV4ZzFObUkwWVdKbU9HTTNcbk9ESXhZak16TURWalpUVXdaRFl3Z1o4
+        d0RRWUpLb1pJaHZjTkFRRUJCUUFEZ1kwQU1JR0pBb0dCQUxuazJhMlpcbmZR
+        WDRLM0RKM0wxWk5reitkaWs0REIycUQydEFJdTlTcU1pL2xWVy90N1RVbUZp
+        Qkt1Q1REMWY0REg3azh1SmZcbnlEYzJFeXcrWTdqYncxNXJaWURXcVdQV0Uz
+        emQxaDkvZlZKWmJWNTZGaWlOMnQ4MWJZeC8xRy9PMUlaOUcwNm5cbmdIWGFK
+        RHBaTUJDUlVETnQ5RW1WNEtwc3VEVzVzbll6dGNqRkFnTUJBQUV3RFFZSktv
+        WklodmNOQVFFRkJRQURcbmdnRUJBT1ZTWDVCVThvcGx5aW1oSDZpY0podWRz
+        UVI1UGVmR0Z4OUFWWGNKSzBKT21KMC80KzBCZW0wQllNYmFcbkdQeEh1L0Rr
+        OVdGSDhwZk9tSXkyUU82NG1obWc2ZlVXMkV2T0dSQ3U0aXp6RmVlRFd5NEdt
+        RFpQZHZjMFhoVzBcbk9xWmduSFhNc0kxbzl0YXN6dXVkdHhzTFhBNW1XK2Y4
+        c2Z6SmRHU0d1Y0VlUWpaT2tsSThYekQvMzZOQy9weGdcbkIxWTFxSmREUWd2
+        ZmtJK3lzU285dGIxYmJ1KzJ6Sm5RL2Z0d3UrSytSbzdZY1UrblMydzFGT2dh
+        YU8vMTBadzRcbllqTndVWCtUSDhubGw4R1ErcksxMVVMeER0amE1QlhVUnFi
+        dUc1RTlUdWVzWlVuWWxNL2dMdW8weUt4VFJwVFlcbjdIWnN2ekhXMUxYeU9H
+        MFNuUWlNVXJWemxScz1cbi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0ifQ==
     http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:01 GMT
+  recorded_at: Fri, 05 Feb 2016 14:04:41 GMT
 - request:
     method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/uuid/
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/uuid/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -109,9 +108,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="sF0H8OpCc1hTAszcsQ2AYuVG5stOn9Yd4Q6qPZzP1c",
-        oauth_signature="s%2B7wwWmTmQcRTLX1aBmAvtpLPwM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628841", oauth_version="1.0"
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="N5RQjZ3ek4q3zQ3F5Nog6IQws2dQzgGbVVE0WsvXQ",
+        oauth_signature="JwxuRjn4SckAwwbrz9%2BiKsqefdA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681081", oauth_version="1.0"
       Pulp-User:
       - admin
       User-Agent:
@@ -122,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 Feb 2016 23:34:01 GMT
+      - Fri, 05 Feb 2016 14:04:41 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -130,11 +129,11 @@ http_interactions:
       Connection:
       - close
       Content-Type:
-      - application/json
+      - application/json; charset=utf-8
     body:
       encoding: UTF-8
       base64_string: |
         bnVsbA==
     http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:01 GMT
+  recorded_at: Fri, 05 Feb 2016 14:04:41 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/actions/pulp/consumer/uninstall_content.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp/consumer/uninstall_content.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/
     body:
       encoding: UTF-8
       base64_string: |
@@ -15,9 +15,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="KTnOyPAYHPa3uQ25jM4DSwUc763H9MgE2JPbqdaIns", oauth_signature="XnMvQ6sDTPKam%2Bgi3nHvzkkTzjc%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628841", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="qS5XI3KV3b4DRb0dCLn8aH9dnZ8F6F8V5FEAHatNrI", oauth_signature="UPBuKaYHLMBX8CkHGfTJQe9W8U8%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681081", oauth_version="1.0"
       Pulp-User:
       - admin
       Content-Length:
@@ -27,77 +27,76 @@ http_interactions:
   response:
     status:
       code: 201
-      message: Created
+      message: CREATED
     headers:
       Date:
-      - Thu, 04 Feb 2016 23:34:01 GMT
+      - Fri, 05 Feb 2016 14:04:41 GMT
       Server:
       - Apache/2.4.6 (CentOS)
-      Location:
-      - "/pulp/api/v2/consumers/uuid/"
       Content-Length:
-      - '2169'
+      - '2158'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/consumers/uuid/
       Connection:
       - close
       Content-Type:
-      - application/json
+      - application/json; charset=utf-8
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25zdW1lciI6IHsiZGlzcGxheV9uYW1lIjogIm5hbWUiLCAiZGVzY3Jp
         cHRpb24iOiBudWxsLCAiX25zIjogImNvbnN1bWVycyIsICJub3RlcyI6IHt9
         LCAicnNhX3B1YiI6IG51bGwsICJjYXBhYmlsaXRpZXMiOiB7fSwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NmIzZGZlOTg0YTA5YzA3MDYzNDMxYzQifSwgImlkIjog
-        InV1aWQiLCAiX2hyZWYiOiB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb25z
-        dW1lcnMvdXVpZC8ifX0sICJjZXJ0aWZpY2F0ZSI6ICItLS0tLUJFR0lOIFJT
-        QSBQUklWQVRFIEtFWS0tLS0tXG5NSUlDV3dJQkFBS0JnUURZTEtqcGI0N1Q1
-        Qm9zUjNrM0hGRnEvSXJXd2h6SFRobFZ3a1B6S05QQk42YzJDNXVRXG5PbkNI
-        WGxIV3BUYkhXTk5ET0g3QzhyZXAwVzVXRWFNdzNEWHJ5eER0L3F3aVd3NWor
-        MFkrQ3lUTjZ0Qi9TamRJXG5TTUpYeXRaWXBsSjJNM1JoWGcvTTNLVXl5N0VI
-        RC9yc0xhbXN5d3Zqa1MxV05ubTJhb0xkYVVMWDBRSURBUUFCXG5Bb0dBV2JX
-        bTMwRHhkOU40WFJuSUh1dThpZmFGczN2WXI0a2trR2RQQlpEUzE2TTkyL3JU
-        TXZaZGpuL0EzSit4XG5iT2JhdlZHcm9VRlNvTUdOMVYvNlppTnNxRXNFTExm
-        cTZjVFVPNU9sc2xXSWpHcU9QMXMrL2RlSE5DYkpEVW5lXG5USVpsdDFxYzZm
-        cVVFbGNmTFlScm1vakdmRjZuamwvd0FyN0RBQVpJSUVEVUViRUNRUUQ1bVNy
-        a0FwRmhrbGMrXG5Rdjh3OWVYUkxsWFVGZ2Z5b0VPYlZYWXJ6WlE1elhPM2hM
-        YlYyWDNrTHp0b3c3M1hodmMzWHVZQ3JRN3UyRzNaXG44Q204NFYrZEFrRUEz
-        YmdKQllaUmZOU3ZzYU95UXE5dDlXZ2ZtZ0lhZ0dNQzZjV0EyWWtwYmo4RjBj
-        MVJnRnlTXG5DWmhtS0tHTHpWSC9jbnlsWWR5b25xZGR1MEk2RFF3VXhRSkFO
-        bjczdTJMSUpUcVRhOWVxNmlDMk5jN2RGSHBlXG43OTJJQlZGS2hOUFU2aTN1
-        ZHdJMS9Va0lVSnJ6YUxOY0xzT2NGRzNXNEh5eWh2bWdPblpTVnBnS2pRSkFk
-        U3JSXG5FYXRXbXJvbWtxQm9EcGQ0YTB4NERzSDMwVXNCZWhwV0toOHkxc0RW
-        U1hiUUVCNWJTbGpQKzc3TEMxaSt2bmlpXG5TU0g3dGNQS1k2L3V6NEJINVFK
-        QUlNRDFoRUJlSDFnYkgrMlgvK1hKVGhNWWNNTFpUQUY1ak1NRm81WFpHejlF
-        XG5HdEhJYXFKcW00OHJIQ3FhZEt6ZzRkWTZNakx0OWhtTDgyNld4UGhoTHc9
-        PVxuLS0tLS1FTkQgUlNBIFBSSVZBVEUgS0VZLS0tLS1cbi0tLS0tQkVHSU4g
-        Q0VSVElGSUNBVEUtLS0tLVxuTUlJQ3NEQ0NBWmdDQWdJWE1BMEdDU3FHU0li
-        M0RRRUJCUVVBTUlHRk1Rc3dDUVlEVlFRR0V3SlZVekVYTUJVR1xuQTFVRUNC
-        TU9UbTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9CZ05WQkFjVEIxSmhiR1ZwWjJn
-        eEVEQU9CZ05WQkFvVFxuQjB0aGRHVnNiRzh4RkRBU0JnTlZCQXNUQzFOdmJX
-        VlBjbWRWYm1sME1TTXdJUVlEVlFRREV4cHJZWFJsYkd4dlxuTFdSbGRtSnZl
-        QzVsZUdGdGNHeGxMbU52YlRBZUZ3MHhOakF5TURReU16TTBNREZhRncweU5q
-        QXlNREV5TXpNMFxuTURGYU1Ea3hEVEFMQmdOVkJBTVRCSFYxYVdReEtEQW1C
-        Z29Ka2lhSmsvSXNaQUVCRXhnMU5tSXpaR1psT1RnMFxuWVRBNVl6QTNNRFl6
-        TkRNeFl6UXdnWjh3RFFZSktvWklodmNOQVFFQkJRQURnWTBBTUlHSkFvR0JB
-        TmdzcU9sdlxuanRQa0dpeEhlVGNjVVdyOGl0YkNITWRPR1ZYQ1EvTW8wOEUz
-        cHpZTG01QTZjSWRlVWRhbE5zZFkwME00ZnNMeVxudDZuUmJsWVJvekRjTmV2
-        TEVPMytyQ0piRG1QN1JqNExKTTNxMEg5S04waEl3bGZLMWxpbVVuWXpkR0Zl
-        RDh6Y1xucFRMTHNRY1ArdXd0cWF6TEMrT1JMVlkyZWJacWd0MXBRdGZSQWdN
-        QkFBRXdEUVlKS29aSWh2Y05BUUVGQlFBRFxuZ2dFQkFLN0FXL3k5WWxQbytV
-        aU9LU3lhdVJsQW5RY1lRREFFWWZKSE5BaWN1NFlpdzlNKzl1VHhTbmR5Wm1Q
-        MFxuZXZUd3YwdFR0T29xd05kSUV4UlF5RUo5eUpySHdJdFVVT3NRcm0wVjBm
-        ZGl4RGx2STNTR2NrTURoVmt0a0o0R1xua1NnSzhNVDJ3eTR0MHNvaW90Q3hh
-        Rko2M2ViSjkxTmNSNGMrV1l6WVZvampGbmpjSitGOWxFcUl1RnJPY0RYZVxu
-        RlRDYjFHWGpsV1YwTktuUmVJQTBodm52aktudGFBcmRNZDVPSVNYZHo5TjV1
-        NFl1dW1mbkxJVmhrVVZDbVFUd1xuRG5jVFNFVGY0eW85N0dBRHg5VEhRSi84
-        U3htV3F5N0tQYm04NnZ1NlM1SmhxL3RxV3NjalpSL0VyQi80aGlQeFxudHNl
-        MTFxTTk1T0ZCaWVXb2dBblpwdWJmK0xFPVxuLS0tLS1FTkQgQ0VSVElGSUNB
-        VEUtLS0tLSJ9
+        IHsiJG9pZCI6ICI1NmI0YWJmOWM3ODIxYjMzMDVjZTUwZGEifSwgImlkIjog
+        InV1aWQiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnN1bWVycy91dWlk
+        LyJ9LCAiY2VydGlmaWNhdGUiOiAiLS0tLS1CRUdJTiBSU0EgUFJJVkFURSBL
+        RVktLS0tLVxuTUlJQ1hRSUJBQUtCZ1FEaFp3Ly9EM3loWXNqS0REaVhmOFlW
+        dXpsRWxSL0NZdzJCSWtnT1k0ajZKYWp2ODh6MFxuRmtQS2pKN1hTNkp4T01M
+        d203QmJqZkRXTkQ0S291NEZrQXVrMjJKWkNNd2lOS28rN0RRbE5hOVpRc1Q4
+        eCt3MVxuU0pSaFRhVnpGMTArUGw1bCtrMTl5aXR0VzQzV2w4UW9XV29Ccy9u
+        NzZOK242bEhTRzFRek95VldOUUlEQVFBQlxuQW9HQVlJdUxmMzE3cllpcFps
+        bWJ0OUNENFBVRGo0dXNRYys1amhGSCtkbktaeExRYkk3cHY3YjFySUZVMi9U
+        S1xuakdKNnBTS2FoR3lrdHF0RDA3eDc1U2dRdyt0WDdkakNka2tNMzZ1eUs0
+        cVFiS3JldmVuckRUN2VPVHFMRXdRQlxuVWgvY0swNlY2V2pIdkxUcW9Nd252
+        cnp3TlVXUXc1cEZtRVZpOW1qU0hYTHR6aUVDUVFEMk10cWowWnEwcEdtK1xu
+        Nzg5Z1Q0SmxDRzJ1ZnRYZURXekMyK3lqWWpTbDJrSy9SbjdhdktqdnphbEpG
+        RFFidklQd2ZqTTZrOHdoYnVNWlxuS3lUcEY1dXRBa0VBNm1CRHFvemROamNn
+        bm9JUzNxWkNnUENHY3FNRGRCYm95ZmRJYmRTeWF5azdDUXBDd0o2b1xuMzVQ
+        Tmo3QVZMTmZadXFNV290QVNTeVEyNjJTS256LzFxUUpCQU0rakJCSzFiQ3g5
+        blZHVEh1cXpJOTNoeGQ4c1xueVdLRkgvMFhUZlJkbHRscHduRmZHdzJQbjBy
+        ZndLNEpoQWtBYktZZlNVVlY4UXNoWWhhUDlJbEJoK0VDUVFEU1xuSFdUc1JB
+        YVk4UWtFTVRZN2RxL09LbE5OK0VoRFRicDZQWDhvUDNPSVVGbEZmSFpsZXBl
+        SWdGZmJ4ZzdsdWNqT1xuNGlDTDY1OUt6L2VRUmYxa1VSR3BBa0JKbVpzSm1t
+        VVZtSWtQYUVHQ0FRc3o0VUxqK0hkRTRtMFZuN2pnWnpBTFxud3UrNnMxUENl
+        UkxxZWtJQzVzS0x3NWQrSkJuWnIxVnZTTlBzZi9Ba3hrTUtcbi0tLS0tRU5E
+        IFJTQSBQUklWQVRFIEtFWS0tLS0tXG4tLS0tLUJFR0lOIENFUlRJRklDQVRF
+        LS0tLS1cbk1JSUNzRENDQVpnQ0FVSXdEUVlKS29aSWh2Y05BUUVGQlFBd2dZ
+        WXhDekFKQmdOVkJBWVRBbFZUTVJjd0ZRWURcblZRUUlFdzVPYjNKMGFDQkRZ
+        WEp2YkdsdVlURVFNQTRHQTFVRUJ4TUhVbUZzWldsbmFERVFNQTRHQTFVRUNo
+        TUhcblMyRjBaV3hzYnpFVU1CSUdBMVVFQ3hNTFUyOXRaVTl5WjFWdWFYUXhK
+        REFpQmdOVkJBTVRHMnRoZEdWc2JHOHRcbk1pMDRMV1JsZGk1bGVHRnRjR3hs
+        TG1OdmJUQWVGdzB4TmpBeU1EVXhOREEwTkRGYUZ3MHlOakF5TURJeE5EQTBc
+        bk5ERmFNRGt4RFRBTEJnTlZCQU1UQkhWMWFXUXhLREFtQmdvSmtpYUprL0lz
+        WkFFQkV4ZzFObUkwWVdKbU9XTTNcbk9ESXhZak16TURWalpUVXdaR0V3Z1o4
+        d0RRWUpLb1pJaHZjTkFRRUJCUUFEZ1kwQU1JR0pBb0dCQU9GbkQvOFBcbmZL
+        Rml5TW9NT0pkL3hoVzdPVVNWSDhKakRZRWlTQTVqaVBvbHFPL3p6UFFXUThx
+        TW50ZExvbkU0d3ZDYnNGdU5cbjhOWTBQZ3FpN2dXUUM2VGJZbGtJekNJMHFq
+        N3NOQ1UxcjFsQ3hQekg3RFZJbEdGTnBYTVhYVDQrWG1YNlRYM0tcbksyMWJq
+        ZGFYeENoWmFnR3orZnZvMzZmcVVkSWJWRE03SlZZMUFnTUJBQUV3RFFZSktv
+        WklodmNOQVFFRkJRQURcbmdnRUJBQmR5TGZUekIvaHNMT3RHNzBtMDBtYUVX
+        bnFpaThSNGxPY2xrMWFwM0FyZDcvbVZObHZhZzIxRlI2M2hcblI0UlY1SElJ
+        d3g4K2JxMHNIQ2d0bkNDam56Y3RtUXYraGxKcUdETHh5bEZwZEpyeCszbU9I
+        N0xnNUtSRW51TExcbm1zMEFWdm5yaGJCWUtrVHU2NlNQVzE1TGdOODFUeGtQ
+        NkRUWXJ5YTdURVpsdWI1RDVnS2Vuc2UybTdHcXFqTjBcbkFXRWg1Zkh2dkZT
+        dHhXR0RjRmpTUndFdWVuZnVWcTJ5ZDAxb2tpeXdabUNLTkxwdEhacXA5SWN0
+        aTRIaDV3bnZcblV0SmdiZWI5bHlRLzdHdjRybTR1WnlYY210Qmhqc0ZnMmtV
+        S29xTmN4SzlDdUZJTGZUb1F4M0RLeG1sSkttdC9cbnpOM1VZb1BsTGFUVEgv
+        d1AyRi95YVB2c3o4Yz1cbi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0ifQ==
     http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:01 GMT
+  recorded_at: Fri, 05 Feb 2016 14:04:41 GMT
 - request:
     method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/uuid/
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/uuid/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -109,9 +108,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="Rk3frt0kawRWkQx2k4JJoOdC3qw2JE61aJ89dHtZWU",
-        oauth_signature="q4JAKTcXF%2FiovOSQPDJVJBJknqg%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628841", oauth_version="1.0"
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="UdAlWAcLOweOYFwKMlwNQyAybORO0RYvA0vmgzQ0g",
+        oauth_signature="yTQ90I75LDGdCm5Aiuu8bw%2B501g%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681081", oauth_version="1.0"
       Pulp-User:
       - admin
       User-Agent:
@@ -122,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 Feb 2016 23:34:01 GMT
+      - Fri, 05 Feb 2016 14:04:41 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -130,11 +129,11 @@ http_interactions:
       Connection:
       - close
       Content-Type:
-      - application/json
+      - application/json; charset=utf-8
     body:
       encoding: UTF-8
       base64_string: |
         bnVsbA==
     http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:01 GMT
+  recorded_at: Fri, 05 Feb 2016 14:04:41 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/actions/pulp/consumer/update_content.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp/consumer/update_content.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/
     body:
       encoding: UTF-8
       base64_string: |
@@ -15,9 +15,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="oXTCUxYt5ThaUS8gZcJwuup1zTVfkH5mytuJsldCF8", oauth_signature="3Kv%2BOeWCTsLJeLCHKjr3Ri84abk%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628842", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="lC0nHMF4G9upOZJNv7KUG0M4abMSpmV5sTqD9ckk", oauth_signature="TXwBvEILY2XWgcW%2BG70hSmqSuhA%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681082", oauth_version="1.0"
       Pulp-User:
       - admin
       Content-Length:
@@ -27,77 +27,76 @@ http_interactions:
   response:
     status:
       code: 201
-      message: Created
+      message: CREATED
     headers:
       Date:
-      - Thu, 04 Feb 2016 23:34:02 GMT
+      - Fri, 05 Feb 2016 14:04:42 GMT
       Server:
       - Apache/2.4.6 (CentOS)
-      Location:
-      - "/pulp/api/v2/consumers/uuid/"
       Content-Length:
-      - '2169'
+      - '2158'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/consumers/uuid/
       Connection:
       - close
       Content-Type:
-      - application/json
+      - application/json; charset=utf-8
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb25zdW1lciI6IHsiZGlzcGxheV9uYW1lIjogIm5hbWUiLCAiZGVzY3Jp
         cHRpb24iOiBudWxsLCAiX25zIjogImNvbnN1bWVycyIsICJub3RlcyI6IHt9
         LCAicnNhX3B1YiI6IG51bGwsICJjYXBhYmlsaXRpZXMiOiB7fSwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NmIzZGZlYTg0YTA5YzA3MDYzNDMxY2QifSwgImlkIjog
-        InV1aWQiLCAiX2hyZWYiOiB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb25z
-        dW1lcnMvdXVpZC8ifX0sICJjZXJ0aWZpY2F0ZSI6ICItLS0tLUJFR0lOIFJT
-        QSBQUklWQVRFIEtFWS0tLS0tXG5NSUlDWFFJQkFBS0JnUURvTllTa0p2aWNl
-        UmFnVTYwUkJHU0tzZU1GemY2NVo4KzJoQW93ZlNVNEh5c002MThKXG4xY1Zt
-        djJscmxOdFRwZGpuRFduMW9sbEIvTFhVa015cDFnS0c1TXdxQ1NjK1lhTW92
-        QXc1L3RvcEZSY0czN3o2XG5iaENHTkhEa2F1NXZIQ1lHdjVsc0ZUY2twMkNj
-        cG1xb0xCVXI3TlFPcWZjd0NXUlNXT0hYak1tdTJ3SURBUUFCXG5Bb0dBT0Zq
-        Y1FmVU8rUEZOTTBSNng1bFlTR3VZR2sxOVZVSkNuaGgyWElQUnAwZXc2NmFs
-        M2o0WWM3RlpCSGtQXG5xOEdmMjVsZXIvTmdVMm5lT2FHVmVGVHRNWll5S242
-        ZkVGc2JRY0dxNGlCeHFUWnY5LzEyeWg4M1IxcGJtRWkyXG45cEJuT29FakM1
-        b1VHdWYyYlVXUHlVOFpNWlRCSHhnMEJqTGtKeXJNeE5CcGFUa0NRUUQ1UHNN
-        SVVjZkk3czVUXG4yOU5IOEpBdXdhajhOQ3RuVmF5cExUWDFuZVgrcWNVV1p0
-        elZZZjhFelM3UmVuSnNwUUFQcjgyTWxnOE5HdjllXG45SGEvU2Q1SEFrRUE3
-        b0NQdTh4aWRLYnlNVUQ0RGV4alByQ3lsbDI0M0J6MG1BTzNKVjYyallNSSti
-        VjBDdHd5XG5zR29hVFRQV2lFdTdSektFN2I2bVBpTFJWOWQxblMvUXpRSkJB
-        Tkdmem9wZHRhaXg2RWd4TnhabkpleWRKaEhQXG5rcjJiR2RkRFZnR1laa3B6
-        NEhYQjEzT0RzdWNINXB0NTMyaXVzVW1BTTJGTkI2V2ZFaTU3YnEvZFlac0NR
-        UURYXG5VUjF5TC95YXo3VkxIaHBUaDV1NWx4QkRpKzArV3EyL0oydUt3MDBQ
-        eU1Lcm5WTmNFcHQ0aFBHbHpTemE4M1BwXG52UVFoRnNOQ3lYQXhXNFVGR1l2
-        cEFrQWZGMWtxQUIwNlIvMXRhKzA1elhWV3d5eDRYVHVOM3ptQ1oyVk0vdWVh
-        XG5RS1pWQ21pWmFVMzFaV3dkQWxyVmd6V0lqMHZha3RxQUhHdnRzMW9NVGtT
-        M1xuLS0tLS1FTkQgUlNBIFBSSVZBVEUgS0VZLS0tLS1cbi0tLS0tQkVHSU4g
-        Q0VSVElGSUNBVEUtLS0tLVxuTUlJQ3NEQ0NBWmdDQWdJWU1BMEdDU3FHU0li
-        M0RRRUJCUVVBTUlHRk1Rc3dDUVlEVlFRR0V3SlZVekVYTUJVR1xuQTFVRUNC
-        TU9UbTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9CZ05WQkFjVEIxSmhiR1ZwWjJn
-        eEVEQU9CZ05WQkFvVFxuQjB0aGRHVnNiRzh4RkRBU0JnTlZCQXNUQzFOdmJX
-        VlBjbWRWYm1sME1TTXdJUVlEVlFRREV4cHJZWFJsYkd4dlxuTFdSbGRtSnZl
-        QzVsZUdGdGNHeGxMbU52YlRBZUZ3MHhOakF5TURReU16TTBNREphRncweU5q
-        QXlNREV5TXpNMFxuTURKYU1Ea3hEVEFMQmdOVkJBTVRCSFYxYVdReEtEQW1C
-        Z29Ka2lhSmsvSXNaQUVCRXhnMU5tSXpaR1psWVRnMFxuWVRBNVl6QTNNRFl6
-        TkRNeFkyUXdnWjh3RFFZSktvWklodmNOQVFFQkJRQURnWTBBTUlHSkFvR0JB
-        T2cxaEtRbVxuK0p4NUZxQlRyUkVFWklxeDR3WE4vcmxuejdhRUNqQjlKVGdm
-        S3d6clh3blZ4V2EvYVd1VTIxT2wyT2NOYWZXaVxuV1VIOHRkU1F6S25XQW9i
-        a3pDb0pKejVob3lpOEREbisyaWtWRndiZnZQcHVFSVkwY09ScTdtOGNKZ2Ev
-        bVd3VlxuTnlTbllKeW1hcWdzRlN2czFBNnA5ekFKWkZKWTRkZU15YTdiQWdN
-        QkFBRXdEUVlKS29aSWh2Y05BUUVGQlFBRFxuZ2dFQkFGWTloUmVNbVdEMWNC
-        QTRvY3hHaWdSSVZzUHN5KzdTbzFmcjRlZXhqamlsZFpkMVVkVHE0cGVOelA1
-        NFxuczgxc1ZaSW5DY3J2cko5YXJkeDIrbXZ0azJOSUFWTHpKMU5SSFYrWlow
-        WnZHaXZ5bzRQa2pJKytxcFo1R0IvNFxuK3dlTEw5RzhtWmt1SU9IOVB0N2tH
-        eU5GRys5SVlxdFFGRUdObTlaLzBOVDFELzFaRjN6RTczSFFJSmJQK3h6Nlxu
-        QXBScWdtZDRQeDlVNndhZ3BmK0RvbFJZUUVMMzB6MU1EY281aVFyRHBKQnNM
-        N0xOWXNCZDBibmZ5aUdaRG1rVlxuUHlwVmxnWnhnWThLOVZLSWpGbmtRQ2NE
-        bEFPNnBSTDQ2Y3JGY2RyNFRUYjVQY3R1SzlCenlIZXE2elNTSDNQY1xuRkdX
-        dDRHU2ZUVXIwYkFQUjYydmdQcWl1cTUwPVxuLS0tLS1FTkQgQ0VSVElGSUNB
-        VEUtLS0tLSJ9
+        IHsiJG9pZCI6ICI1NmI0YWJmYWM3ODIxYjMzMDVjZTUwZGUifSwgImlkIjog
+        InV1aWQiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnN1bWVycy91dWlk
+        LyJ9LCAiY2VydGlmaWNhdGUiOiAiLS0tLS1CRUdJTiBSU0EgUFJJVkFURSBL
+        RVktLS0tLVxuTUlJQ1d3SUJBQUtCZ1FEVk9POXVpZm9qamgvRGg3YWNMUWt0
+        SjFHSU1mSUlHbFlVZlVKOW93ZFFzRWVadmhzTFxuQ25wUDdGSlpGNmNjeDgv
+        NzZqQ0xXNnY5K015TDEvY3YxeUNKZnNYQWN6MGpoclNuUnlseDg1NDRXUkds
+        My9kYlxuMzExUVJlVTJYUWR5SmlsTlZtcXIvS3o0VHYzY3BtdXU3NWFxWUI3
+        UWZMQjVMeGRwWWhOYnU3UmxWd0lEQVFBQlxuQW9HQVdzME5RYkNtZ2wreTdT
+        eXRPbUwvWm1nNUUxdlpxMU96MXJQbERlWFFacTg3UHFDem1ZY1R3VmR0Vmgx
+        NVxuZ0FzamFpODREeEN4OU16d0pwbUkzYW1xWTd1SlBaVGpqYVppVERidGc5
+        ZkxpdlJhcXI5dTdTckFHdUdobGFtQ1xuU0N6cUFFRU1OQmE2VWpqSWhpUkV1
+        d2ovR0lUQ3pTakdhdHJXRkFVZzNnTlI5dEVDUVFEK3g0ZnZISS9HQ2lJc1xu
+        SUUzNHF6RjFtZktYUUgvTGJWVzBVQ1dKNGx4TzhETytORG91Tjlpbm5PZ2l1
+        VWRnNzdnRWk2Z096d0Y3OWlqNVxuNE1LQlhRaFBBa0VBMWo1d0FuTzJtYU1K
+        NmlPQlFSa3RwemMrT0xZQ29qR2ZMTFRJT09YVlg1ZHJ4YVplUXBrYlxueGRm
+        dk81NkdTY1g3ZDYxTS90QVNCdzBlY0ZFRjRyY0llUUpBY25ncGZlZ0NQTU11
+        eVU2V1dhUm82MktJbVNaVVxuaEl5U0ZocHdVendOcHpYS3VhbHpmbkorK0Fm
+        S1VGZVlWMWc5QUdYUzB4eDBtVUptOUtYa0hnVXpod0pBSENJcVxuMTBlV3JP
+        b3AvU01ZY0JIOFdyNzRYcjRYN25DUnRHOHc4N2ZLb3pqaElCMU90M1FmbjRW
+        Umx3U2tJYi9yMjdWWVxuTFFYcHVCOVM1ZkRkMHYyeUVRSkFma3FyY3JpYXdq
+        eDQxWk1TQVFEVjZTUlQ0UnVRYVhUVkRnWWM1bkQ5UTdHY1xuWkdja0YzbHlG
+        a2VIZHFoMmpzT1h4RGxxMEhPclBzMkFyckp5THBkakh3PT1cbi0tLS0tRU5E
+        IFJTQSBQUklWQVRFIEtFWS0tLS0tXG4tLS0tLUJFR0lOIENFUlRJRklDQVRF
+        LS0tLS1cbk1JSUNzRENDQVpnQ0FVTXdEUVlKS29aSWh2Y05BUUVGQlFBd2dZ
+        WXhDekFKQmdOVkJBWVRBbFZUTVJjd0ZRWURcblZRUUlFdzVPYjNKMGFDQkRZ
+        WEp2YkdsdVlURVFNQTRHQTFVRUJ4TUhVbUZzWldsbmFERVFNQTRHQTFVRUNo
+        TUhcblMyRjBaV3hzYnpFVU1CSUdBMVVFQ3hNTFUyOXRaVTl5WjFWdWFYUXhK
+        REFpQmdOVkJBTVRHMnRoZEdWc2JHOHRcbk1pMDRMV1JsZGk1bGVHRnRjR3hs
+        TG1OdmJUQWVGdzB4TmpBeU1EVXhOREEwTkRKYUZ3MHlOakF5TURJeE5EQTBc
+        bk5ESmFNRGt4RFRBTEJnTlZCQU1UQkhWMWFXUXhLREFtQmdvSmtpYUprL0lz
+        WkFFQkV4ZzFObUkwWVdKbVlXTTNcbk9ESXhZak16TURWalpUVXdaR1V3Z1o4
+        d0RRWUpLb1pJaHZjTkFRRUJCUUFEZ1kwQU1JR0pBb0dCQU5VNDcyNkpcbitp
+        T09IOE9IdHB3dENTMG5VWWd4OGdnYVZoUjlRbjJqQjFDd1I1bStHd3NLZWsv
+        c1Vsa1hweHpIei92cU1JdGJcbnEvMzR6SXZYOXkvWElJbCt4Y0J6UFNPR3RL
+        ZEhLWEh6bmpoWkVhWGY5MXZmWFZCRjVUWmRCM0ltS1UxV2FxdjhcbnJQaE8v
+        ZHltYTY3dmxxcGdIdEI4c0hrdkYybGlFMXU3dEdWWEFnTUJBQUV3RFFZSktv
+        WklodmNOQVFFRkJRQURcbmdnRUJBS3ZJN0VKdTcwaG1DWG54MjBGaldlb3FJ
+        cnhXaEFVRUVodmw4YWQ2UDU1MURyZkhwQ1RlNDNQOVpBMkFcblEzRGVQTGh4
+        WUVQQm1KV2w4dVNJRGRYWlR4U09lTmQxZFdDeVBWc0hhTHZuWmRuZXVoL0Yw
+        UDAvTEZpUDhQNlNcbkNUYWZSNXM0eFFydjZrZ0dsajk4WUhQaVZjRGt6VXRH
+        bGN3VG5XNVlaTjh1amE2dTEvbVFDY0VGLzN5Z0ZCaStcbi90T1NhVTh2ZzhP
+        Y1pwdWJZVXJhNGsrQkpuS01JcnEvZ2xSM3EybG1zdm1JdFJ3VjdSS1Y5OVl4
+        cys5UUNpZjdcbkZzNHlMdnVMM2NvblBKdXh5bnhpcktXUGE4SmxwMkJBOVB0
+        UjFpV29nd3pnV1ZpNGtnQmlLQVAva05pVnZVMElcblpieU1ORisvaVl4QzJ0
+        WFNzVkd0dlF2QWM3MD1cbi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0ifQ==
     http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:02 GMT
+  recorded_at: Fri, 05 Feb 2016 14:04:42 GMT
 - request:
     method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/uuid/
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/uuid/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -109,9 +108,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="dqrMIMhkhj4BiXhBZAlCykwXipEZjZ36VrIFaCiJzw",
-        oauth_signature="ObyVVGIzwio8guhqXn02NPJZsok%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628842", oauth_version="1.0"
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="C0LTGbcmb1BSyiRvqmKHqLjRT86fUYFhXrATSmDl0J0",
+        oauth_signature="RBuvSPix91qJPtpq%2FxAnQnBI5jU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681082", oauth_version="1.0"
       Pulp-User:
       - admin
       User-Agent:
@@ -122,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 Feb 2016 23:34:02 GMT
+      - Fri, 05 Feb 2016 14:04:42 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -130,11 +129,11 @@ http_interactions:
       Connection:
       - close
       Content-Type:
-      - application/json
+      - application/json; charset=utf-8
     body:
       encoding: UTF-8
       base64_string: |
         bnVsbA==
     http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:02 GMT
+  recorded_at: Fri, 05 Feb 2016 14:04:42 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/actions/pulp/node_bindings/bind_node_distributor.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp/node_bindings/bind_node_distributor.yml
@@ -73,53 +73,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:02 GMT
 - request:
-    method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/2/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="fbuzayxh46INZYO5Ic3780yqRSP6GXDd4r8Muis",
-        oauth_signature="c7Dm1Me8gRn82xfUqm8KhrMpgHc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628842", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:02 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzI4MWQ5ZWFmLTViZmYtNDY3MS1iYmQ3LWMzZWNjMzZkZDIxZC8iLCAi
-        dGFza19pZCI6ICIyODFkOWVhZi01YmZmLTQ2NzEtYmJkNy1jM2VjYzM2ZGQy
-        MWQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:02 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/281d9eaf-5bff-4671-bbd7-c3ecc36dd21d/
     body:
@@ -229,4 +182,233 @@ http_interactions:
         MiJ9
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:03 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjIiLCJkaXNwbGF5X25hbWUiOiJGZWRvcmEgMTcgeDg2XzY0IGRl
+        diIsImltcG9ydGVyX3R5cGVfaWQiOiJ5dW1faW1wb3J0ZXIiLCJpbXBvcnRl
+        cl9jb25maWciOnsiZmVlZCI6ImZpbGU6Ly8vdmFyL3d3dy90ZXN0X3JlcG9z
+        L3pvbyIsInNzbF9jYV9jZXJ0IjpudWxsLCJzc2xfY2xpZW50X2NlcnQiOm51
+        bGwsInNzbF9jbGllbnRfa2V5IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlw
+        ZSI6InJwbS1yZXBvIn0sImRpc3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3Jf
+        dHlwZV9pZCI6Inl1bV9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZp
+        ZyI6eyJyZWxhdGl2ZV91cmwiOiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwi
+        aHR0cHMiOnRydWUsInByb3RlY3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6
+        dHJ1ZSwiZGlzdHJpYnV0b3JfaWQiOiIyIn0seyJkaXN0cmlidXRvcl90eXBl
+        X2lkIjoieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29u
+        ZmlnIjp7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjoiMiJ9LCJhdXRv
+        X3B1Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRvcl9pZCI6IjJfY2xvbmUifSx7
+        ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJleHBvcnRfZGlzdHJpYnV0b3IiLCJk
+        aXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBzIjpmYWxz
+        ZSwicmVsYXRpdmVfdXJsIjpudWxsfSwiYXV0b19wdWJsaXNoIjpmYWxzZSwi
+        ZGlzdHJpYnV0b3JfaWQiOiJleHBvcnRfZGlzdHJpYnV0b3IifV19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="3qYwqLvIytnVwMnZeDnrEkEUNT5Cke2SIJ3wAlhQAs8", oauth_signature="5VHnx4S6EsEP6QeeJ936yZD9nyE%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681083", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '759'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:43 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '308'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/2/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCBkZXYiLCAiZGVzY3JpcHRpb24iOiBudWxsLCAibGFzdF91bml0
+        X2FkZGVkIjogbnVsbCwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
+        ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3Vu
+        aXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lkIjogeyIkb2lk
+        IjogIjU2YjRhYmZiYzc4MjFiMzMwNWNlNTBlMiJ9LCAiaWQiOiAiMiIsICJf
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzLzIvIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:43 GMT
+- request:
+    method: delete
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="d0lkcnVRwY0PLHPasJZnD4qCQhG8xXqjWzWPnMDFJI",
+        oauth_signature="0oqxLz8ZME73jnHk9CNFddpe9jU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681083", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:43 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2Q1YmI5YTRkLTgyYTYtNDBhNy1iOGQxLTU5YmNjOTQ5YTE3MC8iLCAi
+        dGFza19pZCI6ICJkNWJiOWE0ZC04MmE2LTQwYTctYjhkMS01OWJjYzk0OWEx
+        NzAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:43 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/d5bb9a4d-82a6-40a7-b8d1-59bcc949a170/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="uJSWysCxi2kcbWuJ3DiUuNNavmaH4Szu9BRCapIKqg",
+        oauth_signature="nJ8RpCreyKIRyGZEqZlm3GXiFOA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681083", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:43 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '541'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kNWJiOWE0ZC04MmE2LTQwYTctYjhkMS01OWJjYzk0OWEx
+        NzAvIiwgInRhc2tfaWQiOiAiZDViYjlhNGQtODJhNi00MGE3LWI4ZDEtNTli
+        Y2M5NDlhMTcwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1
+        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiBudWxsLCAiX25z
+        IjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAidHJhY2Vi
+        YWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3Jl
+        cG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6ICJ3YWl0
+        aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51bGwsICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFiZmI4YWRhNDBk
+        YjA0ZWUwOTljIn0sICJpZCI6ICI1NmI0YWJmYjhhZGE0MGRiMDRlZTA5OWMi
+        fQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:43 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/d5bb9a4d-82a6-40a7-b8d1-59bcc949a170/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="xGfR8tfnJb5ZOZ0Ex7sZSccNuggBVsmpThtPIx2nlok",
+        oauth_signature="7Ol6LTiK7DL14pl7WFGGUbS6FNU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681084", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:44 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '680'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kNWJiOWE0ZC04MmE2LTQwYTctYjhkMS01OWJjYzk0OWEx
+        NzAvIiwgInRhc2tfaWQiOiAiZDViYjlhNGQtODJhNi00MGE3LWI4ZDEtNTli
+        Y2M5NDlhMTcwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1
+        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0w
+        NVQxNDowNDo0M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3Rp
+        bWUiOiAiMjAxNi0wMi0wNVQxNDowNDo0M1oiLCAidHJhY2ViYWNrIjogbnVs
+        bCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9
+        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
+        by0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVk
+        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
+        QGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhYmZiOGFk
+        YTQwZGIwNGVlMDk5YyJ9LCAiaWQiOiAiNTZiNGFiZmI4YWRhNDBkYjA0ZWUw
+        OTljIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:44 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/actions/pulp/node_bindings/unbind_node_distributor.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp/node_bindings/unbind_node_distributor.yml
@@ -73,53 +73,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:04 GMT
 - request:
-    method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/2/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="XCEW59Yks2cLt0Z9Btx5VqAEfJWpXk0ey6WedkcxDV4",
-        oauth_signature="gLxLQ5%2FKtzG%2Fq0HPht5dA5jUTok%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628844", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:04 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzdkMTJjYmU0LTk3MzQtNDIxMi1iZDhjLWMzYjZkNmVmMDI2My8iLCAi
-        dGFza19pZCI6ICI3ZDEyY2JlNC05NzM0LTQyMTItYmQ4Yy1jM2I2ZDZlZjAy
-        NjMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:04 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/7d12cbe4-9734-4212-bd8c-c3b6d6ef0263/
     body:
@@ -229,4 +182,233 @@ http_interactions:
         OSJ9
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:04 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjIiLCJkaXNwbGF5X25hbWUiOiJGZWRvcmEgMTcgeDg2XzY0IGRl
+        diIsImltcG9ydGVyX3R5cGVfaWQiOiJ5dW1faW1wb3J0ZXIiLCJpbXBvcnRl
+        cl9jb25maWciOnsiZmVlZCI6ImZpbGU6Ly8vdmFyL3d3dy90ZXN0X3JlcG9z
+        L3pvbyIsInNzbF9jYV9jZXJ0IjpudWxsLCJzc2xfY2xpZW50X2NlcnQiOm51
+        bGwsInNzbF9jbGllbnRfa2V5IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlw
+        ZSI6InJwbS1yZXBvIn0sImRpc3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3Jf
+        dHlwZV9pZCI6Inl1bV9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZp
+        ZyI6eyJyZWxhdGl2ZV91cmwiOiJ0ZXN0X3BhdGgiLCJodHRwIjpmYWxzZSwi
+        aHR0cHMiOnRydWUsInByb3RlY3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlzaCI6
+        dHJ1ZSwiZGlzdHJpYnV0b3JfaWQiOiIyIn0seyJkaXN0cmlidXRvcl90eXBl
+        X2lkIjoieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29u
+        ZmlnIjp7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjoiMiJ9LCJhdXRv
+        X3B1Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRvcl9pZCI6IjJfY2xvbmUifSx7
+        ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJleHBvcnRfZGlzdHJpYnV0b3IiLCJk
+        aXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBzIjpmYWxz
+        ZSwicmVsYXRpdmVfdXJsIjpudWxsfSwiYXV0b19wdWJsaXNoIjpmYWxzZSwi
+        ZGlzdHJpYnV0b3JfaWQiOiJleHBvcnRfZGlzdHJpYnV0b3IifV19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="9FQUjDelehAe4h5fYwSMhDYdSrgcssJYwaQQ1ZEqUo", oauth_signature="lt1fY2aRurgq5VvCEKQQO3vuzPk%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681084", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '759'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:44 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '308'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/2/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCBkZXYiLCAiZGVzY3JpcHRpb24iOiBudWxsLCAibGFzdF91bml0
+        X2FkZGVkIjogbnVsbCwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
+        ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3Vu
+        aXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lkIjogeyIkb2lk
+        IjogIjU2YjRhYmZjYzc4MjFiMzMwNWNlNTBlNyJ9LCAiaWQiOiAiMiIsICJf
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzLzIvIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:44 GMT
+- request:
+    method: delete
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="traIXA2ViVmIiuk1NBmyi15vboDBUZp9Mkc3V7Mvt3A",
+        oauth_signature="cLwJDBj2IlhsjGe2xLmQprHIYuw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681085", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:45 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2YyYWNlYzkyLTVkYTUtNGQ2NS05OTkzLTM5MTEwYWMzMzI4My8iLCAi
+        dGFza19pZCI6ICJmMmFjZWM5Mi01ZGE1LTRkNjUtOTk5My0zOTExMGFjMzMy
+        ODMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:45 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f2acec92-5da5-4d65-9993-39110ac33283/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="j0TfCsluD4rg7DutKnl6jFQStdF5t7MFIt5XQMjQ",
+        oauth_signature="I84Zi1Kqy6gc2NMbgOAAxfHLSJ0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681085", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:45 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '541'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mMmFjZWM5Mi01ZGE1LTRkNjUtOTk5My0zOTExMGFjMzMy
+        ODMvIiwgInRhc2tfaWQiOiAiZjJhY2VjOTItNWRhNS00ZDY1LTk5OTMtMzkx
+        MTBhYzMzMjgzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1
+        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiBudWxsLCAiX25z
+        IjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAidHJhY2Vi
+        YWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3Jl
+        cG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6ICJ3YWl0
+        aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51bGwsICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFiZmQ4YWRhNDBk
+        YjA0ZWUwOTlkIn0sICJpZCI6ICI1NmI0YWJmZDhhZGE0MGRiMDRlZTA5OWQi
+        fQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:45 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f2acec92-5da5-4d65-9993-39110ac33283/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="57x8YNxFA9N0YHVvHimx9UAGynIlF3pLheLkQQ7b0",
+        oauth_signature="JiJTWQyArXwRIZnpvlFC0DeA7Sw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681085", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:45 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '680'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mMmFjZWM5Mi01ZGE1LTRkNjUtOTk5My0zOTExMGFjMzMy
+        ODMvIiwgInRhc2tfaWQiOiAiZjJhY2VjOTItNWRhNS00ZDY1LTk5OTMtMzkx
+        MTBhYzMzMjgzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1
+        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0w
+        NVQxNDowNDo0NVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3Rp
+        bWUiOiAiMjAxNi0wMi0wNVQxNDowNDo0NVoiLCAidHJhY2ViYWNrIjogbnVs
+        bCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9
+        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
+        by0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVk
+        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
+        QGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhYmZkOGFk
+        YTQwZGIwNGVlMDk5ZCJ9LCAiaWQiOiAiNTZiNGFiZmQ4YWRhNDBkYjA0ZWUw
+        OTlkIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:45 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/actions/pulp/repository/remove_schedule/remove_schedule.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp/repository/remove_schedule/remove_schedule.yml
@@ -76,179 +76,6 @@ http_interactions:
   recorded_at: Thu, 04 Feb 2016 23:34:05 GMT
 - request:
     method: get
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="B3OScojWRFgATvL0vgXNDyBtsDBlvwxAq6YsXu4Xg",
-        oauth_signature="SO7sPi8FfYlK63i7mwNC9jAn9rQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628845", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:05 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '2'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W10=
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:05 GMT
-- request:
-    method: get
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="Rixk38JGyN0L90ZQUMRp21fKHCMybb2R1EaWAQyq8",
-        oauth_signature="IoVFOAS04uMuWXTF1mdpfvlXiOw%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628845", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:05 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '2'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W10=
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:05 GMT
-- request:
-    method: get
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="5vRabOBnAbmjvFi3gIb1OqnfVCFqXKbM8aLeanGhRMA",
-        oauth_signature="VaSuK5vzdV27Juyy332HOYYP4%2BI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628845", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:05 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '2'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W10=
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:05 GMT
-- request:
-    method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="hapfnu4cR7Up0PGgsq3nlAgLlcbB6nhHvh4u2GThmto",
-        oauth_signature="J4YCQVmYkmJyYbTEdTbVEHyCkQ4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628845", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:05 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzNkNzdiYTdmLWVlZGEtNDJiZS1iMDk2LWYzZDJmMTY5Y2RhYy8iLCAi
-        dGFza19pZCI6ICIzZDc3YmE3Zi1lZWRhLTQyYmUtYjA5Ni1mM2QyZjE2OWNk
-        YWMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:05 GMT
-- request:
-    method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/3d77ba7f-eeda-42be-b096-f3d2f169cdac/
     body:
       encoding: US-ASCII
@@ -357,4 +184,361 @@ http_interactions:
         N2RiZjRkODgwIn0=
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:06 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
+        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
+        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
+        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
+        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
+        LXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1
+        dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9j
+        b25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIiwiaHR0cCI6ZmFs
+        c2UsImh0dHBzIjp0cnVlLCJwcm90ZWN0ZWQiOnRydWV9LCJhdXRvX3B1Ymxp
+        c2giOnRydWUsImRpc3RyaWJ1dG9yX2lkIjoiRmVkb3JhXzE3In0seyJkaXN0
+        cmlidXRvcl90eXBlX2lkIjoieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwiZGlz
+        dHJpYnV0b3JfY29uZmlnIjp7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lk
+        IjoiRmVkb3JhXzE3In0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1
+        dG9yX2lkIjoiRmVkb3JhXzE3X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBl
+        X2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmln
+        Ijp7Imh0dHAiOmZhbHNlLCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6
+        bnVsbH0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoi
+        ZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="YsXL53rxooTSbaDztjEpcGHaaQ3T64Fr3UQrzDReUCQ", oauth_signature="pIR%2FsoF6wLSp5opE3JFjVG2V8Lc%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681086", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '787'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:46 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '320'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
+        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
+        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NTZiNGFiZmVjNzgyMWIzMzA0MmQ5ZGM1In0sICJpZCI6ICJGZWRvcmFfMTci
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
+        MTcvIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:46 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="R5beg10UsF3XcGDBD7n9VBpaLXOsOsmtWTgO2V7q1I4",
+        oauth_signature="M01E0KogkptKXS3LFMU7reyNTIU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681087", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '2'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        W10=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:47 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="hJl87snWBqiQg4boNUky0B3KqIxQSEoFGOKKGOb0",
+        oauth_signature="vOw8Qn2DZPrR7QRDt5dK90heprk%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681087", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '2'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        W10=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:47 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="DMGTcNUBJGX6X1v7MeRXuu7oxOQUr4blM8YJUd1ZJQ",
+        oauth_signature="bJa9dQNm6w3V5p%2F%2BEL%2ByN4SOmPU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681087", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '2'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        W10=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:47 GMT
+- request:
+    method: delete
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="shdZahyEAKB5VzBNEQhDFGTqsOZsuxBa9Kcp1XpFE",
+        oauth_signature="uG99A2xvXEpYL8OX%2BIfXLVCwIV4%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681087", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzVhYTVlYjQ5LWFiNDgtNDFkZC05ZWZjLWM1MTQ4NGY0Y2VlZi8iLCAi
+        dGFza19pZCI6ICI1YWE1ZWI0OS1hYjQ4LTQxZGQtOWVmYy1jNTE0ODRmNGNl
+        ZWYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:47 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/5aa5eb49-ab48-41dd-9efc-c51484f4ceef/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="VXBUoTDcpdS9s1CCaUQ2khBtObh49rhfN4xx9HefI",
+        oauth_signature="mdi8awTWZAO%2BFijWubjRuJPYy14%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681087", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81YWE1ZWI0OS1hYjQ4LTQxZGQtOWVmYy1jNTE0ODRmNGNl
+        ZWYvIiwgInRhc2tfaWQiOiAiNWFhNWViNDktYWI0OC00MWRkLTllZmMtYzUx
+        NDg0ZjRjZWVmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWJm
+        ZjhhZGE0MGRiMDRlZTA5OWUifSwgImlkIjogIjU2YjRhYmZmOGFkYTQwZGIw
+        NGVlMDk5ZSJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:47 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/5aa5eb49-ab48-41dd-9efc-c51484f4ceef/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="G75NByis3Hz4ut4QESijF5DUFnf42j8xCSVcU4XAEvs",
+        oauth_signature="I5C3YIqwIXbmlInqC1ShEli7MOU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681088", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:48 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81YWE1ZWI0OS1hYjQ4LTQxZGQtOWVmYy1jNTE0ODRmNGNl
+        ZWYvIiwgInRhc2tfaWQiOiAiNWFhNWViNDktYWI0OC00MWRkLTllZmMtYzUx
+        NDg0ZjRjZWVmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA0OjQ4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA0OjQ3WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFiZmY4YWRhNDBkYjA0ZWUwOTllIn0sICJpZCI6ICI1NmI0YWJmZjhhZGE0
+        MGRiMDRlZTA5OWUifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:48 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/actions/pulp/repository/sync/sync.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp/repository/sync/sync.yml
@@ -75,57 +75,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:07 GMT
 - request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
-        Ijp0cnVlfX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="ajA3y2tZD16ArOjpTOE53TmoiW5lAOC8WVzl0CAyK8", oauth_signature="3KDPFsLsFkHXa7GW%2BX4K4eE0QUc%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628847", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '53'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:07 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzlmODUyMGZkLWQ3NzktNDRlNS1hODdjLTQzMTI5NjY4YmVmNC8iLCAi
-        dGFza19pZCI6ICI5Zjg1MjBmZC1kNzc5LTQ0ZTUtYTg3Yy00MzEyOTY2OGJl
-        ZjQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:07 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/9f8520fd-d779-44e5-a87c-43129668bef4/
     body:
@@ -811,136 +760,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:08 GMT
 - request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwiZmllbGRzIjp7InVu
-        aXQiOltdLCJhc3NvY2lhdGlvbiI6WyJ1bml0X2lkIl19fX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="wKcRvEeLKoNVnJt8tlh0fQLWWvuEnxBigoVKsSTBIM", oauth_signature="0u7vZCQZmtRabWQy3mm2HyLPtyU%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628848", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '80'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:08 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '1672'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICJjYThlNjc1ZC02OWFiLTQ1N2MtYTE5
-        NC00ZWEyMTIwODUzOGQiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
-        Il9pZCI6IHsiJG9pZCI6ICI1NmIzZGZlZjg0YTA5YzA3ZGE5NzlhNmUifSwg
-        InVuaXRfaWQiOiAiY2E4ZTY3NWQtNjlhYi00NTdjLWExOTQtNGVhMjEyMDg1
-        MzhkIiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogImQxM2U0YTc3LWMxYzgtNGY5NC1hYWI4LThjZmNlZjg3ZTRmMCIs
-        ICJfY29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjog
-        IjU2YjNkZmVmODRhMDljMDdkYTk3OWE2YSJ9LCAidW5pdF9pZCI6ICJkMTNl
-        NGE3Ny1jMWM4LTRmOTQtYWFiOC04Y2ZjZWY4N2U0ZjAiLCAidW5pdF90eXBl
-        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiYzQ0MDQzNmMt
-        Mzg0NC00MjhmLThiYjQtMWRhYWQzODg5MjUxIiwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiM2RmZWY4NGEwOWMw
-        N2RhOTc5YTY5In0sICJ1bml0X2lkIjogImM0NDA0MzZjLTM4NDQtNDI4Zi04
-        YmI0LTFkYWFkMzg4OTI1MSIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
-        bWV0YWRhdGEiOiB7Il9pZCI6ICJlNzEzMjNhYi0wMDhjLTQxY2UtOWQzOC1h
-        Yjc0YjdhMWVhNWYiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1NmIzZGZlZjg0YTA5YzA3ZGE5NzlhNmIifSwgInVu
-        aXRfaWQiOiAiZTcxMzIzYWItMDA4Yy00MWNlLTlkMzgtYWI3NGI3YTFlYTVm
-        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lk
-        IjogIjI0YzRiZmQ2LTkxOGItNDQ3MC04ZWQ4LWY4NzgyYzRlYTYzYyIsICJf
-        Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2
-        YjNkZmVmODRhMDljMDdkYTk3OWE2YyJ9LCAidW5pdF9pZCI6ICIyNGM0YmZk
-        Ni05MThiLTQ0NzAtOGVkOC1mODc4MmM0ZWE2M2MiLCAidW5pdF90eXBlX2lk
-        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiYWM3OWZjMjgtM2Mz
-        Ni00Y2FhLTlhMWYtNDMzNTYzOWI1MzM1IiwgIl9jb250ZW50X3R5cGVfaWQi
-        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiM2RmZWY4NGEwOWMwN2Rh
-        OTc5YTZkIn0sICJ1bml0X2lkIjogImFjNzlmYzI4LTNjMzYtNGNhYS05YTFm
-        LTQzMzU2MzliNTMzNSIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
-        YWRhdGEiOiB7Il9pZCI6ICIxYWM4OGFlMS1kYjViLTRlZWMtYmE4ZS03MjQw
-        ZmYxM2NjMzkiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NmIzZGZlZjg0YTA5YzA3ZGE5NzlhNzAifSwgInVuaXRf
-        aWQiOiAiMWFjODhhZTEtZGI1Yi00ZWVjLWJhOGUtNzI0MGZmMTNjYzM5Iiwg
-        InVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjog
-        ImI3YzJiZWQ2LWRjZmUtNDI5Yi1iOTRkLTdkMzNiOTg3ZmYzYSIsICJfY29u
-        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2YjNk
-        ZmVmODRhMDljMDdkYTk3OWE2ZiJ9LCAidW5pdF9pZCI6ICJiN2MyYmVkNi1k
-        Y2ZlLTQyOWItYjk0ZC03ZDMzYjk4N2ZmM2EiLCAidW5pdF90eXBlX2lkIjog
-        InJwbSJ9XQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:08 GMT
-- request:
-    method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="TVBKVXVtFOt7SdL8E2m9FyUZxrwVTC8w7uIBz9oo3s",
-        oauth_signature="pDR3Ached27Br9yHo5BnGHuAQas%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628849", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:09 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzMyMTJlMTc0LWIyODUtNDg2Zi1hZTdhLTE4YjU2YjFlYTk3Zi8iLCAi
-        dGFza19pZCI6ICIzMjEyZTE3NC1iMjg1LTQ4NmYtYWU3YS0xOGI1NmIxZWE5
-        N2YifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:09 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/3212e174-b285-486f-ae7a-18b56b1ea97f/
     body:
@@ -1052,4 +871,996 @@ http_interactions:
         N2RiZjRkODk5In0=
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:09 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
+        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
+        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
+        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
+        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
+        LXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1
+        dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9j
+        b25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIiwiaHR0cCI6ZmFs
+        c2UsImh0dHBzIjp0cnVlLCJwcm90ZWN0ZWQiOnRydWV9LCJhdXRvX3B1Ymxp
+        c2giOnRydWUsImRpc3RyaWJ1dG9yX2lkIjoiRmVkb3JhXzE3In0seyJkaXN0
+        cmlidXRvcl90eXBlX2lkIjoieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwiZGlz
+        dHJpYnV0b3JfY29uZmlnIjp7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lk
+        IjoiRmVkb3JhXzE3In0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1
+        dG9yX2lkIjoiRmVkb3JhXzE3X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBl
+        X2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmln
+        Ijp7Imh0dHAiOmZhbHNlLCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6
+        bnVsbH0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoi
+        ZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="se6TdofbvKEMSnKUvX714S1Rf0zUWJdaARujlmiwhc", oauth_signature="FbXxqutBPvChCWRUAFTpI9qtDJE%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681089", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '787'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:49 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '320'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
+        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
+        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NTZiNGFjMDFjNzgyMWIzMzA1Y2U1MGVjIn0sICJpZCI6ICJGZWRvcmFfMTci
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
+        MTcvIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:49 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
+        Ijp0cnVlfX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="HWlLs7qTwqydqaWoMwCiiS72JW5zOPovodhGS7V4o", oauth_signature="zGMMVNNrPjEs9hsXhG%2Bs%2BtI8Tio%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681089", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '53'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:49 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzMyNmVlYjM1LTQxMGUtNDNhNi05ZTFlLWZmNGY2YTI5ZTZhNi8iLCAi
+        dGFza19pZCI6ICIzMjZlZWIzNS00MTBlLTQzYTYtOWUxZS1mZjRmNmEyOWU2
+        YTYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:49 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/326eeb35-410e-43a6-9e1e-ff4f6a29e6a6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="3spw5AzCk8TO6GwRJjivve5bZitsnnwbSbkt54mwlks",
+        oauth_signature="b694Ctmy2VxTCucSdxq5vVwD31M%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681089", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:49 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zMjZlZWIzNS00MTBlLTQzYTYtOWUxZS1mZjRmNmEyOWU2
+        YTYvIiwgInRhc2tfaWQiOiAiMzI2ZWViMzUtNDEwZS00M2E2LTllMWUtZmY0
+        ZjZhMjllNmE2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMDE4
+        YWRhNDBkYjA0ZWUwOTlmIn0sICJpZCI6ICI1NmI0YWMwMThhZGE0MGRiMDRl
+        ZTA5OWYifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:49 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/326eeb35-410e-43a6-9e1e-ff4f6a29e6a6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="dkJ6se7ei2UdsTKThHjPrcAlOllxUoDcJ3OWgFaqpQ",
+        oauth_signature="L9OZOFd1EGjYd44gHMTsV4kDD0s%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681090", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:50 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1093'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zMjZlZWIzNS00MTBlLTQzYTYtOWUxZS1mZjRmNmEyOWU2
+        YTYvIiwgInRhc2tfaWQiOiAiMzI2ZWViMzUtNDEwZS00M2E2LTllMWUtZmY0
+        ZjZhMjllNmE2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0wNVQxNDowNDo0OVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
+        bCI6IDAsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiSU5fUFJP
+        R1JFU1MifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjMDE4YWRhNDBkYjA0ZWUwOTlmIn0sICJpZCI6ICI1NmI0YWMwMThhZGE0
+        MGRiMDRlZTA5OWYifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:50 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/326eeb35-410e-43a6-9e1e-ff4f6a29e6a6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="d6E4XiuEeOMsk9BJJYJucPA6hV0dsgXwhZ2uGXXM02w",
+        oauth_signature="gqNnMywnv63yGjkV4i%2BOZroPIp8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681090", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:50 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zMjZlZWIzNS00MTBlLTQzYTYtOWUxZS1mZjRmNmEyOWU2
+        YTYvIiwgInRhc2tfaWQiOiAiMzI2ZWViMzUtNDEwZS00M2E2LTllMWUtZmY0
+        ZjZhMjllNmE2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNDo1MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNDo0OVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNWI1YzYzOTctYTZjMy00MzZjLWJjNTItZjJmYTUzM2I4
+        MzUzLyIsICJ0YXNrX2lkIjogIjViNWM2Mzk3LWE2YzMtNDM2Yy1iYzUyLWYy
+        ZmE1MzNiODM1MyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzAxYzc4MjFiMzMwNWNlNTBlZCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDQ6NDlaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNDo1
+        MFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjMDJjNzgyMWIzNDQ0ZmNjMjRmIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMDE4YWRhNDBkYjA0ZWUwOTlmIn0s
+        ICJpZCI6ICI1NmI0YWMwMThhZGE0MGRiMDRlZTA5OWYifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:50 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/5b5c6397-a6c3-436c-bc52-f2fa533b8353/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="VvUnq4U3jUpIz9GCbBwiSLTNJTAf9CqF5pQOAamtKs",
+        oauth_signature="R9%2BXjHItnuR2szUhEzsCiQK7Zyw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681090", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:50 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '3529'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy81YjVjNjM5Ny1hNmMzLTQzNmMtYmM1Mi1mMmZh
+        NTMzYjgzNTMvIiwgInRhc2tfaWQiOiAiNWI1YzYzOTctYTZjMy00MzZjLWJj
+        NTItZjJmYTUzM2I4MzUzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxNi0wMi0wNVQxNDowNDo1MFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJm
+        ODJhZmMwNS1jOGJhLTQ1NTYtOWEyMi0xNjZlODdlOTExNzQiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlw
+        ZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjA3Y2Yx
+        YjgtZTgyNC00M2E5LTg2MTktNGZlOTAwZjZhN2MxIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiMDg4MTU2YWEtYzZlMC00MzhlLTkxOTEtMWUxYmEzNGNl
+        OGJiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3Rl
+        cF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM3ODZmZDlh
+        LTRhY2QtNGEzMS05MjdlLWY0YWZhNThkNjY5YiIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVt
+        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICI5ZTQwNWViNi1iY2Y1LTQwNTgtYjgxZS0wYjgyYzUx
+        YmQxNjYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJz
+        dGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTQ3Mzgx
+        MTgtYmI3Zi00YjljLWJhM2UtN2E2YTllOGIxNDEzIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNGExODk4OTgtMTYwOC00Y2NhLWE2OWYt
+        NGZjNWJmYTdiN2M3IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRh
+        dGEiLCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiMzg2NWQ4YTctMmFkMi00ODM2LWI2ZWYtMjljN2Mx
+        MmEwNjc2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIs
+        ICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogImI4YTgxZGJkLTAwYjctNGRmYy1iMjIwLTMwZDIxYjlmMWQyMyIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
+        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90
+        eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        ImVlMWQyZmQ2LWM1MmItNGM4Yi05MDZhLTJiNzg4ZGNmNWY5YiIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJp
+        bml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        OWVmY2FlN2QtNjRkOC00MDZkLWIzZDktMWQ3ZTczODc1NmU5IiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0
+        YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwg
+        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNTZiNGFjMDI4YWRhNDBkYjA0ZWUwOWFmIn0sICJpZCI6ICI1NmI0YWMw
+        MjhhZGE0MGRiMDRlZTA5YWYifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:50 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/326eeb35-410e-43a6-9e1e-ff4f6a29e6a6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="6bCndwDtQhF7D9qacXhqoVlyKBBTFPBqr2LqihHTgc",
+        oauth_signature="SPbdEz3nB%2BZNylMKpfOWkHcGF9Q%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681091", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:51 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zMjZlZWIzNS00MTBlLTQzYTYtOWUxZS1mZjRmNmEyOWU2
+        YTYvIiwgInRhc2tfaWQiOiAiMzI2ZWViMzUtNDEwZS00M2E2LTllMWUtZmY0
+        ZjZhMjllNmE2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNDo1MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNDo0OVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNWI1YzYzOTctYTZjMy00MzZjLWJjNTItZjJmYTUzM2I4
+        MzUzLyIsICJ0YXNrX2lkIjogIjViNWM2Mzk3LWE2YzMtNDM2Yy1iYzUyLWYy
+        ZmE1MzNiODM1MyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzAxYzc4MjFiMzMwNWNlNTBlZCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDQ6NDlaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNDo1
+        MFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjMDJjNzgyMWIzNDQ0ZmNjMjRmIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMDE4YWRhNDBkYjA0ZWUwOTlmIn0s
+        ICJpZCI6ICI1NmI0YWMwMThhZGE0MGRiMDRlZTA5OWYifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:51 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/5b5c6397-a6c3-436c-bc52-f2fa533b8353/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="CPVDvakN2TJAt8nnILFg8AK95kUXbofkDI5tdSsoY",
+        oauth_signature="%2BThdoqtO2IUfF2Pl1YamaC19M5o%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681091", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:51 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '6929'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy81YjVjNjM5Ny1hNmMzLTQzNmMtYmM1Mi1mMmZh
+        NTMzYjgzNTMvIiwgInRhc2tfaWQiOiAiNWI1YzYzOTctYTZjMy00MzZjLWJj
+        NTItZjJmYTUzM2I4MzUzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0wMi0wNVQxNDowNDo1MVoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNDo1MFoiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICJmODJhZmMwNS1jOGJhLTQ1NTYtOWEyMi0xNjZlODdl
+        OTExNzQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiMjA3Y2YxYjgtZTgyNC00M2E5LTg2MTktNGZlOTAwZjZhN2MxIiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
+        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMDg4MTU2YWEtYzZlMC00MzhlLTkxOTEt
+        MWUxYmEzNGNlOGJiIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
+        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzc4
+        NmZkOWEtNGFjZC00YTMxLTkyN2UtZjRhZmE1OGQ2NjliIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjllNDA1ZWI2LWJjZjUtNDA1OC1iODFlLTBiODJj
+        NTFiZDE2NiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
+        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5NDczODEx
+        OC1iYjdmLTRiOWMtYmEzZS03YTZhOWU4YjE0MTMiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI0YTE4OTg5OC0xNjA4LTRjY2EtYTY5Zi00ZmM1
+        YmZhN2I3YzciLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
+        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICIzODY1ZDhhNy0yYWQyLTQ4MzYtYjZlZi0yOWM3YzEyYTA2NzYi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
+        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiOGE4
+        MWRiZC0wMGI3LTRkZmMtYjIyMC0zMGQyMWI5ZjFkMjMiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
+        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlZTFkMmZkNi1jNTJi
+        LTRjOGItOTA2YS0yYjc4OGRjZjVmOWIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
+        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjllZmNhZTdkLTY0ZDgtNDA2
+        ZC1iM2Q5LTFkN2U3Mzg3NTZlOSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
+        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE0OjA0OjUw
+        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMDVUMTQ6MDQ6NTFaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
+        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
+        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
+        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
+        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
+        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
+        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
+        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
+        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGFjMDNjNzgyMWIz
+        NDQ0ZmNjMjUwIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
+        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
+        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImY4MmFmYzA1LWM4YmEtNDU1Ni05YTIyLTE2NmU4N2U5MTE3
+        NCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
+        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICIyMDdjZjFiOC1lODI0LTQzYTktODYxOS00ZmU5MDBmNmE3YzEiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
+        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICIwODgxNTZhYS1jNmUwLTQzOGUtOTE5MS0xZTFi
+        YTM0Y2U4YmIiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
+        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjNzg2ZmQ5
+        YS00YWNkLTRhMzEtOTI3ZS1mNGFmYTU4ZDY2OWIiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiOWU0MDVlYjYtYmNmNS00MDU4LWI4MWUtMGI4MmM1MWJk
+        MTY2IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjk0NzM4MTE4LWJi
+        N2YtNGI5Yy1iYTNlLTdhNmE5ZThiMTQxMyIsICJudW1fcHJvY2Vzc2VkIjog
+        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjRhMTg5ODk4LTE2MDgtNGNjYS1hNjlmLTRmYzViZmE3
+        YjdjNyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
+        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjM4NjVkOGE3LTJhZDItNDgzNi1iNmVmLTI5YzdjMTJhMDY3NiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
+        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI4YTgxZGJk
+        LTAwYjctNGRmYy1iMjIwLTMwZDIxYjlmMWQyMyIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
+        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVlMWQyZmQ2LWM1MmItNGM4
+        Yi05MDZhLTJiNzg4ZGNmNWY5YiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
+        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOWVmY2FlN2QtNjRkOC00MDZkLWIz
+        ZDktMWQ3ZTczODc1NmU5IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhYzAyOGFkYTQwZGIw
+        NGVlMDlhZiJ9LCAiaWQiOiAiNTZiNGFjMDI4YWRhNDBkYjA0ZWUwOWFmIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:51 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwiZmllbGRzIjp7InVu
+        aXQiOltdLCJhc3NvY2lhdGlvbiI6WyJ1bml0X2lkIl19fX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="6wUMVrfHRTkUclaftOLjzmckY80ghQPUmBLuekbw", oauth_signature="euv7y%2FDJFkLRKlbrrkK%2FMxG96Sw%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681091", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '80'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:51 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1672'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIyY2I1MDQzZS1mYjYzLTQzODMtYmEz
+        NS1hNTY4MDZmOGQzYWQiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmI0YWMwMjhhZGE0MGRiMDRlZTA5YTUifSwg
+        InVuaXRfaWQiOiAiMmNiNTA0M2UtZmI2My00MzgzLWJhMzUtYTU2ODA2Zjhk
+        M2FkIiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
+        X2lkIjogIjJlODAyYzNjLTY3YTItNDZjNy1iZGI2LTQzMGVkZjJhMGRkMyIs
+        ICJfY29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjog
+        IjU2YjRhYzAyOGFkYTQwZGIwNGVlMDlhNiJ9LCAidW5pdF9pZCI6ICIyZTgw
+        MmMzYy02N2EyLTQ2YzctYmRiNi00MzBlZGYyYTBkZDMiLCAidW5pdF90eXBl
+        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiMzY5ZjhhZmUt
+        OWM4Yi00ZGJhLWEyNGYtODU2MWVjZWI0YmI2IiwgIl9jb250ZW50X3R5cGVf
+        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMDI4YWRhNDBk
+        YjA0ZWUwOWEyIn0sICJ1bml0X2lkIjogIjM2OWY4YWZlLTljOGItNGRiYS1h
+        MjRmLTg1NjFlY2ViNGJiNiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
+        bWV0YWRhdGEiOiB7Il9pZCI6ICI0YzBhYjA3ZS1hMWYyLTRjNzYtOGZhNy0w
+        ZGMyNTg5MWYxODAiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1NmI0YWMwMjhhZGE0MGRiMDRlZTA5YTQifSwgInVu
+        aXRfaWQiOiAiNGMwYWIwN2UtYTFmMi00Yzc2LThmYTctMGRjMjU4OTFmMTgw
+        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lk
+        IjogImE2NzUyYjA5LTg1MTUtNGU5ZS1hMjA3LTEwNmEzYWEzYTZlYyIsICJf
+        Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2
+        YjRhYzAyOGFkYTQwZGIwNGVlMDlhNyJ9LCAidW5pdF9pZCI6ICJhNjc1MmIw
+        OS04NTE1LTRlOWUtYTIwNy0xMDZhM2FhM2E2ZWMiLCAidW5pdF90eXBlX2lk
+        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiYmZhNzNkZjgtMDk3
+        Yy00NTBlLTgyODQtYjA1YjRhMTJmOTdkIiwgIl9jb250ZW50X3R5cGVfaWQi
+        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMDI4YWRhNDBkYjA0
+        ZWUwOWExIn0sICJ1bml0X2lkIjogImJmYTczZGY4LTA5N2MtNDUwZS04Mjg0
+        LWIwNWI0YTEyZjk3ZCIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
+        YWRhdGEiOiB7Il9pZCI6ICJkMTkzY2I1Ny03NzQ2LTQ1Y2EtYmZjMi1jNWUz
+        ZmUzYmZhOTMiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
+        IHsiJG9pZCI6ICI1NmI0YWMwMjhhZGE0MGRiMDRlZTA5YTAifSwgInVuaXRf
+        aWQiOiAiZDE5M2NiNTctNzc0Ni00NWNhLWJmYzItYzVlM2ZlM2JmYTkzIiwg
+        InVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjog
+        ImRiMDdhZWE5LWJlZjgtNGI2Ni04OTcyLTE2ZjVlN2E1MmIxNiIsICJfY29u
+        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzAyOGFkYTQwZGIwNGVlMDlhMyJ9LCAidW5pdF9pZCI6ICJkYjA3YWVhOS1i
+        ZWY4LTRiNjYtODk3Mi0xNmY1ZTdhNTJiMTYiLCAidW5pdF90eXBlX2lkIjog
+        InJwbSJ9XQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:51 GMT
+- request:
+    method: delete
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="oYpwGN98E6xb9ekuYUQHz90WnqwYGpq1Ggd9Dry4Dc",
+        oauth_signature="aLp8Pojxl%2F9psW0d751Lsb3oTZk%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681091", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:51 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzA3ZTJmZGYxLTM3MDMtNDZkMi1hYWI5LTcyZDMyNWQ2MTU5My8iLCAi
+        dGFza19pZCI6ICIwN2UyZmRmMS0zNzAzLTQ2ZDItYWFiOS03MmQzMjVkNjE1
+        OTMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:51 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/07e2fdf1-3703-46d2-aab9-72d325d61593/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="RdHkSrSFqrOEweJN6laBBOiAgbnXONxDvoJ009RJ5eA",
+        oauth_signature="SyMsiwfjG3vVZ5EhfBXJUG8vFdk%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681091", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:51 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wN2UyZmRmMS0zNzAzLTQ2ZDItYWFiOS03MmQzMjVkNjE1
+        OTMvIiwgInRhc2tfaWQiOiAiMDdlMmZkZjEtMzcwMy00NmQyLWFhYjktNzJk
+        MzI1ZDYxNTkzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWMw
+        MzhhZGE0MGRiMDRlZTA5YjAifSwgImlkIjogIjU2YjRhYzAzOGFkYTQwZGIw
+        NGVlMDliMCJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:51 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/07e2fdf1-3703-46d2-aab9-72d325d61593/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="iqOfYsHFZVSbHk09DNg7bNKP4DgHxFutcBTK6nfIw",
+        oauth_signature="SDe3tdx0FXu%2BJnuSi5HXwI7poAI%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681092", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:52 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wN2UyZmRmMS0zNzAzLTQ2ZDItYWFiOS03MmQzMjVkNjE1
+        OTMvIiwgInRhc2tfaWQiOiAiMDdlMmZkZjEtMzcwMy00NmQyLWFhYjktNzJk
+        MzI1ZDYxNTkzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA0OjUyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA0OjUyWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjMDM4YWRhNDBkYjA0ZWUwOWIwIn0sICJpZCI6ICI1NmI0YWMwMzhhZGE0
+        MGRiMDRlZTA5YjAifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:52 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/actions/pulp/repository/update_schedule/disable_schedule.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp/repository/update_schedule/disable_schedule.yml
@@ -75,163 +75,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:10 GMT
 - request:
-    method: get
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="SYvxTfjdRTuWnqDjNhC3I21dZLkhdBsiyoVMcTeEw",
-        oauth_signature="HIybHaDHZ7V1iB6RUQ2RT5F8H70%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628850", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:10 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '2'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W10=
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:10 GMT
-- request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY2hlZHVsZSI6IlIxLzAzMC0wMS0wMVQwNTowMDowMFovUDFEIn0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="sWz45F6gS2coRMTp3Apa4qnKwDTxWvA3vyM57sDWwAU", oauth_signature="nHTtc97jizcYyMxbqNkIkGKC4WU%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628850", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '41'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:10 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Location:
-      - "/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56b3dff284a09c0706343226/"
-      Content-Length:
-      - '599'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJuZXh0X3J1biI6ICIyMDE2LTAyLTA0VDIzOjM0OjEwWiIsICJyZW1haW5p
-        bmdfcnVucyI6IDEsICJsYXN0X3VwZGF0ZWQiOiAxNDU0NjI4ODUwLjQ1ODk5
-        NSwgImZpcnN0X3J1biI6ICIwMzAxLTAxLTAxVDA1OjAwOjAwWiIsICJ0b3Rh
-        bF9ydW5fY291bnQiOiAwLCAic2NoZWR1bGUiOiAiUjEvMDMwLTAxLTAxVDA1
-        OjAwOjAwWi9QMUQiLCAia3dhcmdzIjogeyJvdmVycmlkZXMiOiB7fX0sICJh
-        cmdzIjogWyJGZWRvcmFfMTciXSwgImVuYWJsZWQiOiB0cnVlLCAibGFzdF9y
-        dW5fYXQiOiBudWxsLCAidGFzayI6ICJwdWxwLnNlcnZlci50YXNrcy5yZXBv
-        c2l0b3J5LnN5bmNfd2l0aF9hdXRvX3B1Ymxpc2giLCAiZmFpbHVyZV90aHJl
-        c2hvbGQiOiBudWxsLCAicmVzb3VyY2UiOiAicHVscDppbXBvcnRlcjpGZWRv
-        cmFfMTc6eXVtX2ltcG9ydGVyIiwgIl9pZCI6ICI1NmIzZGZmMjg0YTA5YzA3
-        MDYzNDMyMjYiLCAiY29uc2VjdXRpdmVfZmFpbHVyZXMiOiAwLCAiX2hyZWYi
-        OiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvaW1wb3J0
-        ZXJzL3l1bV9pbXBvcnRlci9zY2hlZHVsZXMvc3luYy81NmIzZGZmMjg0YTA5
-        YzA3MDYzNDMyMjYvIn0=
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:10 GMT
-- request:
-    method: get
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="6rPOZeOq01XojiMmqOk8Qf4xiCqHz5iKBdmfmvxEq4",
-        oauth_signature="2Bnz4XDZGGwAjzxgYprSII4pYhw%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628850", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:10 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '601'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W3sibmV4dF9ydW4iOiAiMjAxNi0wMi0wNFQyMzozNDoxMFoiLCAicmVtYWlu
-        aW5nX3J1bnMiOiAxLCAibGFzdF91cGRhdGVkIjogMTQ1NDYyODg1MC40NTg5
-        OTUsICJmaXJzdF9ydW4iOiAiMDMwMS0wMS0wMVQwNTowMDowMFoiLCAidG90
-        YWxfcnVuX2NvdW50IjogMCwgInNjaGVkdWxlIjogIlIxLzAzMC0wMS0wMVQw
-        NTowMDowMFovUDFEIiwgImt3YXJncyI6IHsib3ZlcnJpZGVzIjoge319LCAi
-        YXJncyI6IFsiRmVkb3JhXzE3Il0sICJlbmFibGVkIjogdHJ1ZSwgImxhc3Rf
-        cnVuX2F0IjogbnVsbCwgInRhc2siOiAicHVscC5zZXJ2ZXIudGFza3MucmVw
-        b3NpdG9yeS5zeW5jX3dpdGhfYXV0b19wdWJsaXNoIiwgImZhaWx1cmVfdGhy
-        ZXNob2xkIjogbnVsbCwgInJlc291cmNlIjogInB1bHA6aW1wb3J0ZXI6RmVk
-        b3JhXzE3Onl1bV9pbXBvcnRlciIsICJfaWQiOiAiNTZiM2RmZjI4NGEwOWMw
-        NzA2MzQzMjI2IiwgImNvbnNlY3V0aXZlX2ZhaWx1cmVzIjogMCwgIl9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvRmVkb3JhXzE3L2ltcG9y
-        dGVycy95dW1faW1wb3J0ZXIvc2NoZWR1bGVzL3N5bmMvNTZiM2RmZjI4NGEw
-        OWMwNzA2MzQzMjI2LyJ9XQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:10 GMT
-- request:
     method: put
     uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56b3dff284a09c0706343226/
     body:
@@ -287,108 +130,6 @@ http_interactions:
         IjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvRmVkb3JhXzE3L2ltcG9y
         dGVycy95dW1faW1wb3J0ZXIvc2NoZWR1bGVzL3N5bmMvNTZiM2RmZjI4NGEw
         OWMwNzA2MzQzMjI2LyJ9
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:10 GMT
-- request:
-    method: get
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="AkX0eGbEFARaRxg1rq2cKRHYrR01Fc8pQgCWV5ggTc",
-        oauth_signature="cXZqMS7%2B8SVAnIJiaehPsXjkqS4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628850", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:10 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '602'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W3sibmV4dF9ydW4iOiAiMjAxNi0wMi0wNFQyMzozNDoxMFoiLCAicmVtYWlu
-        aW5nX3J1bnMiOiAxLCAibGFzdF91cGRhdGVkIjogMTQ1NDYyODg1MC42MDE0
-        NjUsICJmaXJzdF9ydW4iOiAiMDMwMS0wMS0wMVQwNTowMDowMFoiLCAidG90
-        YWxfcnVuX2NvdW50IjogMCwgInNjaGVkdWxlIjogIlIxLzAzMC0wMS0wMVQw
-        NTowMDowMFovUDFEIiwgImt3YXJncyI6IHsib3ZlcnJpZGVzIjoge319LCAi
-        YXJncyI6IFsiRmVkb3JhXzE3Il0sICJlbmFibGVkIjogZmFsc2UsICJsYXN0
-        X3J1bl9hdCI6IG51bGwsICJ0YXNrIjogInB1bHAuc2VydmVyLnRhc2tzLnJl
-        cG9zaXRvcnkuc3luY193aXRoX2F1dG9fcHVibGlzaCIsICJmYWlsdXJlX3Ro
-        cmVzaG9sZCI6IG51bGwsICJyZXNvdXJjZSI6ICJwdWxwOmltcG9ydGVyOkZl
-        ZG9yYV8xNzp5dW1faW1wb3J0ZXIiLCAiX2lkIjogIjU2YjNkZmYyODRhMDlj
-        MDcwNjM0MzIyNiIsICJjb25zZWN1dGl2ZV9mYWlsdXJlcyI6IDAsICJfaHJl
-        ZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy9pbXBv
-        cnRlcnMveXVtX2ltcG9ydGVyL3NjaGVkdWxlcy9zeW5jLzU2YjNkZmYyODRh
-        MDljMDcwNjM0MzIyNi8ifV0=
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:10 GMT
-- request:
-    method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="njtgAZonYKFKj1NO187ctWe7BJKQSR9JdjPlJ9lcY",
-        oauth_signature="z9dwAhVSSHNyinXGjFOPumbUikk%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628850", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:10 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzJjMmM3MzQ2LTNjOTMtNDQ0Ny04NWU4LTAxY2VlZjNlNGVmYy8iLCAi
-        dGFza19pZCI6ICIyYzJjNzM0Ni0zYzkzLTQ0NDctODVlOC0wMWNlZWYzZTRl
-        ZmMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:10 GMT
 - request:
@@ -503,4 +244,515 @@ http_interactions:
         N2RiZjRkOGEwIn0=
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:11 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
+        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
+        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
+        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
+        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
+        LXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1
+        dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9j
+        b25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIiwiaHR0cCI6ZmFs
+        c2UsImh0dHBzIjp0cnVlLCJwcm90ZWN0ZWQiOnRydWV9LCJhdXRvX3B1Ymxp
+        c2giOnRydWUsImRpc3RyaWJ1dG9yX2lkIjoiRmVkb3JhXzE3In0seyJkaXN0
+        cmlidXRvcl90eXBlX2lkIjoieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwiZGlz
+        dHJpYnV0b3JfY29uZmlnIjp7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lk
+        IjoiRmVkb3JhXzE3In0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1
+        dG9yX2lkIjoiRmVkb3JhXzE3X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBl
+        X2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmln
+        Ijp7Imh0dHAiOmZhbHNlLCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6
+        bnVsbH0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoi
+        ZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="dbPeRdjtyf6uVGpmS8qjbl2ZZmMKYihPkao6s2ZrpA", oauth_signature="aBgNDlpONDn0dyOQvd1ktNuG3qE%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681093", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '787'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:53 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '320'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
+        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
+        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NTZiNGFjMDVjNzgyMWIzMzA1Y2U1MGYxIn0sICJpZCI6ICJGZWRvcmFfMTci
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
+        MTcvIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:53 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="dfwoVcKRS7Qgua8w0CsHNuMT7KdwPUr3hsGoKHTiWis",
+        oauth_signature="EOEfScvVQaz8Kk3SfirXIh3yqO4%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681093", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:53 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '2'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        W10=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:53 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY2hlZHVsZSI6IlIxLzAzMC0wMS0wMVQwNTowMDowMFovUDFEIn0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="UqcG7vaAl6bQUrOrz14nNA7fQ6YFAeypMXrJz78O4a8", oauth_signature="1ZAlP7kgOg2SGWoVr3PbubNo9Fo%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681093", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '41'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:53 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '660'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56b4ac05c7821b3305ce50f7/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuZXh0X3J1biI6ICIyMDE2LTAyLTA1VDE0OjA0OjUzWiIsICJyZW1haW5p
+        bmdfcnVucyI6IDEsICJsYXN0X3VwZGF0ZWQiOiAxNDU0NjgxMDkzLjgxMzY2
+        NiwgImZpcnN0X3J1biI6ICIwMzAxLTAxLTAxVDA1OjAwOjAwWiIsICJ0b3Rh
+        bF9ydW5fY291bnQiOiAwLCAic2NoZWR1bGUiOiAiUjEvMDMwLTAxLTAxVDA1
+        OjAwOjAwWi9QMUQiLCAia3dhcmdzIjogeyJvdmVycmlkZXMiOiB7fSwgInNj
+        aGVkdWxlZF9jYWxsX2lkIjogIjU2YjRhYzA1Yzc4MjFiMzMwNWNlNTBmNyJ9
+        LCAiYXJncyI6IFsiRmVkb3JhXzE3Il0sICJlbmFibGVkIjogdHJ1ZSwgImxh
+        c3RfcnVuX2F0IjogbnVsbCwgInRhc2siOiAicHVscC5zZXJ2ZXIuY29udHJv
+        bGxlcnMucmVwb3NpdG9yeS5xdWV1ZV9zeW5jX3dpdGhfYXV0b19wdWJsaXNo
+        IiwgImZhaWx1cmVfdGhyZXNob2xkIjogbnVsbCwgInJlc291cmNlIjogInB1
+        bHA6aW1wb3J0ZXI6RmVkb3JhXzE3Onl1bV9pbXBvcnRlciIsICJfaWQiOiAi
+        NTZiNGFjMDVjNzgyMWIzMzA1Y2U1MGY3IiwgImNvbnNlY3V0aXZlX2ZhaWx1
+        cmVzIjogMCwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
+        RmVkb3JhXzE3L2ltcG9ydGVycy95dW1faW1wb3J0ZXIvc2NoZWR1bGVzL3N5
+        bmMvNTZiNGFjMDVjNzgyMWIzMzA1Y2U1MGY3LyJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:53 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="FtSlEVZZ8ObdjpQO2QAID55bhCn9gCJWIb29F8wdz8Q",
+        oauth_signature="bMbR1Evw0O%2Bl2whY12IB8tDfr%2B8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681094", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:54 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '662'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibmV4dF9ydW4iOiAiMjAxNi0wMi0wNVQxNDowNDo1NFoiLCAicmVtYWlu
+        aW5nX3J1bnMiOiAxLCAibGFzdF91cGRhdGVkIjogMTQ1NDY4MTA5My44MTM2
+        NjYsICJmaXJzdF9ydW4iOiAiMDMwMS0wMS0wMVQwNTowMDowMFoiLCAidG90
+        YWxfcnVuX2NvdW50IjogMCwgInNjaGVkdWxlIjogIlIxLzAzMC0wMS0wMVQw
+        NTowMDowMFovUDFEIiwgImt3YXJncyI6IHsib3ZlcnJpZGVzIjoge30sICJz
+        Y2hlZHVsZWRfY2FsbF9pZCI6ICI1NmI0YWMwNWM3ODIxYjMzMDVjZTUwZjci
+        fSwgImFyZ3MiOiBbIkZlZG9yYV8xNyJdLCAiZW5hYmxlZCI6IHRydWUsICJs
+        YXN0X3J1bl9hdCI6IG51bGwsICJ0YXNrIjogInB1bHAuc2VydmVyLmNvbnRy
+        b2xsZXJzLnJlcG9zaXRvcnkucXVldWVfc3luY193aXRoX2F1dG9fcHVibGlz
+        aCIsICJmYWlsdXJlX3RocmVzaG9sZCI6IG51bGwsICJyZXNvdXJjZSI6ICJw
+        dWxwOmltcG9ydGVyOkZlZG9yYV8xNzp5dW1faW1wb3J0ZXIiLCAiX2lkIjog
+        IjU2YjRhYzA1Yzc4MjFiMzMwNWNlNTBmNyIsICJjb25zZWN1dGl2ZV9mYWls
+        dXJlcyI6IDAsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVz
+        L0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyL3NjaGVkdWxlcy9z
+        eW5jLzU2YjRhYzA1Yzc4MjFiMzMwNWNlNTBmNy8ifV0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:54 GMT
+- request:
+    method: put
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56b4ac05c7821b3305ce50f7/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJlbmFibGVkIjpmYWxzZX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="6mAWX3u6U3XdHQrI4bEsSxNmaddrxVdQzrDbrAtI4", oauth_signature="haStdtyUm%2FtB0p4FFpggAgDbz%2FA%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681094", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '17'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:54 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '661'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJuZXh0X3J1biI6ICIyMDE2LTAyLTA1VDE0OjA0OjU0WiIsICJyZW1haW5p
+        bmdfcnVucyI6IDEsICJsYXN0X3VwZGF0ZWQiOiAxNDU0NjgxMDk0LjEyODQ4
+        NCwgImZpcnN0X3J1biI6ICIwMzAxLTAxLTAxVDA1OjAwOjAwWiIsICJ0b3Rh
+        bF9ydW5fY291bnQiOiAwLCAic2NoZWR1bGUiOiAiUjEvMDMwLTAxLTAxVDA1
+        OjAwOjAwWi9QMUQiLCAia3dhcmdzIjogeyJvdmVycmlkZXMiOiB7fSwgInNj
+        aGVkdWxlZF9jYWxsX2lkIjogIjU2YjRhYzA1Yzc4MjFiMzMwNWNlNTBmNyJ9
+        LCAiYXJncyI6IFsiRmVkb3JhXzE3Il0sICJlbmFibGVkIjogZmFsc2UsICJs
+        YXN0X3J1bl9hdCI6IG51bGwsICJ0YXNrIjogInB1bHAuc2VydmVyLmNvbnRy
+        b2xsZXJzLnJlcG9zaXRvcnkucXVldWVfc3luY193aXRoX2F1dG9fcHVibGlz
+        aCIsICJmYWlsdXJlX3RocmVzaG9sZCI6IG51bGwsICJyZXNvdXJjZSI6ICJw
+        dWxwOmltcG9ydGVyOkZlZG9yYV8xNzp5dW1faW1wb3J0ZXIiLCAiX2lkIjog
+        IjU2YjRhYzA1Yzc4MjFiMzMwNWNlNTBmNyIsICJjb25zZWN1dGl2ZV9mYWls
+        dXJlcyI6IDAsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVz
+        L0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyL3NjaGVkdWxlcy9z
+        eW5jLzU2YjRhYzA1Yzc4MjFiMzMwNWNlNTBmNy8ifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:54 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="h4D5lATNJ7845OVmLGnznBWMWF6BerI9UYtz4ORf0",
+        oauth_signature="5DTFOe0CxTL0X6cG6LSlJMu7ILg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681094", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:54 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '663'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibmV4dF9ydW4iOiAiMjAxNi0wMi0wNVQxNDowNDo1NFoiLCAicmVtYWlu
+        aW5nX3J1bnMiOiAxLCAibGFzdF91cGRhdGVkIjogMTQ1NDY4MTA5NC4xMjg0
+        ODQsICJmaXJzdF9ydW4iOiAiMDMwMS0wMS0wMVQwNTowMDowMFoiLCAidG90
+        YWxfcnVuX2NvdW50IjogMCwgInNjaGVkdWxlIjogIlIxLzAzMC0wMS0wMVQw
+        NTowMDowMFovUDFEIiwgImt3YXJncyI6IHsib3ZlcnJpZGVzIjoge30sICJz
+        Y2hlZHVsZWRfY2FsbF9pZCI6ICI1NmI0YWMwNWM3ODIxYjMzMDVjZTUwZjci
+        fSwgImFyZ3MiOiBbIkZlZG9yYV8xNyJdLCAiZW5hYmxlZCI6IGZhbHNlLCAi
+        bGFzdF9ydW5fYXQiOiBudWxsLCAidGFzayI6ICJwdWxwLnNlcnZlci5jb250
+        cm9sbGVycy5yZXBvc2l0b3J5LnF1ZXVlX3N5bmNfd2l0aF9hdXRvX3B1Ymxp
+        c2giLCAiZmFpbHVyZV90aHJlc2hvbGQiOiBudWxsLCAicmVzb3VyY2UiOiAi
+        cHVscDppbXBvcnRlcjpGZWRvcmFfMTc6eXVtX2ltcG9ydGVyIiwgIl9pZCI6
+        ICI1NmI0YWMwNWM3ODIxYjMzMDVjZTUwZjciLCAiY29uc2VjdXRpdmVfZmFp
+        bHVyZXMiOiAwLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
+        cy9GZWRvcmFfMTcvaW1wb3J0ZXJzL3l1bV9pbXBvcnRlci9zY2hlZHVsZXMv
+        c3luYy81NmI0YWMwNWM3ODIxYjMzMDVjZTUwZjcvIn1d
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:54 GMT
+- request:
+    method: delete
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="1TtMEsWRWPFfwbGUxZM1hyBvvqViwy0Tm0pQyqRxY",
+        oauth_signature="1FnuaF7fkZLT8Zm9rzBX1DdMoBQ%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681094", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:54 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2MyYjlkNTI4LTA5YWItNGRlNi1iYWJlLTc2MmFmN2EwNDc2OC8iLCAi
+        dGFza19pZCI6ICJjMmI5ZDUyOC0wOWFiLTRkZTYtYmFiZS03NjJhZjdhMDQ3
+        NjgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:54 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/c2b9d528-09ab-4de6-babe-762af7a04768/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="cwPLhrkAhdjkk6rHB9jaaE2PhVra9V0qsqRRdoH5Y",
+        oauth_signature="1qjwR5zSAPJWCzHX85gTN8S6N48%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681094", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:54 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jMmI5ZDUyOC0wOWFiLTRkZTYtYmFiZS03NjJhZjdhMDQ3
+        NjgvIiwgInRhc2tfaWQiOiAiYzJiOWQ1MjgtMDlhYi00ZGU2LWJhYmUtNzYy
+        YWY3YTA0NzY4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWMw
+        NjhhZGE0MGRiMDRlZTA5YjEifSwgImlkIjogIjU2YjRhYzA2OGFkYTQwZGIw
+        NGVlMDliMSJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:54 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/c2b9d528-09ab-4de6-babe-762af7a04768/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="sYvgd4sWAL5Xm1PFtoGwQk9jD2nHyFCbY4gUZrY",
+        oauth_signature="88MCUypWwSUFx2R9PIPznnl7huM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681095", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:55 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jMmI5ZDUyOC0wOWFiLTRkZTYtYmFiZS03NjJhZjdhMDQ3
+        NjgvIiwgInRhc2tfaWQiOiAiYzJiOWQ1MjgtMDlhYi00ZGU2LWJhYmUtNzYy
+        YWY3YTA0NzY4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA0OjU0WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA0OjU0WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjMDY4YWRhNDBkYjA0ZWUwOWIxIn0sICJpZCI6ICI1NmI0YWMwNjhhZGE0
+        MGRiMDRlZTA5YjEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:55 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/actions/pulp/repository/update_schedule/update_schedule.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp/repository/update_schedule/update_schedule.yml
@@ -75,163 +75,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:12 GMT
 - request:
-    method: get
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="YAL039u1BsmKaqgmsLJd69qCnMKARttEqKFaOVm8Hno",
-        oauth_signature="yRPKxaHcSvI56OmVGOAaFv87im0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628852", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:12 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '2'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W10=
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:12 GMT
-- request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY2hlZHVsZSI6IlIxLzAzMC0wMS0wMVQwNTowMDowMFovUDFEIn0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="wkFvsD3bwRJfbb5eXcXmLa0Ti9o5oHb0gzkCO51Jx4", oauth_signature="SdDdU63W72OEwT1MROjNUVNgfxs%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628852", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '41'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:12 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Location:
-      - "/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56b3dff484a09c070634323c/"
-      Content-Length:
-      - '599'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJuZXh0X3J1biI6ICIyMDE2LTAyLTA0VDIzOjM0OjEyWiIsICJyZW1haW5p
-        bmdfcnVucyI6IDEsICJsYXN0X3VwZGF0ZWQiOiAxNDU0NjI4ODUyLjE4MDY5
-        NCwgImZpcnN0X3J1biI6ICIwMzAxLTAxLTAxVDA1OjAwOjAwWiIsICJ0b3Rh
-        bF9ydW5fY291bnQiOiAwLCAic2NoZWR1bGUiOiAiUjEvMDMwLTAxLTAxVDA1
-        OjAwOjAwWi9QMUQiLCAia3dhcmdzIjogeyJvdmVycmlkZXMiOiB7fX0sICJh
-        cmdzIjogWyJGZWRvcmFfMTciXSwgImVuYWJsZWQiOiB0cnVlLCAibGFzdF9y
-        dW5fYXQiOiBudWxsLCAidGFzayI6ICJwdWxwLnNlcnZlci50YXNrcy5yZXBv
-        c2l0b3J5LnN5bmNfd2l0aF9hdXRvX3B1Ymxpc2giLCAiZmFpbHVyZV90aHJl
-        c2hvbGQiOiBudWxsLCAicmVzb3VyY2UiOiAicHVscDppbXBvcnRlcjpGZWRv
-        cmFfMTc6eXVtX2ltcG9ydGVyIiwgIl9pZCI6ICI1NmIzZGZmNDg0YTA5YzA3
-        MDYzNDMyM2MiLCAiY29uc2VjdXRpdmVfZmFpbHVyZXMiOiAwLCAiX2hyZWYi
-        OiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvaW1wb3J0
-        ZXJzL3l1bV9pbXBvcnRlci9zY2hlZHVsZXMvc3luYy81NmIzZGZmNDg0YTA5
-        YzA3MDYzNDMyM2MvIn0=
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:12 GMT
-- request:
-    method: get
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="CH2S7uQPSKMEhXSSHp3EAYYPyWcRIAVgxZyeAxL6Yjo",
-        oauth_signature="IAmZVsTsToPUHVfuUlY2spMHfqc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628852", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:12 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '601'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W3sibmV4dF9ydW4iOiAiMjAxNi0wMi0wNFQyMzozNDoxMloiLCAicmVtYWlu
-        aW5nX3J1bnMiOiAxLCAibGFzdF91cGRhdGVkIjogMTQ1NDYyODg1Mi4xODA2
-        OTQsICJmaXJzdF9ydW4iOiAiMDMwMS0wMS0wMVQwNTowMDowMFoiLCAidG90
-        YWxfcnVuX2NvdW50IjogMCwgInNjaGVkdWxlIjogIlIxLzAzMC0wMS0wMVQw
-        NTowMDowMFovUDFEIiwgImt3YXJncyI6IHsib3ZlcnJpZGVzIjoge319LCAi
-        YXJncyI6IFsiRmVkb3JhXzE3Il0sICJlbmFibGVkIjogdHJ1ZSwgImxhc3Rf
-        cnVuX2F0IjogbnVsbCwgInRhc2siOiAicHVscC5zZXJ2ZXIudGFza3MucmVw
-        b3NpdG9yeS5zeW5jX3dpdGhfYXV0b19wdWJsaXNoIiwgImZhaWx1cmVfdGhy
-        ZXNob2xkIjogbnVsbCwgInJlc291cmNlIjogInB1bHA6aW1wb3J0ZXI6RmVk
-        b3JhXzE3Onl1bV9pbXBvcnRlciIsICJfaWQiOiAiNTZiM2RmZjQ4NGEwOWMw
-        NzA2MzQzMjNjIiwgImNvbnNlY3V0aXZlX2ZhaWx1cmVzIjogMCwgIl9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvRmVkb3JhXzE3L2ltcG9y
-        dGVycy95dW1faW1wb3J0ZXIvc2NoZWR1bGVzL3N5bmMvNTZiM2RmZjQ4NGEw
-        OWMwNzA2MzQzMjNjLyJ9XQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:12 GMT
-- request:
     method: put
     uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56b3dff484a09c070634323c/
     body:
@@ -287,108 +130,6 @@ http_interactions:
         ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy9pbXBvcnRl
         cnMveXVtX2ltcG9ydGVyL3NjaGVkdWxlcy9zeW5jLzU2YjNkZmY0ODRhMDlj
         MDcwNjM0MzIzYy8ifQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:12 GMT
-- request:
-    method: get
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="9QWLACC93u5YUiDbvFPcyp7sz38kT2Cx9MQ6dnTYFVk",
-        oauth_signature="YAb4jAB2k3kXOEqF9v1V09OQxUo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628852", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:12 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '600'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W3sibmV4dF9ydW4iOiAiMjAxNi0wMi0wNFQyMzozNDoxMloiLCAicmVtYWlu
-        aW5nX3J1bnMiOiAxLCAibGFzdF91cGRhdGVkIjogMTQ1NDYyODg1Mi4zMTg1
-        NCwgImZpcnN0X3J1biI6ICIwMzAxLTAxLTAxVDA1OjAwOjAwWiIsICJ0b3Rh
-        bF9ydW5fY291bnQiOiAwLCAic2NoZWR1bGUiOiAiUjEvMDMwLTAxLTAxVDA1
-        OjAwOjAwWi9QMUQiLCAia3dhcmdzIjogeyJvdmVycmlkZXMiOiB7fX0sICJh
-        cmdzIjogWyJGZWRvcmFfMTciXSwgImVuYWJsZWQiOiB0cnVlLCAibGFzdF9y
-        dW5fYXQiOiBudWxsLCAidGFzayI6ICJwdWxwLnNlcnZlci50YXNrcy5yZXBv
-        c2l0b3J5LnN5bmNfd2l0aF9hdXRvX3B1Ymxpc2giLCAiZmFpbHVyZV90aHJl
-        c2hvbGQiOiBudWxsLCAicmVzb3VyY2UiOiAicHVscDppbXBvcnRlcjpGZWRv
-        cmFfMTc6eXVtX2ltcG9ydGVyIiwgIl9pZCI6ICI1NmIzZGZmNDg0YTA5YzA3
-        MDYzNDMyM2MiLCAiY29uc2VjdXRpdmVfZmFpbHVyZXMiOiAwLCAiX2hyZWYi
-        OiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvaW1wb3J0
-        ZXJzL3l1bV9pbXBvcnRlci9zY2hlZHVsZXMvc3luYy81NmIzZGZmNDg0YTA5
-        YzA3MDYzNDMyM2MvIn1d
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:12 GMT
-- request:
-    method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="mKq18zy0a2GKmqywAtFpBhMHBTyUkx905SX000QeCo",
-        oauth_signature="Za9SyUxQae6ord4X8a2e%2FwIEi8c%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628852", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:12 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzM3NDM0NDA3LTAyZjAtNDY4My05ZWMyLTU0OTc1N2RiNDc2OS8iLCAi
-        dGFza19pZCI6ICIzNzQzNDQwNy0wMmYwLTQ2ODMtOWVjMi01NDk3NTdkYjQ3
-        NjkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:12 GMT
 - request:
@@ -501,4 +242,517 @@ http_interactions:
         N2RiZjRkOGE3In0=
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:13 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
+        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
+        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
+        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
+        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
+        LXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1
+        dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9j
+        b25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIiwiaHR0cCI6ZmFs
+        c2UsImh0dHBzIjp0cnVlLCJwcm90ZWN0ZWQiOnRydWV9LCJhdXRvX3B1Ymxp
+        c2giOnRydWUsImRpc3RyaWJ1dG9yX2lkIjoiRmVkb3JhXzE3In0seyJkaXN0
+        cmlidXRvcl90eXBlX2lkIjoieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwiZGlz
+        dHJpYnV0b3JfY29uZmlnIjp7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lk
+        IjoiRmVkb3JhXzE3In0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1
+        dG9yX2lkIjoiRmVkb3JhXzE3X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBl
+        X2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmln
+        Ijp7Imh0dHAiOmZhbHNlLCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6
+        bnVsbH0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoi
+        ZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="TXdLhZRB7dMevK67nvDPqFKa6OmrgwAo80VEaduAbw", oauth_signature="IuP4rsCT%2BQW7zjSZr6Mv6E3%2FcXU%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681095", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '787'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:55 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '320'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
+        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
+        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NTZiNGFjMDdjNzgyMWIzMzAzNGJhZTA4In0sICJpZCI6ICJGZWRvcmFfMTci
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
+        MTcvIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:55 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="C1vpSMIDcNbuH9otvl0Rrx30pxTHMjFGViH1YBY0",
+        oauth_signature="R8qxlAzjceS7v%2F1B3OXgeXhEYHA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681096", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '2'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        W10=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:56 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY2hlZHVsZSI6IlIxLzAzMC0wMS0wMVQwNTowMDowMFovUDFEIn0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="23MSV7oMPV30W7qStsbSpAvSG5Lm41hQ3UiJdM2ic", oauth_signature="gmXlDIXSaA6%2FuWfFBCvARTmgU%2BA%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681096", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '41'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '660'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56b4ac08c7821b33034bae0e/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuZXh0X3J1biI6ICIyMDE2LTAyLTA1VDE0OjA0OjU2WiIsICJyZW1haW5p
+        bmdfcnVucyI6IDEsICJsYXN0X3VwZGF0ZWQiOiAxNDU0NjgxMDk2LjMwNjI0
+        MywgImZpcnN0X3J1biI6ICIwMzAxLTAxLTAxVDA1OjAwOjAwWiIsICJ0b3Rh
+        bF9ydW5fY291bnQiOiAwLCAic2NoZWR1bGUiOiAiUjEvMDMwLTAxLTAxVDA1
+        OjAwOjAwWi9QMUQiLCAia3dhcmdzIjogeyJvdmVycmlkZXMiOiB7fSwgInNj
+        aGVkdWxlZF9jYWxsX2lkIjogIjU2YjRhYzA4Yzc4MjFiMzMwMzRiYWUwZSJ9
+        LCAiYXJncyI6IFsiRmVkb3JhXzE3Il0sICJlbmFibGVkIjogdHJ1ZSwgImxh
+        c3RfcnVuX2F0IjogbnVsbCwgInRhc2siOiAicHVscC5zZXJ2ZXIuY29udHJv
+        bGxlcnMucmVwb3NpdG9yeS5xdWV1ZV9zeW5jX3dpdGhfYXV0b19wdWJsaXNo
+        IiwgImZhaWx1cmVfdGhyZXNob2xkIjogbnVsbCwgInJlc291cmNlIjogInB1
+        bHA6aW1wb3J0ZXI6RmVkb3JhXzE3Onl1bV9pbXBvcnRlciIsICJfaWQiOiAi
+        NTZiNGFjMDhjNzgyMWIzMzAzNGJhZTBlIiwgImNvbnNlY3V0aXZlX2ZhaWx1
+        cmVzIjogMCwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
+        RmVkb3JhXzE3L2ltcG9ydGVycy95dW1faW1wb3J0ZXIvc2NoZWR1bGVzL3N5
+        bmMvNTZiNGFjMDhjNzgyMWIzMzAzNGJhZTBlLyJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:56 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="LmFJvUW2BDafdMzjCPZ10pMUXo4wTQmtzzSDv0skg",
+        oauth_signature="GKHToVA5GHohOtk6Me4rRBBM4cM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681096", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '662'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibmV4dF9ydW4iOiAiMjAxNi0wMi0wNVQxNDowNDo1NloiLCAicmVtYWlu
+        aW5nX3J1bnMiOiAxLCAibGFzdF91cGRhdGVkIjogMTQ1NDY4MTA5Ni4zMDYy
+        NDMsICJmaXJzdF9ydW4iOiAiMDMwMS0wMS0wMVQwNTowMDowMFoiLCAidG90
+        YWxfcnVuX2NvdW50IjogMCwgInNjaGVkdWxlIjogIlIxLzAzMC0wMS0wMVQw
+        NTowMDowMFovUDFEIiwgImt3YXJncyI6IHsib3ZlcnJpZGVzIjoge30sICJz
+        Y2hlZHVsZWRfY2FsbF9pZCI6ICI1NmI0YWMwOGM3ODIxYjMzMDM0YmFlMGUi
+        fSwgImFyZ3MiOiBbIkZlZG9yYV8xNyJdLCAiZW5hYmxlZCI6IHRydWUsICJs
+        YXN0X3J1bl9hdCI6IG51bGwsICJ0YXNrIjogInB1bHAuc2VydmVyLmNvbnRy
+        b2xsZXJzLnJlcG9zaXRvcnkucXVldWVfc3luY193aXRoX2F1dG9fcHVibGlz
+        aCIsICJmYWlsdXJlX3RocmVzaG9sZCI6IG51bGwsICJyZXNvdXJjZSI6ICJw
+        dWxwOmltcG9ydGVyOkZlZG9yYV8xNzp5dW1faW1wb3J0ZXIiLCAiX2lkIjog
+        IjU2YjRhYzA4Yzc4MjFiMzMwMzRiYWUwZSIsICJjb25zZWN1dGl2ZV9mYWls
+        dXJlcyI6IDAsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVz
+        L0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyL3NjaGVkdWxlcy9z
+        eW5jLzU2YjRhYzA4Yzc4MjFiMzMwMzRiYWUwZS8ifV0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:56 GMT
+- request:
+    method: put
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56b4ac08c7821b33034bae0e/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY2hlZHVsZSI6IlIxLzAzMC0wMS0wMVQwNTowMDowMFovUDFEIn0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="235xTk9vjVpOVCU6rV13h6XcVuEJ1ioPzAcDB0NncjU", oauth_signature="oXSKIDLSz%2BnMrJA85vD9iJxR9Wk%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681096", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '41'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '660'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJuZXh0X3J1biI6ICIyMDE2LTAyLTA1VDE0OjA0OjU2WiIsICJyZW1haW5p
+        bmdfcnVucyI6IDEsICJsYXN0X3VwZGF0ZWQiOiAxNDU0NjgxMDk2LjY0ODAz
+        OSwgImZpcnN0X3J1biI6ICIwMzAxLTAxLTAxVDA1OjAwOjAwWiIsICJ0b3Rh
+        bF9ydW5fY291bnQiOiAwLCAic2NoZWR1bGUiOiAiUjEvMDMwLTAxLTAxVDA1
+        OjAwOjAwWi9QMUQiLCAia3dhcmdzIjogeyJvdmVycmlkZXMiOiB7fSwgInNj
+        aGVkdWxlZF9jYWxsX2lkIjogIjU2YjRhYzA4Yzc4MjFiMzMwMzRiYWUwZSJ9
+        LCAiYXJncyI6IFsiRmVkb3JhXzE3Il0sICJlbmFibGVkIjogdHJ1ZSwgImxh
+        c3RfcnVuX2F0IjogbnVsbCwgInRhc2siOiAicHVscC5zZXJ2ZXIuY29udHJv
+        bGxlcnMucmVwb3NpdG9yeS5xdWV1ZV9zeW5jX3dpdGhfYXV0b19wdWJsaXNo
+        IiwgImZhaWx1cmVfdGhyZXNob2xkIjogbnVsbCwgInJlc291cmNlIjogInB1
+        bHA6aW1wb3J0ZXI6RmVkb3JhXzE3Onl1bV9pbXBvcnRlciIsICJfaWQiOiAi
+        NTZiNGFjMDhjNzgyMWIzMzAzNGJhZTBlIiwgImNvbnNlY3V0aXZlX2ZhaWx1
+        cmVzIjogMCwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
+        RmVkb3JhXzE3L2ltcG9ydGVycy95dW1faW1wb3J0ZXIvc2NoZWR1bGVzL3N5
+        bmMvNTZiNGFjMDhjNzgyMWIzMzAzNGJhZTBlLyJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:56 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="HjhYJEDT2uRBbku82VAKgpl1Vvq6RWlsM7T6yI4S8",
+        oauth_signature="WjfPrU4kRlbtLcT7Fd6I%2Fpm9Mmc%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681096", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '662'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibmV4dF9ydW4iOiAiMjAxNi0wMi0wNVQxNDowNDo1NloiLCAicmVtYWlu
+        aW5nX3J1bnMiOiAxLCAibGFzdF91cGRhdGVkIjogMTQ1NDY4MTA5Ni42NDgw
+        MzksICJmaXJzdF9ydW4iOiAiMDMwMS0wMS0wMVQwNTowMDowMFoiLCAidG90
+        YWxfcnVuX2NvdW50IjogMCwgInNjaGVkdWxlIjogIlIxLzAzMC0wMS0wMVQw
+        NTowMDowMFovUDFEIiwgImt3YXJncyI6IHsib3ZlcnJpZGVzIjoge30sICJz
+        Y2hlZHVsZWRfY2FsbF9pZCI6ICI1NmI0YWMwOGM3ODIxYjMzMDM0YmFlMGUi
+        fSwgImFyZ3MiOiBbIkZlZG9yYV8xNyJdLCAiZW5hYmxlZCI6IHRydWUsICJs
+        YXN0X3J1bl9hdCI6IG51bGwsICJ0YXNrIjogInB1bHAuc2VydmVyLmNvbnRy
+        b2xsZXJzLnJlcG9zaXRvcnkucXVldWVfc3luY193aXRoX2F1dG9fcHVibGlz
+        aCIsICJmYWlsdXJlX3RocmVzaG9sZCI6IG51bGwsICJyZXNvdXJjZSI6ICJw
+        dWxwOmltcG9ydGVyOkZlZG9yYV8xNzp5dW1faW1wb3J0ZXIiLCAiX2lkIjog
+        IjU2YjRhYzA4Yzc4MjFiMzMwMzRiYWUwZSIsICJjb25zZWN1dGl2ZV9mYWls
+        dXJlcyI6IDAsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVz
+        L0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyL3NjaGVkdWxlcy9z
+        eW5jLzU2YjRhYzA4Yzc4MjFiMzMwMzRiYWUwZS8ifV0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:56 GMT
+- request:
+    method: delete
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="yc1tmYgYZozCf7Ce9DtHFdMh28LHGeNxDgZ31rHRDHs",
+        oauth_signature="JMXUz4N6V8AdphohOCO2mFhHNPk%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681096", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzUxOWNmYzQ5LTBjZTYtNGZiYi05NDlhLTEyNWY5YjdhZWE0OS8iLCAi
+        dGFza19pZCI6ICI1MTljZmM0OS0wY2U2LTRmYmItOTQ5YS0xMjVmOWI3YWVh
+        NDkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:56 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/519cfc49-0ce6-4fbb-949a-125f9b7aea49/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="KegRNOgXEBbgO4x5Q29Sj2CuXDDAwyIvbE1OHQgK2cg",
+        oauth_signature="R4tR19b%2B92nSXVnBbwWxNUFtEes%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681096", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:57 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '651'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81MTljZmM0OS0wY2U2LTRmYmItOTQ5YS0xMjVmOWI3YWVh
+        NDkvIiwgInRhc2tfaWQiOiAiNTE5Y2ZjNDktMGNlNi00ZmJiLTk0OWEtMTI1
+        ZjliN2FlYTQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAi
+        c3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
+        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1NmI0YWMwODhhZGE0MGRiMDRlZTA5YjIifSwgImlkIjogIjU2YjRh
+        YzA4OGFkYTQwZGIwNGVlMDliMiJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:57 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/519cfc49-0ce6-4fbb-949a-125f9b7aea49/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="aUTrp0yYguLah8mWjhN6O1MuA4RrFDk6kKpgxByAM",
+        oauth_signature="vSjeO%2BgHNre%2BadAiqaNXh4QUvNY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681097", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:57 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81MTljZmM0OS0wY2U2LTRmYmItOTQ5YS0xMjVmOWI3YWVh
+        NDkvIiwgInRhc2tfaWQiOiAiNTE5Y2ZjNDktMGNlNi00ZmJiLTk0OWEtMTI1
+        ZjliN2FlYTQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA0OjU3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA0OjU3WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjMDg4YWRhNDBkYjA0ZWUwOWIyIn0sICJpZCI6ICI1NmI0YWMwODhhZGE0
+        MGRiMDRlZTA5YjIifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:57 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/actions/pulp/repository/upload_file/upload_file.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp/repository/upload_file/upload_file.yml
@@ -1,198 +1,6 @@
 ---
 http_interactions:
 - request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IjQiLCJkaXNwbGF5X25hbWUiOiJQIEZvcmdlIiwiaW1wb3J0ZXJf
-        dHlwZV9pZCI6InB1cHBldF9pbXBvcnRlciIsImltcG9ydGVyX2NvbmZpZyI6
-        eyJmZWVkIjoiaHR0cDovL2RhdmlkZC5mZWRvcmFwZW9wbGUub3JnL3JlcG9z
-        L3JhbmRvbV9wdXBwZXQvIn0sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJwdXBw
-        ZXQtcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVf
-        aWQiOiJwdXBwZXRfaW5zdGFsbF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9y
-        X2NvbmZpZyI6eyJpbnN0YWxsX3BhdGgiOiIvdmFyL2xpYi9wdWxwL3B1Ymxp
-        c2hlZC9wdXBwZXRfa2F0ZWxsb190ZXN0IiwiYXV0b19wdWJsaXNoIjp0cnVl
-        fSwiYXV0b19wdWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9pZCI6IjQifSx7
-        ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJub2Rlc19odHRwX2Rpc3RyaWJ1dG9y
-        IiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7fSwiYXV0b19wdWJsaXNoIjp0cnVl
-        LCJkaXN0cmlidXRvcl9pZCI6IjRfbm9kZXMifSx7ImRpc3RyaWJ1dG9yX3R5
-        cGVfaWQiOiJwdXBwZXRfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25m
-        aWciOnsiYWJzb2x1dGVfcGF0aCI6bnVsbCwic2VydmVfaHR0cCI6ZmFsc2Us
-        InNlcnZlX2h0dHBzIjp0cnVlfSwiYXV0b19wdWJsaXNoIjp0cnVlLCJkaXN0
-        cmlidXRvcl9pZCI6IjRfcHVwcGV0In1dfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="405StV3o3KriWsJOn8yryCloEF1V19PrHhpHy87is", oauth_signature="g%2BkQhAFEByKezeXfV7TYGzfJZs0%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628853", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '700'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:13 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Location:
-      - '4'
-      Content-Length:
-      - '298'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUCBGb3JnZSIs
-        ICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRkZWQiOiBudWxs
-        LCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicHVwcGV0LXJlcG8ifSwgImxh
-        c3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3VudHMi
-        OiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNTZiM2Rm
-        ZjU4NGEwOWMwNzA2MzQzMjRiIn0sICJpZCI6ICI0IiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvNC8ifQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:13 GMT
-- request:
-    method: get
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/4/?details=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="oKhRyZlmejQaq4t4CSehxcNDiIx5NhV4knj9FuUsE4",
-        oauth_signature="GjYOvV7Ur%2BInV1R7C567fag8gSE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628853", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:13 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '1444'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUCBGb3JnZSIs
-        ICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMiOiBbeyJyZXBv
-        X2lkIjogIjQiLCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgImxhc3Rf
-        cHVibGlzaCI6IG51bGwsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAic2NoZWR1
-        bGVkX3B1Ymxpc2hlcyI6IFtdLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJw
-        dXBwZXRfZGlzdHJpYnV0b3IiLCAiX2lkIjogeyIkb2lkIjogIjU2YjNkZmY1
-        ODRhMDljMDcwNjM0MzI0ZiJ9LCAiY29uZmlnIjogeyJzZXJ2ZV9odHRwcyI6
-        IHRydWUsICJzZXJ2ZV9odHRwIjogZmFsc2V9LCAiaWQiOiAiNF9wdXBwZXQi
-        fSwgeyJyZXBvX2lkIjogIjQiLCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3Jz
-        IiwgImxhc3RfcHVibGlzaCI6IG51bGwsICJhdXRvX3B1Ymxpc2giOiB0cnVl
-        LCAic2NoZWR1bGVkX3B1Ymxpc2hlcyI6IFtdLCAiZGlzdHJpYnV0b3JfdHlw
-        ZV9pZCI6ICJub2Rlc19odHRwX2Rpc3RyaWJ1dG9yIiwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmIzZGZmNTg0YTA5YzA3MDYzNDMyNGUifSwgImNvbmZpZyI6IHt9
-        LCAiaWQiOiAiNF9ub2RlcyJ9LCB7InJlcG9faWQiOiAiNCIsICJfbnMiOiAi
-        cmVwb19kaXN0cmlidXRvcnMiLCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImF1
-        dG9fcHVibGlzaCI6IHRydWUsICJzY2hlZHVsZWRfcHVibGlzaGVzIjogW10s
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInB1cHBldF9pbnN0YWxsX2Rpc3Ry
-        aWJ1dG9yIiwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzZGZmNTg0YTA5YzA3MDYz
-        NDMyNGQifSwgImNvbmZpZyI6IHsiaW5zdGFsbF9wYXRoIjogIi92YXIvbGli
-        L3B1bHAvcHVibGlzaGVkL3B1cHBldF9rYXRlbGxvX3Rlc3QiLCAiYXV0b19w
-        dWJsaXNoIjogdHJ1ZX0sICJpZCI6ICI0In1dLCAibGFzdF91bml0X2FkZGVk
-        IjogbnVsbCwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInB1cHBldC1yZXBv
-        In0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3VuaXRf
-        Y291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiaW1wb3J0ZXJzIjogW3si
-        cmVwb19pZCI6ICI0IiwgIl9ucyI6ICJyZXBvX2ltcG9ydGVycyIsICJpbXBv
-        cnRlcl90eXBlX2lkIjogInB1cHBldF9pbXBvcnRlciIsICJsYXN0X3N5bmMi
-        OiBudWxsLCAic2NoZWR1bGVkX3N5bmNzIjogW10sICJfaWQiOiB7IiRvaWQi
-        OiAiNTZiM2RmZjU4NGEwOWMwNzA2MzQzMjRjIn0sICJjb25maWciOiB7ImZl
-        ZWQiOiAiaHR0cDovL2RhdmlkZC5mZWRvcmFwZW9wbGUub3JnL3JlcG9zL3Jh
-        bmRvbV9wdXBwZXQvIn0sICJpZCI6ICJwdXBwZXRfaW1wb3J0ZXIifV0sICJf
-        aWQiOiB7IiRvaWQiOiAiNTZiM2RmZjU4NGEwOWMwNzA2MzQzMjRiIn0sICJp
-        ZCI6ICI0IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
-        NC8ifQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:13 GMT
-- request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/4/actions/publish/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IjQiLCJvdmVycmlkZV9jb25maWciOm51bGx9
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="emmIDwwcpDO8oAsvUoRfiNYDqLIEmd5bYXb8Oy0Q", oauth_signature="91SMWBUkvV9F2cJT%2BHGT1y%2FgbLQ%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628853", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '33'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:13 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzY0NjMyNGI4LTkxMWEtNDk3My05OTEzLTU4ZjllMjQ5MDBkMS8iLCAi
-        dGFza19pZCI6ICI2NDYzMjRiOC05MTFhLTQ5NzMtOTkxMy01OGY5ZTI0OTAw
-        ZDEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:13 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/646324b8-911a-4973-9913-58f9e24900d1/
     body:
@@ -308,52 +116,6 @@ http_interactions:
         YTg2IiwgInJlc3VsdCI6ICJzdWNjZXNzIn0sICJlcnJvciI6IG51bGwsICJf
         aWQiOiB7IiRvaWQiOiAiNTZiM2RmZjU4NjgwYjVjYTVjODQyMjZlIn0sICJp
         ZCI6ICI1NmIzZGZmNTg0YTA5YzA3ZGJmNGQ4YWUifQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:14 GMT
-- request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/content/uploads/
-    body:
-      encoding: UTF-8
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="rRoBrWz9JFyKSr5T8E73CvSvlYjTDDPCMGF700woZo", oauth_signature="tHr2FzY14Q2BoRHpwfhzyL4nUE8%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628854", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:14 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Location:
-      - "/pulp/api/v2/content/uploads/51cbb084-8a6e-48dd-89a8-7437170893b1/"
-      Content-Length:
-      - '132'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ1cGxvYWRfaWQiOiAiNTFjYmIwODQtOGE2ZS00OGRkLTg5YTgtNzQzNzE3
-        MDg5M2IxIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VwbG9h
-        ZHMvNTFjYmIwODQtOGE2ZS00OGRkLTg5YTgtNzQzNzE3MDg5M2IxLyJ9
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:14 GMT
 - request:
@@ -960,104 +722,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:15 GMT
 - request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/4/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwdXBwZXRfbW9kdWxlIl0sImZp
-        ZWxkcyI6eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="cLjHA7RbNUNlGFIxiOKXrIjx2Js8irioONKozBVVYT8", oauth_signature="TAR%2FrruQCojS1VQfsNYoxCMiceQ%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628855", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '90'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '229'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIzMTRkNDU5MC1hNjk4LTQxMTQtYjA1
-        NC1mZWZjNzc5MjRiNGYiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwdXBwZXRf
-        bW9kdWxlIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiM2RmZjc4NGEwOWMwN2Rh
-        OTc5YTg4In0sICJ1bml0X2lkIjogIjMxNGQ0NTkwLWE2OTgtNDExNC1iMDU0
-        LWZlZmM3NzkyNGI0ZiIsICJ1bml0X3R5cGVfaWQiOiAicHVwcGV0X21vZHVs
-        ZSJ9XQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:15 GMT
-- request:
-    method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="YqlC1YCqsBzf9RmWtI2Nts2MjYXaylMmDEacFspUTQ",
-        oauth_signature="CO0d9W6M%2BEKKdHje22lSi4ulDs8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628855", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzg2MjM0ZDZjLWUwZGEtNDU2Ni1iZGVlLTIwMThkZWU2ODI1MC8iLCAi
-        dGFza19pZCI6ICI4NjIzNGQ2Yy1lMGRhLTQ1NjYtYmRlZS0yMDE4ZGVlNjgy
-        NTAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:15 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/86234d6c-e0da-4566-bdee-2018dee68250/
     body:
@@ -1167,4 +831,1189 @@ http_interactions:
         YyJ9
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:16 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjQiLCJkaXNwbGF5X25hbWUiOiJQIEZvcmdlIiwiaW1wb3J0ZXJf
+        dHlwZV9pZCI6InB1cHBldF9pbXBvcnRlciIsImltcG9ydGVyX2NvbmZpZyI6
+        eyJmZWVkIjoiaHR0cDovL2RhdmlkZC5mZWRvcmFwZW9wbGUub3JnL3JlcG9z
+        L3JhbmRvbV9wdXBwZXQvIn0sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJwdXBw
+        ZXQtcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVf
+        aWQiOiJwdXBwZXRfaW5zdGFsbF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9y
+        X2NvbmZpZyI6eyJpbnN0YWxsX3BhdGgiOiIvdmFyL2xpYi9wdWxwL3B1Ymxp
+        c2hlZC9wdXBwZXRfa2F0ZWxsb190ZXN0IiwiYXV0b19wdWJsaXNoIjp0cnVl
+        fSwiYXV0b19wdWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9pZCI6IjQifSx7
+        ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJub2Rlc19odHRwX2Rpc3RyaWJ1dG9y
+        IiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7fSwiYXV0b19wdWJsaXNoIjp0cnVl
+        LCJkaXN0cmlidXRvcl9pZCI6IjRfbm9kZXMifSx7ImRpc3RyaWJ1dG9yX3R5
+        cGVfaWQiOiJwdXBwZXRfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25m
+        aWciOnsiYWJzb2x1dGVfcGF0aCI6bnVsbCwic2VydmVfaHR0cCI6ZmFsc2Us
+        InNlcnZlX2h0dHBzIjp0cnVlfSwiYXV0b19wdWJsaXNoIjp0cnVlLCJkaXN0
+        cmlidXRvcl9pZCI6IjRfcHVwcGV0In1dfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="3QRz9Un0DQitvmJoB0chQ7OwtR2zMVEt7nztYyqKQ", oauth_signature="swxC%2BgzhFqBveezRQkv80gIQ6ek%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681099", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '700'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:04:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '298'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/4/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUCBGb3JnZSIs
+        ICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRkZWQiOiBudWxs
+        LCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicHVwcGV0LXJlcG8ifSwgImxh
+        c3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3VudHMi
+        OiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFj
+        MGJjNzgyMWIzMzA0MmQ5ZGNhIn0sICJpZCI6ICI0IiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvNC8ifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:04:59 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/4/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="nqj9iqIQeDiKS7An8g6rQjZ8vkWQBDBdJ5RgqHKH8w",
+        oauth_signature="zW9nb3hV%2FrYJx6p8O68tNWy2EJg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681100", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1718'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUCBGb3JnZSIs
+        ICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMiOiBbeyJyZXBv
+        X2lkIjogIjQiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
+        cy80L2Rpc3RyaWJ1dG9ycy80X3B1cHBldC8iLCAiX25zIjogInJlcG9fZGlz
+        dHJpYnV0b3JzIiwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRv
+        cl90eXBlX2lkIjogInB1cHBldF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxp
+        c2giOiB0cnVlLCAic2NyYXRjaHBhZCI6IHt9LCAiX2lkIjogeyIkb2lkIjog
+        IjU2YjRhYzBiYzc4MjFiMzMwNDJkOWRjZSJ9LCAiY29uZmlnIjogeyJzZXJ2
+        ZV9odHRwcyI6IHRydWUsICJzZXJ2ZV9odHRwIjogZmFsc2V9LCAiaWQiOiAi
+        NF9wdXBwZXQifSwgeyJyZXBvX2lkIjogIjQiLCAiX2hyZWYiOiAiL3B1bHAv
+        YXBpL3YyL3JlcG9zaXRvcmllcy80L2Rpc3RyaWJ1dG9ycy80X25vZGVzLyIs
+        ICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAibGFzdF9wdWJsaXNoIjog
+        bnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0cF9kaXN0
+        cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAic2NyYXRjaHBhZCI6
+        IHt9LCAiX2lkIjogeyIkb2lkIjogIjU2YjRhYzBiYzc4MjFiMzMwNDJkOWRj
+        ZCJ9LCAiY29uZmlnIjoge30sICJpZCI6ICI0X25vZGVzIn0sIHsicmVwb19p
+        ZCI6ICI0IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
+        NC9kaXN0cmlidXRvcnMvNC8iLCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3Jz
+        IiwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lk
+        IjogInB1cHBldF9pbnN0YWxsX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlz
+        aCI6IHRydWUsICJzY3JhdGNocGFkIjoge30sICJfaWQiOiB7IiRvaWQiOiAi
+        NTZiNGFjMGJjNzgyMWIzMzA0MmQ5ZGNjIn0sICJjb25maWciOiB7Imluc3Rh
+        bGxfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL3B1Ymxpc2hlZC9wdXBwZXRfa2F0
+        ZWxsb190ZXN0IiwgImF1dG9fcHVibGlzaCI6IHRydWV9LCAiaWQiOiAiNCJ9
+        XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3RlcyI6IHsiX3JlcG8t
+        dHlwZSI6ICJwdXBwZXQtcmVwbyJ9LCAibGFzdF91bml0X3JlbW92ZWQiOiBu
+        dWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25zIjogInJlcG9z
+        IiwgImltcG9ydGVycyI6IFt7InNjcmF0Y2hwYWQiOiBudWxsLCAiX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy80L2ltcG9ydGVycy9wdXBw
+        ZXRfaW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBvX2ltcG9ydGVycyIsICJpbXBv
+        cnRlcl90eXBlX2lkIjogInB1cHBldF9pbXBvcnRlciIsICJsYXN0X3N5bmMi
+        OiBudWxsLCAicmVwb19pZCI6ICI0IiwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0
+        YWMwYmM3ODIxYjMzMDQyZDlkY2IifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJo
+        dHRwOi8vZGF2aWRkLmZlZG9yYXBlb3BsZS5vcmcvcmVwb3MvcmFuZG9tX3B1
+        cHBldC8ifSwgImlkIjogInB1cHBldF9pbXBvcnRlciJ9XSwgImxvY2FsbHlf
+        c3RvcmVkX3VuaXRzIjogMCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWMwYmM3
+        ODIxYjMzMDQyZDlkY2EifSwgInRvdGFsX3JlcG9zaXRvcnlfdW5pdHMiOiAw
+        LCAiaWQiOiAiNCIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9y
+        aWVzLzQvIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:00 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/4/actions/publish/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjQiLCJvdmVycmlkZV9jb25maWciOm51bGx9
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="KBTPu38aQQBpR4aEdRZ70afLoj0u6Rl35dkOexGLg", oauth_signature="zVB8x1NwRm7HK%2BRlYEAHxtDJ5t4%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681100", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '33'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzk2MTExMGEzLWQ0NTYtNDUyZS05ZWEzLThlYTk5NzhkNGNhNi8iLCAi
+        dGFza19pZCI6ICI5NjExMTBhMy1kNDU2LTQ1MmUtOWVhMy04ZWE5OTc4ZDRj
+        YTYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:00 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/961110a3-d456-452e-9ea3-8ea9978d4ca6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="KYO6LaUSkRpIXT3SE9tVwQuuP2SOirnSTmMVznillI",
+        oauth_signature="0MIGaiakQcNMv2sEBS62%2B%2Bi7Hao%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681100", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '548'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy85NjExMTBhMy1kNDU2LTQ1MmUtOWVhMy04ZWE5
+        OTc4ZDRjYTYvIiwgInRhc2tfaWQiOiAiOTYxMTEwYTMtZDQ1Ni00NTJlLTll
+        YTMtOGVhOTk3OGQ0Y2E2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0
+        IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogbnVs
+        bCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogbnVsbCwg
+        InRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9n
+        cmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIk5vbmUuZHEiLCAic3RhdGUi
+        OiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6IG51bGwsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhYzBj
+        OGFkYTQwZGIwNGVlMDliMyJ9LCAiaWQiOiAiNTZiNGFjMGM4YWRhNDBkYjA0
+        ZWUwOWIzIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:00 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/961110a3-d456-452e-9ea3-8ea9978d4ca6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="fIONymTlN9r0Ks8z10TvcJHRTa2PYJQh1NYcjBa32mk",
+        oauth_signature="ABQt6bfEiTjDSSAf%2FY1jBoQ9RoE%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681100", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1068'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy85NjExMTBhMy1kNDU2LTQ1MmUtOWVhMy04ZWE5
+        OTc4ZDRjYTYvIiwgInRhc2tfaWQiOiAiOTYxMTEwYTMtZDQ1Ni00NTJlLTll
+        YTMtOGVhOTk3OGQ0Y2E2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0
+        IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogIjIw
+        MTYtMDItMDVUMTQ6MDU6MDBaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
+        dGFydF90aW1lIjogIjIwMTYtMDItMDVUMTQ6MDU6MDBaIiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBv
+        cnQiOiB7fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
+        QGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJm
+        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0
+        IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAi
+        cmVwb19pZCI6ICI0IiwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNTow
+        MFoiLCAiX25zIjogInJlcG9fcHVibGlzaF9yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDE2LTAyLTA1VDE0OjA1OjAwWiIsICJ0cmFjZWJhY2siOiBudWxs
+        LCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJwdXBwZXRfaW5zdGFsbF9kaXN0
+        cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2Nlc3MiLCAiZXJyb3JfbWVzc2Fn
+        ZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICI0IiwgImlkIjogIjU2YjRh
+        YzBjYzc4MjFiMzQ0NGZjYzI1MSIsICJkZXRhaWxzIjogeyJlcnJvcnMiOiBb
+        XSwgInN1Y2Nlc3NfdW5pdF9rZXlzIjogW119fSwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmI0YWMwYzhhZGE0MGRiMDRlZTA5YjMifSwg
+        ImlkIjogIjU2YjRhYzBjOGFkYTQwZGIwNGVlMDliMyJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:00 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/content/uploads/
+    body:
+      encoding: UTF-8
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="vR2wUnwIvmVdLjPCoiK5iceKhaBPbKlZmk4XZr3F02E", oauth_signature="IsLelzzGzPqjfX9L%2Fu5vxfl9NnM%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681100", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '132'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/content/uploads/ff7bf509-6086-490f-9fab-e60510dbee0a/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ1cGxvYWRfaWQiOiAiZmY3YmY1MDktNjA4Ni00OTBmLTlmYWItZTYwNTEw
+        ZGJlZTBhIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VwbG9h
+        ZHMvZmY3YmY1MDktNjA4Ni00OTBmLTlmYWItZTYwNTEwZGJlZTBhLyJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:01 GMT
+- request:
+    method: put
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/content/uploads/ff7bf509-6086-490f-9fab-e60510dbee0a/0//
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        H4sIAAAAAAAAAO1963rbyJHo/l0+RUeefJQSkiJ4JzeeRGPLHu3Yso4kzyTr
+        eDW4NCiMQIDBRTJn4nz7Guf1zpOcqupuoAGCIiXLcjLL/hIPBXRXd9etq6qr
+        G/N0PueJb1pxM0jmzU6r3TL2/+1hS7vdaw/7fdYWpfxf+m10OkbHGHT6A6hn
+        9Hr9/r+x/gOPo7KkcWJGMMQkMq+9+P5wypN7sAF+3jKvon/CZ3PfTHj8MJxw
+        N/r3gP6DXr+zpf9jlDX0h2ctOwzcFo+se/fRNtrtQa+3iv6dDrxT9O92gE86
+        7cGg+2+s/YDzXFn+l9P/CVMknrDXZmBOucOsBRNs0ao9qf3ht8xz2Z/mZuDZ
+        7OlT5pp+zFnzt1/XnrDvOJ9je4e5UThjVOfKC6bMC1hyyRm/5kHCQpeZzDej
+        KWe2H9pXLL7iN9D65pIH8Ob712ya8jhhXsziNJ7zwIExmIHDIh6nM+60aokX
+        XPFIwGdtHBJUojGo4UHVJPLshP3mKXv3Xg7vhEczL2GJN+MsXgT2ZRQG3s9m
+        4oUBu/GSSxamkXwLv2zeYFaaMCdkQZjUof1ctr9UFVgSsr+lPFqwMGKz0PHc
+        hXjLo2sPXoc4bZzGIgYRatVxdNnQWi6IVMKDFjftS+zl7+rN32m8f/jtU5ZN
+        g/6mWea/aL5P2Bl0xqMYn777Uyz+eL8MXLwRoMVvhj3In7/9WtE14i6PIu5c
+        SFAtL7D91OF/3BUP9hACE9WqhyQgxXY45y0/DK/S+bUZ7dYnEy++uPaiJDX9
+        +h6yzg7xzo6kztvA8WLbm/teAPR+Fdqmz54hf7TYOSIR/mcCt11x5kQejtkL
+        EsEbLmDfMm3oCMAgoxAnBSHQM4k9J6MWMF5OdmhHpEaw16YHGs/nLSZR8+9G
+        Z9ii/7fa//6E+TQYYtaamzpTrr9nQCIzSWfMaP97iTTPI89NXA8A1xz1k7D+
+        p/xPjWmv+CK+4AGOhCDg36I6vVHVoXYa+DyO5fMkAp0FYgFKOln8kVrKR/Ba
+        a6/q/RR6wW6dAQ2KhNNHEfG/oQwiAJCgep0qaA9zqNrD1eBAnyRR6BfBaQ9z
+        cNrDJXDq55fWkb/mUrn+t1zvQ5KCMmotZv6n97Fm/Yflvltc/42hYRjb9f8x
+        iqL0pMZg9ZmHsZeEkSf+ZmwnThzfs3YmbGfqJZP9ffj3MrXAXpjt55yj/WyK
+        Bi2otwMQYuAfWLsVNOAwBPXkF6GgLxwv+rizFe8vWSrl/9mb4/PTo2/enh8d
+        v2zNnE/tY438o+iX5H8wGG7l/1HKCdGfvQIGQIs2BTtDmLGcyVcvQrTczQjs
+        KbDNwRIMf+J2EjfI8gJFMEsDL1kwWsg9MKDBuo5rWB0sFjD/PbCk0GC7Al8B
+        XQOAPGPTiJtJi/0AHoEZ/L//+b8JM20bLRzs9zKF/oJ0ZoHNByYceqIAYBZj
+        h7XZIvJMB59fmpFzA/00wNxzE/ELh+TwuR8uZuh5oFvjTdOITH4EbiZqVmhg
+        KnsSrHoyA1u1GozoxoSW8AgHzMD8N2PGzXiB/wX1GHtorcHrbL4wh0szmALe
+        4lB0gW6FwuVNGF3VwB1a4EMegD0cBjg2NHJ5JPAKZi6/AScITFc0huVAbwAJ
+        nDt5R2EUY8du6PvhDXRWU9UAh4CNawSEQxGWr8I3EjOc4xNwTYJpDJP8S5hS
+        GyCCQxgHKs59DjMRoy7QUoyLvSsyBfHLjXfltd7vXibJHJYGxRitXKWIdUI+
+        3xfAm7DC8H1suv+aHlzkvQXTve1q8LhlRfwnTh4o9ofl7vHf/sAYbuN/j1Fu
+        ob8Her01n396H2vt/8Fw2f4fbtf/xyhBCMrd4a6Z+gn7pQZ2ehAmGNf6hdVh
+        dUxhYWxaHNZfXp+wj5WvTTfhEb2F17ZvwjIOb4Gb6sLsx4iBB8vc06/ZMTV+
+        V4b8vkEVxV+sqqLog+pBNx+3q8RDlUr5PzWvOEafHqiPdfJvGP2y/W+0B1v5
+        f4yihLOeM8JFPOf2xSX35zzaj4AVLhIzvorrtaxuhDWaIsqd16hvpfJfr1TL
+        /+HB89eHrZkZXTnhTfCpfdwu/0anW7H+97fy/yjlCVC9VnsC5Zz2IcBPfBai
+        Y5zEtZrRYu/eXOPmFr95v/sklD/3ah14Ibw39pzHduTNyVVssh/QJUU/UXqS
+        TshjuUWzQGca3G5Yz93UB3DSH3RyAHu1LgA+40k6B1jgIDPLjD07xlFNeYIO
+        IkNyJeAW0wYeDB4Axdhgj0yI37F3NAR4wUzXRb8TKtzAI2Jv+SirK7qSeg3d
+        8liBa+oPs/rf8KkXBDgMrXtLPWziQ+xnr9aDebyNzSmHeTzToxAsnItgBCLF
+        dBwP/8IQSRrY4qeXLABoio33an2Ac4pbbxzd+iY7CFgaOGAQAY6bl2HosDnn
+        VwzjACXMA6adEEeKHV2GSL9IARJwX3kzL5GhkSZ7c0ZhAPjb8nAMDcYTG7z7
+        J35eba82gHbP+TX3wzlFWJrsJYUHMMKj+/EYqMgHA1CcvNEe8ptiq1oNyXx8
+        fpKNOwAK+37cyKI3XMaaZrQ9LWJESF+569pCcMvMuAT4EmBgRCZKBQXxlWlH
+        YYz7jBFGcJDNQlj0TMFotLyJqJPjxXlwq8WAzTF2k4WDbjhyNQ0snUNNbs5o
+        hFkeRRYagio13Nb2kxj3F2PuL2BeiX0p6LcI07qDrI5bafCH2GT2uAjTzE37
+        CllKmeuIoBraaTHhgJiZZLksArXa7+hPCaAl/yyEx5jYt/zdEmqfLDN9rSY3
+        iVl9MkFDH7mNB2E6vUTC4/hx8CBatI0vEA5oOxKTuvFiqjdHV8ELanMzMmcc
+        DPyY+d4VoPPSA4TI/WisKJFLUTSKXMGDSa32448/iuWrlnkdYjjod6jm4Ey8
+        I2/EaNlhhKkOs3qDHnTyBww8i48IDydMclurHfg+hQgj084zBhTvqUAZjMUJ
+        wXGBfwMcYyRwgJxveoHAMo6tVaM97Rk3QdjULGIP2GMBE5xOfcE9SjnI/Ims
+        ucKq5CDQnyWNISh1xH6C5UxEMIG9G8RUdSExM3DnZ+mMHVFU8Y869krEVHgo
+        gEN5vuHmVZbvALhtoDOIQUXG/RiZ5TMR5MkRCAVxBoxihhkBMWgFmEmWLnFz
+        GRJGgaMDYHiM1d5w3990SJuPieV9Qpt69gfmBrTRdqqvGjeQFvMTROT6WkbC
+        s8wRuQ3uc6ehtImJyOURtA1FBB0VyMYzEuU+88paVs+OST18oYYONSmvQ5/4
+        qzC8ikWU/zeMfQPTzlBhMtBotA4lmX5sZMFuQBTIUxyCOiDGSgPvbynobqh/
+        x6l/wtzvMHlt9kzq0ws1KwKTTVaGv/dtEKlw1lKVMLFO55lssSc8PsNpcqW/
+        MUMLNAPNvcGk1MICBcoAeQlHLBX4ZCKX0Qn7Vi572gISZ7XEiIuVVq4Kk4mc
+        dbF+Ya04yVS5WH/FZgVSUlPytOehcnB0XSdQJMzRH800CdO5AzgCxDzn84jb
+        8NuZiOygDBymJl17YRqDJnXwwYzyiTy3rKvjyzD1HdDVNYQMi65nA4IWTPTh
+        KIuF1uuEISvh/LVcIXbKgWS2TJATqPzrRY0HqI1actQCez/WhL4HU1IgiXJ5
+        oIebyEt4xeILC01YBJGxkYKVTS6WC2TGZ0Im1ARRdwh1UdGR6iPLR1oaKeY+
+        CUNVYDDPXEKgmCwoQZTSdwDQDzQs2Y6SmYS576A+lqyFtfFdAYrIgQIIZ2IK
+        augEo7DO4VIrajsFCHIqr0qDFwCIhbXKeQrTJoOWtfVBS+JfCNIrFOICZKE8
+        0GpZB77E/c865grWBVfRb5Nh9ASsOjtjMtxOBGNeWDk1zVLDN1ZmE+dzVgMI
+        QAYq+IPwB6/UtDRoElQOKPDsCgggPmQHCnrUqVq9Iq3zGpMhy7mdLdxGJTQg
+        VNyypJxRYdLWI8qThKYiNRA0qg2qnqNQKcNWYH6BRlU9qcGCYIq1hP0UWsIO
+        y3aTvVlG26VURmQIMNxxpMqolQalqIqGvAfK05xj0ql8SGxuBguVKenJnE4f
+        IIkdV5hMSG3MKLPUFGyspcajVpAlEcuWlipzr0pa8/lIQD5a9YWOpZUsZRS9
+        wijWm4OGzsWsgtq6MZJpSiVqaHdaYZgsA9T5fxOAyvnCYS7DE4treZoArKjh
+        RLVCDxKDrhcBvUlLl2HroqIjUJcTzfUhTMpuyeoMyHFCoJrfLOFlHmYMcwQ3
+        xUo94GLkcmArFHxE4dRE2VMb6J3WUHjm3hSMm5ZYLctwZNMwmKAFcMqdb4EQ
+        h+iTzCMPqP3KC9IPrL8/gLfPueWBAhrsD+GPZyCg4NCLN2+tNEhSsGNa7R78
+        +RLehSH8OIhA8REI+ONFxPk3Z89hHNCnzBsQ9meef5GNy4dBJyL/wwyAjkjZ
+        aQorMgwNlBRDLGlRglrtobJMaoUsE/YJWSa127JM2F2yTGpfLsukpmeZsE/J
+        MqmtzDJh2yyTX3OpjP8LlD3YDuC6/b+BUY7/D3qD9jb+/xiFlj8o9SIj1GvK
+        Nq0TS9Rr8kxFfcM8YIIBjtYlWr+aONdrPqyuASxe9QMwS0HWv5cdQT/QSzqb
+        mWBS1jE6K9iwXtN2CPQXpPDFsteQi1xDrnwNdvrt4asGe4P/vOBOGJkNtcQ1
+        aOETSydqcrEetuo1qUIu5mhc1KW+2WyisN6xA4dWBVT2ge1h0BoMFzAkJ7Xs
+        6UJH875IlcaYxNdPGeC4NfgCO6jV+f9CGB4m+3/9+b92d2n/v4/nf7fy//lL
+        s9msWWC4gSRSln4Y+Av8bxNMXjA+o5oPVkcKEjEB291a1EDMHJ9HF+DyxRPW
+        pC0vDGtq+zs1Ia0TtiMqM/6B2yyiuC14vuzs5PDZxZuT87On9WYTbS4TD93Z
+        KbYlG6q+U6N8n4s4JXtNjAckEX1M8BSbf2O3aaHp5Ty1wBFDuxobtVy0LZsR
+        GP3BlEAVnuzL2rXoejapNZnRGrWG9N9xqwv/RZFo18ComlD4D4yIDyKvqclO
+        3p6cHJ5fvDx8ffH94enZ0Zvjpzv/+Bpt+1Z75/Y6XYS6to6xQZ2OqDP1Q8v0
+        85F98+ro7NvD04tXb14eHT/N0SMrxNwG123C/t6sqajnf3lHV39xxr9/5pz8
+        PL85++nFSfD91bMPxosj35t/mFvO4nm3+7dx77Jz/lP/5z//dGwZL//s/fz9
+        on18mgG5+v7Dy8u3/VfOaDH+efT8/G/fnU6fHRl/Wcym3W/399+8/f3vT757
+        9eb//LT/5/5P6Q/fn/benn5zfMK/efNzmgE5+s9vnvvG64Pn3x30POP3Px38
+        18n8597s/Po8+e6sN//hu8No+uxsdnnmxn8xLuNhMLCf1nLS8A8UGVW4QLpK
+        agrwSMuNaEctBf0/Z8sCL9yxpVFqKbh3k5bEN5TN54mgGckZn5mePxERm62V
+        /Osv1ed/vj04fnkImuNh+liz/vfaRvn8X3/Q723X/8coHUB+sz1utvugQTRT
+        vGXUamfCGJ/Uas/CKMJ9VfTNXx09Ozw+O1Rh9W/Sqet9QOOhSSawjMSZczCn
+        55GH+xMLbkZkapOzARUkCGgtuh82u0ap+7bePcbG4CHDBdukKKedxiKENOPR
+        lLJc5CYYZWqEWYi9lqdg4BYLBt+hto8x2DSm7adsF0XlggCgLBiEcTlo5Mlp
+        gaEyDU2fgibhDVaFf3E3nwL4lEJS2DJp1NQuhggazXlUOmwP+DPtqxszcuKm
+        F6gEHD+L9sDkD+JVk9PySygwQ7G5iM/Ca3mBgllLA5E+gmaTjeEw+E15JSZt
+        pcy8GPFR2mOBCjVtVw2wLkC0GDsRBKAtMtuMMJPLX6jEbdzABmg1tAeFOeLj
+        lkkx/8nxkJO8axWAmlEsUca8aFAiaYU7yFE/IhqnPPiRfuNR/B/ZLvp9pd2D
+        eA8rIKapph9OxY4Q/M7D8NoftPcDf8doccaJZ4t2+Tn6H2u1F4AucTQWOBsp
+        kGEbmQ73GAscle3oQnV0Ur/DvaQY1GsYJZjphbs3QkSyjYosei+rYYV8BxV5
+        7kdgoB/Fji+szjDCfONuwoBXLgtbfU5+/wCT6FBB/wk7FBcN4NDEtpiYnlZV
+        gj3RwebVi2AlpqC62ECjOriFis+1etoGoVZV365Y2hjM2mr7dLe0LezPYdvl
+        faAJuPwRcDxeCLG0CURtMibRqqpnetZeQjs/xNZKdRm65jRIc+o68YX3AcMC
+        cveagagH8oYUfYc7389GHpDqFsThb2mYYC6fukgDDDM70Tpvj0qdtwts+0yG
+        XEmKsWkYyUj03Megs1B5MfhuEV14QdkGOAKR4a32P/A4EADAzeuEi+1KzAVl
+        szDKcpbyViJxTrbKGT8LuohEPAdE2GRh7JozD4aHeyNchNxJveFwTJQsbDu/
+        XSY0PE50XENd17wOKb4v1I6P23oij7S4hys5h3ZDJ2oLV9+2zJLWhNIvb3nG
+        uOkBRDGa+L82e24G7Bs8WvMHxwz+VIxVfw1dYUJJr4bK4GBm/gy0k/EozEWU
+        ygAmoNYhqogbIAKpoqP2oGkM2H9y12Wv7WcpKPg//AR/rOisWzuC9ohWtYhS
+        HinTHMMvbYpsyxcolfb/Sz4jdY/s/QB9rIv/DXt5/K/Xp/vfhu3t+f9HKS8P
+        X1MC3AzWmQnDoHc82d/HUN+Ug/0bRtN9zK0DlSwv8cC9bVQcuxhB6IjMeExy
+        a/p2zHYNeNgTD3G5wXpGa6jq4WY37j3iw0HLGIunYP76eKRwt53XBG1vihy/
+        Xcq9k09DMIvxidFrtfdklEOr+o+vmVY74EkztufYmaHgyqegyne/fgo+xaDV
+        1yrjY3w2ks/Cq3DqRR5C6LcM2aNcFHcx3tPpKrBqtjAEQ8EUNZsw4wQH3VWD
+        qD5qhVV6auzZXMXWQFuBZBRHVT8pnComMs4RUli7JQAFl6KwuwY+kfUj63oW
+        zjxBkgyGpLLCWYYIgGboo6Sk1XBe04bTQeoYxcHYaCjsUpBMJ514yT/Av+og
+        wqpKgI6r5bc6dHre158XAdP7jA1ylqUpGa1ug/0BnUwdgOyUWnb1Fwq5tGtT
+        GKhWSdpB0LyTzyZjduLVYYkvkVuJg4wldqWZZ33lFBEM1xpno1D0pBfFwSn8
+        ZVwrhpjK5wXkiVfNnNs7ZZKo+VHbdkVbaWtTx2Sbrm+fpfGq0bZzrtTf4ONs
+        FkqtFFFWMXEFSM0apqwIIBkZn8la1+YUE1qaNxHmekVCtxFlaievDs5fvDl9
+        fYaqE3dFas8PTw6Pnx8ePzs6xIcKayosvFcraIPaKh1Qy+S7ggjlpzk+ajpy
+        aktDv82yq1z/Z2AHuw93B8Td738Aa2Gwvf/hMcoa+qt00U+6BmLt+e9ht3z/
+        a6+33f99lPJEHqXQDw2A43zJwdenp+JSCJVBXLjYQbjOeMzhq6I3La5zkKkl
+        +mt8tL3D4Z+prJX/B7gDZt3+T1fT//L897C7Pf/9KCWTfrYLcvlVHkpjsjxl
+        X5FuoBhcPJnkNVCQvxLJr0wr5QaihlY5PyC1qnJWg1rlJ1BWdaFtuEB9/Vrd
+        6vpajbzFrT1kNfL62s21K+rnNfJW2vW5K1rlNfJWMtp+y9hkDWpSVMZVTZbV
+        dUFFV/dTVuJfifu4b6M91RB1y0H55brlGtSufDRvuQ9Vg6qXDwEuV9eBFw9G
+        rKqd1yg1WoXdYo1CI3l04ZZGokah0WqS6DUatb3Cwq1qiQX8GtxOFNoL0PSh
+        n8IP3D3alSK5p9dAdAbT3bK07t0CJRPAQiUrDP1dXRwLbyO+WxakBntX/++/
+        Or//CpMi6++rq2vycUt1E3dxdgvSUznJoiRUgdDZvmJ6xOKV7cr8XFVJMW/V
+        u6pmos8iV1bOq8iDt8AQ/HYrDDFzqOG5hRXiFxklS6DSbl17kR/OzI6MaNsy
+        4mp/eZSSTnOV9mIYO9MOj8kDmWq7L0ZhsDieocaDWjHT+gVTE2jNW/U9YWMy
+        Vjzanlm49YpXgt2r3kg81BHgE3YQ2Jc0FrxJPsY9ffZkBB4ua4pnYhJyd1tu
+        qbEbPMnGXD/EgxuuS5dKILAZHkfB7beFPO88h9kXTk6YFm6ni96SCTWSqclO
+        aC8fg6A/9zut4X5228c+pnCSlJmeOBVymcz8J1dBeBM0vTgGaQKwppiWMPAn
+        E7rURF75VnrFA0fd9iZw8U5v8p41v2Z0bvldGekVryTS3xMn/aP8ViGeGhb6
+        wjG83zoRn17W2P/qcPdn9f8H5fvfwf/vbv3/RykF/z8/TVn2/0Hz/4aVVxXc
+        YH/H6vJMJy7CcRICOzl19n5Prg6u6fm79VK7fH2Y4QUjxXOhCkauw90l++np
+        U1L0sg817EJwIgtPMBmDWLbKRKXMTyhWUvaeFskoV1KGMBZY6DCXKBWXieDg
+        tDe4yptRUnzz8Z8iDrJG/oUJ+YkRgDXyPxj0luS/M+xs5f8xiib9urtQGQgQ
+        SeEr/HgUvcLnwuqrfPEMTJUbXc+blVxl7U3JHX73fpXXm13CsMoFFU2rnMx3
+        JKT5NTDqboKr0AGTV378CWzfyJzDf/C8PfyHPg5Vb5SaNgef0rp4/0wJ7mQi
+        Hr9f5c6ivlnltWaae5WHSo3J5HwTLGVcrsyEykMDT/FbSR3hb+ifg9pjf5Sq
+        m7Q4K16jwzJsafpSXC6MeUsAKcsaE0Dq4hAgGKW/SJ27FJaCye7zxM4YtK4q
+        lkM/WsV9fJdVLEehsOK1Ge37nkWV6X1WuxxNeSrvIqqz96pK2bsXIlTXXxeu
+        M5IcSRNutxyacmsOuG3hpMJoyjwrjeKk3sjrGRvW62xYr7tJvffZ8gYtxKUF
+        9yLN3TC+MSHvTRpnU9rYeKI0LuCoSJQ1FTq3Viig9yw9O/x8yKVmj43mTbGM
+        90TEacxvwfPaKp31VbprqhTIIY8YPyhFHCKI84B0qAecSFt/KIZ3YdpW7FRp
+        BVguPsxD32fjImnu3KRz9ybdOzYpkBLzlX1Myv3fpbtWC9NqGVovF69KiHzC
+        Dmw7TAMR1ivcririZnTzkzjVoq/32ckXmcVNxgaWzDJQ17fK5KJf8nGKc/7a
+        IO5E0btT9U6UXUVdFNXmzIvtgrxuQui1xJYEn4rrD1ZQV9J+g0qdTSp111bK
+        p/gx+yXNwSLlKLCwgyfDvvpF3PlCmPio3X+MNxPlyfR0HRNUXmKSjwUGbO3s
+        LQ3ho8bLS4P5lIFIvv6I91zjcSDx3Vg5AhEg+MzxgTX+vxCPz+v/twft4ZL/
+        39vu/z9KKcT/pDKsDP8VXHnB+1+JQzVhtADFAr+R7XdzlSfTwFH5/aLVLYfn
+        wMnL3ilNEN4E4BHTu7Z6No3CdF56NsMjNuJZHVMMM1US4fUGMa+MuOVjktef
+        1krDUfv8VeNYHkVhDMDmcgy2uEWfRiDjJMtbql8+F6pS/nGZfbjPf93n+1/Q
+        YJv/+RhlNf3xvNkXy//tDrb5v49S1tBf7id/Wh93p/9w2O5u6f8YZTP6z6Pw
+        2nN4dD9GuDP9O0Yf93+39P/85Y70v9eXodbm/3dK9791ep1Od2v/P0Y5kZRl
+        Z3jEs/a0UPDefRfPa9L5T4rV0A2zih1ieYicspMyI761Tcr51ymbyX+ymPP7
+        GwF31/+YE7DV/49R7kD/e38VcK3+7xkl/d/t9rf3/z5KOeXyYt9zIHHlInDr
+        ShCp5sghcfaxhO1a8K9SVsu/diy5FVmf0sc6+YeXS/FfY3v/36OUdd//lTsa
+        2qPtZ35/TWW1/MujCw8QArxH/Kfd29p/j1LW0x8ek/jffxFY8/3nYX/J/zc6
+        7W3+/6OUTP8XNLz85ILFZXaJE+K22TuVaNnI8voaIgOtkac+NfTUmUaWdvG+
+        xU37Ej/u+Hexy/132iXzXLnpjSn9qq7cw/N5sjvBe5XiPfbLLyzPAsGdtlcS
+        /lLGB7yUvz6KDXsuso3XQSw1CpyaGGDCflHfnZLnwi5IMnbrhbNNezI9YF19
+        eeBp0+rqBNSe2LjE9AONMNmObRiwJ7/IbAailpivDl2e/6Kd2d1SjsteC4/h
+        XdBu5269nY3uzhBod/STIOBu6q7YR83mrM+ako7j/NZe8YE8vI0y8hyHB9rs
+        Jb1FWrsgeNUXOmeLi6XUdcUGd5/Arp6jUpebwHXsaF9+UM4NQ8uM9j8up5lk
+        TKdNeEdcvoqXWCpmzSi9o8+VuvqQsJ0b/FCy/HBbocYSPgq5OZNyqn7pGIte
+        S09o+lrLaEJcUFZTVSMtaR8/zVo3UDt08J9u/X1VA+1kAPbSqYSqHRLASt1C
+        pY8ZA21GyCoaAhVFakCdyQ+6Ste2rlFQz1b6JI4p80x+ITEzWId19x+jUw3x
+        nUfpUCPiyhlyOjGrfqm0vwLTO168zPWreb6K47VDCHqlOzH8Hdl9A2Zfy+o6
+        o2t0ucDEs81ZfQNGr1SLt3SzoWq8jc0/U5ermPwzdbeKxW/T/fWli8LrqzV+
+        zJO7aPuKizKQS01kUPomlY3/OEuaueIQldZOT1C9q/LdWFvIddSUF3j/NZAP
+        rPIDO/vlrNcqZXxSzuaXxOlGuLwPY67B550UcMkcVReIrbBHKyyy0qk9VDzq
+        zF6DFa6cEcikNOjGKoWXoUI2JCta4UBXqFXd6e/zu8v0IymM7Wn95nOXnYsD
+        ceqqNNnFrQbqZgiRH49ejQ/dXN0YH7KHXQV+r0TrdfPUPyxN43mAmd5K+ktz
+        ZpnW4r7TpezUDEh5tus4WzliG5oW5fPqy7Z06WqhNVUyDGWH7avqreLaj5Vc
+        S1evyHT2uESsKqTKXlbJFEnVqqkURa5qErcIHYmdTqwq1iygqjQbbc6o2ley
+        aAWTFlCrRtaoJE12+UGBPTfGZSaP2QUIBXNbX6nW4EAw3e3it7xyFdl1yRDe
+        iGM359mVXOvc7sHVlbGTfaBhiYYVK2MV6xZRQNYvTqtePS/NOl49JaiEk6nr
+        sylUKCytZYoWf2U0VmZJIX6UzzmPFFCQQEXDVDxLhNSWPSI9CrYcQVORuPL0
+        cuJl0QhZ8phceW2u06ea1Ldk8OBP9hEWa6H0T4mID2oo/tWpOnW0X2CzvVso
+        oeMYPwWjZi6CobejVg9ZiqPTt+BHVMi+Qv+oGFp9rnszRN2KKREs3hxTMri8
+        GlNgK+MpwS+CqYqz2Q+AIgyjb44gCrqvRo86sfxlEFR5XvoBUCR3GDbHktqS
+        WI0oeT74y+Bpo8PJD4C37MtLm2Mua/JPqc0fgK8q10qJgDTIzmregjHd/s4X
+        Q0Se1v62EJ34OgVYhqmFnx1nH1tg0USmF4PtFEVhpNvW+/99Lj/xdvuhUq3r
+        4pHSfd2DLWIow09uSFZ9YE+j6UrWkUVxkNwDrLYhtOtg8lZod+kshwwnuQen
+        iyrND236VBneN0Ofy0o8MB9FFlqB7x4qcif4rvU7vIeH/t9qt35HnyIsPMOr
+        bswknTGjrfFkxpEaF+Kk5DbW0uU5FTP4xMiqF1zhZ77oPp6VI7uFD+aXi9iz
+        H5sRpGVf5ASM72+OtweISt8JdxKD+M+X3tS/Q7kl/480x0OcALzH+b9hd3v+
+        61HKWvrDMuLZn5YAtC7/c9julPN/ur3t998epVTl/1wI0tdrtSfsWw4vbzib
+        p+Lrz/TJT+IJ/GiwY+J9wqYvvkvZYGD7RSYLLfp0MKyIqeu28lyiHdGO6k6k
+        aZVFN2b4ZTIKGUFvdPGLHc7xu8OiV7J6xPdKM13/hB2HYILi59Ucz5wGIX3L
+        2AwWYpSeq7e9MWO8UkYCxY9T88hfFCIsMUzfZ3U/ZrRQyLMPoj3lwRVSa+Ld
+        SZw4YZrs5eG9p/9g+6+pPi44+1oSjKgNhp1W2wJLbzZPFsVq/IOXXNihw4s1
+        f+ZRyD6WVptPX2zWyj+m/8m0mfsqgTXyb3QG5fs/Oz1jK/+PUm6X/+psM0pQ
+        k7JAJmAY72WXwTu8RRbhu7qyBmlXmAw5wWwX9AXl3d+KFuL6EXV1r7ijYy+7
+        7HElPAoDZx4+QaIvSz7d/D6yDIrMaiwBueWmw6ylDFSVWlbd3pc1odBNqUH1
+        DXNZE+GJC2wtIaUYvJU78KJd7sUrez3rsdyRalLKwMzqV13bVLZ8Nc+h0txW
+        ylPfDwHFRrk1y9mQ0nIXY/j4L2pd//OXtfp/KTnh7svAWvuvW77/qdc2hlv9
+        /xhlU/2/KhWJghmgzz0egyrnZgD6WQl6lbrXFD595CG7rT37hKUWGlibPrMi
+        G6lcUd7ftvd5NVVdJdLUN6hkbVLJlhPcpK5TqLuxcbhW/olcn9X/67R7gyX/
+        b7g9//soZUP538HYM7HCkuMm+TFKA3DfbJvHsZv6uhaYgwmxUzbzdoqb2wVV
+        MZ/vLTta93SdKAr49CkzijVBVCIeXxYhBp7/2T22AuaWUiVk6sfkduStbLdF
+        azVaZbbGndGqvkqyAVrZ36O//zpRuzW5f81l7fqvvjbxCSbAWvt/UF7/wQDY
+        xn8epdx5/Rdf7FNc8TDWQPZFE7Le6XN/6lH9/f/mNe3ubop0C3ZLWNxbFULZ
+        KP4r0/rvqwLWyv+wvP/TGRjb+58fpdwu/+UAsDrfce8I8J2DujKTX6Rfs+zL
+        FQ8fGy13pBLQq+Kiy4PK7+jXhVidPK+GLWX8TkHxjB7qhIMGelXYQhIN3YNl
+        HbCR/CvL+DPJ//L3HzuD9nb9f5RyN/lXX1r8rPKvrpYo3CmhyaochCZNlGWf
+        Sdvy+0+WNnV+QAO9StrkyfuKiB28zBzKf5r9jNXy73ofEvyQ8adnAN3j/h9Q
+        ANv8n8coG9A//xrIPfu4x/3Pnb6xpf9jlE3oLxNg7t3HPe5/HXa38v8o5Q70
+        lxfl3L2Pu9O/0+luv//wKOXu9FeXJ22uEO5O/16nu73/71HKp9BfvzLrtj7W
+        3v/aK9//B7W3/t+jlCezBUst/Pw0Bngpv6/2pFYr3FW23f759ZaN7n+WAYH7
+        JoCsy//tGkv5/wNje//no5Qs/hMhvZsy6Fe4DLSySlNmx4tK8apaMi0L+Smr
+        Ke+5ZGfZu8nkW3o5mZziDfRn1PbWes95wu3kzVlWSWt4QiNTdeNajd61hHLD
+        nX3crbdxt/4JO4lCOnwZhWGC0SH48wJ/s6fshefzFv8wNwPnYm4ml7v04KfQ
+        C8Qv9cHDi4sXR68OLy72GqzeatX3KHL0hB2KSzLs0A/TCCNfrSTB7yTiEUeK
+        hLU2GTpCOscb9eF/N5fyLEY95kk6r9PpBoylxcziLp54UOElvJmfTllQP/Ll
+        JE69hOdnJ45kLF8QUk/YkwHjWqmitAMYIIQ5fM4Dhwe2x2O9qbwuXELYnciv
+        Azz9Okdtg020z6Rmd6qII3V0BGNXXkaeHXYtjJR0VZw4vmfVVUbfFw+j/cuW
+        2/V/K5wnn6ATZVlr//VL+b/GsLO1/x6nNJugHGZmUotrzaZUVs2mH5qOtajN
+        8Gw1/GmZ9hXgx+ZbIfu1lUr5b9GqwpPWYuY/QB9r7b9B6fs/xmDY3ub/P0pp
+        Nps1eWvHBVB8wuri9FJz0Gt+GPTq4AkmMeboq+f9MT2fZJt9scrg35mZXtAC
+        l7F1PdvJ0/oxLd20JmUAGkjZ1f1BqrECSJc7YWQ2jdF9QRYBIEhxEKw5aA/v
+        C7MEQQM6bEe28YlgcxgIOLXSIEml4d0EyevdG7urQFV002n3Og/UTQYKu4nB
+        4GwaRjy/N5JKELYrWLFU6v9XR88Oj88OH6qP2/V/ZwC6v6T/+73+9vtPj1LY
+        unIwN23wM19h2kP2IY3K8j14rF4YMOChBvtPM0jNaME6oDVWNrpMkvlkf//m
+        5qZlUjd0o5Mvuor3yQE9Pzx9fcYOjp+zZ2+Onx+dH705PmMv3pyyt2eHDXZ6
+        eHL65vnbZ/i4QbWeH52dnx598xafEACjxejbdV4Cg4tb6kKZHTmjHfA5ybvl
+        ZkAedcKjmXBy7TBwRCv6AEMa8waLODiyTmrjY3W8jBxiDzMtrRSf471EDn0u
+        z8FLsc64LYAYAD8K0+klG7PQlV/KC+0U71AojyuMlgZmh/NF5E0vE0Yf6mAw
+        JGjoJQtmpsllGHk/U38STlWLBC/Ng06nkRnQxVdJTlltAHxq+uyQQC8NIg1w
+        gqG4WsG0CYoaRUBXA0swIVSQA/ToxjBT3MYThX6DmRFXf/g06AbOBp+KD8ra
+        4WwWBhKSrCgSjwmO6LDFXoSRuIY4jeYh3kuWYTUjuKLRjoSyQ1OJ2a63J5qG
+        NzxqyA8W4iC8QPxu4AWjtolXTkE9CUW8IgxETFyWisTDfuPUvpQDa2CohqYP
+        1Kd+TYKtY+bGQ24CKLsejITIE196c4Tkei5gc84jtG7Ybr/92z3qDoM4AvEK
+        UJqA8oLx4hVml4C9WEEEkBYPAAm2B6QsQNfGmZP8L2G6w3ahLf6KdvZ0qsP/
+        ECfXnoM3NEEdnT8kAP4BRuvR9Rsw7pkXx8TwxGdCCIgsS6x2RuGhHRSvWZnT
+        8hOn9NYljF9hF7PQ8WBqJkmVIrCIpuFrEEK6Lcz3Zh72DnSMQze5QfaS8SjM
+        wG5kskeAJBhRoaHknyKG9J5SsDX18YZubVseOl4/Qs+AHGBU44DcKJzBS/sS
+        L5IylYAAVwSxcL4lQ9ETX/7pMpMJ9BC4RnGCEkZpmiA2cw8FKhRXyolpToET
+        YA7wuDBhXXvBTK+F9o4RjpDdGXc8U3zYM5/2D2F0taQUbuAhjZj0EHJaLgJe
+        oKaRCYBAnZzWzHRAkVybnk/xUvVB6UwvNVCbIgPapmQlM9MLSrsBGjArUak3
+        GVjFLyqRWkkSXFsIQ2q0EsQuTIB/MGdzcaWe/K61I75jymHtwyin9wGEyQ9v
+        9nIsPOeRdw1YvOYMERLvlDkA+6jGgZy9hCRwoAYuruwD6qMoOtgHcj9wj9BV
+        2BWRC2Xh5tKzLzVlAMRKYA0AyYw4GDIkGlAZUCPlhHHAcBipv/ACREFmXZok
+        MFzl6Cb2hrhj7+Yy9EkooJk39QLoZZnmy/pY6Sm3IP4NVkafxB5yswqK39Bz
+        QkzE0cRX8snxDmvkFMQLTWPGI+4v8KKIK0KcBdyCfCKyNCXRPVBEkWvatEg0
+        tDUyQ+rSoBA7PHRzqj9DVS7X+EqKl2UgE1mtvwyBUuDUWpqNQ9xfpNGEeNiR
+        loiCFArcUCt4v2rwDU0o8GI7AAGjVmo7Ti3QHVJ5KLuDuItGTsOTokAdkR5f
+        MisUlWm5u3W10A0V1MrUPfK7xQGZLqBitfGy2WrPdrI57UhYYr3P1DI04j4I
+        YBSCMm4gFSzTJz66ibBdQMZHGkjsM5QCHek8RxTiKYlzYSH8x41bl6JMd+l9
+        wP/yMYFG9Hxs7Ht0p5a2ZGWmkNhdi3UVDmtuynEJsa/yK02lBOHKJ6yVzNbS
+        kd7Q1EiBCzRsI97AxrXTWF6yBT3OSF9KM/IH0nj50sQ/KCQU56r4EaYSzz07
+        DdMYhBc/Ko6qL8qtI2Vy8dibBqT7gRWRRoTYSk5EZbVzDPg2mS6rrZ1lES7Z
+        19m0lQSuNXl0BKJ+nJU6ZZcm7ssBP4HJyEmTw6D1fnIhjPHjQEHiY7d2CPgW
+        yzUavJr4CUXUabGXaFZht8+y6SvLip3J22Qlr1Y6M5qY6VqZPtCoIYihCoEx
+        kxVHdgEYh/iZGB7NOV7XqdgPVJ/v3HhoawRh0CTKxzBj/LMJVk80RccpXJh+
+        smji3UwgImDYXYc2KvKl1Vz6f9ih8ragBcjYHPl4SdPl6nyeWtAWsAiMOvdN
+        YPTsCYxZLLUxPZGGhe636WZ+povJWF7qsWI5J90iCNTVCHRiotL9FVBnF5rx
+        eYICBi5HokwkGGAsHKI9Nhdz1aiHV/o1xF1+aOWpAZEfHbou2nmwCHAf1K/4
+        FzRKGCWCMJkekIaytApJzaiZ0YY40Uj1qq6iCQMgOmEZdZccmu2bHuBb1NUm
+        B1gkIDp2M70ZcDzEakYeSacbgfZRHg331NqnC/5uvAducBhwuSKC+gOLJLPq
+        qVm5gZqQ8HDlagvDF0ZecXCyixskhVrrWuzIRfpnvlAMmgp5OiNK4k3FEMyp
+        ia9JyUnHfTdfsDLbGi9abBLCcBp2mKL9JP4GypvMN28wnwCn6vOpWATMJBt8
+        bhOUtOJtCo7WBDHwWLraORw7J85CTUvRY0aWaoKnh3BaRU5UJpNyRqWkKEcj
+        lzG55CmrSqwOKKJIPcUrZqwMNgc/ICqZL8MuQEM/0RGqoNfCTx9okaEWdT0z
+        F7lmK2shuqAyLjr666w8IgmajdBZCkqO+AgtGvhvmK3IRbdZLOErNFkjd4UI
+        ITlrzTgXVHZDvIpZrO9Kd03UOrtr7omZpsBpUxwvDk/4G0BWD6aISks3fTPv
+        EMvSRE1aH8qexH/QMqr6tLQ+ReAmN6XRj0L/XQR1ImQhcB+8APlEeI+x1j2q
+        uIylESa67lN5FynBKfZsaz1HHM9fN5TdrLnw5B0Ei6XJaR1nHeYM0WB04Fat
+        jg3J3Q1Uiw5Hu6mhGRPEokkubnJuIgRRMZ6ySsWSW25CeyoYNDgnJIMWVhm6
+        fQrQKSQuSvKFS8xkeakuIs3ZQ6WV0V86fkjqneM350fPDncYnfenW7dA7GQf
+        aHJr/ejSpamACklZwizRSwOlXE8TaGg6MntLMR2vRKs8bc919EulRppBTISm
+        0NgErxqYagxX4pWYDWD43IzRndKj9LJJLq1gGEGnEzVMU40xx3WOoQJXxbeO
+        4T90ZV5gMl2uiwEovKE30zO4ZE7zFXAZfhg1lrFsKltPi3JJ36ACS25JUsiA
+        wDxnIhYAjJwmTnKR0SbA+Bw4zGhYcBOc0PNL4YWh/lpGs0ZvMh6EK50F+Uxf
+        c17RQikOR8oWaaxFITafLRum4+DvCP0dnSM1KGroEkObSEJDYD8GQuhzIn8K
+        wxv4qTQnnSmztcAxSrEI/0+Rs6zTCMEqiAFoqBQmilbhNwTJDojSMv8JxKza
+        t6hEUe5VkNlKwXphAJQCXxopEIichz5kDMl5aLUWrNwKCz4P7VVsGQkw2l5R
+        6FaMppGLjUvO4mKFK6JH5zJRInhp/vm24gCWdqsKq3BmdWMsmUxp5KNCWCbz
+        VEqeQIEgfXJ25E6A8FVzKzBusbcBrKIxEY1/gI5sD91fgqhtkGTxjUXZitSC
+        WVoYa2XoKrf0scdyIEeYepYefb6LaybNLBqmxjAChDBdHbX7KNofhwk2ynZv
+        aH2xQuGUodhOyb3DZYSGFqeYDswdLjaCUAw0ksiOhHUhAqSAxcwlmoJPR4y/
+        kBJCHhn/wG1NxZPizRAS8akZiX2lsu8h9wIGoAqVARK3RI6ysqOdkIvP05DJ
+        re0IIeLlhpowX9Q2hjnDuFlm0WDUS940IP/ED5EIHhaVFdOqEStOyd1UmY8u
+        eAIW9DgUCdlEUlj4wxluT+NoAMvyoL8kReZ0YKR2KT6rpEnRTa4GFUuAwNSw
+        xZ57MblOuGnrsh/A/gS8LDIhyIZqLYQDS543uli5GiAqkvOSR8EaOcGk7Mf5
+        UHdxrBg0KLuoem0MXxaIuyc/JLRzcMaOznbYNwdnR2cKuT8cnX/75u05++Hg
+        9PTg+Pzo8Iy9OdW35d+8YAfHf2HfHR0/B3PHEzvAHzA6Gucz8UivOFqYNJcg
+        ipOaSk8twMklVJFDFC2rWEDm+dH5q8MGYP24eXT84vTo+OXh68Pj8wZ7fXj6
+        7FsY5cE3R6+Ozv9CLPTi6Pz48EykDxxIGCcHp0Cwt68OTtnJ29OTN2eHYrUV
+        u4U+7izA+OfQqUe7DrQzI7zCIrsA5aJwHnlontOEXeAuysZH/ss1rhYvFdHG
+        OAabCKer1LUXk2aPQ9vL3GSh1OU+K0Vj9Y3WZWdW8N6oBX8rlGKjV55peT5t
+        nh/hysvA/AkSGoeAAY98CnbCGMHT1kItaicLGCjRQwYBn/oeWF8232tku92N
+        Qig3i/ys5fddYShgTN/3LDLoaHBTjEdk+xaqy4SJbw/hElkpH0J7FpYPDMoo
+        kvkedSwjAkRac2ZOizF8bK1SAvLkAMyO9/IgG1QHgcJPYTQkp8qYLm7ISaBK
+        Q2PMDcaN4epI7JnjKp6t1bhrXHZ0CZtppmNS8cQLJDE1vapHDHZv3RNXo8Jp
+        +6Fg2GkYOjeer8cOr8TloiZGCdEmSHHgrun5eJKG9uR9Nw1y44YWwYpMENwF
+        QObV8SE65jEwDvIhGujlQJyEkQXTTefao01SV6ZvgARIJKjkBgleSMC4xQ5s
+        XBMQC0rzYs8H+UKtCcUPl2i6F8W1vFl463abskLtyzAUUVCKdBY22ynmCnab
+        y0mfgKqjEZqBzcUk5iIMKrXfgviOzwJMLckDYgKtvho7Cy1fRqHIbtlHtYOW
+        r9hqgfmgvEj/ylMaNHMwvg1v0BMSrmSGMMKnBjifH2W0BL62G5LZ3HJbhIK4
+        8jEq0lyN0njJ0sl3UXKNnkeKNDaQMWH0mTxX6GcUeCHvhBs3w43DXXBXRAuw
+        jJ2K0LkZzUgTKeM6w2IuzmkU5btlMnIMOpnTt/VkELWxHDe2FtLYyCe0QAzk
+        OM2M+RuNGzWzMRuLYODD4+e4rlalwdH7g5MTqHL05wmSkKIFeLWRTF/QU/fw
+        HQ3lJttLgnK+YYOGTKMoRhOUWR2C1ER0Klx6c43ck3c97jsxgwUChF0ofQt3
+        KTlw5s679zuZ4qPIhFztFoqZSKtKr0/zpFts93mI3/ORQRtNRhXw3+wx8tbl
+        p33kFUz5OKR3oC3b2t4sykq8AH3+IdsIJadeDAD0BDT0Y9ygErVlnFRpcaor
+        +Aa4jM65iVNzaGbO1WKstlYtnqes0A6pGkmMDXdgcBS4Rh28g2tFcedTJr/g
+        MIHxvGw/XmJO7btm4Zk8yGFG9iXuWAtmyDcT33XaRvc9eydOI7JXphW/pyqS
+        MRzNTyqyTENPAmW7WCHLs9z7DwShfBD1OUda5Qhd0nT3Aul6kjrMuCgza1ju
+        6YcWRcjMQphOMa+ZZN/bXJNmKrOdMfeZmmxila+yN2SeGYLRwmjLWU24UaBX
+        WGV1f6LJrYxtQtsZ54UhKMYmUwb4BKYWTFP8/vsUPNEoKGfzyQhJbqPHy/MC
+        VvrSGc3bcpdSff7LAsL6/CG+/YjlHt9/hCbb+18eo9xKf5EA+8l9rL//RTv/
+        1+3h+V+jv73/91FKs9lktW/eHj9/dXghF5sJ2CnX3A/naAVt1fmvu1TK/0s+
+        Q5PsofpYd/63PRyUz38Ne92t/D9GkdmldbSRYzCSo9RaTPksFl/4q02jMJ2z
+        iaYQGmxCV8vTPSJQk9Uj84rXG6yiTNSlME+/ZvRFb9Uk57oL/aqZxi1NKi6f
+        kZ2u6aXpg/tUGt/KJvl9NeUZbTawQvuVTa5N2hlp3kS4rRxpXS03oWuCcaOc
+        JqOSxp+yw+Pv39VP3oL3f37x8vD1xfeHp2fgEdA9ytrs641iy6pR8SWcVQ6e
+        RvKEXXuziZs8RUbZLg7/8qVS/894YjpmYrZ+isPg0/tYo//7Rt8o3/9sdLb3
+        PzxKwRvQdzBAtTNhO0Vm2MEIxI7UG/iamEM8jdMZ7p/i0+PzEya+eS1eiTMe
+        +EaLH4lXWvyr2JJiEeIzvA32lu4DaLBnsNq8OWuw028PXzXYG/znBV3OAP8V
+        F8M3WPYZB4qvia80tFRn+RVV0Ns7igapj1BWTHlf3Cm1k50YlTO/kIoQFz9s
+        8de03e5y+tdhgJDWQIQw8U53+uLkDh2Zwy7Fn/Ylt68AYfhI9L9TdLAQ6tA1
+        7PFoNOyNhqOu0zFHTq/f7w4HnDtGb9i25bB2WupaTrybBRuO2+NhZzwY9yzT
+        GnRsg3fBeQaJ6liDkTlynayhdqcLths5hjUcDjpOz+j0bd7vdofj8WBgGo7p
+        dvv9vEMhGKqZMe5yu2MZPdseg0zbo5Hb6/TGvU6nP2o7Zkc1w73Xl4ev3ryk
+        Rtxt865rDgaGBd2ObGvEDXD1ur2u44yMrK9nb47l2e3jl62ZQzzHXcMZuL2e
+        MXQcPjbdgT10ewO3b8PsBj1Frh1pshIqh2M+sox2zxr3Bp2OaY/soWM4Q8t2
+        ux27b5aatPzQvqJRmjA4x+wObHMw7g+tAZBg4DjOsM87MPS+aifjhdjEbVsD
+        17G7RrvfNfqdgdvpD7vDEfRlOnhdhmqSfxMeW9mj9sB125220RmbVg96HJr9
+        dscCFBkWH2YdnR4ePH992MIUCCe8IZEZ9syxaYz5cDQYjMcj3jf7496o17eM
+        vtXm/WHWFGwy1V271xlxszvsj83eYNyxx8ag3euOB3avPTDHtqHa5Pe8C7Zs
+        zeeCUQDr1oD3up1hZzgEstv9gTE0ncFoCHDM5eZ4GEs1Ho26o17PHfbbo57T
+        NaweDHkMs7XH7bYzGlY1psveZHvT7nZtwGnXhe4NaOkOzd6wC6ju28Z4NFhu
+        j9kvYL6K5h2Xj3t2fzx2hoAmw3DG/bbl9EDOxoABp6J7mXci23eBLN2R1W/z
+        MfDseOB0hm2zYw8H5qAH3Ouq9nRhGgX7xbW46kspCIPb426v73QsazweDmwg
+        umUYQxCCoTty2/1OAcbdLt1F8P3BgHeB6YDGY8vocsfsGwPD6AODmWPXahfA
+        Z3e6EW5BUTjcGY/7DiCHd8dd1+LggLUtExgrl8rybaByXm0HMGIDT40Gjgtq
+        wW7zXrs97oMq4MbYWdk8v0wUoYAG6bvIXCPgzB4oomHfdHgPhKLj9vruqAhF
+        3E5pmbFn6yh226Bbhu0BCL0BEtTpAa87dntg25YzNninCkjhu7bEql3HNi2Y
+        Bchtt2P1O+Pu2OQjs++4YxibWQUESS2ERYfkDNqWDSpg3B7abdCKo7HRAQ4Y
+        uEYX1Et7uApS6TNbpN0tUMsDyxrCItBxTLNr9jum2Tasdn8MMjBYBar0xR5C
+        ksU5DMft94BsfMTdUcftgNp2h+CAW2NeBWrlx79JOIZjEC+rP7CN9rjdNYbA
+        zl2nB1LdbndMo1cFsPw1QRIQa+yMHA7rVXvUbbvDEceIoGV1QW0DOxbnmIJu
+        2Zd3j8o0pmi/QlFyUBGD0bjX43xguh3X6jt9mORwPOr2OoNefyVQXLyrADq8
+        MzCHIPYjowsLxcDu8CHvjNpDw4LlbZzNdrWkdgYd3jb7I8t2RiOnbVuDfncw
+        bo8Mx+q2rW4nh1BSok4XNP0Q1C23DWCmLnc7XVy9wUxw7TZ0De0+CrNM3KcA
+        baZeAt48/HuZWjCK2b5m6FSZeXNxEeoFbTJCe7lntjkAuZ2GbeWeoLYVuFP7
+        +KUN3W3Zlm3Zlm3Zlm3Zlm3Zlm3Zlm3Zlm3Zlm3Zlm3Zlm3Zlm3Zlm3Zlm3Z
+        lm3Zlm3Zll9p+f+6giEkAGgBAA==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="1ivnFCJzDLjPMa4YAYhvBlndxB1WocaK26nM0HYo", oauth_signature="QJK2VQPdgFLMRAVY82FRT84NHMc%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681101", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '15859'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:01 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '4'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        bnVsbA==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:01 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/4/actions/import_upload//
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvX2lkIjoiNCIsInVuaXRfdHlwZV9pZCI6InB1cHBldF9tb2R1bGUi
+        LCJ1cGxvYWRfaWQiOiJmZjdiZjUwOS02MDg2LTQ5MGYtOWZhYi1lNjA1MTBk
+        YmVlMGEiLCJ1bml0X2tleSI6e30sInVuaXRfbWV0YWRhdGEiOnt9fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="EL2A4L2LgPT6tzuaD0fTac4dDdR4FISV9kxYbuuzTo", oauth_signature="Mf9pU30lPInfmf4QjTVhzB97kjE%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681101", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '130'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:01 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzhmYzUyMTg3LTUxZTUtNGExYy05MzQ1LWIyNzZhNDA5NzZlZi8iLCAi
+        dGFza19pZCI6ICI4ZmM1MjE4Ny01MWU1LTRhMWMtOTM0NS1iMjc2YTQwOTc2
+        ZWYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:01 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/8fc52187-51e5-4a1c-9345-b276a40976ef/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="NgusGmKuGDtzSeZyxNiQEB0XAYdjWxXDSRftleUTnzU",
+        oauth_signature="r%2B7SFcg6MYOzfv7mpuWCVrVZnrA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681101", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:01 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '569'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLmNvbnRlbnQudXBsb2FkLmltcG9ydF91cGxvYWRlZF91bml0
+        IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84ZmM1MjE4Ny01MWU1
+        LTRhMWMtOTM0NS1iMjc2YTQwOTc2ZWYvIiwgInRhc2tfaWQiOiAiOGZjNTIx
+        ODctNTFlNS00YTFjLTkzNDUtYjI3NmE0MDk3NmVmIiwgInRhZ3MiOiBbInB1
+        bHA6cmVwb3NpdG9yeTo0IiwgInB1bHA6YWN0aW9uOmltcG9ydF91cGxvYWQi
+        XSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogbnVsbCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVl
+        IjogIk5vbmUuZHEiLCAic3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFt
+        ZSI6IG51bGwsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjU2YjRhYzBkOGFkYTQwZGIwNGVlMDliNCJ9LCAiaWQi
+        OiAiNTZiNGFjMGQ4YWRhNDBkYjA0ZWUwOWI0In0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:01 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/8fc52187-51e5-4a1c-9345-b276a40976ef/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="LuGgEaygDC7T2hhbBBPmDmwBCMpsjMJGm9NUE5yW18",
+        oauth_signature="jHFbpOxMG7A7Mrv95JgPjPvgSA0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681102", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:02 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '756'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLmNvbnRlbnQudXBsb2FkLmltcG9ydF91cGxvYWRlZF91bml0
+        IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84ZmM1MjE4Ny01MWU1
+        LTRhMWMtOTM0NS1iMjc2YTQwOTc2ZWYvIiwgInRhc2tfaWQiOiAiOGZjNTIx
+        ODctNTFlNS00YTFjLTkzNDUtYjI3NmE0MDk3NmVmIiwgInRhZ3MiOiBbInB1
+        bHA6cmVwb3NpdG9yeTo0IiwgInB1bHA6YWN0aW9uOmltcG9ydF91cGxvYWQi
+        XSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMDVUMTQ6MDU6MDFaIiwgIl9u
+        cyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMDVU
+        MTQ6MDU6MDFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogInJlc2Vy
+        dmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5leGFtcGxl
+        LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJkZXRhaWxzIjoge30sICJzdWNj
+        ZXNzX2ZsYWciOiB0cnVlLCAic3VtbWFyeSI6ICIifSwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWMwZDhhZGE0MGRiMDRlZTA5YjQi
+        fSwgImlkIjogIjU2YjRhYzBkOGFkYTQwZGIwNGVlMDliNCJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:02 GMT
+- request:
+    method: delete
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/content/uploads/ff7bf509-6086-490f-9fab-e60510dbee0a//
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="bJ3oJ3gELxg9BZ8dJYQYQECiikCUVNIhvBuQtZq1E",
+        oauth_signature="EQIAMc4wwpyUclCuSfihe7ln9GU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681102", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:02 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '4'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        bnVsbA==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:02 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/4/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwdXBwZXRfbW9kdWxlIl0sImZp
+        ZWxkcyI6eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="DFIw7eTLYVP9ElxHdisCZ8rnN3cxjPwT1XdaPHus2mQ", oauth_signature="k7y876Zq3KK1LbZDTC8l17ehEJs%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681102", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '90'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:02 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '229'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICJmMGUwYzZmOS1jYWU0LTQxYmMtYjA4
+        NS0wYTkwZmUzNDQwNzEiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwdXBwZXRf
+        bW9kdWxlIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMGQ4YWRhNDBkYjA0
+        ZWUwOWI1In0sICJ1bml0X2lkIjogImYwZTBjNmY5LWNhZTQtNDFiYy1iMDg1
+        LTBhOTBmZTM0NDA3MSIsICJ1bml0X3R5cGVfaWQiOiAicHVwcGV0X21vZHVs
+        ZSJ9XQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:02 GMT
+- request:
+    method: delete
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="K9j2UASW9Cb8bXSx1e7XnsszajTHRGsMDVQJgl9XrM",
+        oauth_signature="5EX3hr1L96ftz4%2BaQRb42KymduY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681102", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:02 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzdhMmViNGJmLTdjOWMtNDk5YS1hNTc3LTAzYTliM2QzMzg5NC8iLCAi
+        dGFza19pZCI6ICI3YTJlYjRiZi03YzljLTQ5OWEtYTU3Ny0wM2E5YjNkMzM4
+        OTQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:02 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/7a2eb4bf-7c9c-499a-a577-03a9b3d33894/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="YYwVaWLHRs3GCJgIpQOg270DzUzLJyMJLAZZCbtg2M",
+        oauth_signature="0iPNN2UK%2Fw%2FEe7yguz6VP%2B9K92w%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681102", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:02 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '541'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83YTJlYjRiZi03YzljLTQ5OWEtYTU3Ny0wM2E5YjNkMzM4
+        OTQvIiwgInRhc2tfaWQiOiAiN2EyZWI0YmYtN2M5Yy00OTlhLWE1NzctMDNh
+        OWIzZDMzODk0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiBudWxsLCAiX25z
+        IjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAidHJhY2Vi
+        YWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3Jl
+        cG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6ICJ3YWl0
+        aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51bGwsICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMGU4YWRhNDBk
+        YjA0ZWUwOWI2In0sICJpZCI6ICI1NmI0YWMwZThhZGE0MGRiMDRlZTA5YjYi
+        fQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:02 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/7a2eb4bf-7c9c-499a-a577-03a9b3d33894/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="FjlKkWlvzVvtGvqcA87hWJsqKao7NsypVQPLMYAT6c",
+        oauth_signature="4xabeiYzcD%2BydMYNqi6GSQq0VXg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681103", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:03 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '680'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83YTJlYjRiZi03YzljLTQ5OWEtYTU3Ny0wM2E5YjNkMzM4
+        OTQvIiwgInRhc2tfaWQiOiAiN2EyZWI0YmYtN2M5Yy00OTlhLWE1NzctMDNh
+        OWIzZDMzODk0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0w
+        NVQxNDowNTowMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3Rp
+        bWUiOiAiMjAxNi0wMi0wNVQxNDowNTowMloiLCAidHJhY2ViYWNrIjogbnVs
+        bCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9
+        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
+        by0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVk
+        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
+        QGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhYzBlOGFk
+        YTQwZGIwNGVlMDliNiJ9LCAiaWQiOiAiNTZiNGFjMGU4YWRhNDBkYjA0ZWUw
+        OWI2In0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:03 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/glue_candlepin_consumer.yml
+++ b/test/fixtures/vcr_cassettes/glue_candlepin_consumer.yml
@@ -14,15 +14,15 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="ZjmxWG07r1yrIVgefMvtyTugECDYBXiFAuyuPn80s", oauth_signature="s6PFxmtSBzrKuzAEd3TyuBICFdY%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628859", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="dzJJxMRoE9dvNO2ljPnGJqQ0tGieDvXn45jbOFeMOkA", oauth_signature="A2MFFsaqy8vADEIKeRwzN9SmFSI%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681109", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
       - application/json
       Cp-User:
-      - admin
+      - foreman_admin
       Content-Length:
       - '64'
       User-Agent:
@@ -35,27 +35,27 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 90936603-0f3a-4215-8ee4-b054fff609d7
+      - 092e465b-fcf8-405b-a26c-e1a01891b48a
       X-Version:
-      - 0.9.47-1
+      - 0.9.51.3-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 04 Feb 2016 23:34:19 GMT
+      - Fri, 05 Feb 2016 14:05:08 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJvd25lciI6eyJpZCI6IjQwMjhmOWI4NTJhY2E5MTYwMTUyYWVhMmVkNTIw
-        MDJmIiwia2V5IjoiT3JnYW5pemF0aW9uXzIiLCJkaXNwbGF5TmFtZSI6Ik9y
+        eyJvd25lciI6eyJpZCI6ImZmODA4MDgxNTJhNzg3MTkwMTUyYjFjMDMwOGYw
+        MDNjIiwia2V5IjoiT3JnYW5pemF0aW9uXzIiLCJkaXNwbGF5TmFtZSI6Ik9y
         Z2FuaXphdGlvbiAyIiwiaHJlZiI6Ii9vd25lcnMvT3JnYW5pemF0aW9uXzIi
         fSwibmFtZSI6ImNhbmRsZXBpbl9saWJyYXJ5X2Rldl9jdmUiLCJkZXNjcmlw
         dGlvbiI6bnVsbCwiaWQiOiI4IiwiZW52aXJvbm1lbnRDb250ZW50IjpbXSwi
-        Y3JlYXRlZCI6IjIwMTYtMDItMDRUMjM6MzQ6MTkuNDQzKzAwMDAiLCJ1cGRh
-        dGVkIjoiMjAxNi0wMi0wNFQyMzozNDoxOS40NDMrMDAwMCJ9
+        Y3JlYXRlZCI6IjIwMTYtMDItMDVUMTQ6MDU6MDkuMDQzKzAwMDAiLCJ1cGRh
+        dGVkIjoiMjAxNi0wMi0wNVQxNDowNTowOS4wNDMrMDAwMCJ9
     http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:19 GMT
+  recorded_at: Fri, 05 Feb 2016 14:05:09 GMT
 - request:
     method: delete
     uri: https://localhost:8443/candlepin/owners/Organization_2
@@ -68,11 +68,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="vGAI1KDtkGXrPbUqmXguiKgIomMq68paXtkgibrshx8",
-        oauth_signature="OXDwRCUfSMBPhdAHbbJK%2By1%2FL1c%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628859", oauth_version="1.0"
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="QNQyMcUlAxWjeGDNQA0mkjFUxBxNQDPDJ3bET44Mq3Y",
+        oauth_signature="G7I5sl0s6nFPPXt0qwkm2IQbr4k%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681109", oauth_version="1.0"
       Cp-User:
-      - secret_admin
+      - foreman_admin
       User-Agent:
       - Ruby
   response:
@@ -83,14 +83,14 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 84d23873-5e5f-42fd-b40a-11af261a6707
+      - d81a3156-277a-4dbe-8def-d26f9734c4d3
       X-Version:
-      - 0.9.47-1
+      - 0.9.51.3-1
       Date:
-      - Thu, 04 Feb 2016 23:34:19 GMT
+      - Fri, 05 Feb 2016 14:05:08 GMT
     body:
       encoding: UTF-8
       base64_string: ''
     http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:19 GMT
+  recorded_at: Fri, 05 Feb 2016 14:05:09 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/glue_candlepin_owner.yml
+++ b/test/fixtures/vcr_cassettes/glue_candlepin_owner.yml
@@ -1,106 +1,6 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: https://localhost:8443/candlepin/owners/GlueCandlepinOwnerTestSystem_1
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="aP1mDVecaD9BpEvpcOmyJVobjREzoBqOhgnWUA2aaI",
-        oauth_signature="o2VhfomOASH2Ih6Rnit37p5pLAE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628859", oauth_version="1.0"
-      Cp-User:
-      - secret_admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 5261fa05-83cc-4e87-af00-ed783f12e260
-      X-Version:
-      - 0.9.47-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Thu, 04 Feb 2016 23:34:19 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiI0MDI4ZjliODUyYWNhOTE2MDE1
-        MmFlYTJlZmQ5MDAzMiIsImtleSI6IkdsdWVDYW5kbGVwaW5Pd25lclRlc3RT
-        eXN0ZW1fMSIsImRpc3BsYXlOYW1lIjoiR2x1ZUNhbmRsZXBpbk93bmVyVGVz
-        dFN5c3RlbV8xIiwiY29udGVudFByZWZpeCI6Ii9HbHVlQ2FuZGxlcGluT3du
-        ZXJUZXN0U3lzdGVtXzEvJGVudiIsImRlZmF1bHRTZXJ2aWNlTGV2ZWwiOm51
-        bGwsInVwc3RyZWFtQ29uc3VtZXIiOm51bGwsImxvZ0xldmVsIjpudWxsLCJo
-        cmVmIjoiL293bmVycy9HbHVlQ2FuZGxlcGluT3duZXJUZXN0U3lzdGVtXzEi
-        LCJjcmVhdGVkIjoiMjAxNi0wMi0wNFQyMzozNDoxOS44NjUrMDAwMCIsInVw
-        ZGF0ZWQiOiIyMDE2LTAyLTA0VDIzOjM0OjE5Ljg2NSswMDAwIn0=
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:19 GMT
-- request:
-    method: get
-    uri: https://localhost:8443/candlepin/owners/GlueCandlepinOwnerTestSystem_1
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="bhDYwzThREOHHxjnF1QX24S49SRsWcwAqxwuLttGBY",
-        oauth_signature="wCdELk7leGeBYt9Zg167wv1oA4g%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628859", oauth_version="1.0"
-      Cp-User:
-      - secret_admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - d8a82adf-5c83-4600-b5c0-f66c51e8219b
-      X-Version:
-      - 0.9.47-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Thu, 04 Feb 2016 23:34:19 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiI0MDI4ZjliODUyYWNhOTE2MDE1
-        MmFlYTJlZmQ5MDAzMiIsImtleSI6IkdsdWVDYW5kbGVwaW5Pd25lclRlc3RT
-        eXN0ZW1fMSIsImRpc3BsYXlOYW1lIjoiR2x1ZUNhbmRsZXBpbk93bmVyVGVz
-        dFN5c3RlbV8xIiwiY29udGVudFByZWZpeCI6Ii9HbHVlQ2FuZGxlcGluT3du
-        ZXJUZXN0U3lzdGVtXzEvJGVudiIsImRlZmF1bHRTZXJ2aWNlTGV2ZWwiOm51
-        bGwsInVwc3RyZWFtQ29uc3VtZXIiOm51bGwsImxvZ0xldmVsIjpudWxsLCJo
-        cmVmIjoiL293bmVycy9HbHVlQ2FuZGxlcGluT3duZXJUZXN0U3lzdGVtXzEi
-        LCJjcmVhdGVkIjoiMjAxNi0wMi0wNFQyMzozNDoxOS44NjUrMDAwMCIsInVw
-        ZGF0ZWQiOiIyMDE2LTAyLTA0VDIzOjM0OjE5Ljg2NSswMDAwIn0=
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:19 GMT
-- request:
     method: put
     uri: https://localhost:8443/candlepin/owners/GlueCandlepinOwnerTestSystem_1
     body:
@@ -161,106 +61,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:20 GMT
 - request:
-    method: get
-    uri: https://localhost:8443/candlepin/owners/GlueCandlepinOwnerTestSystem_1
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="xuC0xjpmHU1D4tIfalRD2ka7v1iR8FKW6puhbHFo",
-        oauth_signature="0bCnMi4wllPcBnXkq4mrIaiEAW8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628860", oauth_version="1.0"
-      Cp-User:
-      - secret_admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - ca203c3b-a1a5-421e-b7e3-2d0271002445
-      X-Version:
-      - 0.9.47-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Thu, 04 Feb 2016 23:34:19 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiI0MDI4ZjliODUyYWNhOTE2MDE1
-        MmFlYTJlZmQ5MDAzMiIsImtleSI6IkdsdWVDYW5kbGVwaW5Pd25lclRlc3RT
-        eXN0ZW1fMSIsImRpc3BsYXlOYW1lIjoiR2x1ZUNhbmRsZXBpbk93bmVyVGVz
-        dFN5c3RlbV8xIiwiY29udGVudFByZWZpeCI6Ii9HbHVlQ2FuZGxlcGluT3du
-        ZXJUZXN0U3lzdGVtXzEvJGVudiIsImRlZmF1bHRTZXJ2aWNlTGV2ZWwiOm51
-        bGwsInVwc3RyZWFtQ29uc3VtZXIiOm51bGwsImxvZ0xldmVsIjpudWxsLCJo
-        cmVmIjoiL293bmVycy9HbHVlQ2FuZGxlcGluT3duZXJUZXN0U3lzdGVtXzEi
-        LCJjcmVhdGVkIjoiMjAxNi0wMi0wNFQyMzozNDoxOS44NjUrMDAwMCIsInVw
-        ZGF0ZWQiOiIyMDE2LTAyLTA0VDIzOjM0OjE5Ljg2NSswMDAwIn0=
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:20 GMT
-- request:
-    method: get
-    uri: https://localhost:8443/candlepin/owners/GlueCandlepinOwnerTestSystem_1
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="wU8DTxMbEyPbNyjDcEcPW7p3zFfvbDUoH62yvR78Oc",
-        oauth_signature="WtJ9Y0toFs%2BNQf1SeIQkm02n2f8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628860", oauth_version="1.0"
-      Cp-User:
-      - secret_admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 1bad7460-691f-4cae-affa-ea71602cb5db
-      X-Version:
-      - 0.9.47-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Thu, 04 Feb 2016 23:34:19 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiI0MDI4ZjliODUyYWNhOTE2MDE1
-        MmFlYTJlZmQ5MDAzMiIsImtleSI6IkdsdWVDYW5kbGVwaW5Pd25lclRlc3RT
-        eXN0ZW1fMSIsImRpc3BsYXlOYW1lIjoiR2x1ZUNhbmRsZXBpbk93bmVyVGVz
-        dFN5c3RlbV8xIiwiY29udGVudFByZWZpeCI6Ii9HbHVlQ2FuZGxlcGluT3du
-        ZXJUZXN0U3lzdGVtXzEvJGVudiIsImRlZmF1bHRTZXJ2aWNlTGV2ZWwiOm51
-        bGwsInVwc3RyZWFtQ29uc3VtZXIiOm51bGwsImxvZ0xldmVsIjpudWxsLCJo
-        cmVmIjoiL293bmVycy9HbHVlQ2FuZGxlcGluT3duZXJUZXN0U3lzdGVtXzEi
-        LCJjcmVhdGVkIjoiMjAxNi0wMi0wNFQyMzozNDoxOS44NjUrMDAwMCIsInVw
-        ZGF0ZWQiOiIyMDE2LTAyLTA0VDIzOjM0OjE5Ljg2NSswMDAwIn0=
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:20 GMT
-- request:
     method: put
     uri: https://localhost:8443/candlepin/owners/GlueCandlepinOwnerTestSystem_1
     body:
@@ -303,106 +103,6 @@ http_interactions:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
       - 5e6ca11e-d516-4348-964f-b13d51f6bb50
-      X-Version:
-      - 0.9.47-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Thu, 04 Feb 2016 23:34:19 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiI0MDI4ZjliODUyYWNhOTE2MDE1
-        MmFlYTJlZmQ5MDAzMiIsImtleSI6IkdsdWVDYW5kbGVwaW5Pd25lclRlc3RT
-        eXN0ZW1fMSIsImRpc3BsYXlOYW1lIjoiR2x1ZUNhbmRsZXBpbk93bmVyVGVz
-        dFN5c3RlbV8xIiwiY29udGVudFByZWZpeCI6Ii9HbHVlQ2FuZGxlcGluT3du
-        ZXJUZXN0U3lzdGVtXzEvJGVudiIsImRlZmF1bHRTZXJ2aWNlTGV2ZWwiOm51
-        bGwsInVwc3RyZWFtQ29uc3VtZXIiOm51bGwsImxvZ0xldmVsIjpudWxsLCJo
-        cmVmIjoiL293bmVycy9HbHVlQ2FuZGxlcGluT3duZXJUZXN0U3lzdGVtXzEi
-        LCJjcmVhdGVkIjoiMjAxNi0wMi0wNFQyMzozNDoxOS44NjUrMDAwMCIsInVw
-        ZGF0ZWQiOiIyMDE2LTAyLTA0VDIzOjM0OjE5Ljg2NSswMDAwIn0=
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:20 GMT
-- request:
-    method: get
-    uri: https://localhost:8443/candlepin/owners/GlueCandlepinOwnerTestSystem_1
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="MtBQSpnrGUEWikCxxUf1rsB5vACuXoEUohKugcRLw",
-        oauth_signature="SlLs84qwtf%2BsAXY5NIBbpUmePiM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628860", oauth_version="1.0"
-      Cp-User:
-      - secret_admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 3b67a3e8-57e2-4fc2-8729-42e3d86cb404
-      X-Version:
-      - 0.9.47-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Thu, 04 Feb 2016 23:34:19 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiI0MDI4ZjliODUyYWNhOTE2MDE1
-        MmFlYTJlZmQ5MDAzMiIsImtleSI6IkdsdWVDYW5kbGVwaW5Pd25lclRlc3RT
-        eXN0ZW1fMSIsImRpc3BsYXlOYW1lIjoiR2x1ZUNhbmRsZXBpbk93bmVyVGVz
-        dFN5c3RlbV8xIiwiY29udGVudFByZWZpeCI6Ii9HbHVlQ2FuZGxlcGluT3du
-        ZXJUZXN0U3lzdGVtXzEvJGVudiIsImRlZmF1bHRTZXJ2aWNlTGV2ZWwiOm51
-        bGwsInVwc3RyZWFtQ29uc3VtZXIiOm51bGwsImxvZ0xldmVsIjpudWxsLCJo
-        cmVmIjoiL293bmVycy9HbHVlQ2FuZGxlcGluT3duZXJUZXN0U3lzdGVtXzEi
-        LCJjcmVhdGVkIjoiMjAxNi0wMi0wNFQyMzozNDoxOS44NjUrMDAwMCIsInVw
-        ZGF0ZWQiOiIyMDE2LTAyLTA0VDIzOjM0OjE5Ljg2NSswMDAwIn0=
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:20 GMT
-- request:
-    method: get
-    uri: https://localhost:8443/candlepin/owners/GlueCandlepinOwnerTestSystem_1
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="GYGGEX4IUiOS0fITEPtTaiHqnaQwINX8VQdB2tmoqs",
-        oauth_signature="4YpbAQhp8fcx3b1tBhK%2FGrCYeQM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628860", oauth_version="1.0"
-      Cp-User:
-      - secret_admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 8f3fe7b4-04b8-4dad-89ea-67c691af4841
       X-Version:
       - 0.9.47-1
       Content-Type:
@@ -502,11 +202,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="tt3wvPaFypFDph84dh6jbRDPGyk8IaXYrzGmCdPzs",
-        oauth_signature="puqW1ug6Z0FS7h8Q0Q%2BNpjANIK4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628860", oauth_version="1.0"
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="jayDIkZG90bNLkfyKuwEO1hXymN5uR2bOeGFLTEMzw",
+        oauth_signature="oEjLwkuU4eBWjS%2BXZU0C1GioTVc%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681110", oauth_version="1.0"
       Cp-User:
-      - secret_admin
+      - foreman_admin
       User-Agent:
       - Ruby
   response:
@@ -517,27 +217,517 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - bc792d61-9479-47e1-9cdc-852e4ebe55f1
+      - b38485fd-587a-42aa-a330-4306eb9a3713
       X-Version:
-      - 0.9.47-1
+      - 0.9.51.3-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 04 Feb 2016 23:34:19 GMT
+      - Fri, 05 Feb 2016 14:05:10 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiI0MDI4ZjliODUyYWNhOTE2MDE1
-        MmFlYTJlZmQ5MDAzMiIsImtleSI6IkdsdWVDYW5kbGVwaW5Pd25lclRlc3RT
+        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiJmZjgwODA4MTUyYTc4NzE5MDE1
+        MmIxYzAzN2QwMDAzZiIsImtleSI6IkdsdWVDYW5kbGVwaW5Pd25lclRlc3RT
         eXN0ZW1fMSIsImRpc3BsYXlOYW1lIjoiR2x1ZUNhbmRsZXBpbk93bmVyVGVz
         dFN5c3RlbV8xIiwiY29udGVudFByZWZpeCI6Ii9HbHVlQ2FuZGxlcGluT3du
         ZXJUZXN0U3lzdGVtXzEvJGVudiIsImRlZmF1bHRTZXJ2aWNlTGV2ZWwiOm51
         bGwsInVwc3RyZWFtQ29uc3VtZXIiOm51bGwsImxvZ0xldmVsIjpudWxsLCJo
         cmVmIjoiL293bmVycy9HbHVlQ2FuZGxlcGluT3duZXJUZXN0U3lzdGVtXzEi
-        LCJjcmVhdGVkIjoiMjAxNi0wMi0wNFQyMzozNDoxOS44NjUrMDAwMCIsInVw
-        ZGF0ZWQiOiIyMDE2LTAyLTA0VDIzOjM0OjE5Ljg2NSswMDAwIn0=
+        LCJjcmVhdGVkIjoiMjAxNi0wMi0wNVQxNDowNToxMC40ODArMDAwMCIsInVw
+        ZGF0ZWQiOiIyMDE2LTAyLTA1VDE0OjA1OjEwLjQ4MCswMDAwIn0=
     http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:20 GMT
+  recorded_at: Fri, 05 Feb 2016 14:05:10 GMT
+- request:
+    method: get
+    uri: https://localhost:8443/candlepin/owners/GlueCandlepinOwnerTestSystem_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="D2imWvQsnKMQw0pxBwe7nIkHixNHmAC9j1vroovHM",
+        oauth_signature="k2LztZIyIafVfxg9wgb6oLRRAv0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681110", oauth_version="1.0"
+      Cp-User:
+      - foreman_admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 858cac96-59e7-42f6-8a71-a96230698682
+      X-Version:
+      - 0.9.51.3-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 05 Feb 2016 14:05:10 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiJmZjgwODA4MTUyYTc4NzE5MDE1
+        MmIxYzAzN2QwMDAzZiIsImtleSI6IkdsdWVDYW5kbGVwaW5Pd25lclRlc3RT
+        eXN0ZW1fMSIsImRpc3BsYXlOYW1lIjoiR2x1ZUNhbmRsZXBpbk93bmVyVGVz
+        dFN5c3RlbV8xIiwiY29udGVudFByZWZpeCI6Ii9HbHVlQ2FuZGxlcGluT3du
+        ZXJUZXN0U3lzdGVtXzEvJGVudiIsImRlZmF1bHRTZXJ2aWNlTGV2ZWwiOm51
+        bGwsInVwc3RyZWFtQ29uc3VtZXIiOm51bGwsImxvZ0xldmVsIjpudWxsLCJo
+        cmVmIjoiL293bmVycy9HbHVlQ2FuZGxlcGluT3duZXJUZXN0U3lzdGVtXzEi
+        LCJjcmVhdGVkIjoiMjAxNi0wMi0wNVQxNDowNToxMC40ODArMDAwMCIsInVw
+        ZGF0ZWQiOiIyMDE2LTAyLTA1VDE0OjA1OjEwLjQ4MCswMDAwIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:10 GMT
+- request:
+    method: put
+    uri: https://localhost:8443/candlepin/owners/GlueCandlepinOwnerTestSystem_1
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiJmZjgwODA4MTUyYTc4NzE5MDE1
+        MmIxYzAzN2QwMDAzZiIsImtleSI6IkdsdWVDYW5kbGVwaW5Pd25lclRlc3RT
+        eXN0ZW1fMSIsImRpc3BsYXlOYW1lIjoiR2x1ZUNhbmRsZXBpbk93bmVyVGVz
+        dFN5c3RlbV8xIiwiY29udGVudFByZWZpeCI6Ii9HbHVlQ2FuZGxlcGluT3du
+        ZXJUZXN0U3lzdGVtXzEvJGVudiIsImRlZmF1bHRTZXJ2aWNlTGV2ZWwiOiJQ
+        cmVtaXVtIiwidXBzdHJlYW1Db25zdW1lciI6bnVsbCwibG9nTGV2ZWwiOm51
+        bGwsImhyZWYiOiIvb3duZXJzL0dsdWVDYW5kbGVwaW5Pd25lclRlc3RTeXN0
+        ZW1fMSIsImNyZWF0ZWQiOiIyMDE2LTAyLTA1VDE0OjA1OjEwLjQ4MCswMDAw
+        IiwidXBkYXRlZCI6IjIwMTYtMDItMDVUMTQ6MDU6MTAuNDgwKzAwMDAifQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="4AIupBX1qdzUoCIPpUJDTrE5oLDP9aD79JM1BQA", oauth_signature="KP7xsFZvlxot3XwFbvP6dGd9kss%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681110", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '403'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Version:
+      - 0.9.51.3-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 05 Feb 2016 14:05:10 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJkaXNwbGF5TWVzc2FnZSI6IlNlcnZpY2UgbGV2ZWwgJ1ByZW1pdW0nIGlz
+        IG5vdCBhdmFpbGFibGUgdG8gdW5pdHMgb2Ygb3JnYW5pemF0aW9uIEdsdWVD
+        YW5kbGVwaW5Pd25lclRlc3RTeXN0ZW1fMS4iLCJyZXF1ZXN0VXVpZCI6IjE0
+        YzJmMDYyLWRjN2MtNGY2Yi1hNjY5LWRmZTJmMTQ3YmE5MCJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:10 GMT
+- request:
+    method: get
+    uri: https://localhost:8443/candlepin/owners/GlueCandlepinOwnerTestSystem_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="iApOp8zTiVDnHAKryzO4Pka9Gi1NeOOBYY7Yrto5m4",
+        oauth_signature="FDgdntEQuLR3BvrTenEMrD63DXs%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681110", oauth_version="1.0"
+      Cp-User:
+      - foreman_admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - d2c00b40-3de7-4099-87a2-2e1c32d8c29c
+      X-Version:
+      - 0.9.51.3-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 05 Feb 2016 14:05:10 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiJmZjgwODA4MTUyYTc4NzE5MDE1
+        MmIxYzAzN2QwMDAzZiIsImtleSI6IkdsdWVDYW5kbGVwaW5Pd25lclRlc3RT
+        eXN0ZW1fMSIsImRpc3BsYXlOYW1lIjoiR2x1ZUNhbmRsZXBpbk93bmVyVGVz
+        dFN5c3RlbV8xIiwiY29udGVudFByZWZpeCI6Ii9HbHVlQ2FuZGxlcGluT3du
+        ZXJUZXN0U3lzdGVtXzEvJGVudiIsImRlZmF1bHRTZXJ2aWNlTGV2ZWwiOm51
+        bGwsInVwc3RyZWFtQ29uc3VtZXIiOm51bGwsImxvZ0xldmVsIjpudWxsLCJo
+        cmVmIjoiL293bmVycy9HbHVlQ2FuZGxlcGluT3duZXJUZXN0U3lzdGVtXzEi
+        LCJjcmVhdGVkIjoiMjAxNi0wMi0wNVQxNDowNToxMC40ODArMDAwMCIsInVw
+        ZGF0ZWQiOiIyMDE2LTAyLTA1VDE0OjA1OjEwLjQ4MCswMDAwIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:10 GMT
+- request:
+    method: get
+    uri: https://localhost:8443/candlepin/owners/GlueCandlepinOwnerTestSystem_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="dyuNIi0sfR6EO7YwiKwtgf4IVu065t3W8u3PwdPwSc",
+        oauth_signature="5WVsIU6Gzej2bd2CKMjf2RgcYRI%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681110", oauth_version="1.0"
+      Cp-User:
+      - foreman_admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 7e90ab55-c9b6-4eb8-9a2a-51c3f98f944c
+      X-Version:
+      - 0.9.51.3-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 05 Feb 2016 14:05:10 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiJmZjgwODA4MTUyYTc4NzE5MDE1
+        MmIxYzAzN2QwMDAzZiIsImtleSI6IkdsdWVDYW5kbGVwaW5Pd25lclRlc3RT
+        eXN0ZW1fMSIsImRpc3BsYXlOYW1lIjoiR2x1ZUNhbmRsZXBpbk93bmVyVGVz
+        dFN5c3RlbV8xIiwiY29udGVudFByZWZpeCI6Ii9HbHVlQ2FuZGxlcGluT3du
+        ZXJUZXN0U3lzdGVtXzEvJGVudiIsImRlZmF1bHRTZXJ2aWNlTGV2ZWwiOm51
+        bGwsInVwc3RyZWFtQ29uc3VtZXIiOm51bGwsImxvZ0xldmVsIjpudWxsLCJo
+        cmVmIjoiL293bmVycy9HbHVlQ2FuZGxlcGluT3duZXJUZXN0U3lzdGVtXzEi
+        LCJjcmVhdGVkIjoiMjAxNi0wMi0wNVQxNDowNToxMC40ODArMDAwMCIsInVw
+        ZGF0ZWQiOiIyMDE2LTAyLTA1VDE0OjA1OjEwLjQ4MCswMDAwIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:10 GMT
+- request:
+    method: put
+    uri: https://localhost:8443/candlepin/owners/GlueCandlepinOwnerTestSystem_1
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiJmZjgwODA4MTUyYTc4NzE5MDE1
+        MmIxYzAzN2QwMDAzZiIsImtleSI6IkdsdWVDYW5kbGVwaW5Pd25lclRlc3RT
+        eXN0ZW1fMSIsImRpc3BsYXlOYW1lIjoiR2x1ZUNhbmRsZXBpbk93bmVyVGVz
+        dFN5c3RlbV8xIiwiY29udGVudFByZWZpeCI6Ii9HbHVlQ2FuZGxlcGluT3du
+        ZXJUZXN0U3lzdGVtXzEvJGVudiIsImRlZmF1bHRTZXJ2aWNlTGV2ZWwiOiIi
+        LCJ1cHN0cmVhbUNvbnN1bWVyIjpudWxsLCJsb2dMZXZlbCI6bnVsbCwiaHJl
+        ZiI6Ii9vd25lcnMvR2x1ZUNhbmRsZXBpbk93bmVyVGVzdFN5c3RlbV8xIiwi
+        Y3JlYXRlZCI6IjIwMTYtMDItMDVUMTQ6MDU6MTAuNDgwKzAwMDAiLCJ1cGRh
+        dGVkIjoiMjAxNi0wMi0wNVQxNDowNToxMC40ODArMDAwMCJ9
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="fVMYkVW1B640Wqh5dDKsOo78TfOiQTkWBIEKxwXyzHU", oauth_signature="oVZGGsdsRda6eficgSc66rJgAh8%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681110", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '396'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 3737fcbc-83ef-475e-a2b7-14e836cf9d4f
+      X-Version:
+      - 0.9.51.3-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 05 Feb 2016 14:05:10 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiJmZjgwODA4MTUyYTc4NzE5MDE1
+        MmIxYzAzN2QwMDAzZiIsImtleSI6IkdsdWVDYW5kbGVwaW5Pd25lclRlc3RT
+        eXN0ZW1fMSIsImRpc3BsYXlOYW1lIjoiR2x1ZUNhbmRsZXBpbk93bmVyVGVz
+        dFN5c3RlbV8xIiwiY29udGVudFByZWZpeCI6Ii9HbHVlQ2FuZGxlcGluT3du
+        ZXJUZXN0U3lzdGVtXzEvJGVudiIsImRlZmF1bHRTZXJ2aWNlTGV2ZWwiOm51
+        bGwsInVwc3RyZWFtQ29uc3VtZXIiOm51bGwsImxvZ0xldmVsIjpudWxsLCJo
+        cmVmIjoiL293bmVycy9HbHVlQ2FuZGxlcGluT3duZXJUZXN0U3lzdGVtXzEi
+        LCJjcmVhdGVkIjoiMjAxNi0wMi0wNVQxNDowNToxMC40ODArMDAwMCIsInVw
+        ZGF0ZWQiOiIyMDE2LTAyLTA1VDE0OjA1OjEwLjQ4MCswMDAwIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:10 GMT
+- request:
+    method: get
+    uri: https://localhost:8443/candlepin/owners/GlueCandlepinOwnerTestSystem_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="hwuYAQgOxB4Gbr6RSfs0uwGisWikTDMCQNEFbGX5MM",
+        oauth_signature="BXSO3lcwgQBuceStby2%2FCF9kbIw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681110", oauth_version="1.0"
+      Cp-User:
+      - foreman_admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 366d812a-f30f-460a-98e1-f4e22a8db825
+      X-Version:
+      - 0.9.51.3-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 05 Feb 2016 14:05:10 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiJmZjgwODA4MTUyYTc4NzE5MDE1
+        MmIxYzAzN2QwMDAzZiIsImtleSI6IkdsdWVDYW5kbGVwaW5Pd25lclRlc3RT
+        eXN0ZW1fMSIsImRpc3BsYXlOYW1lIjoiR2x1ZUNhbmRsZXBpbk93bmVyVGVz
+        dFN5c3RlbV8xIiwiY29udGVudFByZWZpeCI6Ii9HbHVlQ2FuZGxlcGluT3du
+        ZXJUZXN0U3lzdGVtXzEvJGVudiIsImRlZmF1bHRTZXJ2aWNlTGV2ZWwiOm51
+        bGwsInVwc3RyZWFtQ29uc3VtZXIiOm51bGwsImxvZ0xldmVsIjpudWxsLCJo
+        cmVmIjoiL293bmVycy9HbHVlQ2FuZGxlcGluT3duZXJUZXN0U3lzdGVtXzEi
+        LCJjcmVhdGVkIjoiMjAxNi0wMi0wNVQxNDowNToxMC40ODArMDAwMCIsInVw
+        ZGF0ZWQiOiIyMDE2LTAyLTA1VDE0OjA1OjEwLjQ4MCswMDAwIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:11 GMT
+- request:
+    method: get
+    uri: https://localhost:8443/candlepin/owners/GlueCandlepinOwnerTestSystem_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="ShWoalUCwLKcxP83oOZTYXpFfqR9uFkZhEBfAfXIvw",
+        oauth_signature="mYFar%2Biu%2F6T3a9mwKrijEgXZq3c%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681111", oauth_version="1.0"
+      Cp-User:
+      - foreman_admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - a074b141-015b-4317-a9b9-f382927bd8ad
+      X-Version:
+      - 0.9.51.3-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 05 Feb 2016 14:05:10 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiJmZjgwODA4MTUyYTc4NzE5MDE1
+        MmIxYzAzN2QwMDAzZiIsImtleSI6IkdsdWVDYW5kbGVwaW5Pd25lclRlc3RT
+        eXN0ZW1fMSIsImRpc3BsYXlOYW1lIjoiR2x1ZUNhbmRsZXBpbk93bmVyVGVz
+        dFN5c3RlbV8xIiwiY29udGVudFByZWZpeCI6Ii9HbHVlQ2FuZGxlcGluT3du
+        ZXJUZXN0U3lzdGVtXzEvJGVudiIsImRlZmF1bHRTZXJ2aWNlTGV2ZWwiOm51
+        bGwsInVwc3RyZWFtQ29uc3VtZXIiOm51bGwsImxvZ0xldmVsIjpudWxsLCJo
+        cmVmIjoiL293bmVycy9HbHVlQ2FuZGxlcGluT3duZXJUZXN0U3lzdGVtXzEi
+        LCJjcmVhdGVkIjoiMjAxNi0wMi0wNVQxNDowNToxMC40ODArMDAwMCIsInVw
+        ZGF0ZWQiOiIyMDE2LTAyLTA1VDE0OjA1OjEwLjQ4MCswMDAwIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:11 GMT
+- request:
+    method: put
+    uri: https://localhost:8443/candlepin/owners/GlueCandlepinOwnerTestSystem_1
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiJmZjgwODA4MTUyYTc4NzE5MDE1
+        MmIxYzAzN2QwMDAzZiIsImtleSI6IkdsdWVDYW5kbGVwaW5Pd25lclRlc3RT
+        eXN0ZW1fMSIsImRpc3BsYXlOYW1lIjoiR2x1ZUNhbmRsZXBpbk93bmVyVGVz
+        dFN5c3RlbV8xIiwiY29udGVudFByZWZpeCI6Ii9HbHVlQ2FuZGxlcGluT3du
+        ZXJUZXN0U3lzdGVtXzEvJGVudiIsImRlZmF1bHRTZXJ2aWNlTGV2ZWwiOm51
+        bGwsInVwc3RyZWFtQ29uc3VtZXIiOm51bGwsImxvZ0xldmVsIjpudWxsLCJo
+        cmVmIjoiL293bmVycy9HbHVlQ2FuZGxlcGluT3duZXJUZXN0U3lzdGVtXzEi
+        LCJjcmVhdGVkIjoiMjAxNi0wMi0wNVQxNDowNToxMC40ODArMDAwMCIsInVw
+        ZGF0ZWQiOiIyMDE2LTAyLTA1VDE0OjA1OjEwLjQ4MCswMDAwIn0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="J7ZoxYrCg4oyP42NK1ynZ2KTPNSywh4USUhbTblRMHQ", oauth_signature="Ca%2BwhAG0ejegNuGWK4PZopyKhTQ%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681111", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '398'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 36ca609e-4242-4d43-9c18-33410e431323
+      X-Version:
+      - 0.9.51.3-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 05 Feb 2016 14:05:10 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiJmZjgwODA4MTUyYTc4NzE5MDE1
+        MmIxYzAzN2QwMDAzZiIsImtleSI6IkdsdWVDYW5kbGVwaW5Pd25lclRlc3RT
+        eXN0ZW1fMSIsImRpc3BsYXlOYW1lIjoiR2x1ZUNhbmRsZXBpbk93bmVyVGVz
+        dFN5c3RlbV8xIiwiY29udGVudFByZWZpeCI6Ii9HbHVlQ2FuZGxlcGluT3du
+        ZXJUZXN0U3lzdGVtXzEvJGVudiIsImRlZmF1bHRTZXJ2aWNlTGV2ZWwiOm51
+        bGwsInVwc3RyZWFtQ29uc3VtZXIiOm51bGwsImxvZ0xldmVsIjpudWxsLCJo
+        cmVmIjoiL293bmVycy9HbHVlQ2FuZGxlcGluT3duZXJUZXN0U3lzdGVtXzEi
+        LCJjcmVhdGVkIjoiMjAxNi0wMi0wNVQxNDowNToxMC40ODArMDAwMCIsInVw
+        ZGF0ZWQiOiIyMDE2LTAyLTA1VDE0OjA1OjEwLjQ4MCswMDAwIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:11 GMT
+- request:
+    method: get
+    uri: https://localhost:8443/candlepin/owners/GlueCandlepinOwnerTestSystem_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="klMVbY5BrMgLXoujCJUP52WVo5YyjL2wt9JAHUMeA",
+        oauth_signature="3ec8PZy4pKhIOrK89g0eO6o4hO0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681111", oauth_version="1.0"
+      Cp-User:
+      - foreman_admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - dbdf0d14-fb25-4bc6-9101-43250405433f
+      X-Version:
+      - 0.9.51.3-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 05 Feb 2016 14:05:10 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiJmZjgwODA4MTUyYTc4NzE5MDE1
+        MmIxYzAzN2QwMDAzZiIsImtleSI6IkdsdWVDYW5kbGVwaW5Pd25lclRlc3RT
+        eXN0ZW1fMSIsImRpc3BsYXlOYW1lIjoiR2x1ZUNhbmRsZXBpbk93bmVyVGVz
+        dFN5c3RlbV8xIiwiY29udGVudFByZWZpeCI6Ii9HbHVlQ2FuZGxlcGluT3du
+        ZXJUZXN0U3lzdGVtXzEvJGVudiIsImRlZmF1bHRTZXJ2aWNlTGV2ZWwiOm51
+        bGwsInVwc3RyZWFtQ29uc3VtZXIiOm51bGwsImxvZ0xldmVsIjpudWxsLCJo
+        cmVmIjoiL293bmVycy9HbHVlQ2FuZGxlcGluT3duZXJUZXN0U3lzdGVtXzEi
+        LCJjcmVhdGVkIjoiMjAxNi0wMi0wNVQxNDowNToxMC40ODArMDAwMCIsInVw
+        ZGF0ZWQiOiIyMDE2LTAyLTA1VDE0OjA1OjEwLjQ4MCswMDAwIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:11 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/pulp/consumer/consumer.yml
+++ b/test/fixtures/vcr_cassettes/pulp/consumer/consumer.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/
     body:
       encoding: UTF-8
       base64_string: |
@@ -17,9 +17,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="t1yD9lxnodNDXDQyg4GvHd8Y0azcEpCY1HhIeMZrZ8", oauth_signature="hUy4n4byU7cmomoXgcG%2F%2FyNPLQY%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628864", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="pN8yocwhWJXYsh2VA5w5DkVpdGg0yFvkuB5knQwlY", oauth_signature="0WOtL3iKLpkZz7D9CQn8P3kVJNo%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681116", oauth_version="1.0"
       Pulp-User:
       - admin
       Content-Length:
@@ -29,20 +29,20 @@ http_interactions:
   response:
     status:
       code: 201
-      message: Created
+      message: CREATED
     headers:
       Date:
-      - Thu, 04 Feb 2016 23:34:24 GMT
+      - Fri, 05 Feb 2016 14:05:16 GMT
       Server:
       - Apache/2.4.6 (CentOS)
-      Location:
-      - "/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/"
       Content-Length:
-      - '2311'
+      - '2300'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
       Connection:
       - close
       Content-Type:
-      - application/json
+      - application/json; charset=utf-8
     body:
       encoding: UTF-8
       base64_string: |
@@ -50,59 +50,59 @@ http_interactions:
         MTFFMi04MUMxLTA4MDAyMDBDOUE2NiIsICJkZXNjcmlwdGlvbiI6IG51bGws
         ICJfbnMiOiAiY29uc3VtZXJzIiwgIm5vdGVzIjoge30sICJyc2FfcHViIjog
         bnVsbCwgImNhcGFiaWxpdGllcyI6IHt9LCAiX2lkIjogeyIkb2lkIjogIjU2
-        YjNlMDAwODRhMDljMDcwNjM0MzI4MSJ9LCAiaWQiOiAiMDEwRTk5QzAtMzI3
-        Ni0xMUUyLTgxQzEtMDgwMDIwMEM5QTY2IiwgIl9ocmVmIjogeyJfaHJlZiI6
-        ICIvcHVscC9hcGkvdjIvY29uc3VtZXJzLzAxMEU5OUMwLTMyNzYtMTFFMi04
-        MUMxLTA4MDAyMDBDOUE2Ni8ifX0sICJjZXJ0aWZpY2F0ZSI6ICItLS0tLUJF
-        R0lOIFJTQSBQUklWQVRFIEtFWS0tLS0tXG5NSUlDWEFJQkFBS0JnUUNmeC9o
-        ck5YOFVEVk5BZjZNdXRXSE02M1J1T1J3VXZhSDU3TkMybWQ4V0V2WUs1S01L
-        XG5NcGVJQzZUaGNMWVVYQzlFRnIwazZMbEVXdlZTek9oalkyYmF3SVRNTURl
-        SDFob242eTBDNnI3OStZam01cG94XG4yUnVpRFNXejZHRjdUU0V3Wk1mZkh5
-        T21GWmIvS2luS2dHMDV5M280NjZEYlZtSlYvYmpMcHdDZ1V3SURBUUFCXG5B
-        b0dBU1JlVlVKWGNXRFB3VGFVVjVSd2NiVDJZdVlOdWtSNWVwcEhxdUYyVGEr
-        bW9uRHNUU21yeVhzM1UwenhZXG5UdUFNenowSHNZYTBtY3h5UlRwdlpHZm9l
-        SmhOODZqeWJuZU1iN1ZHcDYrOS9SZW9IUXRHYU5MVVRpdXpZdVl5XG5nV242
-        QUFnTCtTMDdBUWQvZ1pMR3VsNXArUlNyMXlBMkJ4Sk9PT1VPNDBqVjZFRUNR
-        UURROERGNzB4cWpVWEdLXG5PSVpUeDBNZFEvM0UxZEVIakRoTC9VVEdLQzZO
-        aExuTjhsdUZmUG15UXdPdGppdzlyY1FJa1g1a1lBeW82UEdDXG5MeVBGd3R1
-        TEFrRUF3OFZHN2R2eG1zeDUxdWozeFROa3ZTU0dVdEhuTmxoaEMyOG1NbWJl
-        QzEvYWFQWmNuaWg3XG5RQXBNYXM5YTNHbk5BZlFSOTY5cE1tN1BtaTEzTFBT
-        SFdRSkJBTTBGSkVsUTJLNnhXQ3c5VXZJYWNTemlicjBhXG40a1g1dmJRekRh
-        MHorSm85UnVWamo1THBFMHRzbnN0SzJ2YWE3K1ZJZnpHWFhsVFFYMHRUWGxM
-        TDVna0NRRi9PXG54eFNYSkJsVzRuWExrNTVkdFhwZlNxRnpla3o5V1pqbjcz
-        Q1JLUysxM0VTcjlNMnVFQXRhUHVXeXpzdTV0NHV5XG5MNnpnbW9JRSt2S0FO
-        NmUza0JrQ1FCZEhwU1BsSWVnaEFRdkdPNktadGh2alEzQzc1d1lWaWw4aEh2
-        blA1RGZmXG5lTkxiMUhoY0ZGODFmUVVPM1VNWnZkZG1GK054WWlGdVRTRjB5
-        UzZBVzlFPVxuLS0tLS1FTkQgUlNBIFBSSVZBVEUgS0VZLS0tLS1cbi0tLS0t
-        QkVHSU4gQ0VSVElGSUNBVEUtLS0tLVxuTUlJQzBEQ0NBYmdDQWdJY01BMEdD
-        U3FHU0liM0RRRUJCUVVBTUlHRk1Rc3dDUVlEVlFRR0V3SlZVekVYTUJVR1xu
-        QTFVRUNCTU9UbTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9CZ05WQkFjVEIxSmhi
-        R1ZwWjJneEVEQU9CZ05WQkFvVFxuQjB0aGRHVnNiRzh4RkRBU0JnTlZCQXNU
-        QzFOdmJXVlBjbWRWYm1sME1TTXdJUVlEVlFRREV4cHJZWFJsYkd4dlxuTFdS
-        bGRtSnZlQzVsZUdGdGNHeGxMbU52YlRBZUZ3MHhOakF5TURReU16TTBNalJh
-        RncweU5qQXlNREV5TXpNMFxuTWpSYU1Ga3hMVEFyQmdOVkJBTVRKREF4TUVV
-        NU9VTXdMVE15TnpZdE1URkZNaTA0TVVNeExUQTRNREF5TURCRFxuT1VFMk5q
-        RW9NQ1lHQ2dtU0pvbVQ4aXhrQVFFVEdEVTJZak5sTURBd09EUmhNRGxqTURj
-        d05qTTBNekk0TVRDQlxubnpBTkJna3Foa2lHOXcwQkFRRUZBQU9CalFBd2dZ
-        a0NnWUVBbjhmNGF6Vi9GQTFUUUgrakxyVmh6T3QwYmprY1xuRkwyaCtlelF0
-        cG5mRmhMMkN1U2pDaktYaUF1azRYQzJGRnd2UkJhOUpPaTVSRnIxVXN6b1ky
-        Tm0yc0NFekRBM1xuaDlZYUorc3RBdXErL2ZtSTV1YWFNZGtib2cwbHMraGhl
-        MDBoTUdUSDN4OGpwaFdXL3lvcHlvQnRPY3Q2T091Z1xuMjFaaVZmMjR5NmNB
-        b0ZNQ0F3RUFBVEFOQmdrcWhraUc5dzBCQVFVRkFBT0NBUUVBZEJua3JFOE5z
-        WHBBRHZWZlxudzBTaHptNlRLTmpjQVFHVTFadjN5UkJ5LzBNalJVbGQva3Na
-        aW43SWFCL2lVd3JzVE5waDBmdkVoWTZLdUpwTFxuZWRlcHZERWp5a3VWT3p5
-        Q0N4eU5FaXRFdTRYY2JXcDExSGxwY1FMWWNwQTQ2Ym1oZWh0SytIbDhmVEkv
-        d2RsSVxuUHpZVHFiZCthbDlodldvM2x4eXhmVVlybnAraDQwSXBDYzRiUmlv
-        NlRzU3JGaFU0K0JYOUFzU3hxUlIzQ24zbFxud3o5WDJNUWsxU3ZxSStlYXdR
-        eUZTK1FmQzRaRFlnaHVTZFNNbkszS2R3WVFEWExqN2xPREZEZEQrK1p5UCtq
-        K1xud2dEbjJ1RkcvZzNYbmtOWEszNEpKc2l6a1dKVVVwbmMyZ2xpUFpMdHRK
-        YUF0cHpOQkQ3SmpDMWk5bUQxcGh1NFxuT0ZGTVZnPT1cbi0tLS0tRU5EIENF
-        UlRJRklDQVRFLS0tLS0ifQ==
+        YjRhYzFjYzc4MjFiMzMwNDJkOWRkOSJ9LCAiaWQiOiAiMDEwRTk5QzAtMzI3
+        Ni0xMUUyLTgxQzEtMDgwMDIwMEM5QTY2IiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi9jb25zdW1lcnMvMDEwRTk5QzAtMzI3Ni0xMUUyLTgxQzEtMDgwMDIw
+        MEM5QTY2LyJ9LCAiY2VydGlmaWNhdGUiOiAiLS0tLS1CRUdJTiBSU0EgUFJJ
+        VkFURSBLRVktLS0tLVxuTUlJQ1hRSUJBQUtCZ1FEWjFvU0lJak1WQnNQd1E5
+        SVd5blltTktQZ0ZUMmVPS2dwaHoxWGRLd3kwaU1HSVBFZlxuM1M4ZGFBamx5
+        ZUVySkxmbkYwZVYrRUp0R2QzS1ZxekRtVUdEdXh2WU1USnI3cXZUaSsvSmRW
+        RFNlWGkySzZFSVxuRUVBTTREQ1RaYmdIbzNFME1zdnJ0eHBEejNyYjFHc21J
+        VW54U2dZSUJuVjFaNHdVSGFFa1pVZytwUUlEQVFBQlxuQW9HQVNiYkd1RTVp
+        WE00aVJjNmRiQ3JzMmpiYjhYc2VrOGoyVnI4MTZiOUllaFlUMWdJVnRrT2hx
+        dURHaWdQTFxubDA3Z2tHbVhSczl3b3Z5cXljcVV3Y2U5bkJieWl4dTlvR1g4
+        YjliUkRYOU1YRjArRjJUZVBITDdnUi82VUV3VlxuM3FsV25QZlY4S0VFdmJJ
+        Vnk4R09MM0hFSFZISVhSS2FUQ3phd0lNdTlFWVI5d0VDUVFEN3BYcmEycXR0
+        WkZ2blxuNGxoR0lOS2w4dlZEbTVmVHhsenA5VlhmUXhOWXVwb09LQ2MyOXJi
+        N1VaVTYrSU9uTHZGUmJ2dit4eVhSbFV5UVxuekxmanZRUEJBa0VBM1p0Tm1h
+        ZnJmMWQ5NGdmZjRlSGpieERWYmw1Z21wUVRGSW9nR0tSR0lmOElzNVYxdDNs
+        ZVxuSXlqQ0ZtNEtWWlpDb3NwNWsvL1NjT2tEOGtlM0I5Q2o1UUpCQUxsRHZp
+        d0wyek9CTkd5R1pralM5MkozZVh3WlxudS9DTTFIRG1UeDg4cWF5a1RMRHBm
+        TjFwUzVQQkgyVzMrbTBHRVdITG5MaVk4MDNXWmZVZzBxMVd4Y0VDUUVVYlxu
+        NTZsaG1xbU55VzR4OG5ucERocFc3NWlKeWlxcXZ3Q0t5dE9rZDFLbXpEbmxC
+        RjhCZElBV2QrQ3kxSG80Yi9PQVxublVXd1pCcGVNS0xnQm81alhKa0NRUUN2
+        bUVVb3cwcnVoZnhINEQ0YU9FR2VSQ1N2R3dxNCt0UFBXTEVhTkR0TVxuSVZr
+        OEhVKzhtNUxzN0l0Tk1PTThoZGlqMmdwMlk5dGZFaE1xUTUzWmIrSXpcbi0t
+        LS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tXG4tLS0tLUJFR0lOIENFUlRJ
+        RklDQVRFLS0tLS1cbk1JSUMwRENDQWJnQ0FVY3dEUVlKS29aSWh2Y05BUUVG
+        QlFBd2dZWXhDekFKQmdOVkJBWVRBbFZUTVJjd0ZRWURcblZRUUlFdzVPYjNK
+        MGFDQkRZWEp2YkdsdVlURVFNQTRHQTFVRUJ4TUhVbUZzWldsbmFERVFNQTRH
+        QTFVRUNoTUhcblMyRjBaV3hzYnpFVU1CSUdBMVVFQ3hNTFUyOXRaVTl5WjFW
+        dWFYUXhKREFpQmdOVkJBTVRHMnRoZEdWc2JHOHRcbk1pMDRMV1JsZGk1bGVH
+        RnRjR3hsTG1OdmJUQWVGdzB4TmpBeU1EVXhOREExTVRaYUZ3MHlOakF5TURJ
+        eE5EQTFcbk1UWmFNRmt4TFRBckJnTlZCQU1USkRBeE1FVTVPVU13TFRNeU56
+        WXRNVEZGTWkwNE1VTXhMVEE0TURBeU1EQkRcbk9VRTJOakVvTUNZR0NnbVNK
+        b21UOGl4a0FRRVRHRFUyWWpSaFl6RmpZemM0TWpGaU16TXdOREprT1dSa09U
+        Q0Jcbm56QU5CZ2txaGtpRzl3MEJBUUVGQUFPQmpRQXdnWWtDZ1lFQTJkYUVp
+        Q0l6RlFiRDhFUFNGc3AySmpTajRCVTlcbm5qaW9LWWM5VjNTc010SWpCaUR4
+        SDkwdkhXZ0k1Y25oS3lTMzV4ZEhsZmhDYlJuZHlsYXN3NWxCZzdzYjJERXlc
+        bmErNnIwNHZ2eVhWUTBubDR0aXVoQ0JCQURPQXdrMlc0QjZOeE5ETEw2N2Nh
+        UTg5NjI5UnJKaUZKOFVvR0NBWjFcbmRXZU1GQjJoSkdWSVBxVUNBd0VBQVRB
+        TkJna3Foa2lHOXcwQkFRVUZBQU9DQVFFQVozVzM2SmJuRG4vTE9tTThcblJp
+        S0xQUVNPQU1HNW1EZUtvQkpqZTlPWDMxUHJtdTJUZ0phUjUxMnA3a0VIcWdn
+        aitsMFBiSUZmcklxN1RkS1dcbjJ6OWVDblpFdjJMdjFlaUc0TW5lOXlKWmds
+        T1V0cGxKVHR1M1RHcmx1V0loSVpBdG1XK0xieVordmVZQlA1bUFcblFISE9a
+        cTk3dG41dWo3Z3ZCc1RIaFFicnFrMENhRFFHT2N3Y3MvaWJBK3JXZ0hmVDg0
+        ZXJwZ29hVzJNYkxLRTlcbjNOVXJNNGY4YUlmb0xleTQ2QkV5bGhKcDBqN2FK
+        TWJsZnhvaUZvbzZvNVNPNlpsQ3dXdzFRV2VBWE9SR29XWURcbmpZOHhEeFg4
+        TnlpbEgva1h0Zmg2eXhTd1ZyNzlYSllzbE9rUmFYS2FtVFpXTjZIaTNjSW44
+        bUtBWFVmMndFcU5cbjMwd1c2dz09XG4tLS0tLUVORCBDRVJUSUZJQ0FURS0t
+        LS0tIn0=
     http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:24 GMT
+  recorded_at: Fri, 05 Feb 2016 14:05:16 GMT
 - request:
     method: put
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
     body:
       encoding: UTF-8
       base64_string: |
@@ -116,9 +116,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="9Xs6fgqEC22zmCFo1xWGBG3CSnnGIEnOEhMyIiqllc", oauth_signature="dsUjdOeQMRdBP31F%2FgVBvhrUlxI%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628864", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="wY1reapCtEGgpkMxTJUAXBXgJLqzh6oxgEGZKPfRSM", oauth_signature="rvAypUaDpdQs0h3oxi3%2BLQcLxgo%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681116", oauth_version="1.0"
       Pulp-User:
       - admin
       Content-Length:
@@ -131,30 +131,32 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 Feb 2016 23:34:24 GMT
+      - Fri, 05 Feb 2016 14:05:16 GMT
       Server:
       - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
       Content-Length:
       - '295'
       Connection:
       - close
       Content-Type:
-      - application/json
+      - application/json; charset=utf-8
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       base64_string: |
         eyJkaXNwbGF5X25hbWUiOiAiTm90IFNvIFNpbXBsZSBTZXJ2ZXIiLCAiZGVz
         Y3JpcHRpb24iOiBudWxsLCAiX25zIjogImNvbnN1bWVycyIsICJub3RlcyI6
         IHt9LCAicnNhX3B1YiI6IG51bGwsICJjYXBhYmlsaXRpZXMiOiB7fSwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1NmIzZTAwMDg0YTA5YzA3MDYzNDMyODEifSwgImlk
+        ZCI6IHsiJG9pZCI6ICI1NmI0YWMxY2M3ODIxYjMzMDQyZDlkZDkifSwgImlk
         IjogIjAxMEU5OUMwLTMyNzYtMTFFMi04MUMxLTA4MDAyMDBDOUE2NiIsICJf
         aHJlZiI6ICIvcHVscC9hcGkvdjIvY29uc3VtZXJzLzAxMEU5OUMwLTMyNzYt
         MTFFMi04MUMxLTA4MDAyMDBDOUE2Ni8ifQ==
     http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:24 GMT
+  recorded_at: Fri, 05 Feb 2016 14:05:16 GMT
 - request:
     method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -166,9 +168,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="QYjosLzEAFKINUf2MjU2tcfIN6VudgnSk3K1geJQ",
-        oauth_signature="SJryA0%2FWIT1gcNib0v1X%2Fr14X6I%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628864", oauth_version="1.0"
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="piqGVQqnnKo5MWByRPKbL11trt1UqC5tARrEg9xGZ8Y",
+        oauth_signature="zaFQ1Ei5lkHaVvzNDE36XSAu3ps%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681116", oauth_version="1.0"
       Pulp-User:
       - admin
       User-Agent:
@@ -179,7 +181,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 Feb 2016 23:34:24 GMT
+      - Fri, 05 Feb 2016 14:05:16 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -187,11 +189,11 @@ http_interactions:
       Connection:
       - close
       Content-Type:
-      - application/json
+      - application/json; charset=utf-8
     body:
       encoding: UTF-8
       base64_string: |
         bnVsbA==
     http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:24 GMT
+  recorded_at: Fri, 05 Feb 2016 14:05:16 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/pulp/consumer/content.yml
+++ b/test/fixtures/vcr_cassettes/pulp/consumer/content.yml
@@ -1193,57 +1193,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:29 GMT
 - request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/actions/content/install//
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ1bml0cyI6W3sidHlwZV9pZCI6InJwbSIsInVuaXRfa2V5Ijp7Im5hbWUi
-        OiJlbGVwaGFudCJ9fV0sIm9wdGlvbnMiOnsiaW1wb3J0a2V5cyI6dHJ1ZX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="nBermzgQ2JoPXjb3iLQw70u2kFrhIEPuKZPfUQFbk", oauth_signature="WoFs8d3kdxS6d%2BtgTOoWTuTD7NE%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628869", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '90'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:29 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2UzZjE5MDg0LTNiNTctNDI2Ny1hMzIyLTc4NmMyZTM4ZWI3OS8iLCAi
-        dGFza19pZCI6ICJlM2YxOTA4NC0zYjU3LTQyNjctYTMyMi03ODZjMmUzOGVi
-        NzkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:29 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/6feed625-61ab-48db-86fd-358c65e7745c/
     body:
@@ -1959,58 +1908,6 @@ http_interactions:
         YTA5YzA3ZGE5NzlhZTIiLCAicmVzdWx0IjogInN1Y2Nlc3MifSwgImVycm9y
         IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzZTAwNzg2ODBiNWNhNWM4
         NDIyYTQifSwgImlkIjogIjU2YjNlMDA3ODRhMDljMDdkYmY0ZDhmZCJ9
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:32 GMT
-- request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/actions/content/install//
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ1bml0cyI6W3sidHlwZV9pZCI6InBhY2thZ2VfZ3JvdXAiLCJ1bml0X2tl
-        eSI6eyJuYW1lIjoibWFtbWxzIn19XSwib3B0aW9ucyI6eyJpbXBvcnRrZXlz
-        Ijp0cnVlfX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="pR7dw51RceHqGbZOMbqTPwUoCmDH3P8YdvmjopuBc", oauth_signature="5qSCg9JnoM5JcuD3VouGKwYjh0U%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628872", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '98'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:32 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2I0YjVkYTM2LWFjODItNGZhZS05NjA5LTQ4OWY1MDNmYjYyYi8iLCAi
-        dGFza19pZCI6ICJiNGI1ZGEzNi1hYzgyLTRmYWUtOTYwOS00ODlmNTAzZmI2
-        MmIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:32 GMT
 - request:
@@ -2732,57 +2629,6 @@ http_interactions:
         NDIyYjQifSwgImlkIjogIjU2YjNlMDBiODRhMDljMDdkYmY0ZDkxNiJ9
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:35 GMT
-- request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/actions/content/uninstall//
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ1bml0cyI6W3sidHlwZV9pZCI6InJwbSIsInVuaXRfa2V5Ijp7Im5hbWUi
-        OiJjaGVldGFoIn19XSwib3B0aW9ucyI6e319
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="aESB2g6iEAIuBK643g7SHzAFv2gOCfxbDLfbYiMwmTA", oauth_signature="vr9I9cOekiAvHFWWnLomJD0bpS4%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628876", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '72'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:36 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2Y0ZjQ0ZmU0LTVmODQtNGI1Ny05YmY2LTc5ZWNlZjViMTFkZC8iLCAi
-        dGFza19pZCI6ICJmNGY0NGZlNC01Zjg0LTRiNTctOWJmNi03OWVjZWY1YjEx
-        ZGQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:36 GMT
 - request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/8bc84617-7c7a-4520-bc06-0e28ef6d5c63/
@@ -3512,57 +3358,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:39 GMT
 - request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/actions/content/uninstall//
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ1bml0cyI6W3sidHlwZV9pZCI6InBhY2thZ2VfZ3JvdXAiLCJ1bml0X2tl
-        eSI6eyJuYW1lIjoibWFtbWFscyJ9fV0sIm9wdGlvbnMiOnt9fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="mNcE8e28GdXOlBdcWFEMHldlRRsGTdQL0yj2Rq7VPRw", oauth_signature="3%2Be%2Bnr%2BUqRmt5GYYwOoxafJ8bEY%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628879", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '82'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:39 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzJjMDc3YWM3LTQxNjktNDFkNy05NTg0LWVjNDAzZmRkNGM5MC8iLCAi
-        dGFza19pZCI6ICIyYzA3N2FjNy00MTY5LTQxZDctOTU4NC1lYzQwM2ZkZDRj
-        OTAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:39 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/8ba45e98-d3a5-48a0-b91e-9372e54a018f/
     body:
@@ -4284,57 +4079,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:42 GMT
 - request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/actions/content/update//
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ1bml0cyI6W3sidHlwZV9pZCI6InJwbSIsInVuaXRfa2V5Ijp7fX1dLCJv
-        cHRpb25zIjp7ImltcG9ydGtleXMiOnRydWUsImFsbCI6dHJ1ZX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="SjK8GmFUtGnU53SdP2VxAUStaAt79Ovk79AtmfAegY", oauth_signature="NasmedevG4jTeg7WoFchJYOozeg%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628882", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '84'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:42 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzg5MGJlMDM2LTMxZWQtNDIzOS04NmVhLWU3Y2I2ZWMzMTE2YS8iLCAi
-        dGFza19pZCI6ICI4OTBiZTAzNi0zMWVkLTQyMzktODZlYS1lN2NiNmVjMzEx
-        NmEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:42 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/414d0c9a-5c53-49ec-b9b6-95d0be42004e/
     body:
@@ -4516,57 +4260,6 @@ http_interactions:
         NTZiM2UwMTQ4NGEwOWMwNzA2MzQzMzg4In0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:44 GMT
-- request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
-        Ijp0cnVlfX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="SsFpEwX4mP9mIh4JxRgsD4fedQCdoPRk6Rjm0Z0iNA", oauth_signature="u5tUvXpRiCtKkuxKmyeiZpINe1A%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628884", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '53'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:44 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzRhODk2MjcwLWM0NTktNDQzMS05ZmI2LTQzYzY5ODk3MDdjNC8iLCAi
-        dGFza19pZCI6ICI0YTg5NjI3MC1jNDU5LTQ0MzEtOWZiNi00M2M2OTg5NzA3
-        YzQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:44 GMT
 - request:
@@ -5179,384 +4872,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:45 GMT
 - request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IjAxMEU5OUMwLTMyNzYtMTFFMi04MUMxLTA4MDAyMDBDOUE2NiIs
-        ImRpc3BsYXlfbmFtZSI6IjAxMEU5OUMwLTMyNzYtMTFFMi04MUMxLTA4MDAy
-        MDBDOUE2NiJ9
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="fW4YCNrEEIch2wHg7lgahazw4XAeMcZhaCg1kKksxMI", oauth_signature="TcdMTi5cmUjxSau3djnJ9trQ6Ls%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628885", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '99'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:45 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Location:
-      - "/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/"
-      Content-Length:
-      - '2311'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb25zdW1lciI6IHsiZGlzcGxheV9uYW1lIjogIjAxMEU5OUMwLTMyNzYt
-        MTFFMi04MUMxLTA4MDAyMDBDOUE2NiIsICJkZXNjcmlwdGlvbiI6IG51bGws
-        ICJfbnMiOiAiY29uc3VtZXJzIiwgIm5vdGVzIjoge30sICJyc2FfcHViIjog
-        bnVsbCwgImNhcGFiaWxpdGllcyI6IHt9LCAiX2lkIjogeyIkb2lkIjogIjU2
-        YjNlMDE1ODRhMDljMDcwNjM0MzM5ZSJ9LCAiaWQiOiAiMDEwRTk5QzAtMzI3
-        Ni0xMUUyLTgxQzEtMDgwMDIwMEM5QTY2IiwgIl9ocmVmIjogeyJfaHJlZiI6
-        ICIvcHVscC9hcGkvdjIvY29uc3VtZXJzLzAxMEU5OUMwLTMyNzYtMTFFMi04
-        MUMxLTA4MDAyMDBDOUE2Ni8ifX0sICJjZXJ0aWZpY2F0ZSI6ICItLS0tLUJF
-        R0lOIFJTQSBQUklWQVRFIEtFWS0tLS0tXG5NSUlDWEFJQkFBS0JnUURqcW13
-        V2hxekZjUVB0VlBraXhEbkJ0K0E3dGhrMnpTNjk1MHJzZ3MxWUN4cmtSZWY3
-        XG5xR3dXbmw0a3dCZ1FwNnRKRzViVHh0azV0R1dwaFkxSGlNR0JFMlBVaXpn
-        c280OXUyck1XWFJzdkg2Mml3WlpxXG5aYlB5ZzNIZjR3Mno0a3BNYTlZcHd4
-        UVdpWWFoYmQ2cDdMNnRLcDF1SzU1bDIvQ05Cb0U5V2hqMWN3SURBUUFCXG5B
-        b0dBSFljWkJjTHAzYUhPMUpWVXlzR1FqQ09CSGIxOGY3TVZBT1JpdjFJbnQr
-        ZVkwVXFQMEFBRUpOcmRjdjdIXG5JRUhlNFZpR3MyankrNXorSW9LRDFHZFVV
-        VjYzRkdGNTkzLzF3RG91REVkdVRKSlFVQVpCU0VNU2JubGxuNEhLXG5rOUtN
-        RFBRTTZRNmwyN1B4TldiT29jV2tpSWMxWUlxUWFvcUdZb0xpTExFaGlxRUNR
-        UUQ4V1ltRSs5YUNFcW13XG5JdzFMYlRRdGYyVUdvOU01YzU3T3N3ZCtTRTJB
-        NG5hUGZaTUdPZm9pcmRKNEtYVm8zbWF6RCtmNkdyNXBmc1RQXG4wK2taTDlE
-        OUFrRUE1dlY2bCs4MHM5Sk1kUEhuYWNsVHR1SHByMWZVbWlqb3U3clhzRDVO
-        eFVlUWQzUyszaUp4XG5abFpyTmEwOGxCSDIxLzROSDB0Y2JQN1NhbGFhWTJz
-        akx3SkFDM1NKRUpkYUNuZU1hbWw4N2dLY0RzQ3N0bHR6XG5lRFV1YlZXbExt
-        OWJ6VkQ2YnRNVmZIL2ZRZm5BQnlKaXFRc0hnSE5sWlc0WFhMU2JmSSt6RWlp
-        Z2hRSkFRZnBxXG5sVERPbTNnK1EwSS8yNmFaOWFxLytVbGNBTllpOWs1QUE2
-        Y296R3pQUm5EaGZjL1ZHV2tpbzJqajMyRHFaWFc4XG5CZTZmYnJ1MUhJKzA5
-        eVhLSFFKQkFNbExWY2xoOHN2QWw1TDFiYWJuYU01MXBSVDFWQk5CbHR3aXU3
-        STR3VWY4XG5HaFNsU3B6OGoyVzc5OVJHK1JFbnZyWnIvbkRpbENKR3JWVmNz
-        bE1DSCtVPVxuLS0tLS1FTkQgUlNBIFBSSVZBVEUgS0VZLS0tLS1cbi0tLS0t
-        QkVHSU4gQ0VSVElGSUNBVEUtLS0tLVxuTUlJQzBEQ0NBYmdDQWdJak1BMEdD
-        U3FHU0liM0RRRUJCUVVBTUlHRk1Rc3dDUVlEVlFRR0V3SlZVekVYTUJVR1xu
-        QTFVRUNCTU9UbTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9CZ05WQkFjVEIxSmhi
-        R1ZwWjJneEVEQU9CZ05WQkFvVFxuQjB0aGRHVnNiRzh4RkRBU0JnTlZCQXNU
-        QzFOdmJXVlBjbWRWYm1sME1TTXdJUVlEVlFRREV4cHJZWFJsYkd4dlxuTFdS
-        bGRtSnZlQzVsZUdGdGNHeGxMbU52YlRBZUZ3MHhOakF5TURReU16TTBORFZh
-        RncweU5qQXlNREV5TXpNMFxuTkRWYU1Ga3hMVEFyQmdOVkJBTVRKREF4TUVV
-        NU9VTXdMVE15TnpZdE1URkZNaTA0TVVNeExUQTRNREF5TURCRFxuT1VFMk5q
-        RW9NQ1lHQ2dtU0pvbVQ4aXhrQVFFVEdEVTJZak5sTURFMU9EUmhNRGxqTURj
-        d05qTTBNek01WlRDQlxubnpBTkJna3Foa2lHOXcwQkFRRUZBQU9CalFBd2dZ
-        a0NnWUVBNDZwc0ZvYXN4WEVEN1ZUNUlzUTV3YmZnTzdZWlxuTnMwdXZlZEs3
-        SUxOV0FzYTVFWG4rNmhzRnA1ZUpNQVlFS2VyU1J1VzA4YlpPYlJscVlXTlI0
-        akJnUk5qMUlzNFxuTEtPUGJ0cXpGbDBiTHgrdG9zR1dhbVd6OG9OeDMrTU5z
-        K0pLVEd2V0tjTVVGb21Hb1czZXFleStyU3FkYml1ZVxuWmR2d2pRYUJQVm9Z
-        OVhNQ0F3RUFBVEFOQmdrcWhraUc5dzBCQVFVRkFBT0NBUUVBT0pKUkZTajgw
-        RkorZ29mTVxuQmNyRUt6TTNXdGtPSnJXeTFFOWllNGhqQ0pqVjg1elZpK2E1
-        cmI1VmZNMDRPalA0amlpZ2tPa0t3Zmcwd0NPTlxuRHFyRWd4Qkk3STh5eXll
-        aVBwOXNXV0xDcjFTM1lDQTd1bmlBNndUYW85TlBHbmFJVzdDR1laYmpIWkR5
-        SGFXL1xuVWZHZVNwaTZnb3ZOZk5OeXVzV3phUVErM2RNM0Y2WDVsR0VrTVJh
-        a1hmbU1xRkNSM3hKa2ZpMzU1Mk5FaGhFZ1xucXVmT2RJV0JLTllaczcyMUFR
-        MmlxRVJodnNqcndhb2srRXVhTmVMS3ZHaGtzb3NTNCtFWGdzWDFmMnd2M2Ux
-        OVxuSXlqdHl6V1l5djJ6eVVnb1NQU29Jd3p2bkhPelNURWJyNjdjeEtIWGlH
-        TlQ5b0VGRUk0UEtZSWN0SlFHM0lEU1xueDVUUHlRPT1cbi0tLS0tRU5EIENF
-        UlRJRklDQVRFLS0tLS0ifQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:45 GMT
-- request:
-    method: get
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/bindings//
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="boRcFxAw9hsu3s1Y7XFDWvMLQZ8kqrqxNy8ILFYE",
-        oauth_signature="OURMNhVf%2FyCG%2BWbK%2Fjjnxd8fjMM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628885", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:45 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '2'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W10=
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:45 GMT
-- request:
-    method: get
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="DsnuAULOHqv78NyxX4Or1gICcfV7EPRE6OT4p2Edcc",
-        oauth_signature="I3RQf%2BR5DkC%2BALvSEFq38kuOkds%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628885", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:45 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '1976'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjogeyJjaGVja3N1bV90eXBlIjogInNoYTI1NiJ9LCAi
-        ZGlzcGxheV9uYW1lIjogIkZlZG9yYSAxNyB4ODZfNjQiLCAiZGVzY3JpcHRp
-        b24iOiBudWxsLCAiZGlzdHJpYnV0b3JzIjogW3sicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgImxhc3RfcHVi
-        bGlzaCI6IG51bGwsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjaGVkdWxl
-        ZF9wdWJsaXNoZXMiOiBbXSwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhw
-        b3J0X2Rpc3RyaWJ1dG9yIiwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzZTAxNDg0
-        YTA5YzA3MDYzNDMzOGQifSwgImNvbmZpZyI6IHsiaHR0cCI6IGZhbHNlLCAi
-        aHR0cHMiOiBmYWxzZX0sICJpZCI6ICJleHBvcnRfZGlzdHJpYnV0b3IifSwg
-        eyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJfbnMiOiAicmVwb19kaXN0cmli
-        dXRvcnMiLCAibGFzdF9wdWJsaXNoIjogIjIwMTYtMDItMDRUMjM6MzQ6NDVa
-        IiwgImF1dG9fcHVibGlzaCI6IHRydWUsICJzY2hlZHVsZWRfcHVibGlzaGVz
-        IjogW10sICJkaXN0cmlidXRvcl90eXBlX2lkIjogIm5vZGVzX2h0dHBfZGlz
-        dHJpYnV0b3IiLCAiX2lkIjogeyIkb2lkIjogIjU2YjNlMDE0ODRhMDljMDcw
-        NjM0MzM4YyJ9LCAiY29uZmlnIjoge30sICJpZCI6ICJGZWRvcmFfMTdfbm9k
-        ZXMifSwgeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJfbnMiOiAicmVwb19k
-        aXN0cmlidXRvcnMiLCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImF1dG9fcHVi
-        bGlzaCI6IGZhbHNlLCAic2NoZWR1bGVkX3B1Ymxpc2hlcyI6IFtdLCAiZGlz
-        dHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlzdHJpYnV0b3IiLCAi
-        X2lkIjogeyIkb2lkIjogIjU2YjNlMDE0ODRhMDljMDcwNjM0MzM4YiJ9LCAi
-        Y29uZmlnIjogeyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRv
-        cmFfMTcifSwgImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9LCB7InJlcG9faWQi
-        OiAiRmVkb3JhXzE3IiwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJs
-        YXN0X3B1Ymxpc2giOiAiMjAxNi0wMi0wNFQyMzozNDo0NVoiLCAiYXV0b19w
-        dWJsaXNoIjogdHJ1ZSwgInNjaGVkdWxlZF9wdWJsaXNoZXMiOiBbXSwgImRp
-        c3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NmIzZTAxNDg0YTA5YzA3MDYzNDMzOGEifSwgImNvbmZp
-        ZyI6IHsiY2hlY2tzdW1fdHlwZSI6ICJzaGEyNTYiLCAicHJvdGVjdGVkIjog
-        dHJ1ZSwgImh0dHAiOiBmYWxzZSwgImh0dHBzIjogdHJ1ZSwgInJlbGF0aXZl
-        X3VybCI6ICJ0ZXN0X3BhdGgifSwgImlkIjogIkZlZG9yYV8xNyJ9XSwgImxh
-        c3RfdW5pdF9hZGRlZCI6ICIyMDE2LTAyLTA0VDIzOjM0OjQ0WiIsICJub3Rl
-        cyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3Jl
-        bW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHsicGFja2Fn
-        ZV9ncm91cCI6IDIsICJkaXN0cmlidXRpb24iOiAxLCAicGFja2FnZV9jYXRl
-        Z29yeSI6IDEsICJycG0iOiA4LCAiZXJyYXR1bSI6IDN9LCAiX25zIjogInJl
-        cG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        Il9ucyI6ICJyZXBvX2ltcG9ydGVycyIsICJpbXBvcnRlcl90eXBlX2lkIjog
-        Inl1bV9pbXBvcnRlciIsICJsYXN0X3N5bmMiOiAiMjAxNi0wMi0wNFQyMzoz
-        NDo0NFoiLCAic2NoZWR1bGVkX3N5bmNzIjogW10sICJfaWQiOiB7IiRvaWQi
-        OiAiNTZiM2UwMTQ4NGEwOWMwNzA2MzQzMzg5In0sICJjb25maWciOiB7ImZl
-        ZWQiOiAiZmlsZTovLy92YXIvd3d3L3Rlc3RfcmVwb3Mvem9vIn0sICJpZCI6
-        ICJ5dW1faW1wb3J0ZXIifV0sICJfaWQiOiB7IiRvaWQiOiAiNTZiM2UwMTQ4
-        NGEwOWMwNzA2MzQzMzg4In0sICJpZCI6ICJGZWRvcmFfMTciLCAiX2hyZWYi
-        OiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvIn0=
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:45 GMT
-- request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/bindings//
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJyZXBvX2lkIjoiRmVkb3JhXzE3IiwiZGlzdHJpYnV0b3JfaWQiOiJGZWRv
-        cmFfMTciLCJub3RpZnlfYWdlbnQiOmZhbHNlfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="v90VzJnSeseyAg8jN8lNxlJtO6mrDfxbyeczXZREv8", oauth_signature="T4z8NQIZLOzvSEkgkXo4RZVeREg%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628885", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '73'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:45 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '352'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW10sICJyZXN1bHQiOiB7Im5vdGlmeV9hZ2Vu
-        dCI6IGZhbHNlLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiZGVsZXRlZCI6
-        IGZhbHNlLCAiX25zIjogImNvbnN1bWVyX2JpbmRpbmdzIiwgImRpc3RyaWJ1
-        dG9yX2lkIjogIkZlZG9yYV8xNyIsICJjb25zdW1lcl9pZCI6ICIwMTBFOTlD
-        MC0zMjc2LTExRTItODFDMS0wODAwMjAwQzlBNjYiLCAiY29uc3VtZXJfYWN0
-        aW9ucyI6IFtdLCAiYmluZGluZ19jb25maWciOiB7fSwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmIzZTAxNTg0YTA5YzA3MDYzNDMzYTQifSwgImlkIjogIjU2YjNl
-        MDE1ODRhMDljMDcwNjM0MzNhNCJ9LCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:45 GMT
-- request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/actions/content/update//
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ1bml0cyI6W3sidHlwZV9pZCI6InJwbSIsInVuaXRfa2V5Ijp7Im5hbWUi
-        OiJjaGVldGFoIn19XSwib3B0aW9ucyI6eyJpbXBvcnRrZXlzIjp0cnVlfX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="ojraWaNLQmmIlDFNAevqlYgv36fjBYOFuXDHekgJ5Gw", oauth_signature="R7SEyquKQWw9QDsMJiYv92ntGcM%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628885", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '89'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:45 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzZlMDFkODcyLTdkOGUtNDA0Ny1hYTVhLTY3MjYxZTJiN2NmMS8iLCAi
-        dGFza19pZCI6ICI2ZTAxZDg3Mi03ZDhlLTQwNDctYWE1YS02NzI2MWUyYjdj
-        ZjEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:45 GMT
-- request:
-    method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="WZVLPvoUmfZYj8O2elUzuukQ330QIS8eYsYKDrEwQ",
-        oauth_signature="26g6J7jvf91nVpiSaCBx0TjyDAo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628886", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:46 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzljOTU3Mjk4LTRkMzUtNDc1Ni04OGY4LWQzNzUxZWYwOTU5Yy8iLCAi
-        dGFza19pZCI6ICI5Yzk1NzI5OC00ZDM1LTQ3NTYtODhmOC1kMzc1MWVmMDk1
-        OWMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:46 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/9c957298-4d35-4756-88f8-d3751ef0959c/
     body:
@@ -5667,8 +4982,8 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:46 GMT
 - request:
-    method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/56bbdbea-95c7-4b2f-8ced-057f11ee89a6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5680,9 +4995,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="oSUjfwb0CjVdhmlGQqxt68ERY8ZmjJldid3W0XfyOQU",
-        oauth_signature="2lRxStqHXLPNZR%2Brds0f7qGqzfs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628886", oauth_version="1.0"
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="94dZ3eLeChIRnvV4DZsKf9JKQrYtdzCzWhQBM2P7f8o",
+        oauth_signature="g%2BUDCCfIOA4V9z7i3VhcoFJGqjw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681117", oauth_version="1.0"
       Pulp-User:
       - admin
       User-Agent:
@@ -5693,7 +5008,5772 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 Feb 2016 23:34:46 GMT
+      - Fri, 05 Feb 2016 14:05:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '649'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NmJiZGJlYS05NWM3LTRiMmYtOGNlZC0wNTdmMTFlZTg5
+        YTYvIiwgInRhc2tfaWQiOiAiNTZiYmRiZWEtOTVjNy00YjJmLThjZWQtMDU3
+        ZjExZWU4OWE2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0
+        YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwg
+        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNTZiNGFjMWQ4YWRhNDBkYjA0ZWUwOWJiIn0sICJpZCI6ICI1NmI0YWMx
+        ZDhhZGE0MGRiMDRlZTA5YmIifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:17 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/56bbdbea-95c7-4b2f-8ced-057f11ee89a6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="zjkXo03lqHdc2DpRNQqTKcQ8nQgIyjJYEmP3f3nBZE0",
+        oauth_signature="z0faLrVa9ELdMSbYrXuClHXhcUI%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681118", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:18 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NmJiZGJlYS05NWM3LTRiMmYtOGNlZC0wNTdmMTFlZTg5
+        YTYvIiwgInRhc2tfaWQiOiAiNTZiYmRiZWEtOTVjNy00YjJmLThjZWQtMDU3
+        ZjExZWU4OWE2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNToxOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNToxN1oiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMWU1MzgxOTQtZmRlOS00NDEwLWJjZTgtZjY4NzE4ZjEy
+        YzMzLyIsICJ0YXNrX2lkIjogIjFlNTM4MTk0LWZkZTktNDQxMC1iY2U4LWY2
+        ODcxOGYxMmMzMyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzFkYzc4MjFiMzMwNDJkOWRkZSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDU6MTdaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNTox
+        OFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjMWVjNzgyMWIzNDQ0ZmNjMjU1IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMWQ4YWRhNDBkYjA0ZWUwOWJiIn0s
+        ICJpZCI6ICI1NmI0YWMxZDhhZGE0MGRiMDRlZTA5YmIifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:18 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/1e538194-fde9-4410-bce8-f68718f12c33/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="RGNtR9mVtHQcUNX7yDgfK3yAAY6VChi2rj559coChPo",
+        oauth_signature="YANyKTdfQqRpeDKtrAvSxSKqf1o%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681118", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:18 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '658'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8xZTUzODE5NC1mZGU5LTQ0MTAtYmNlOC1mNjg3
+        MThmMTJjMzMvIiwgInRhc2tfaWQiOiAiMWU1MzgxOTQtZmRlOS00NDEwLWJj
+        ZTgtZjY4NzE4ZjEyYzMzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiBudWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBb
+        XSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRf
+        cmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVz
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1w
+        bGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQi
+        OiB7IiRvaWQiOiAiNTZiNGFjMWU4YWRhNDBkYjA0ZWUwOWNiIn0sICJpZCI6
+        ICI1NmI0YWMxZThhZGE0MGRiMDRlZTA5Y2IifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:18 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/56bbdbea-95c7-4b2f-8ced-057f11ee89a6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="If1ilCDTJgkIYjKZbhRxLxcl7a5xgYPdqWt3GXAtN9Q",
+        oauth_signature="tTxAGDuR5p0UQ2QtibBm1Uy1hyA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681119", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:19 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NmJiZGJlYS05NWM3LTRiMmYtOGNlZC0wNTdmMTFlZTg5
+        YTYvIiwgInRhc2tfaWQiOiAiNTZiYmRiZWEtOTVjNy00YjJmLThjZWQtMDU3
+        ZjExZWU4OWE2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNToxOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNToxN1oiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMWU1MzgxOTQtZmRlOS00NDEwLWJjZTgtZjY4NzE4ZjEy
+        YzMzLyIsICJ0YXNrX2lkIjogIjFlNTM4MTk0LWZkZTktNDQxMC1iY2U4LWY2
+        ODcxOGYxMmMzMyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzFkYzc4MjFiMzMwNDJkOWRkZSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDU6MTdaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNTox
+        OFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjMWVjNzgyMWIzNDQ0ZmNjMjU1IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMWQ4YWRhNDBkYjA0ZWUwOWJiIn0s
+        ICJpZCI6ICI1NmI0YWMxZDhhZGE0MGRiMDRlZTA5YmIifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:19 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/1e538194-fde9-4410-bce8-f68718f12c33/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="C0eCPY06tKVMwhIHYfJp3cuAc53Er3DlLmWEqvEt6FU",
+        oauth_signature="ApPOK8gd28evcrbi3RyzQEzmeRQ%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681119", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:19 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '6929'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8xZTUzODE5NC1mZGU5LTQ0MTAtYmNlOC1mNjg3
+        MThmMTJjMzMvIiwgInRhc2tfaWQiOiAiMWU1MzgxOTQtZmRlOS00NDEwLWJj
+        ZTgtZjY4NzE4ZjEyYzMzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0wMi0wNVQxNDowNToxOVoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNToxOFoiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICIwNTVjNmYxOS1jYmU2LTRkN2MtOTA5My05NTgwY2Q0
+        NGZiYmYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiNzVmMDk4MTItMjI2Ni00OWM3LTk0OTUtNWYwMTAyNDYzOWFiIiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
+        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZDgyNWVkYTAtMmEyMC00NTM0LTljNjAt
+        MTE2MmU1M2M0MmUzIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
+        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiN2Q0
+        ZWQwYzUtYzE4OS00ZDU3LTg0MmQtN2M5ODljMDkyMGNkIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjA1NmY4MjEwLTY2ZDctNDM0Ni04MTM1LWQxNjFl
+        ZTMwOTBjYiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
+        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhMWQzMmRm
+        Ny00ZWI1LTRlNzEtYWMyMi1iMWE1NTFmZWEzOWUiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI3YWJmZDgyYS1mNzllLTRiYWYtOTlhOC05ODBm
+        NzVlYTk5ZTMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
+        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICJiNjE5NmFlNi01ODE0LTQyN2MtYTEyMy1kZWU5Yjg0OTIwOTUi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
+        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwOTAx
+        ZmVhYy0wMjAxLTQwMDctOTUxMC1kY2I3YTY1NGJjZTciLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
+        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzNTg1Y2MwYy1hNzQz
+        LTQ0NzItYjUyMi1mZTVjMDZiYzA1OTAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
+        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFiMjE5M2U0LTdmZmUtNDY0
+        MC04ODEzLTJhN2UxZjBhMDljMyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
+        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE0OjA1OjE4
+        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMDVUMTQ6MDU6MTlaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
+        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
+        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
+        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
+        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
+        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
+        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
+        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
+        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGFjMWZjNzgyMWIz
+        NDQ0ZmNjMjU2IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
+        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
+        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogIjA1NWM2ZjE5LWNiZTYtNGQ3Yy05MDkzLTk1ODBjZDQ0ZmJi
+        ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
+        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICI3NWYwOTgxMi0yMjY2LTQ5YzctOTQ5NS01ZjAxMDI0NjM5YWIiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
+        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJkODI1ZWRhMC0yYTIwLTQ1MzQtOWM2MC0xMTYy
+        ZTUzYzQyZTMiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
+        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3ZDRlZDBj
+        NS1jMTg5LTRkNTctODQyZC03Yzk4OWMwOTIwY2QiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiMDU2ZjgyMTAtNjZkNy00MzQ2LTgxMzUtZDE2MWVlMzA5
+        MGNiIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImExZDMyZGY3LTRl
+        YjUtNGU3MS1hYzIyLWIxYTU1MWZlYTM5ZSIsICJudW1fcHJvY2Vzc2VkIjog
+        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjdhYmZkODJhLWY3OWUtNGJhZi05OWE4LTk4MGY3NWVh
+        OTllMyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
+        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImI2MTk2YWU2LTU4MTQtNDI3Yy1hMTIzLWRlZTliODQ5MjA5NSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
+        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA5MDFmZWFj
+        LTAyMDEtNDAwNy05NTEwLWRjYjdhNjU0YmNlNyIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
+        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM1ODVjYzBjLWE3NDMtNDQ3
+        Mi1iNTIyLWZlNWMwNmJjMDU5MCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
+        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWIyMTkzZTQtN2ZmZS00NjQwLTg4
+        MTMtMmE3ZTFmMGEwOWMzIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhYzFlOGFkYTQwZGIw
+        NGVlMDljYiJ9LCAiaWQiOiAiNTZiNGFjMWU4YWRhNDBkYjA0ZWUwOWNiIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:19 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/14620f91-5dc2-49ad-b614-fba72c8b4569/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="a3WGhHt4E36cJfWrIo8fyfJB612LVkavNcOg2OjZho",
+        oauth_signature="HW6EnPpvcKoFOErX%2BLAPkvuxUYU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681120", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:20 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '651'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xNDYyMGY5MS01ZGMyLTQ5YWQtYjYxNC1mYmE3MmM4YjQ1
+        NjkvIiwgInRhc2tfaWQiOiAiMTQ2MjBmOTEtNWRjMi00OWFkLWI2MTQtZmJh
+        NzJjOGI0NTY5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAi
+        c3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
+        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1NmI0YWMyMDhhZGE0MGRiMDRlZTA5Y2MifSwgImlkIjogIjU2YjRh
+        YzIwOGFkYTQwZGIwNGVlMDljYyJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:20 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/14620f91-5dc2-49ad-b614-fba72c8b4569/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="StY7hdzSltP8tkpZGSQmkfzKVxXP88KfAPpH09k4s",
+        oauth_signature="2YkGIPuAqy6ojBFvxe3HDSBOpsc%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681120", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:20 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xNDYyMGY5MS01ZGMyLTQ5YWQtYjYxNC1mYmE3MmM4YjQ1
+        NjkvIiwgInRhc2tfaWQiOiAiMTQ2MjBmOTEtNWRjMi00OWFkLWI2MTQtZmJh
+        NzJjOGI0NTY5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA1OjIwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA1OjIwWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjMjA4YWRhNDBkYjA0ZWUwOWNjIn0sICJpZCI6ICI1NmI0YWMyMDhhZGE0
+        MGRiMDRlZTA5Y2MifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:20 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/587312b6-b230-4fc9-967e-f31a1c24ed02/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="7fYIMN42yRgh53MjuFjd48rHNe20m7QsrjHhyPOWiWc",
+        oauth_signature="7YslDLD8gWzlx5O2Hp8jlJu9FbY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681122", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:22 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81ODczMTJiNi1iMjMwLTRmYzktOTY3ZS1mMzFhMWMyNGVk
+        MDIvIiwgInRhc2tfaWQiOiAiNTg3MzEyYjYtYjIzMC00ZmM5LTk2N2UtZjMx
+        YTFjMjRlZDAyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMjI4
+        YWRhNDBkYjA0ZWUwOWNlIn0sICJpZCI6ICI1NmI0YWMyMjhhZGE0MGRiMDRl
+        ZTA5Y2UifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:22 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/587312b6-b230-4fc9-967e-f31a1c24ed02/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="YlFnDQ5cUL7keGcKseMbuQRjKSXefKnUINnG3oUmyI",
+        oauth_signature="R6V8N6Szs%2Bc6SzmAByvRZbMRBaE%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681123", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:23 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1078'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81ODczMTJiNi1iMjMwLTRmYzktOTY3ZS1mMzFhMWMyNGVk
+        MDIvIiwgInRhc2tfaWQiOiAiNTg3MzEyYjYtYjIzMC00ZmM5LTk2N2UtZjMx
+        YTFjMjRlZDAyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0wNVQxNDowNToyMloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
+        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVl
+        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgt
+        ZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29y
+        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
+        by0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJv
+        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMjI4YWRhNDBkYjA0
+        ZWUwOWNlIn0sICJpZCI6ICI1NmI0YWMyMjhhZGE0MGRiMDRlZTA5Y2UifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:23 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/587312b6-b230-4fc9-967e-f31a1c24ed02/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="VMKyvgYwD26WCgjg3bcH07nHEjb7cdtxVNmjw6Ro6OM",
+        oauth_signature="2HJeQ%2BnKDUaJNrzoyW7Dphree5c%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681123", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:23 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81ODczMTJiNi1iMjMwLTRmYzktOTY3ZS1mMzFhMWMyNGVk
+        MDIvIiwgInRhc2tfaWQiOiAiNTg3MzEyYjYtYjIzMC00ZmM5LTk2N2UtZjMx
+        YTFjMjRlZDAyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNToyM1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNToyMloiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNDQzYmY2YjEtMDhkMi00NjhkLTg1ZGQtYTgxNGQxYjBi
+        MzIxLyIsICJ0YXNrX2lkIjogIjQ0M2JmNmIxLTA4ZDItNDY4ZC04NWRkLWE4
+        MTRkMWIwYjMyMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzIyYzc4MjFiMzMwMzRiYWUxNSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDU6MjJaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNToy
+        M1oiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjMjNjNzgyMWIzNDQ0ZmNjMjVhIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMjI4YWRhNDBkYjA0ZWUwOWNlIn0s
+        ICJpZCI6ICI1NmI0YWMyMjhhZGE0MGRiMDRlZTA5Y2UifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:23 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/443bf6b1-08d2-468d-85dd-a814d1b0b321/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="2kBQNZWyqj7xAz1aJ1mb8PgntK4FbxnKjmpST2BdY",
+        oauth_signature="bNgiQFMjnHhyVKGXGSIOyKFj9Ws%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681123", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '3523'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy80NDNiZjZiMS0wOGQyLTQ2OGQtODVkZC1hODE0
+        ZDFiMGIzMjEvIiwgInRhc2tfaWQiOiAiNDQzYmY2YjEtMDhkMi00NjhkLTg1
+        ZGQtYTgxNGQxYjBiMzIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxNi0wMi0wNVQxNDowNToyM1oiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzMzQw
+        YjE1Zi03MDIyLTRmYmItOGU1NC1lOWIxYzBkNzBjYzQiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDMyNDU4ZjctMDI1
+        MC00MTE3LWJiNmQtN2UyMTIyODA0NmNmIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDcsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiZjY1ODRlZTItMDBhZS00ZWZlLWJlZjctNjI2ZWU0YTg1ZDU1Iiwg
+        Im51bV9wcm9jZXNzZWQiOiA3fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
+        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNhMTVkYWExLTZkMzgt
+        NDY2MS1hY2U1LWQ3YzVjMGMwYzk5NyIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI4MjFkZmQyZS0xYzVmLTQyYmMtYjQyZi03MzllNzkyOTA3NzEi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5
+        cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjA2YzY2ODEtN2E3
+        Zi00OWMyLWIxMzMtMGY1YWExNjlmY2M5IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiNTgzMTI2YjctNzhkMC00OGFmLTllYWQtZjhjMGQ0
+        MTFjZjI1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAi
+        c3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiNmQ1MTRmM2ItZTM2ZS00MTg0LTk1MDQtOTZlNGE2OTMxNjI4
+        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
+        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjM3YjM2YzRjLWU3MTItNDA4Ni1iZDk3LTk0NDRhM2UzZTZkZCIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjog
+        InB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImEwN2Ew
+        MTc4LWVkZDUtNGMwOC1iZjI5LWNlMjI0MmM2OGY3YiIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
+        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjNkNDI0
+        NWUtZGQ5MS00Yzc0LWI0NzctZWM2YjI0YThiMjE4IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjMjM4YWRhNDBkYjA0ZWUwOWRlIn0sICJpZCI6ICI1NmI0YWMyMzhhZGE0
+        MGRiMDRlZTA5ZGUifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:24 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/587312b6-b230-4fc9-967e-f31a1c24ed02/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="kj6DliqZj3jGggIRFvQtkjFvLDJuTXHZpbYsPq9K1s",
+        oauth_signature="AECP8Sl3DX9Z6eFVkhKguOI8ff8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681124", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81ODczMTJiNi1iMjMwLTRmYzktOTY3ZS1mMzFhMWMyNGVk
+        MDIvIiwgInRhc2tfaWQiOiAiNTg3MzEyYjYtYjIzMC00ZmM5LTk2N2UtZjMx
+        YTFjMjRlZDAyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNToyM1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNToyMloiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNDQzYmY2YjEtMDhkMi00NjhkLTg1ZGQtYTgxNGQxYjBi
+        MzIxLyIsICJ0YXNrX2lkIjogIjQ0M2JmNmIxLTA4ZDItNDY4ZC04NWRkLWE4
+        MTRkMWIwYjMyMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzIyYzc4MjFiMzMwMzRiYWUxNSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDU6MjJaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNToy
+        M1oiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjMjNjNzgyMWIzNDQ0ZmNjMjVhIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMjI4YWRhNDBkYjA0ZWUwOWNlIn0s
+        ICJpZCI6ICI1NmI0YWMyMjhhZGE0MGRiMDRlZTA5Y2UifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:24 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/443bf6b1-08d2-468d-85dd-a814d1b0b321/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Y2dnAfd61VO3vrkLNW8hhQS25ERrtC91UcAlnqKUM",
+        oauth_signature="IyF8OKyS4vJk1EES13ha%2BHsh8IU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681124", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '6929'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy80NDNiZjZiMS0wOGQyLTQ2OGQtODVkZC1hODE0
+        ZDFiMGIzMjEvIiwgInRhc2tfaWQiOiAiNDQzYmY2YjEtMDhkMi00NjhkLTg1
+        ZGQtYTgxNGQxYjBiMzIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0wMi0wNVQxNDowNToyNFoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNToyM1oiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICIzMzQwYjE1Zi03MDIyLTRmYmItOGU1NC1lOWIxYzBk
+        NzBjYzQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiMDMyNDU4ZjctMDI1MC00MTE3LWJiNmQtN2UyMTIyODA0NmNmIiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
+        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZjY1ODRlZTItMDBhZS00ZWZlLWJlZjct
+        NjI2ZWU0YTg1ZDU1IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
+        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiM2Ex
+        NWRhYTEtNmQzOC00NjYxLWFjZTUtZDdjNWMwYzBjOTk3IiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjgyMWRmZDJlLTFjNWYtNDJiYy1iNDJmLTczOWU3
+        OTI5MDc3MSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
+        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2MDZjNjY4
+        MS03YTdmLTQ5YzItYjEzMy0wZjVhYTE2OWZjYzkiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI1ODMxMjZiNy03OGQwLTQ4YWYtOWVhZC1mOGMw
+        ZDQxMWNmMjUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
+        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI2ZDUxNGYzYi1lMzZlLTQxODQtOTUwNC05NmU0YTY5MzE2Mjgi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
+        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzN2Iz
+        NmM0Yy1lNzEyLTQwODYtYmQ5Ny05NDQ0YTNlM2U2ZGQiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
+        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhMDdhMDE3OC1lZGQ1
+        LTRjMDgtYmYyOS1jZTIyNDJjNjhmN2IiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
+        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImYzZDQyNDVlLWRkOTEtNGM3
+        NC1iNDc3LWVjNmIyNGE4YjIxOCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
+        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE0OjA1OjIz
+        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMDVUMTQ6MDU6MjRaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
+        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
+        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
+        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
+        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
+        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
+        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
+        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
+        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGFjMjRjNzgyMWIz
+        NDQ0ZmNjMjViIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
+        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
+        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogIjMzNDBiMTVmLTcwMjItNGZiYi04ZTU0LWU5YjFjMGQ3MGNj
+        NCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
+        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICIwMzI0NThmNy0wMjUwLTQxMTctYmI2ZC03ZTIxMjI4MDQ2Y2YiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
+        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJmNjU4NGVlMi0wMGFlLTRlZmUtYmVmNy02MjZl
+        ZTRhODVkNTUiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
+        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzYTE1ZGFh
+        MS02ZDM4LTQ2NjEtYWNlNS1kN2M1YzBjMGM5OTciLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiODIxZGZkMmUtMWM1Zi00MmJjLWI0MmYtNzM5ZTc5Mjkw
+        NzcxIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjYwNmM2NjgxLTdh
+        N2YtNDljMi1iMTMzLTBmNWFhMTY5ZmNjOSIsICJudW1fcHJvY2Vzc2VkIjog
+        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjU4MzEyNmI3LTc4ZDAtNDhhZi05ZWFkLWY4YzBkNDEx
+        Y2YyNSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
+        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjZkNTE0ZjNiLWUzNmUtNDE4NC05NTA0LTk2ZTRhNjkzMTYyOCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
+        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM3YjM2YzRj
+        LWU3MTItNDA4Ni1iZDk3LTk0NDRhM2UzZTZkZCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
+        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImEwN2EwMTc4LWVkZDUtNGMw
+        OC1iZjI5LWNlMjI0MmM2OGY3YiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
+        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjNkNDI0NWUtZGQ5MS00Yzc0LWI0
+        NzctZWM2YjI0YThiMjE4IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhYzIzOGFkYTQwZGIw
+        NGVlMDlkZSJ9LCAiaWQiOiAiNTZiNGFjMjM4YWRhNDBkYjA0ZWUwOWRlIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:24 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/actions/content/install//
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ1bml0cyI6W3sidHlwZV9pZCI6InJwbSIsInVuaXRfa2V5Ijp7Im5hbWUi
+        OiJlbGVwaGFudCJ9fV0sIm9wdGlvbnMiOnsiaW1wb3J0a2V5cyI6dHJ1ZX19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="DhKYlM5MIHr1CUX5QmrbSSXhEftXQuXIdHJfG0JE", oauth_signature="2WbcIgMWW4y7rSJFhgCqIsjSPPY%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681125", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '90'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:25 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2QwYmRkZmUyLTc5YWYtNDM3Zi04ZDAwLTY3ZGZjMWZjY2EyZi8iLCAi
+        dGFza19pZCI6ICJkMGJkZGZlMi03OWFmLTQzN2YtOGQwMC02N2RmYzFmY2Nh
+        MmYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:25 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/25e25011-9c15-4680-9463-737c190b410c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="zYNBU9JSnIICB20yJBIA63We6u407RBBsjTvTO5Eg",
+        oauth_signature="k%2FHzLWx77TdctnSr%2F9XBxZAvFEE%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681126", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:26 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '651'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yNWUyNTAxMS05YzE1LTQ2ODAtOTQ2My03MzdjMTkwYjQx
+        MGMvIiwgInRhc2tfaWQiOiAiMjVlMjUwMTEtOWMxNS00NjgwLTk0NjMtNzM3
+        YzE5MGI0MTBjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAi
+        c3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
+        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1NmI0YWMyNThhZGE0MGRiMDRlZTA5ZGYifSwgImlkIjogIjU2YjRh
+        YzI1OGFkYTQwZGIwNGVlMDlkZiJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:26 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/25e25011-9c15-4680-9463-737c190b410c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="UMpR1hxyh8H9RbTvEXqO8aOWHWAqSF2TM23VEAZkLw",
+        oauth_signature="MNZ5Hjtqy%2FPiJdFRa4KU%2FaW12Fw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681126", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:26 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yNWUyNTAxMS05YzE1LTQ2ODAtOTQ2My03MzdjMTkwYjQx
+        MGMvIiwgInRhc2tfaWQiOiAiMjVlMjUwMTEtOWMxNS00NjgwLTk0NjMtNzM3
+        YzE5MGI0MTBjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA1OjI2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA1OjI2WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjMjU4YWRhNDBkYjA0ZWUwOWRmIn0sICJpZCI6ICI1NmI0YWMyNThhZGE0
+        MGRiMDRlZTA5ZGYifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:26 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/79a1db29-6520-4150-982b-85f225f2ed88/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="iJbOcDK592V8phScvbkJMfSALeBD7JnU1FYtcIjzx4",
+        oauth_signature="JY9bQhbq7r%2FtYksPt6yz4t7rtOY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681128", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:28 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83OWExZGIyOS02NTIwLTQxNTAtOTgyYi04NWYyMjVmMmVk
+        ODgvIiwgInRhc2tfaWQiOiAiNzlhMWRiMjktNjUyMC00MTUwLTk4MmItODVm
+        MjI1ZjJlZDg4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMjg4
+        YWRhNDBkYjA0ZWUwOWUxIn0sICJpZCI6ICI1NmI0YWMyODhhZGE0MGRiMDRl
+        ZTA5ZTEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:28 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/79a1db29-6520-4150-982b-85f225f2ed88/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="rRKt7NbvzHwb8FLc0PctnkSOEmCqXIQnaVZbOlg2MTE",
+        oauth_signature="v6yUMseIWPaCdZyjWwXfVict1kI%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681129", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:29 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83OWExZGIyOS02NTIwLTQxNTAtOTgyYi04NWYyMjVmMmVk
+        ODgvIiwgInRhc2tfaWQiOiAiNzlhMWRiMjktNjUyMC00MTUwLTk4MmItODVm
+        MjI1ZjJlZDg4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNToyOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNToyOFoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvY2JhNmI1YTQtOTRhOC00ZDVjLWJmODgtMWM1MTljMDU0
+        MjYxLyIsICJ0YXNrX2lkIjogImNiYTZiNWE0LTk0YTgtNGQ1Yy1iZjg4LTFj
+        NTE5YzA1NDI2MSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzI4Yzc4MjFiMzMwMzRiYWUxYyJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDU6MjhaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNToy
+        OVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjMjljNzgyMWIzNDQ0ZmNjMjVmIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMjg4YWRhNDBkYjA0ZWUwOWUxIn0s
+        ICJpZCI6ICI1NmI0YWMyODhhZGE0MGRiMDRlZTA5ZTEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:29 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/cba6b5a4-94a8-4d5c-bf88-1c519c054261/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="cuCMX2jOGDs1ibuHGQz8D5sNZhJtizQo4s4InEbynbU",
+        oauth_signature="V%2BZPAJv5yhDXGgr7jr36l26l340%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681129", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:29 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '658'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9jYmE2YjVhNC05NGE4LTRkNWMtYmY4OC0xYzUx
+        OWMwNTQyNjEvIiwgInRhc2tfaWQiOiAiY2JhNmI1YTQtOTRhOC00ZDVjLWJm
+        ODgtMWM1MTljMDU0MjYxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiBudWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBb
+        XSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRf
+        cmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVz
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1w
+        bGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQi
+        OiB7IiRvaWQiOiAiNTZiNGFjMjk4YWRhNDBkYjA0ZWUwOWYxIn0sICJpZCI6
+        ICI1NmI0YWMyOThhZGE0MGRiMDRlZTA5ZjEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:29 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/79a1db29-6520-4150-982b-85f225f2ed88/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="CSiVT29Wa4WKjrWV55qATGvxbYRCin6CbqV0peWZYw",
+        oauth_signature="2tnkLszv7hfoJYIUqF52JVOWSO0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681129", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:29 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83OWExZGIyOS02NTIwLTQxNTAtOTgyYi04NWYyMjVmMmVk
+        ODgvIiwgInRhc2tfaWQiOiAiNzlhMWRiMjktNjUyMC00MTUwLTk4MmItODVm
+        MjI1ZjJlZDg4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNToyOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNToyOFoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvY2JhNmI1YTQtOTRhOC00ZDVjLWJmODgtMWM1MTljMDU0
+        MjYxLyIsICJ0YXNrX2lkIjogImNiYTZiNWE0LTk0YTgtNGQ1Yy1iZjg4LTFj
+        NTE5YzA1NDI2MSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzI4Yzc4MjFiMzMwMzRiYWUxYyJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDU6MjhaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNToy
+        OVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjMjljNzgyMWIzNDQ0ZmNjMjVmIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMjg4YWRhNDBkYjA0ZWUwOWUxIn0s
+        ICJpZCI6ICI1NmI0YWMyODhhZGE0MGRiMDRlZTA5ZTEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:29 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/cba6b5a4-94a8-4d5c-bf88-1c519c054261/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="bHFxBWr8GVyEjRpssbUMCZFJXwSh0V3hfc2pfI8tHzo",
+        oauth_signature="zTHnZbeJXldufjFYcPOlEB47GEA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681129", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:29 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '6929'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9jYmE2YjVhNC05NGE4LTRkNWMtYmY4OC0xYzUx
+        OWMwNTQyNjEvIiwgInRhc2tfaWQiOiAiY2JhNmI1YTQtOTRhOC00ZDVjLWJm
+        ODgtMWM1MTljMDU0MjYxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0wMi0wNVQxNDowNToyOVoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNToyOVoiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICIxYjQ3Y2RkZi1mYjFmLTQzZTMtOWEzMy01MDkzNmVk
+        ZmJmM2YiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiMzM0ZmE0MDAtY2QzNC00ZmI5LTk1OWUtMzU0MDRkYmM4OWFiIiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
+        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNGYxMWY3ZmItMmIxOC00MjcyLTgyMmIt
+        M2RlNjFjNTk1ZmNkIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
+        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGFj
+        MGZiOGYtZmEyNC00ZjBmLWFhYzQtZDU0MWQwNzM0NTk5IiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjA3MTM2NmYxLTFjZmItNDgzMC1hOTUzLTYzN2U0
+        NmRmMjEwOSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
+        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiZTA1MTFj
+        ZC1hZjZkLTQwMjItYmIzYS01NTdlMDViMDMzMjUiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJlZjgwMWU5Yi01Nzg1LTQ5M2YtYWZkYi03NzY0
+        ZDMxMjBiYzkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
+        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI3ZTBkYmMyZS0zNTVhLTQ4NmUtOGRlNS0yNGFiMmFmNjc0NWIi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
+        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5NDhi
+        MGQyOC1kOGY5LTQ4YTctYWNkOC1hZGY5N2U5N2MyNTAiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
+        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNDBmZWNkMC1jNTMz
+        LTRmYmQtYjVjOS02YWZkMjVhYzhhNDciLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
+        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ1MDdkYTJlLTZhMTEtNDgy
+        OS05ZmI4LTAzNTM4MzhjN2FkZCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
+        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE0OjA1OjI5
+        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMDVUMTQ6MDU6MjlaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
+        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
+        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
+        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
+        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
+        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
+        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
+        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
+        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGFjMjljNzgyMWIz
+        NDQ0ZmNjMjYwIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
+        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
+        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogIjFiNDdjZGRmLWZiMWYtNDNlMy05YTMzLTUwOTM2ZWRmYmYz
+        ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
+        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICIzMzRmYTQwMC1jZDM0LTRmYjktOTU5ZS0zNTQwNGRiYzg5YWIiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
+        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI0ZjExZjdmYi0yYjE4LTQyNzItODIyYi0zZGU2
+        MWM1OTVmY2QiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
+        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYWMwZmI4
+        Zi1mYTI0LTRmMGYtYWFjNC1kNTQxZDA3MzQ1OTkiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiMDcxMzY2ZjEtMWNmYi00ODMwLWE5NTMtNjM3ZTQ2ZGYy
+        MTA5IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJlMDUxMWNkLWFm
+        NmQtNDAyMi1iYjNhLTU1N2UwNWIwMzMyNSIsICJudW1fcHJvY2Vzc2VkIjog
+        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImVmODAxZTliLTU3ODUtNDkzZi1hZmRiLTc3NjRkMzEy
+        MGJjOSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
+        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjdlMGRiYzJlLTM1NWEtNDg2ZS04ZGU1LTI0YWIyYWY2NzQ1YiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
+        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjk0OGIwZDI4
+        LWQ4ZjktNDhhNy1hY2Q4LWFkZjk3ZTk3YzI1MCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
+        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE0MGZlY2QwLWM1MzMtNGZi
+        ZC1iNWM5LTZhZmQyNWFjOGE0NyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
+        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDUwN2RhMmUtNmExMS00ODI5LTlm
+        YjgtMDM1MzgzOGM3YWRkIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhYzI5OGFkYTQwZGIw
+        NGVlMDlmMSJ9LCAiaWQiOiAiNTZiNGFjMjk4YWRhNDBkYjA0ZWUwOWYxIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:29 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/actions/content/install//
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ1bml0cyI6W3sidHlwZV9pZCI6InBhY2thZ2VfZ3JvdXAiLCJ1bml0X2tl
+        eSI6eyJuYW1lIjoibWFtbWxzIn19XSwib3B0aW9ucyI6eyJpbXBvcnRrZXlz
+        Ijp0cnVlfX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="10BQJmssPl1bg5Et4jl5YXdOKZAEn3M4S20bHERCI", oauth_signature="nyt4cs4P%2B7FTTgGodWyX9rv5NY0%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681130", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '98'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:30 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzg0YTI5ZTM4LTdkNWYtNGJhNi04MjJiLTUzZjQ2YmUzZGY5Ni8iLCAi
+        dGFza19pZCI6ICI4NGEyOWUzOC03ZDVmLTRiYTYtODIyYi01M2Y0NmJlM2Rm
+        OTYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:30 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/b6106c17-30ff-4fd2-bc09-ffa1ed940192/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="L0wS1ZSFFEpDHV2zef3jv5KCwNTEtI9JQjkfxhw",
+        oauth_signature="Wwh%2BJNQLVILY%2B%2Fv314U8OgQXOac%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681131", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:31 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iNjEwNmMxNy0zMGZmLTRmZDItYmMwOS1mZmExZWQ5NDAx
+        OTIvIiwgInRhc2tfaWQiOiAiYjYxMDZjMTctMzBmZi00ZmQyLWJjMDktZmZh
+        MWVkOTQwMTkyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWMy
+        YjhhZGE0MGRiMDRlZTA5ZjIifSwgImlkIjogIjU2YjRhYzJiOGFkYTQwZGIw
+        NGVlMDlmMiJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:31 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/b6106c17-30ff-4fd2-bc09-ffa1ed940192/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="XLLk21hXNQiB2kZ3z3I0RpGDTvpltT6HYydbKom3q0",
+        oauth_signature="%2B2BmkQYsp%2FgqEtH%2BYZj%2BM6p4p7E%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681131", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:31 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iNjEwNmMxNy0zMGZmLTRmZDItYmMwOS1mZmExZWQ5NDAx
+        OTIvIiwgInRhc2tfaWQiOiAiYjYxMDZjMTctMzBmZi00ZmQyLWJjMDktZmZh
+        MWVkOTQwMTkyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA1OjMxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA1OjMxWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjMmI4YWRhNDBkYjA0ZWUwOWYyIn0sICJpZCI6ICI1NmI0YWMyYjhhZGE0
+        MGRiMDRlZTA5ZjIifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:31 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/34fe7c39-63bd-489b-a6c7-57bd07cb0055/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Y9om259hE4PHmkH8QQLLC49brlq7fV7YmhrJnxqrhQ",
+        oauth_signature="RwVdD0E9ZRbUW9HRZiAbanLtLA0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681133", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:33 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNGZlN2MzOS02M2JkLTQ4OWItYTZjNy01N2JkMDdjYjAw
+        NTUvIiwgInRhc2tfaWQiOiAiMzRmZTdjMzktNjNiZC00ODliLWE2YzctNTdi
+        ZDA3Y2IwMDU1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMmQ4
+        YWRhNDBkYjA0ZWUwOWY0In0sICJpZCI6ICI1NmI0YWMyZDhhZGE0MGRiMDRl
+        ZTA5ZjQifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:33 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/34fe7c39-63bd-489b-a6c7-57bd07cb0055/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="4D2zurn9Q5wE2deS6xIxDZzlUi3OtzJbZOax6yJIGI",
+        oauth_signature="7noAV3IWxD1CrJCnetplV%2Be6UCk%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681134", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:34 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1084'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNGZlN2MzOS02M2JkLTQ4OWItYTZjNy01N2JkMDdjYjAw
+        NTUvIiwgInRhc2tfaWQiOiAiMzRmZTdjMzktNjNiZC00ODliLWE2YzctNTdi
+        ZDA3Y2IwMDU1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0wNVQxNDowNTozM1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIklOX1BS
+        T0dSRVNTIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
+        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
+        by0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmci
+        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
+        a2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGws
+        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMmQ4YWRh
+        NDBkYjA0ZWUwOWY0In0sICJpZCI6ICI1NmI0YWMyZDhhZGE0MGRiMDRlZTA5
+        ZjQifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:34 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/34fe7c39-63bd-489b-a6c7-57bd07cb0055/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="hEBx0TZFGKiknbrxkBwJvdJuM1XCatrAkjVsliwGdY",
+        oauth_signature="KxcvUN%2B2o1vOHdLfRc%2FPkoIp%2Fpw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681134", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:34 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNGZlN2MzOS02M2JkLTQ4OWItYTZjNy01N2JkMDdjYjAw
+        NTUvIiwgInRhc2tfaWQiOiAiMzRmZTdjMzktNjNiZC00ODliLWE2YzctNTdi
+        ZDA3Y2IwMDU1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNTozNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNTozM1oiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNDE3NDVjM2EtMzM2Yi00NGFhLTg5ZGMtNzFhYzI1Nzdh
+        NDgyLyIsICJ0YXNrX2lkIjogIjQxNzQ1YzNhLTMzNmItNDRhYS04OWRjLTcx
+        YWMyNTc3YTQ4MiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzJkYzc4MjFiMzMwNDJkOWRlZCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDU6MzNaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNToz
+        NFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjMmVjNzgyMWIzNDQ0ZmNjMjY0IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMmQ4YWRhNDBkYjA0ZWUwOWY0In0s
+        ICJpZCI6ICI1NmI0YWMyZDhhZGE0MGRiMDRlZTA5ZjQifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:34 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/41745c3a-336b-44aa-89dc-71ac2577a482/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="rpgPDeVEyXJxDcLMW6WYpUoxVQqaNDva4Iviv9GVD74",
+        oauth_signature="JiPAMzdHwBf8ecclQeIfBeo%2BErM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681134", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:34 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '3516'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy80MTc0NWMzYS0zMzZiLTQ0YWEtODlkYy03MWFj
+        MjU3N2E0ODIvIiwgInRhc2tfaWQiOiAiNDE3NDVjM2EtMzM2Yi00NGFhLTg5
+        ZGMtNzFhYzI1NzdhNDgyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxNi0wMi0wNVQxNDowNTozNFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmNDhl
+        NDYwOC05ODk1LTQ3N2UtODljMi1kNWUyNWRlOWMzOTIiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjNmZmUwODAtMzAx
+        MS00MmUzLThlMzAtYzE2YjYxZDI4NDhjIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiM2RiYWViODAtYzJjNS00YTEzLTgzNjYtNDkyNzk2M2VlMjczIiwgIm51
+        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
+        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
+        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTk0OGEzY2YtOTAxZS00MzA1LWIx
+        YmYtZjJjMWVkNTg0NWM5IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDIsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
+        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
+        InN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjE2YmY2MjQ1LTM3MGItNDhiZS1iMWRiLTY0MWVhY2IwY2RhOCIsICJudW1f
+        cHJvY2Vzc2VkIjogMn0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJj
+        b21wcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1YWYyNzhjNy0zOTg5LTQ0ZmIt
+        YmRlOS04NjVjOTgyY2JkY2EiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0
+        YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICJkNjk2NzVkOS00OWFiLTQ5ODEtODlmMS1hNTM5ZTA3NjdjMWYi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICJjMjk3NzUzZi0wYzg1LTQ2MTAtOWIzMC1jMTllM2ZiNjNmYjMiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTRiMGRm
+        NDItOWNlNi00NWQwLThmMjMtMTZmY2YzOTU2MTlkIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
+        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGVjYTg2OTItNjdl
+        YS00NjJkLWE0YzktYTY0Mjk2ZTNlZGE3IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5n
+        IExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVw
+        b19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
+        U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4NjMxOTY3ZS1kNGU5
+        LTQ1NDUtYjMzMy04YjhlYWVlZjVlZDMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmlu
+        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVs
+        bCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWMyZThh
+        ZGE0MGRiMDRlZTBhMDQifSwgImlkIjogIjU2YjRhYzJlOGFkYTQwZGIwNGVl
+        MGEwNCJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:34 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/34fe7c39-63bd-489b-a6c7-57bd07cb0055/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="6PTrfbLSpvYyJXNdUvE9Mn4MeiWo8KGxuMmplinO08",
+        oauth_signature="G9fbVwfdtf3EsyfaJkDNADrZV4Q%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681135", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:35 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNGZlN2MzOS02M2JkLTQ4OWItYTZjNy01N2JkMDdjYjAw
+        NTUvIiwgInRhc2tfaWQiOiAiMzRmZTdjMzktNjNiZC00ODliLWE2YzctNTdi
+        ZDA3Y2IwMDU1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNTozNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNTozM1oiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNDE3NDVjM2EtMzM2Yi00NGFhLTg5ZGMtNzFhYzI1Nzdh
+        NDgyLyIsICJ0YXNrX2lkIjogIjQxNzQ1YzNhLTMzNmItNDRhYS04OWRjLTcx
+        YWMyNTc3YTQ4MiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzJkYzc4MjFiMzMwNDJkOWRlZCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDU6MzNaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNToz
+        NFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjMmVjNzgyMWIzNDQ0ZmNjMjY0IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMmQ4YWRhNDBkYjA0ZWUwOWY0In0s
+        ICJpZCI6ICI1NmI0YWMyZDhhZGE0MGRiMDRlZTA5ZjQifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:35 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/41745c3a-336b-44aa-89dc-71ac2577a482/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="P3lQZ82HLCNTUwyWmMiSCDurCZbRddHFaJRtSfUSP58",
+        oauth_signature="2XhCCUGq3KEV23Byau%2Ft68yU%2BdA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681135", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:35 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '6929'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy80MTc0NWMzYS0zMzZiLTQ0YWEtODlkYy03MWFj
+        MjU3N2E0ODIvIiwgInRhc2tfaWQiOiAiNDE3NDVjM2EtMzM2Yi00NGFhLTg5
+        ZGMtNzFhYzI1NzdhNDgyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0wMi0wNVQxNDowNTozNVoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNTozNFoiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICJmNDhlNDYwOC05ODk1LTQ3N2UtODljMi1kNWUyNWRl
+        OWMzOTIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiYjNmZmUwODAtMzAxMS00MmUzLThlMzAtYzE2YjYxZDI4NDhjIiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
+        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiM2RiYWViODAtYzJjNS00YTEzLTgzNjYt
+        NDkyNzk2M2VlMjczIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
+        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTk0
+        OGEzY2YtOTAxZS00MzA1LWIxYmYtZjJjMWVkNTg0NWM5IiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjE2YmY2MjQ1LTM3MGItNDhiZS1iMWRiLTY0MWVh
+        Y2IwY2RhOCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
+        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1YWYyNzhj
+        Ny0zOTg5LTQ0ZmItYmRlOS04NjVjOTgyY2JkY2EiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJkNjk2NzVkOS00OWFiLTQ5ODEtODlmMS1hNTM5
+        ZTA3NjdjMWYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
+        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICJjMjk3NzUzZi0wYzg1LTQ2MTAtOWIzMC1jMTllM2ZiNjNmYjMi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
+        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlNGIw
+        ZGY0Mi05Y2U2LTQ1ZDAtOGYyMy0xNmZjZjM5NTYxOWQiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
+        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwZWNhODY5Mi02N2Vh
+        LTQ2MmQtYTRjOS1hNjQyOTZlM2VkYTciLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
+        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjg2MzE5NjdlLWQ0ZTktNDU0
+        NS1iMzMzLThiOGVhZWVmNWVkMyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
+        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE0OjA1OjM0
+        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMDVUMTQ6MDU6MzVaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
+        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
+        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
+        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
+        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
+        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
+        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
+        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
+        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGFjMmZjNzgyMWIz
+        NDQ0ZmNjMjY1IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
+        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
+        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImY0OGU0NjA4LTk4OTUtNDc3ZS04OWMyLWQ1ZTI1ZGU5YzM5
+        MiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
+        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICJiM2ZmZTA4MC0zMDExLTQyZTMtOGUzMC1jMTZiNjFkMjg0OGMiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
+        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICIzZGJhZWI4MC1jMmM1LTRhMTMtODM2Ni00OTI3
+        OTYzZWUyNzMiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
+        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhOTQ4YTNj
+        Zi05MDFlLTQzMDUtYjFiZi1mMmMxZWQ1ODQ1YzkiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiMTZiZjYyNDUtMzcwYi00OGJlLWIxZGItNjQxZWFjYjBj
+        ZGE4IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjVhZjI3OGM3LTM5
+        ODktNDRmYi1iZGU5LTg2NWM5ODJjYmRjYSIsICJudW1fcHJvY2Vzc2VkIjog
+        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImQ2OTY3NWQ5LTQ5YWItNDk4MS04OWYxLWE1MzllMDc2
+        N2MxZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
+        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImMyOTc3NTNmLTBjODUtNDYxMC05YjMwLWMxOWUzZmI2M2ZiMyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
+        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImU0YjBkZjQy
+        LTljZTYtNDVkMC04ZjIzLTE2ZmNmMzk1NjE5ZCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
+        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBlY2E4NjkyLTY3ZWEtNDYy
+        ZC1hNGM5LWE2NDI5NmUzZWRhNyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
+        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODYzMTk2N2UtZDRlOS00NTQ1LWIz
+        MzMtOGI4ZWFlZWY1ZWQzIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhYzJlOGFkYTQwZGIw
+        NGVlMGEwNCJ9LCAiaWQiOiAiNTZiNGFjMmU4YWRhNDBkYjA0ZWUwYTA0In0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:35 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/actions/content/uninstall//
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ1bml0cyI6W3sidHlwZV9pZCI6InJwbSIsInVuaXRfa2V5Ijp7Im5hbWUi
+        OiJjaGVldGFoIn19XSwib3B0aW9ucyI6e319
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="FvfGylcTEBPBb1osVL2r4IDsJvNKUkjltsmCW2MOfg", oauth_signature="wb4o3lFY5dHWK%2BNHfSCWCTlIBa4%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681136", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '72'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:36 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2U3NTI4OGQ4LWRkYjktNDE1OS1hMTliLWY2ZmNmYzZiNjE2Mi8iLCAi
+        dGFza19pZCI6ICJlNzUyODhkOC1kZGI5LTQxNTktYTE5Yi1mNmZjZmM2YjYx
+        NjIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:36 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/19b9ddf9-2c4e-4e1b-b1b0-ee2d0c7ced68/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="75ZrlaND2YqmbngNyu83D2GVRwabUHfsGM9M5JCx6k",
+        oauth_signature="JK%2BwZmYz9YLhNxkhzO3e5m3vp%2Bc%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681136", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:36 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xOWI5ZGRmOS0yYzRlLTRlMWItYjFiMC1lZTJkMGM3Y2Vk
+        NjgvIiwgInRhc2tfaWQiOiAiMTliOWRkZjktMmM0ZS00ZTFiLWIxYjAtZWUy
+        ZDBjN2NlZDY4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWMz
+        MDhhZGE0MGRiMDRlZTBhMDUifSwgImlkIjogIjU2YjRhYzMwOGFkYTQwZGIw
+        NGVlMGEwNSJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:36 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/19b9ddf9-2c4e-4e1b-b1b0-ee2d0c7ced68/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="07wgXoEaTpxA9FhtwwlsGdpbDLaP1yOIqtHYDMnByW8",
+        oauth_signature="wBXLrckoOzUvec%2BwW60jHkyJv4A%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681137", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:37 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xOWI5ZGRmOS0yYzRlLTRlMWItYjFiMC1lZTJkMGM3Y2Vk
+        NjgvIiwgInRhc2tfaWQiOiAiMTliOWRkZjktMmM0ZS00ZTFiLWIxYjAtZWUy
+        ZDBjN2NlZDY4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA1OjM3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA1OjM3WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjMzA4YWRhNDBkYjA0ZWUwYTA1In0sICJpZCI6ICI1NmI0YWMzMDhhZGE0
+        MGRiMDRlZTBhMDUifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:37 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f04a70fc-5b1a-4a70-b420-072b26e3a2f9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="9108giSbI46Zhhx5EDlEXnSIqhhEfLhoid9a9lUa8",
+        oauth_signature="DVtlwAmlpLDX8QPTVJp8x%2B9gnGY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681139", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:39 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mMDRhNzBmYy01YjFhLTRhNzAtYjQyMC0wNzJiMjZlM2Ey
+        ZjkvIiwgInRhc2tfaWQiOiAiZjA0YTcwZmMtNWIxYS00YTcwLWI0MjAtMDcy
+        YjI2ZTNhMmY5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMzM4
+        YWRhNDBkYjA0ZWUwYTA3In0sICJpZCI6ICI1NmI0YWMzMzhhZGE0MGRiMDRl
+        ZTBhMDcifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:39 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f04a70fc-5b1a-4a70-b420-072b26e3a2f9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="A6CDW8hXPSbL4aTOB6gPmEwho9yn7TO5MC8ESra3E",
+        oauth_signature="F2iHK%2BfI%2FwoknMr9jZu%2FCeD2II4%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681139", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:39 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1087'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mMDRhNzBmYy01YjFhLTRhNzAtYjQyMC0wNzJiMjZlM2Ey
+        ZjkvIiwgInRhc2tfaWQiOiAiZjA0YTcwZmMtNWIxYS00YTcwLWI0MjAtMDcy
+        YjI2ZTNhMmY5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0wNVQxNDowNTozOVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJpdGVtc19sZWZ0IjogMn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
+        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0
+        ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5p
+        bmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMzM4
+        YWRhNDBkYjA0ZWUwYTA3In0sICJpZCI6ICI1NmI0YWMzMzhhZGE0MGRiMDRl
+        ZTBhMDcifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:39 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f04a70fc-5b1a-4a70-b420-072b26e3a2f9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="GeS7QCAbn6n0hblzV84QF3ZUqrhmXtpagCrnCsM1Y",
+        oauth_signature="ojAOQvPXhQwvfR2Mp2uyKznvgxw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681140", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:40 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mMDRhNzBmYy01YjFhLTRhNzAtYjQyMC0wNzJiMjZlM2Ey
+        ZjkvIiwgInRhc2tfaWQiOiAiZjA0YTcwZmMtNWIxYS00YTcwLWI0MjAtMDcy
+        YjI2ZTNhMmY5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNTozOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNTozOVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvN2U5OTEyYTctM2I1OC00YzVkLTkxZTUtZDhhZmM2MmE5
+        NWRmLyIsICJ0YXNrX2lkIjogIjdlOTkxMmE3LTNiNTgtNGM1ZC05MWU1LWQ4
+        YWZjNjJhOTVkZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzMyYzc4MjFiMzMwNWNlNTEwMiJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDU6MzlaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNToz
+        OVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjMzNjNzgyMWIzNDQ0ZmNjMjY5IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMzM4YWRhNDBkYjA0ZWUwYTA3In0s
+        ICJpZCI6ICI1NmI0YWMzMzhhZGE0MGRiMDRlZTBhMDcifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:40 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/7e9912a7-3b58-4c5d-91e5-d8afc62a95df/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="1YnHHvn7JhyBa4WxJgdX9IzzJhsuL5fAv0Gb7kVH0",
+        oauth_signature="rRqkVGfVZH0Wac8YLrGVDl5vj3o%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681140", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:40 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '3523'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy83ZTk5MTJhNy0zYjU4LTRjNWQtOTFlNS1kOGFm
+        YzYyYTk1ZGYvIiwgInRhc2tfaWQiOiAiN2U5OTEyYTctM2I1OC00YzVkLTkx
+        ZTUtZDhhZmM2MmE5NWRmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxNi0wMi0wNVQxNDowNTo0MFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNDEz
+        YWQyZi0yZjM4LTQzN2UtODc3Zi02ZTI0M2JlMWVlZmMiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODEwMmQ4Y2UtMDkw
+        NS00Mjc3LTkzYTItNWE5NmFmYjIzNzdmIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiMzAzMWY3MzUtYzM4ZC00NmFlLTgwNTUtZDIwZjcxMDIzMGRkIiwg
+        Im51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
+        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI2ZjJiMWQzLTI4NmIt
+        NGU5OC1hYjQxLThkMjhiZmIyOTFjYiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICIxNjI2ZDRmMS1iMDIwLTQzYzUtOTExYy1lNzllZWNhOTdjMWMi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5
+        cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzk0NzA3MDAtOTFk
+        My00NmEwLWJlODQtZTAzNTdmYmE0YmM0IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiNDZkMDc1MzEtZDY4Zi00N2I1LTg0NTEtNzFkNDk1
+        NGE0MjhhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAi
+        c3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiOWMwNzBlMGUtNTMzYS00NzNjLWExYWUtOWI5YzIxZjJmZmZi
+        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
+        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjdhOTc1MmU3LTAyMjktNDgyNy04MGVkLWNmNzk1ZmFkMDdmMiIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjog
+        InB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjk5NWQ4
+        NjYwLTZkMTgtNDQ1NC1hZjA3LTRmM2M5ODhlYzlkYyIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
+        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTljZWVm
+        YzMtNWExYS00ZTcwLTk4NGItYjY1NTIzOWIyNWYxIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjMzM4YWRhNDBkYjA0ZWUwYTE3In0sICJpZCI6ICI1NmI0YWMzMzhhZGE0
+        MGRiMDRlZTBhMTcifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:40 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f04a70fc-5b1a-4a70-b420-072b26e3a2f9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="0oFumrvW597bihqKEEEcx7YVj9tWOST361lFRsM49Jo",
+        oauth_signature="kGrMHQ4PBJcZgRICIHfPkgg7Ng4%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681141", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:41 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mMDRhNzBmYy01YjFhLTRhNzAtYjQyMC0wNzJiMjZlM2Ey
+        ZjkvIiwgInRhc2tfaWQiOiAiZjA0YTcwZmMtNWIxYS00YTcwLWI0MjAtMDcy
+        YjI2ZTNhMmY5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNTozOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNTozOVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvN2U5OTEyYTctM2I1OC00YzVkLTkxZTUtZDhhZmM2MmE5
+        NWRmLyIsICJ0YXNrX2lkIjogIjdlOTkxMmE3LTNiNTgtNGM1ZC05MWU1LWQ4
+        YWZjNjJhOTVkZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzMyYzc4MjFiMzMwNWNlNTEwMiJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDU6MzlaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNToz
+        OVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjMzNjNzgyMWIzNDQ0ZmNjMjY5IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMzM4YWRhNDBkYjA0ZWUwYTA3In0s
+        ICJpZCI6ICI1NmI0YWMzMzhhZGE0MGRiMDRlZTBhMDcifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:41 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/7e9912a7-3b58-4c5d-91e5-d8afc62a95df/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="SEsseH2012HqTFyOg4VP9cu5MmfYHG4rzXvHhU",
+        oauth_signature="PnIwJtVdUC1loOCyASsQGffcfPM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681141", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:41 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '6929'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy83ZTk5MTJhNy0zYjU4LTRjNWQtOTFlNS1kOGFm
+        YzYyYTk1ZGYvIiwgInRhc2tfaWQiOiAiN2U5OTEyYTctM2I1OC00YzVkLTkx
+        ZTUtZDhhZmM2MmE5NWRmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0wMi0wNVQxNDowNTo0MFoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNTo0MFoiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICIwNDEzYWQyZi0yZjM4LTQzN2UtODc3Zi02ZTI0M2Jl
+        MWVlZmMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiODEwMmQ4Y2UtMDkwNS00Mjc3LTkzYTItNWE5NmFmYjIzNzdmIiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
+        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMzAzMWY3MzUtYzM4ZC00NmFlLTgwNTUt
+        ZDIwZjcxMDIzMGRkIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
+        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjZm
+        MmIxZDMtMjg2Yi00ZTk4LWFiNDEtOGQyOGJmYjI5MWNiIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjE2MjZkNGYxLWIwMjAtNDNjNS05MTFjLWU3OWVl
+        Y2E5N2MxYyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
+        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3OTQ3MDcw
+        MC05MWQzLTQ2YTAtYmU4NC1lMDM1N2ZiYTRiYzQiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI0NmQwNzUzMS1kNjhmLTQ3YjUtODQ1MS03MWQ0
+        OTU0YTQyOGEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
+        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI5YzA3MGUwZS01MzNhLTQ3M2MtYTFhZS05YjljMjFmMmZmZmIi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
+        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3YTk3
+        NTJlNy0wMjI5LTQ4MjctODBlZC1jZjc5NWZhZDA3ZjIiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
+        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5OTVkODY2MC02ZDE4
+        LTQ0NTQtYWYwNy00ZjNjOTg4ZWM5ZGMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
+        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjU5Y2VlZmMzLTVhMWEtNGU3
+        MC05ODRiLWI2NTUyMzliMjVmMSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
+        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE0OjA1OjQw
+        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMDVUMTQ6MDU6NDBaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
+        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
+        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
+        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
+        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
+        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
+        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
+        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
+        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGFjMzRjNzgyMWIz
+        NDQ0ZmNjMjZhIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
+        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
+        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogIjA0MTNhZDJmLTJmMzgtNDM3ZS04NzdmLTZlMjQzYmUxZWVm
+        YyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
+        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICI4MTAyZDhjZS0wOTA1LTQyNzctOTNhMi01YTk2YWZiMjM3N2YiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
+        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICIzMDMxZjczNS1jMzhkLTQ2YWUtODA1NS1kMjBm
+        NzEwMjMwZGQiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
+        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiNmYyYjFk
+        My0yODZiLTRlOTgtYWI0MS04ZDI4YmZiMjkxY2IiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiMTYyNmQ0ZjEtYjAyMC00M2M1LTkxMWMtZTc5ZWVjYTk3
+        YzFjIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc5NDcwNzAwLTkx
+        ZDMtNDZhMC1iZTg0LWUwMzU3ZmJhNGJjNCIsICJudW1fcHJvY2Vzc2VkIjog
+        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjQ2ZDA3NTMxLWQ2OGYtNDdiNS04NDUxLTcxZDQ5NTRh
+        NDI4YSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
+        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjljMDcwZTBlLTUzM2EtNDczYy1hMWFlLTliOWMyMWYyZmZmYiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
+        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdhOTc1MmU3
+        LTAyMjktNDgyNy04MGVkLWNmNzk1ZmFkMDdmMiIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
+        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjk5NWQ4NjYwLTZkMTgtNDQ1
+        NC1hZjA3LTRmM2M5ODhlYzlkYyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
+        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTljZWVmYzMtNWExYS00ZTcwLTk4
+        NGItYjY1NTIzOWIyNWYxIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhYzMzOGFkYTQwZGIw
+        NGVlMGExNyJ9LCAiaWQiOiAiNTZiNGFjMzM4YWRhNDBkYjA0ZWUwYTE3In0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:41 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/actions/content/uninstall//
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ1bml0cyI6W3sidHlwZV9pZCI6InBhY2thZ2VfZ3JvdXAiLCJ1bml0X2tl
+        eSI6eyJuYW1lIjoibWFtbWFscyJ9fV0sIm9wdGlvbnMiOnt9fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="4g9DWViuln06zwSovPAjJnoPHimnRr0NLKkp0m9uQ", oauth_signature="DLagDJVCZMFmRASkBzv2BJPjhZw%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681141", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '82'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:41 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzI0ZmJhNTRhLWJiOGMtNGMzNi1iM2RlLTgxMmZkNjYwZTk3Ni8iLCAi
+        dGFza19pZCI6ICIyNGZiYTU0YS1iYjhjLTRjMzYtYjNkZS04MTJmZDY2MGU5
+        NzYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:41 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/b2a15060-2bd2-4a81-a997-d60a3ca02557/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="uujBdvOwd9aZZF3mv635mV5mHHEwjH6jBVx5HoR5p9k",
+        oauth_signature="Z2KXXKR1GQra3IBvLwrhxfqovm4%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681142", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:42 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '651'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iMmExNTA2MC0yYmQyLTRhODEtYTk5Ny1kNjBhM2NhMDI1
+        NTcvIiwgInRhc2tfaWQiOiAiYjJhMTUwNjAtMmJkMi00YTgxLWE5OTctZDYw
+        YTNjYTAyNTU3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAi
+        c3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
+        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1NmI0YWMzNjhhZGE0MGRiMDRlZTBhMTgifSwgImlkIjogIjU2YjRh
+        YzM2OGFkYTQwZGIwNGVlMGExOCJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:42 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/b2a15060-2bd2-4a81-a997-d60a3ca02557/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="3COepckYLXWJqpefMbauEsNa4TZODnip0j6aoGuG84",
+        oauth_signature="g4yeyFjU9djOmMMFeDjDJI3IWcU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681142", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:42 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iMmExNTA2MC0yYmQyLTRhODEtYTk5Ny1kNjBhM2NhMDI1
+        NTcvIiwgInRhc2tfaWQiOiAiYjJhMTUwNjAtMmJkMi00YTgxLWE5OTctZDYw
+        YTNjYTAyNTU3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA1OjQyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA1OjQyWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjMzY4YWRhNDBkYjA0ZWUwYTE4In0sICJpZCI6ICI1NmI0YWMzNjhhZGE0
+        MGRiMDRlZTBhMTgifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:42 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/124a8886-d954-4173-ae7a-2a96aee6cca8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="jgpp3weWOdP3UaY2CNnQDTXpTUaON7kqrkvw4upmQA",
+        oauth_signature="cu69j1YdDDmQ0V8bECDfQTLUUPs%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681144", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:44 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xMjRhODg4Ni1kOTU0LTQxNzMtYWU3YS0yYTk2YWVlNmNj
+        YTgvIiwgInRhc2tfaWQiOiAiMTI0YTg4ODYtZDk1NC00MTczLWFlN2EtMmE5
+        NmFlZTZjY2E4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMzg4
+        YWRhNDBkYjA0ZWUwYTFhIn0sICJpZCI6ICI1NmI0YWMzODhhZGE0MGRiMDRl
+        ZTBhMWEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:44 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/124a8886-d954-4173-ae7a-2a96aee6cca8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="UnmfVwBCs0vero9NMWTruAVsli4JDTX3z1JPF2c",
+        oauth_signature="lLUGpGrSIod3chRqi8CvDX3PKtY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681145", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:45 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1090'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xMjRhODg4Ni1kOTU0LTQxNzMtYWU3YS0yYTk2YWVlNmNj
+        YTgvIiwgInRhc2tfaWQiOiAiMTI0YTg4ODYtZDk1NC00MTczLWFlN2EtMmE5
+        NmFlZTZjY2E4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0wNVQxNDowNTo0NFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
+        Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
+        bCI6IDAsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
+        a2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1
+        bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
+        IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFj
+        Mzg4YWRhNDBkYjA0ZWUwYTFhIn0sICJpZCI6ICI1NmI0YWMzODhhZGE0MGRi
+        MDRlZTBhMWEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:45 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/124a8886-d954-4173-ae7a-2a96aee6cca8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="N1U4nQua2wNay6grR99cHjk3kloCvYM6ELVB4iPOy1o",
+        oauth_signature="spyT65EOrwLIfCcTWNubRmvtupw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681145", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:46 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xMjRhODg4Ni1kOTU0LTQxNzMtYWU3YS0yYTk2YWVlNmNj
+        YTgvIiwgInRhc2tfaWQiOiAiMTI0YTg4ODYtZDk1NC00MTczLWFlN2EtMmE5
+        NmFlZTZjY2E4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNTo0NVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNTo0NFoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNWYxYjFhYmQtM2Q4ZS00OWEwLTg2NDMtOTgyNDM1OTU0
+        NzhiLyIsICJ0YXNrX2lkIjogIjVmMWIxYWJkLTNkOGUtNDlhMC04NjQzLTk4
+        MjQzNTk1NDc4YiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzM4Yzc4MjFiMzMwNDJkOWRmNCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDU6NDRaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNTo0
+        NVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjMzljNzgyMWIzNDQ0ZmNjMjZlIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMzg4YWRhNDBkYjA0ZWUwYTFhIn0s
+        ICJpZCI6ICI1NmI0YWMzODhhZGE0MGRiMDRlZTBhMWEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:46 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/5f1b1abd-3d8e-49a0-8643-98243595478b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="bWMo96U9rOJq7sncXSrqd4y5AezguDryCovR5O7c",
+        oauth_signature="SRQZAaTUmNrWTUSOlbvP8%2F%2Ft%2F%2FY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681146", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:46 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '3523'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy81ZjFiMWFiZC0zZDhlLTQ5YTAtODY0My05ODI0
+        MzU5NTQ3OGIvIiwgInRhc2tfaWQiOiAiNWYxYjFhYmQtM2Q4ZS00OWEwLTg2
+        NDMtOTgyNDM1OTU0NzhiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxNi0wMi0wNVQxNDowNTo0NVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjZWJl
+        YjE5OS04Mjg1LTRlNzMtYTdkMi00NDIyNmM0MGU3OWIiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzI0N2E2ODQtODM0
+        Mi00NDI3LTkwYzYtZTRlMDgzMWI4ZTA0IiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDQsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiNTM3NGZiOGUtNGZlMS00OGYzLWEwNGEtMjBhZTU0MTY5ZWEyIiwg
+        Im51bV9wcm9jZXNzZWQiOiA0fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
+        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImY2ZTIwYzcyLTRlOTYt
+        NGNiMi1hODc4LTdkOTc3N2M1MjRjNiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI2MTk3NjQ3Ny04YjY2LTRmM2QtYmZlMS03MzY4MjVlZTJkMGMi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5
+        cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTRkZjQ3ZWUtNDlj
+        Yy00NWNhLTgxMGItMGFiMDEyMWQ3Mzk4IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiNzMxNDY1M2MtM2JkMy00ZjkzLThjYTEtOGM3NDk3
+        ZTlkNDA2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAi
+        c3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiNTU2YWM2MDQtMTBlOS00OWEyLWE5YjAtNmI3YmFiZjRiYjli
+        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
+        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjAxODk3MDc2LWFiOGMtNDNjYi05YTM5LWQ3NTc5OGY5NTlmYyIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjog
+        InB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRjNzg3
+        MjYxLTA3MjctNDM3MS1hY2Q5LTMzZGI1ZWMzYWIxMCIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
+        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDNmNThl
+        OWMtZDAxMi00ZWJjLWFiMWItNjdlY2U3NTcyOGJkIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjMzk4YWRhNDBkYjA0ZWUwYTJhIn0sICJpZCI6ICI1NmI0YWMzOThhZGE0
+        MGRiMDRlZTBhMmEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:46 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/124a8886-d954-4173-ae7a-2a96aee6cca8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="RVeNefvjN5uK07vSfqAgtUFMsE1ajlsclEH35waWa4Q",
+        oauth_signature="O4XOOc0kHv1%2F%2BH7IcTXOwRf%2B7JM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681146", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:46 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xMjRhODg4Ni1kOTU0LTQxNzMtYWU3YS0yYTk2YWVlNmNj
+        YTgvIiwgInRhc2tfaWQiOiAiMTI0YTg4ODYtZDk1NC00MTczLWFlN2EtMmE5
+        NmFlZTZjY2E4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNTo0NVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNTo0NFoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNWYxYjFhYmQtM2Q4ZS00OWEwLTg2NDMtOTgyNDM1OTU0
+        NzhiLyIsICJ0YXNrX2lkIjogIjVmMWIxYWJkLTNkOGUtNDlhMC04NjQzLTk4
+        MjQzNTk1NDc4YiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzM4Yzc4MjFiMzMwNDJkOWRmNCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDU6NDRaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNTo0
+        NVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjMzljNzgyMWIzNDQ0ZmNjMjZlIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMzg4YWRhNDBkYjA0ZWUwYTFhIn0s
+        ICJpZCI6ICI1NmI0YWMzODhhZGE0MGRiMDRlZTBhMWEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:46 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/5f1b1abd-3d8e-49a0-8643-98243595478b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="QS4RSHQW6s1EPnxZi62E2t6mlQLu54Mq9ItHYak",
+        oauth_signature="juk14VNiYrICLpaXUBPlo2lhxcA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681146", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:46 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '6929'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy81ZjFiMWFiZC0zZDhlLTQ5YTAtODY0My05ODI0
+        MzU5NTQ3OGIvIiwgInRhc2tfaWQiOiAiNWYxYjFhYmQtM2Q4ZS00OWEwLTg2
+        NDMtOTgyNDM1OTU0NzhiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0wMi0wNVQxNDowNTo0NloiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNTo0NVoiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICJjZWJlYjE5OS04Mjg1LTRlNzMtYTdkMi00NDIyNmM0
+        MGU3OWIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiYzI0N2E2ODQtODM0Mi00NDI3LTkwYzYtZTRlMDgzMWI4ZTA0Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
+        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNTM3NGZiOGUtNGZlMS00OGYzLWEwNGEt
+        MjBhZTU0MTY5ZWEyIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
+        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjZl
+        MjBjNzItNGU5Ni00Y2IyLWE4NzgtN2Q5Nzc3YzUyNGM2IiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjYxOTc2NDc3LThiNjYtNGYzZC1iZmUxLTczNjgy
+        NWVlMmQwYyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
+        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNGRmNDdl
+        ZS00OWNjLTQ1Y2EtODEwYi0wYWIwMTIxZDczOTgiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI3MzE0NjUzYy0zYmQzLTRmOTMtOGNhMS04Yzc0
+        OTdlOWQ0MDYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
+        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI1NTZhYzYwNC0xMGU5LTQ5YTItYTliMC02YjdiYWJmNGJiOWIi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
+        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwMTg5
+        NzA3Ni1hYjhjLTQzY2ItOWEzOS1kNzU3OThmOTU5ZmMiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
+        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0Yzc4NzI2MS0wNzI3
+        LTQzNzEtYWNkOS0zM2RiNWVjM2FiMTAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
+        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjAzZjU4ZTljLWQwMTItNGVi
+        Yy1hYjFiLTY3ZWNlNzU3MjhiZCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
+        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE0OjA1OjQ1
+        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMDVUMTQ6MDU6NDZaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
+        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
+        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
+        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
+        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
+        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
+        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
+        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
+        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGFjM2FjNzgyMWIz
+        NDQ0ZmNjMjZmIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
+        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
+        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImNlYmViMTk5LTgyODUtNGU3My1hN2QyLTQ0MjI2YzQwZTc5
+        YiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
+        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICJjMjQ3YTY4NC04MzQyLTQ0MjctOTBjNi1lNGUwODMxYjhlMDQiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
+        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI1Mzc0ZmI4ZS00ZmUxLTQ4ZjMtYTA0YS0yMGFl
+        NTQxNjllYTIiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
+        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmNmUyMGM3
+        Mi00ZTk2LTRjYjItYTg3OC03ZDk3NzdjNTI0YzYiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiNjE5NzY0NzctOGI2Ni00ZjNkLWJmZTEtNzM2ODI1ZWUy
+        ZDBjIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE0ZGY0N2VlLTQ5
+        Y2MtNDVjYS04MTBiLTBhYjAxMjFkNzM5OCIsICJudW1fcHJvY2Vzc2VkIjog
+        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjczMTQ2NTNjLTNiZDMtNGY5My04Y2ExLThjNzQ5N2U5
+        ZDQwNiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
+        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjU1NmFjNjA0LTEwZTktNDlhMi1hOWIwLTZiN2JhYmY0YmI5YiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
+        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjAxODk3MDc2
+        LWFiOGMtNDNjYi05YTM5LWQ3NTc5OGY5NTlmYyIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
+        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRjNzg3MjYxLTA3MjctNDM3
+        MS1hY2Q5LTMzZGI1ZWMzYWIxMCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
+        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDNmNThlOWMtZDAxMi00ZWJjLWFi
+        MWItNjdlY2U3NTcyOGJkIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhYzM5OGFkYTQwZGIw
+        NGVlMGEyYSJ9LCAiaWQiOiAiNTZiNGFjMzk4YWRhNDBkYjA0ZWUwYTJhIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:46 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/actions/content/update//
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ1bml0cyI6W3sidHlwZV9pZCI6InJwbSIsInVuaXRfa2V5Ijp7fX1dLCJv
+        cHRpb25zIjp7ImltcG9ydGtleXMiOnRydWUsImFsbCI6dHJ1ZX19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="WaGEOnxjdVFaTXdUw38Y9n9xPrsVirGFXi5iDffMU", oauth_signature="QhJTyl4rJlUxwc6Gm%2BSLpCk7AGo%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681147", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '84'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzRlZDExMDg4LWQzYzEtNDZkZi05ZmQ3LTZkMGMxNGU3ZmNmYi8iLCAi
+        dGFza19pZCI6ICI0ZWQxMTA4OC1kM2MxLTQ2ZGYtOWZkNy02ZDBjMTRlN2Zj
+        ZmIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:47 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/6094fed6-740c-4e41-9267-76dd7d0cf959/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="p1kAsJ7EA3AVOe2OeUlgcTeAAZoQEX5jGFyymUWgxU",
+        oauth_signature="bSQGJFbgvl72BzYGPSfMqvBkKA4%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681147", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82MDk0ZmVkNi03NDBjLTRlNDEtOTI2Ny03NmRkN2QwY2Y5
+        NTkvIiwgInRhc2tfaWQiOiAiNjA5NGZlZDYtNzQwYy00ZTQxLTkyNjctNzZk
+        ZDdkMGNmOTU5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWMz
+        YjhhZGE0MGRiMDRlZTBhMmIifSwgImlkIjogIjU2YjRhYzNiOGFkYTQwZGIw
+        NGVlMGEyYiJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:47 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/6094fed6-740c-4e41-9267-76dd7d0cf959/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="0vEgarOCaNwbfmKX2rLuIRwG7D2Hkwyn1jhLwgJBSik",
+        oauth_signature="GgjwpogmnCPmVVgYbK1r4PGU4sA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681148", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:48 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82MDk0ZmVkNi03NDBjLTRlNDEtOTI2Ny03NmRkN2QwY2Y5
+        NTkvIiwgInRhc2tfaWQiOiAiNjA5NGZlZDYtNzQwYy00ZTQxLTkyNjctNzZk
+        ZDdkMGNmOTU5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA1OjQ3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA1OjQ3WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjM2I4YWRhNDBkYjA0ZWUwYTJiIn0sICJpZCI6ICI1NmI0YWMzYjhhZGE0
+        MGRiMDRlZTBhMmIifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:48 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
+        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
+        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
+        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
+        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
+        LXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1
+        dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9j
+        b25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIiwiaHR0cCI6ZmFs
+        c2UsImh0dHBzIjp0cnVlLCJwcm90ZWN0ZWQiOnRydWV9LCJhdXRvX3B1Ymxp
+        c2giOnRydWUsImRpc3RyaWJ1dG9yX2lkIjoiRmVkb3JhXzE3In0seyJkaXN0
+        cmlidXRvcl90eXBlX2lkIjoieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwiZGlz
+        dHJpYnV0b3JfY29uZmlnIjp7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lk
+        IjoiRmVkb3JhXzE3In0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1
+        dG9yX2lkIjoiRmVkb3JhXzE3X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBl
+        X2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmln
+        Ijp7Imh0dHAiOmZhbHNlLCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6
+        bnVsbH0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoi
+        ZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="J7AZx7AdPFqwDg1gzK2L1w8m8MPJ33kakads8es9s", oauth_signature="QjqGzhT7w9LoT7m5SfTvCgkknUU%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681150", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '787'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:50 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '320'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
+        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
+        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NTZiNGFjM2VjNzgyMWIzMzA0MmQ5ZGZhIn0sICJpZCI6ICJGZWRvcmFfMTci
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
+        MTcvIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:50 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
+        Ijp0cnVlfX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="AUrhMInQMmSIz62SqAB82SvkzcJN5dhvUwYmsrZITc", oauth_signature="%2FLL62zWoFV3cy0YHdfOHZnYDQJA%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681150", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '53'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:50 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2Q5MmMwODJiLTAyMWEtNDhmNy1iZmMxLTY5YThlNjU5MzRiMy8iLCAi
+        dGFza19pZCI6ICJkOTJjMDgyYi0wMjFhLTQ4ZjctYmZjMS02OWE4ZTY1OTM0
+        YjMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:50 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/d92c082b-021a-48f7-bfc1-69a8e65934b3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="wqYep2XNFuixpy8U89eTjGkTwiEx0Ra8gVPaQFGKE",
+        oauth_signature="tuCAcFUrMWm45SRzqfeXEDdLbFo%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681150", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:50 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '649'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kOTJjMDgyYi0wMjFhLTQ4ZjctYmZjMS02OWE4ZTY1OTM0
+        YjMvIiwgInRhc2tfaWQiOiAiZDkyYzA4MmItMDIxYS00OGY3LWJmYzEtNjlh
+        OGU2NTkzNGIzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0
+        YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwg
+        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNTZiNGFjM2U4YWRhNDBkYjA0ZWUwYTJkIn0sICJpZCI6ICI1NmI0YWMz
+        ZThhZGE0MGRiMDRlZTBhMmQifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:50 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/d92c082b-021a-48f7-bfc1-69a8e65934b3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="0IpN3QWRivSwGpbslvrQnx9rjMbxKxyGMfbZz69nM",
+        oauth_signature="hmq1dWdK3NrT049vQixJUXcs%2BRA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681151", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:51 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kOTJjMDgyYi0wMjFhLTQ4ZjctYmZjMS02OWE4ZTY1OTM0
+        YjMvIiwgInRhc2tfaWQiOiAiZDkyYzA4MmItMDIxYS00OGY3LWJmYzEtNjlh
+        OGU2NTkzNGIzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNTo1MVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNTo1MVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvZWUyMDMzZDEtZTdhYy00MjY0LTlkNmQtYzJjYTgwNjk5
+        Y2Q0LyIsICJ0YXNrX2lkIjogImVlMjAzM2QxLWU3YWMtNDI2NC05ZDZkLWMy
+        Y2E4MDY5OWNkNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzNlYzc4MjFiMzMwNDJkOWRmYiJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDU6NTFaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNTo1
+        MVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjM2ZjNzgyMWIzNDQ0ZmNjMjczIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjM2U4YWRhNDBkYjA0ZWUwYTJkIn0s
+        ICJpZCI6ICI1NmI0YWMzZThhZGE0MGRiMDRlZTBhMmQifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:51 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ee2033d1-e7ac-4264-9d6d-c2ca80699cd4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="p3CTkgpy19zFkdoQA6snUZ2edX7q0UGotTqZQw8",
+        oauth_signature="5Tw73TVBXiOsSV7ljaAywJJZU6o%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681151", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:51 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '556'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9lZTIwMzNkMS1lN2FjLTQyNjQtOWQ2ZC1jMmNh
+        ODA2OTljZDQvIiwgInRhc2tfaWQiOiAiZWUyMDMzZDEtZTdhYy00MjY0LTlk
+        NmQtYzJjYTgwNjk5Y2Q0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiBudWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBb
+        XSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIs
+        ICJzdGF0ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJl
+        c3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
+        NTZiNGFjM2Y4YWRhNDBkYjA0ZWUwYTNkIn0sICJpZCI6ICI1NmI0YWMzZjhh
+        ZGE0MGRiMDRlZTBhM2QifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:51 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/d92c082b-021a-48f7-bfc1-69a8e65934b3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="QOnwqi993bpXdZ0dZiS1FiL9Cd8XyrZRztmnvd2eEQ",
+        oauth_signature="WHvx3ZNKxEYxAOBFljHhJvXqqSM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681152", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:52 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kOTJjMDgyYi0wMjFhLTQ4ZjctYmZjMS02OWE4ZTY1OTM0
+        YjMvIiwgInRhc2tfaWQiOiAiZDkyYzA4MmItMDIxYS00OGY3LWJmYzEtNjlh
+        OGU2NTkzNGIzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNTo1MVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNTo1MVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvZWUyMDMzZDEtZTdhYy00MjY0LTlkNmQtYzJjYTgwNjk5
+        Y2Q0LyIsICJ0YXNrX2lkIjogImVlMjAzM2QxLWU3YWMtNDI2NC05ZDZkLWMy
+        Y2E4MDY5OWNkNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzNlYzc4MjFiMzMwNDJkOWRmYiJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDU6NTFaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNTo1
+        MVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjM2ZjNzgyMWIzNDQ0ZmNjMjczIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjM2U4YWRhNDBkYjA0ZWUwYTJkIn0s
+        ICJpZCI6ICI1NmI0YWMzZThhZGE0MGRiMDRlZTBhMmQifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:52 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ee2033d1-e7ac-4264-9d6d-c2ca80699cd4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Wr6tiXZCkeHCXAJ7aGRxK5Rs6MIj0F7XKWESB2DrWA",
+        oauth_signature="18HMCPRDTRAD7Tldv6YMeyeodKs%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681152", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:52 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '3513'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9lZTIwMzNkMS1lN2FjLTQyNjQtOWQ2ZC1jMmNh
+        ODA2OTljZDQvIiwgInRhc2tfaWQiOiAiZWUyMDMzZDEtZTdhYy00MjY0LTlk
+        NmQtYzJjYTgwNjk5Y2Q0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxNi0wMi0wNVQxNDowNTo1MVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1MjI0
+        YjM2YS1mOWE2LTRmMmItYTVlMS1iM2RkMzkwNGZhNjAiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTJmMGZmMTAtNWY4
+        ZC00YTJmLWE5ODktYTFhM2FkMjk2NDU2IiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiNmI2MjZiNmUtZjIxYS00NWZjLTg0ZGEtM2M0OTIxMDIwODgyIiwgIm51
+        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
+        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
+        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTRjMGVmYzAtZjIxYy00OTg1LWE5
+        MGMtMWFhYjJmYjI4MDdjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
+        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUy
+        NWFjYjI0LWZkZTUtNDJlMy1hZjA1LWFlNTE2OGNjODRhMCIsICJudW1fcHJv
+        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24i
+        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
+        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzMTYzZWYwYy1lZmMxLTRjZjgtYjNm
+        Mi02MDIzYWVjYmRkZWUiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRh
+        dGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJjM2ZmMzkxZC0xM2ExLTQyYTMtYjk0Mi0wZTZlODlhNTkxMWQiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUi
+        OiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5
+        MzcxOTQ0NC1jY2U2LTQwOGItYTc4ZS1iNjc1YTBiNTIwYmYiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJn
+        ZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOGQ3MDg1Zjgt
+        MTRjYS00MmUxLWI2ZDgtNDNiMTIyOTY1MGFiIiwgIm51bV9wcm9jZXNzZWQi
+        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJs
+        aXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9k
+        aXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
+        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTQ2ZTY2ODQtNmMyYi00
+        YWQxLWIzMWQtNGUzNTc2OWU0NzNkIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
+        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExp
+        c3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19t
+        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RB
+        UlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjODNiOGNhZC0wNTA0LTRj
+        YWYtOWI5Yi02NTgyNDRhNWIwN2UiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0s
+        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwg
+        ImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWMzZjhhZGE0
+        MGRiMDRlZTBhM2QifSwgImlkIjogIjU2YjRhYzNmOGFkYTQwZGIwNGVlMGEz
+        ZCJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:52 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/d92c082b-021a-48f7-bfc1-69a8e65934b3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="FBY8Uc9YZpclIDxah4hvw1vr1EXrgQeh8spTG6rn6oo",
+        oauth_signature="%2F%2BoSCsa3IB0BBZL8Ddw%2BGify8CA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681152", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:52 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kOTJjMDgyYi0wMjFhLTQ4ZjctYmZjMS02OWE4ZTY1OTM0
+        YjMvIiwgInRhc2tfaWQiOiAiZDkyYzA4MmItMDIxYS00OGY3LWJmYzEtNjlh
+        OGU2NTkzNGIzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNTo1MVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNTo1MVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvZWUyMDMzZDEtZTdhYy00MjY0LTlkNmQtYzJjYTgwNjk5
+        Y2Q0LyIsICJ0YXNrX2lkIjogImVlMjAzM2QxLWU3YWMtNDI2NC05ZDZkLWMy
+        Y2E4MDY5OWNkNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzNlYzc4MjFiMzMwNDJkOWRmYiJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDU6NTFaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNTo1
+        MVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjM2ZjNzgyMWIzNDQ0ZmNjMjczIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjM2U4YWRhNDBkYjA0ZWUwYTJkIn0s
+        ICJpZCI6ICI1NmI0YWMzZThhZGE0MGRiMDRlZTBhMmQifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:52 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ee2033d1-e7ac-4264-9d6d-c2ca80699cd4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="tyl6Q3M0U33U4N9fv5Hw8QR0ORPaDKvZhfPNXkrfNE4",
+        oauth_signature="c4mRAQR%2B%2BoyniPMwdIhavZqR%2FzQ%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681152", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:52 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '6929'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9lZTIwMzNkMS1lN2FjLTQyNjQtOWQ2ZC1jMmNh
+        ODA2OTljZDQvIiwgInRhc2tfaWQiOiAiZWUyMDMzZDEtZTdhYy00MjY0LTlk
+        NmQtYzJjYTgwNjk5Y2Q0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0wMi0wNVQxNDowNTo1MloiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNTo1MVoiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICI1MjI0YjM2YS1mOWE2LTRmMmItYTVlMS1iM2RkMzkw
+        NGZhNjAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiYTJmMGZmMTAtNWY4ZC00YTJmLWE5ODktYTFhM2FkMjk2NDU2Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
+        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNmI2MjZiNmUtZjIxYS00NWZjLTg0ZGEt
+        M2M0OTIxMDIwODgyIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
+        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTRj
+        MGVmYzAtZjIxYy00OTg1LWE5MGMtMWFhYjJmYjI4MDdjIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogImUyNWFjYjI0LWZkZTUtNDJlMy1hZjA1LWFlNTE2
+        OGNjODRhMCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
+        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzMTYzZWYw
+        Yy1lZmMxLTRjZjgtYjNmMi02MDIzYWVjYmRkZWUiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJjM2ZmMzkxZC0xM2ExLTQyYTMtYjk0Mi0wZTZl
+        ODlhNTkxMWQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
+        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI5MzcxOTQ0NC1jY2U2LTQwOGItYTc4ZS1iNjc1YTBiNTIwYmYi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
+        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4ZDcw
+        ODVmOC0xNGNhLTQyZTEtYjZkOC00M2IxMjI5NjUwYWIiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
+        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1NDZlNjY4NC02YzJi
+        LTRhZDEtYjMxZC00ZTM1NzY5ZTQ3M2QiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
+        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM4M2I4Y2FkLTA1MDQtNGNh
+        Zi05YjliLTY1ODI0NGE1YjA3ZSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
+        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE0OjA1OjUx
+        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMDVUMTQ6MDU6NTJaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
+        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
+        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
+        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
+        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
+        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
+        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
+        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
+        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGFjNDBjNzgyMWIz
+        NDQ0ZmNjMjc0IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
+        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
+        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogIjUyMjRiMzZhLWY5YTYtNGYyYi1hNWUxLWIzZGQzOTA0ZmE2
+        MCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
+        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICJhMmYwZmYxMC01ZjhkLTRhMmYtYTk4OS1hMWEzYWQyOTY0NTYiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
+        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI2YjYyNmI2ZS1mMjFhLTQ1ZmMtODRkYS0zYzQ5
+        MjEwMjA4ODIiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
+        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5NGMwZWZj
+        MC1mMjFjLTQ5ODUtYTkwYy0xYWFiMmZiMjgwN2MiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiZTI1YWNiMjQtZmRlNS00MmUzLWFmMDUtYWU1MTY4Y2M4
+        NGEwIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjMxNjNlZjBjLWVm
+        YzEtNGNmOC1iM2YyLTYwMjNhZWNiZGRlZSIsICJudW1fcHJvY2Vzc2VkIjog
+        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImMzZmYzOTFkLTEzYTEtNDJhMy1iOTQyLTBlNmU4OWE1
+        OTExZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
+        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjkzNzE5NDQ0LWNjZTYtNDA4Yi1hNzhlLWI2NzVhMGI1MjBiZiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
+        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjhkNzA4NWY4
+        LTE0Y2EtNDJlMS1iNmQ4LTQzYjEyMjk2NTBhYiIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
+        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjU0NmU2Njg0LTZjMmItNGFk
+        MS1iMzFkLTRlMzU3NjllNDczZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
+        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzgzYjhjYWQtMDUwNC00Y2FmLTli
+        OWItNjU4MjQ0YTViMDdlIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhYzNmOGFkYTQwZGIw
+        NGVlMGEzZCJ9LCAiaWQiOiAiNTZiNGFjM2Y4YWRhNDBkYjA0ZWUwYTNkIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:52 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjAxMEU5OUMwLTMyNzYtMTFFMi04MUMxLTA4MDAyMDBDOUE2NiIs
+        ImRpc3BsYXlfbmFtZSI6IjAxMEU5OUMwLTMyNzYtMTFFMi04MUMxLTA4MDAy
+        MDBDOUE2NiJ9
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="4fydWcluXSp9FX32r6JYu4wNK86W23QHHx4Z4UoLW74", oauth_signature="xkbn8XACLybvidYILOzF9GY%2BiPE%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681153", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '99'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:53 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '2300'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb25zdW1lciI6IHsiZGlzcGxheV9uYW1lIjogIjAxMEU5OUMwLTMyNzYt
+        MTFFMi04MUMxLTA4MDAyMDBDOUE2NiIsICJkZXNjcmlwdGlvbiI6IG51bGws
+        ICJfbnMiOiAiY29uc3VtZXJzIiwgIm5vdGVzIjoge30sICJyc2FfcHViIjog
+        bnVsbCwgImNhcGFiaWxpdGllcyI6IHt9LCAiX2lkIjogeyIkb2lkIjogIjU2
+        YjRhYzQxYzc4MjFiMzMwMzRiYWUzMSJ9LCAiaWQiOiAiMDEwRTk5QzAtMzI3
+        Ni0xMUUyLTgxQzEtMDgwMDIwMEM5QTY2IiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi9jb25zdW1lcnMvMDEwRTk5QzAtMzI3Ni0xMUUyLTgxQzEtMDgwMDIw
+        MEM5QTY2LyJ9LCAiY2VydGlmaWNhdGUiOiAiLS0tLS1CRUdJTiBSU0EgUFJJ
+        VkFURSBLRVktLS0tLVxuTUlJQ1hRSUJBQUtCZ1FDYUVsYnJ1NW16TmprTWtl
+        N1dVdVFpSFJ3YmY3REVYV2loTFI1SEZiRVAzZjRoaG9ScFxuMWpwa3UzVkFs
+        Ymd1VWJJRlZtQnZLQ2pCR2laY0lXeGNRanV4Q3g1d0ZIbXp1Vm9ZckVIdXRw
+        dHZjNElJUUxPdlxucEtzWHJzcGlZR3NGUHVSYmtwQTRNZVIrM3R3dFpQbzNH
+        d2VwajV2Y2RvdWRFcHEwN2w5b3RHRWdTUUlEQVFBQlxuQW9HQkFJcmJSbjFV
+        YVZTcjVNU2diV201OFNPUnFyaFozNzFLRmpkVXkzbnpZYzNVRytxcEtvT2Nj
+        S3BDakkwMVxub25ZVWFPWUlrQWIrWWFTUFpjMFl6bWxqeEJrSTJBOUNhL2Nx
+        OWFtdzdYUlFLS2htd2xWUms4b1BiUkZLVTRkK1xuTXVDbkZ0MXR2anhjWFNQ
+        NTRmSElaR1RXcFFiL0lUaFJFTDJGV3lmdnVLaE1LSlZSQWtFQXg5b3FhSjBT
+        ZzZJN1xuNzhWN2ZYS3JuSENBSVY4TWs1R2JxRDh1MlNyWTZrTWpISkVmVmZE
+        TTErUUF1bitwL2puWHRMVDdjR0pNVkVrL1xucnNGaXRIZTFaUUpCQU1WYmgz
+        RGIraDlDVXdwT1k3RHZhWTZIS29lbWMzalA4RU5TdVJhUFJlcGlFYU1FY05Q
+        NFxuY2JtTldjZDhuem1aM2YxODU5cUJ5cGhONDhJaWtuV0oweFVDUVFDNkho
+        SEtsU1VOMDhOdnU0RVN4ZnpOMXZOc1xub0tFTXVOaTJhZ2tPRTlvbzZGZEZu
+        bDBKWXhUUnBiT0wrNkpyY0tEUzJJMGxEMVk0VkhMckk0dnh0MTRGQWtBclxu
+        ZHFIWVlBbXdrcW01RGxSMEpmV29OdXBOMzRGMHJNNnI5TzdnSWdOeXY5QkVo
+        M2pWcGRSZDJkeFl5NEJCYmpwdVxuVmZDMXRYbkptdlc2em1SVTBGcVZBa0Ex
+        UHpFRUorQkI5NkFOYllVcmp6VkdGYU43K1paQ1JmdlZGZkovaHlDdFxuZklX
+        bVlEUVg2eTByZVFUbkJxVDFxMDA3WFNQNXE4N2t3djkydFdtdjBSQ05cbi0t
+        LS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tXG4tLS0tLUJFR0lOIENFUlRJ
+        RklDQVRFLS0tLS1cbk1JSUMwRENDQWJnQ0FVNHdEUVlKS29aSWh2Y05BUUVG
+        QlFBd2dZWXhDekFKQmdOVkJBWVRBbFZUTVJjd0ZRWURcblZRUUlFdzVPYjNK
+        MGFDQkRZWEp2YkdsdVlURVFNQTRHQTFVRUJ4TUhVbUZzWldsbmFERVFNQTRH
+        QTFVRUNoTUhcblMyRjBaV3hzYnpFVU1CSUdBMVVFQ3hNTFUyOXRaVTl5WjFW
+        dWFYUXhKREFpQmdOVkJBTVRHMnRoZEdWc2JHOHRcbk1pMDRMV1JsZGk1bGVH
+        RnRjR3hsTG1OdmJUQWVGdzB4TmpBeU1EVXhOREExTlROYUZ3MHlOakF5TURJ
+        eE5EQTFcbk5UTmFNRmt4TFRBckJnTlZCQU1USkRBeE1FVTVPVU13TFRNeU56
+        WXRNVEZGTWkwNE1VTXhMVEE0TURBeU1EQkRcbk9VRTJOakVvTUNZR0NnbVNK
+        b21UOGl4a0FRRVRHRFUyWWpSaFl6UXhZemM0TWpGaU16TXdNelJpWVdVek1U
+        Q0Jcbm56QU5CZ2txaGtpRzl3MEJBUUVGQUFPQmpRQXdnWWtDZ1lFQW1oSlc2
+        N3Vac3pZNURKSHUxbExrSWgwY0czK3dcbnhGMW9vUzBlUnhXeEQ5MytJWWFF
+        YWRZNlpMdDFRSlc0TGxHeUJWWmdieWdvd1JvbVhDRnNYRUk3c1FzZWNCUjVc
+        bnM3bGFHS3hCN3JhYmIzT0NDRUN6cjZTckY2N0tZbUJyQlQ3a1c1S1FPREhr
+        ZnQ3Y0xXVDZOeHNIcVkrYjNIYUxcbm5SS2F0TzVmYUxSaElFa0NBd0VBQVRB
+        TkJna3Foa2lHOXcwQkFRVUZBQU9DQVFFQXdPc0cyNkM0MmozSElDUWhcblpU
+        SE82ZUQ5U2l0Kzl4VlNZRCtVSFZreFVWN2djNytsSFAxTlJjeVVleElLTmdv
+        djZycUxSNzNpSldGVXU3SkZcbnRRUzJmb05oM2o0WnUwUm1nT1ZoajhHNy8w
+        VWdJZU9RbE5ISTJ0M1oyUngrYUFtUWF0cG9DaVNyR3o1eGRqYTZcbkZoVHFz
+        NTZKMXI4SlBkNy9vUllLMkVDTHJkU08xMTgramhPem5mTXZXVzJYWlgzR2Fo
+        VFJEamRkWmdmemkrWm1cbkhkVCtvaEhINEVBWk5TRSt0cHZWaXVZdUxKWlZl
+        TEhDSk96ZXdaTFNUYmFRTmZ6U3BPaUVpRUN5R2FwMTdlRnBcbnBZdVFENTRV
+        Rkh3N3pFTUtXekdWdlpKOWtla0htYnk0VmY5c2s0SlBsNGN0L2hEVFFwNE9v
+        cjZ5UHBFUWtOSGlcbktTNTRqUT09XG4tLS0tLUVORCBDRVJUSUZJQ0FURS0t
+        LS0tIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:53 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/bindings//
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="W12js7vkbMieMer3U5rF3IPZY5eFzNQ5AhuN39o",
+        oauth_signature="IrK%2F29Hg%2FSFEno2p9LYf5g2NtLU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681153", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:53 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '2'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        W10=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:53 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="LI7ztVBp0mJ2FSskHhj6leMUoZJBjTHHJsIZNXqkM",
+        oauth_signature="3cSD8CXbGpaQF2aCm9CpgQB0u%2BY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681153", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:53 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2066'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjogeyJjaGVja3N1bV90eXBlIjogInNoYTI1NiJ9LCAi
+        ZGlzcGxheV9uYW1lIjogIkZlZG9yYSAxNyB4ODZfNjQiLCAiZGVzY3JpcHRp
+        b24iOiBudWxsLCAiZGlzdHJpYnV0b3JzIjogW3sicmVwb19pZCI6ICJGZWRv
+        cmFfMTciLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9G
+        ZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9kaXN0cmlidXRvci8iLCAi
+        X25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgImxhc3RfcHVibGlzaCI6IG51
+        bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4cG9ydF9kaXN0cmlidXRv
+        ciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hwYWQiOiB7fSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmI0YWMzZWM3ODIxYjMzMDQyZDlkZmUifSwg
+        ImNvbmZpZyI6IHsiaHR0cCI6IGZhbHNlLCAiaHR0cHMiOiBmYWxzZX0sICJp
+        ZCI6ICJleHBvcnRfZGlzdHJpYnV0b3IifSwgeyJyZXBvX2lkIjogIkZlZG9y
+        YV8xNyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0Zl
+        ZG9yYV8xNy9kaXN0cmlidXRvcnMvRmVkb3JhXzE3X2Nsb25lLyIsICJfbnMi
+        OiAicmVwb19kaXN0cmlidXRvcnMiLCAibGFzdF9wdWJsaXNoIjogbnVsbCwg
+        ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Nsb25lX2Rpc3RyaWJ1dG9y
+        IiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6IHt9LCAi
+        X2lkIjogeyIkb2lkIjogIjU2YjRhYzNlYzc4MjFiMzMwNDJkOWRmZCJ9LCAi
+        Y29uZmlnIjogeyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRv
+        cmFfMTcifSwgImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9LCB7InJlcG9faWQi
+        OiAiRmVkb3JhXzE3IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
+        b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTcvIiwgIl9u
+        cyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJsYXN0X3B1Ymxpc2giOiAiMjAx
+        Ni0wMi0wNVQxNDowNTo1MloiLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5
+        dW1fZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogdHJ1ZSwgInNjcmF0
+        Y2hwYWQiOiB7fSwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWMzZWM3ODIxYjMz
+        MDQyZDlkZmMifSwgImNvbmZpZyI6IHsiY2hlY2tzdW1fdHlwZSI6ICJzaGEy
+        NTYiLCAicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxzZSwgImh0dHBz
+        IjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJ0ZXN0X3BhdGgifSwgImlkIjog
+        IkZlZG9yYV8xNyJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3Rl
+        cyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3Jl
+        bW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHsicGFja2Fn
+        ZV9ncm91cCI6IDIsICJkaXN0cmlidXRpb24iOiAxLCAicGFja2FnZV9jYXRl
+        Z29yeSI6IDEsICJycG0iOiA4LCAiZXJyYXR1bSI6IDN9LCAiX25zIjogInJl
+        cG9zIiwgImltcG9ydGVycyI6IFt7InNjcmF0Y2hwYWQiOiB7InJlcG9tZF9y
+        ZXZpc2lvbiI6IDEzMjE4OTM4MDAsICJwcmV2aW91c19za2lwX2xpc3QiOiBb
+        XX0sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9y
+        YV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19p
+        bXBvcnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIi
+        LCAibGFzdF9zeW5jIjogIjIwMTYtMDItMDVUMTQ6MDU6NTFaIiwgInJlcG9f
+        aWQiOiAiRmVkb3JhXzE3IiwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWMzZWM3
+        ODIxYjMzMDQyZDlkZmIifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJmaWxlOi8v
+        L3Zhci93d3cvdGVzdF9yZXBvcy96b28ifSwgImlkIjogInl1bV9pbXBvcnRl
+        ciJ9XSwgImxvY2FsbHlfc3RvcmVkX3VuaXRzIjogMTUsICJfaWQiOiB7IiRv
+        aWQiOiAiNTZiNGFjM2VjNzgyMWIzMzA0MmQ5ZGZhIn0sICJ0b3RhbF9yZXBv
+        c2l0b3J5X3VuaXRzIjogMTUsICJpZCI6ICJGZWRvcmFfMTciLCAiX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:53 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/bindings//
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvX2lkIjoiRmVkb3JhXzE3IiwiZGlzdHJpYnV0b3JfaWQiOiJGZWRv
+        cmFfMTciLCJub3RpZnlfYWdlbnQiOmZhbHNlfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="BnOOUXyMVa0W1KIHUpleSpWgrJiwV3mW1czk9JbN8", oauth_signature="9ZTXsZTopITN49JjWG8iVvYG%2ByQ%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681153", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '73'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:53 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '352'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW10sICJyZXN1bHQiOiB7Im5vdGlmeV9hZ2Vu
+        dCI6IGZhbHNlLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiZGVsZXRlZCI6
+        IGZhbHNlLCAiX25zIjogImNvbnN1bWVyX2JpbmRpbmdzIiwgImRpc3RyaWJ1
+        dG9yX2lkIjogIkZlZG9yYV8xNyIsICJjb25zdW1lcl9pZCI6ICIwMTBFOTlD
+        MC0zMjc2LTExRTItODFDMS0wODAwMjAwQzlBNjYiLCAiY29uc3VtZXJfYWN0
+        aW9ucyI6IFtdLCAiYmluZGluZ19jb25maWciOiB7fSwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1NmI0YWM0MWM3ODIxYjMzMDVjZTUxMGMifSwgImlkIjogIjU2YjRh
+        YzQxYzc4MjFiMzMwNWNlNTEwYyJ9LCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:53 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/actions/content/update//
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ1bml0cyI6W3sidHlwZV9pZCI6InJwbSIsInVuaXRfa2V5Ijp7Im5hbWUi
+        OiJjaGVldGFoIn19XSwib3B0aW9ucyI6eyJpbXBvcnRrZXlzIjp0cnVlfX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="ppnFOGlTHjyMuiUdRWfLXJBhgufefrl772oKMDyogs8", oauth_signature="S2G7KmIrTFXIIIbL%2FOsln3SY7Jo%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681153", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '89'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:53 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzg2MzhjOGZhLTM0OWMtNDZkMy04OTJiLTE5NDVhZGU3NjI4OS8iLCAi
+        dGFza19pZCI6ICI4NjM4YzhmYS0zNDljLTQ2ZDMtODkyYi0xOTQ1YWRlNzYy
+        ODkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:53 GMT
+- request:
+    method: delete
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="ZL3REgG9httIyw0JT0SuUGt5l0vvoOo06t6d7kjsTA",
+        oauth_signature="vpLNtMCYpbHlQevZ72iisLG1VJw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681153", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:53 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzAyNWIzMTUzLWYxZTUtNDJhZC1hMjE2LTQ1MmNjMzdkMjgwOS8iLCAi
+        dGFza19pZCI6ICIwMjViMzE1My1mMWU1LTQyYWQtYTIxNi00NTJjYzM3ZDI4
+        MDkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:53 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/025b3153-f1e5-42ad-a216-452cc37d2809/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="M6HYwJSZwARVTX5CvcMOEqERT6CKi2ZQdzl6TWkI",
+        oauth_signature="6GwMxh5B8yYnt8ibdRFFfBqcohM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681153", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:53 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wMjViMzE1My1mMWU1LTQyYWQtYTIxNi00NTJjYzM3ZDI4
+        MDkvIiwgInRhc2tfaWQiOiAiMDI1YjMxNTMtZjFlNS00MmFkLWEyMTYtNDUy
+        Y2MzN2QyODA5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM0
+        MThhZGE0MGRiMDRlZTBhM2UifSwgImlkIjogIjU2YjRhYzQxOGFkYTQwZGIw
+        NGVlMGEzZSJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:53 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/025b3153-f1e5-42ad-a216-452cc37d2809/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="devJzG6Oqhgk91mol17jmCwEVWLAsYuQiRalho64M",
+        oauth_signature="c3XnCvRyPBGwvEUEgxiLpuiPl2U%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681154", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:54 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wMjViMzE1My1mMWU1LTQyYWQtYTIxNi00NTJjYzM3ZDI4
+        MDkvIiwgInRhc2tfaWQiOiAiMDI1YjMxNTMtZjFlNS00MmFkLWEyMTYtNDUy
+        Y2MzN2QyODA5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA1OjU0WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA1OjU0WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjNDE4YWRhNDBkYjA0ZWUwYTNlIn0sICJpZCI6ICI1NmI0YWM0MThhZGE0
+        MGRiMDRlZTBhM2UifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:54 GMT
+- request:
+    method: delete
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="vWpwyq9HHBqXLv1RBAWpyz605p54OJQwEWKP8GgIcI",
+        oauth_signature="uzkosjb4RcGVLwImaQ%2BpjjJ64So%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681154", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:54 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -5701,11 +10781,11 @@ http_interactions:
       Connection:
       - close
       Content-Type:
-      - application/json
+      - application/json; charset=utf-8
     body:
       encoding: UTF-8
       base64_string: |
         bnVsbA==
     http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:46 GMT
+  recorded_at: Fri, 05 Feb 2016 14:05:54 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/pulp/consumer/create.yml
+++ b/test/fixtures/vcr_cassettes/pulp/consumer/create.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/
     body:
       encoding: UTF-8
       base64_string: |
@@ -17,9 +17,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="SyhccFwwik0AVYcAYc9AIH0DsMutuSvs6T3UHlys", oauth_signature="imDJ7EcMvqhDDDWsH77yKksyU6E%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628862", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="VwREbzS5gWgBahXEJ7j6nA4rQEDKmpcyCPaJnIIFFc", oauth_signature="6HbURyElHICZ56dEwl6KypxoCKc%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681113", oauth_version="1.0"
       Pulp-User:
       - admin
       Content-Length:
@@ -29,20 +29,20 @@ http_interactions:
   response:
     status:
       code: 201
-      message: Created
+      message: CREATED
     headers:
       Date:
-      - Thu, 04 Feb 2016 23:34:22 GMT
+      - Fri, 05 Feb 2016 14:05:13 GMT
       Server:
       - Apache/2.4.6 (CentOS)
-      Location:
-      - "/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/"
       Content-Length:
-      - '2311'
+      - '2304'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
       Connection:
       - close
       Content-Type:
-      - application/json
+      - application/json; charset=utf-8
     body:
       encoding: UTF-8
       base64_string: |
@@ -50,59 +50,59 @@ http_interactions:
         MTFFMi04MUMxLTA4MDAyMDBDOUE2NiIsICJkZXNjcmlwdGlvbiI6IG51bGws
         ICJfbnMiOiAiY29uc3VtZXJzIiwgIm5vdGVzIjoge30sICJyc2FfcHViIjog
         bnVsbCwgImNhcGFiaWxpdGllcyI6IHt9LCAiX2lkIjogeyIkb2lkIjogIjU2
-        YjNkZmZlODRhMDljMDcwNjM0MzI2NiJ9LCAiaWQiOiAiMDEwRTk5QzAtMzI3
-        Ni0xMUUyLTgxQzEtMDgwMDIwMEM5QTY2IiwgIl9ocmVmIjogeyJfaHJlZiI6
-        ICIvcHVscC9hcGkvdjIvY29uc3VtZXJzLzAxMEU5OUMwLTMyNzYtMTFFMi04
-        MUMxLTA4MDAyMDBDOUE2Ni8ifX0sICJjZXJ0aWZpY2F0ZSI6ICItLS0tLUJF
-        R0lOIFJTQSBQUklWQVRFIEtFWS0tLS0tXG5NSUlDWEFJQkFBS0JnUURDVnl0
-        aURUcWFSQ3RPNU5ZTVk5K2J2ZFhNYWxYSGk4RzN4TWdjQWdPSVdJc3RtQXZ6
-        XG5PTmQvZWpKVzFud3lOYys3L2FYa21RZWdINnRmVTFQK3BqVmhWQ2ZKNExT
-        MHVEbjZ0MVY3SjAvWWR2VTBEbzNJXG5KNHJzY1k1YmNRL0hNRzk4U0NidWtj
-        Y1JFcEJXVmw0WkRhNGNrK0hwOURlRE1PVGhyQXUwVlhiS1Z3SURBUUFCXG5B
-        b0dBZHpST3lRTUNTak84T05WR3NpemtzTHY5a3pnNlMzN2ZJU0NUK2hJR0py
-        RGhGZU5vbVJUcG9pakxEZGJjXG5NVlF1aXNvbjRwTTNTVEdEeGFId0tJZTh2
-        MWRMYkJkV2lMYVhzYTIrTnMwK2J1a2htaU5iNG5mOWJoSHVEOExhXG56aDhz
-        ekJyT1hiVUtiRU52a0lYTzBzbExEWTg2YkNlQUpvZTBxeFVYMHcreWRZa0NR
-        UUR1UzBEYkRlUFY5U3lNXG41Q0RLcHo3d1lvMkRoWDladGU5NmFXRWFyRDRz
-        bUR0S1Q3aGNrM0xoQ0FUNjNrWnhYWXRRZHdBbUdkSExOckcyXG5ueFRCVGhv
-        ZEFrRUEwTWZaTnFVK0htbzVUYmV6UjZSREMvUTVaWkZCV1BlMjFjL1VQaUo0
-        WXpBVHo1V25MRDJXXG51eEJUZzQ5b2x4RjRtTmxHR0dUaiswMkM0Yzk3OERX
-        c0F3SkJBSStuMUZoNnZqQ2RWcGMxYkVOZm9nVGZGUHNGXG4vdWxCVWpiVTBw
-        SjI1aUNTUWFRaC9UM3FNaVpSWkZjc3F3RHE2UExBV3RtZFZTbVNObjZtMXFk
-        V2cwMENRR3lmXG5YWHFaMUV6Y3RUMmpFcXAyWXMrb1craGsvMXU3WGF1Mk9s
-        V3RkM2NiZjJNa0dGcmpIRFh0RTVaQ0dZZG5kcGdIXG5pdm1NSERVV0tiODBS
-        T1kvOW1NQ1FEYnhGQ2xDWlVIMjlkVjhEajY1OERCVnVmQk5mTzdhUHU2VEhC
-        RXljdVN0XG4xQ0FZWEg0RUZpRGVtbGJLdTV0WjN4OUYrRiszcXZvQ0VzazNF
-        YkYvSzhFPVxuLS0tLS1FTkQgUlNBIFBSSVZBVEUgS0VZLS0tLS1cbi0tLS0t
-        QkVHSU4gQ0VSVElGSUNBVEUtLS0tLVxuTUlJQzBEQ0NBYmdDQWdJWk1BMEdD
-        U3FHU0liM0RRRUJCUVVBTUlHRk1Rc3dDUVlEVlFRR0V3SlZVekVYTUJVR1xu
-        QTFVRUNCTU9UbTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9CZ05WQkFjVEIxSmhi
-        R1ZwWjJneEVEQU9CZ05WQkFvVFxuQjB0aGRHVnNiRzh4RkRBU0JnTlZCQXNU
-        QzFOdmJXVlBjbWRWYm1sME1TTXdJUVlEVlFRREV4cHJZWFJsYkd4dlxuTFdS
-        bGRtSnZlQzVsZUdGdGNHeGxMbU52YlRBZUZ3MHhOakF5TURReU16TTBNakph
-        RncweU5qQXlNREV5TXpNMFxuTWpKYU1Ga3hMVEFyQmdOVkJBTVRKREF4TUVV
-        NU9VTXdMVE15TnpZdE1URkZNaTA0TVVNeExUQTRNREF5TURCRFxuT1VFMk5q
-        RW9NQ1lHQ2dtU0pvbVQ4aXhrQVFFVEdEVTJZak5rWm1abE9EUmhNRGxqTURj
-        d05qTTBNekkyTmpDQlxubnpBTkJna3Foa2lHOXcwQkFRRUZBQU9CalFBd2dZ
-        a0NnWUVBd2xjcllnMDZta1FyVHVUV0RHUGZtNzNWekdwVlxueDR2QnQ4VElI
-        QUlEaUZpTExaZ0w4empYZjNveVZ0WjhNalhQdS8ybDVKa0hvQityWDFOVC9x
-        WTFZVlFueWVDMFxudExnNStyZFZleWRQMkhiMU5BNk55Q2VLN0hHT1czRVB4
-        ekJ2ZkVnbTdwSEhFUktRVmxaZUdRMnVISlBoNmZRM1xuZ3pEazRhd0x0RlYy
-        eWxjQ0F3RUFBVEFOQmdrcWhraUc5dzBCQVFVRkFBT0NBUUVBQ3Q4K254WXpQ
-        TlZiZ0ZNalxubFVYR3ZNYXFsT3FlQzhtUURJTlJacW03amVKTzJNbDZMZ3R6
-        clErZ3hJUWV3MUlNTHp1WkorTFBYMWZOb0ZkblxuRWZzZUpXcWFpWGczYjg4
-        Rk5UeHhBeHh0ZFBsWlFyWmQwMHM0cmhLTXQwcXZnK0lLNEhJT3Fjc3ppR1hP
-        U003WlxudVhsWmI2bFRvbEY5aVNQT0ZvRTlCUkxnbk1ORWM3NnR5ZktGekpq
-        WGl2UXFYcDdpUUMxSnpUbXVDNEQyVitpelxuSVlaZ29CSGpUOC93czRuaUhx
-        cGl4dUdqNzBSclJtNyt5SWZQUlZ6U1JRT1M3WFNYYXRlK1pZNkUxNVhNRXZo
-        eFxuOGpsSm5mcVRGbDcxVXh5MThnWXBxMzFDcUYxM293VGQ5a09ydUZadUh2
-        NXdwTXRRbk5aVHByRVNXMlNSNXNHVlxuRklzM0RnPT1cbi0tLS0tRU5EIENF
-        UlRJRklDQVRFLS0tLS0ifQ==
+        YjRhYzFhYzc4MjFiMzMwNWNlNTBmYiJ9LCAiaWQiOiAiMDEwRTk5QzAtMzI3
+        Ni0xMUUyLTgxQzEtMDgwMDIwMEM5QTY2IiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi9jb25zdW1lcnMvMDEwRTk5QzAtMzI3Ni0xMUUyLTgxQzEtMDgwMDIw
+        MEM5QTY2LyJ9LCAiY2VydGlmaWNhdGUiOiAiLS0tLS1CRUdJTiBSU0EgUFJJ
+        VkFURSBLRVktLS0tLVxuTUlJQ1h3SUJBQUtCZ1FDOFZhTTZuMUdQT2RRbDBQ
+        R1ptL1hreUxEcU9oK0dKbjZiZjdidEl1UmMweTk4cW1qWlxuczQ0VjJlTWVH
+        T01KOTVqOUpFbjkzM2gzcEkyWWQ5NDJIR0VIUzB5QXdVMHp1Zzg5M20ySG1G
+        elZZU2haWmtvV1xuYklJWDlVVmRITnJIbndreWI3WmR4RWRXdXZTR2MyQ2lw
+        QUZGOGJwcE5wZTZFYXk1QUR4MWZRdU5Nd0lEQVFBQlxuQW9HQkFMa1RZeVBS
+        dXFHSVQ2MlY1a1p3MkRTcThBaE5jL3N0eXc5ZWMxSVlEdGdWaEwzNjdLeTdZ
+        YTZoZnlwdFxuaEhlZ0JJMEhZMXNEaDJ2em5sNHR0WVh4WDNyT3BZTlJVTVNT
+        VmJwV1FPS1hBWFlsRmtVSW1aQWJxWEIxNUM5VlxuQ3NpZnVRMXJXWWpsYmlS
+        b3VOUXc0Q0RYVmd3QnVwWURJRGU1aVhrQUJWNHhPMDRoQWtFQTVGYUlsTUEr
+        ZGRqUVxucWlLeEc1T0VsZSs5MzNpWUhOU1kyUUtpT2VnY3BQM2QrNmgwTTFG
+        RUdHQU1lVlM0dFUzWjM0Qk5xMVpESlpvZ1xuSDVBT1pVK3JzUUpCQU5NbWVO
+        OVFDTDVQZ1lkQzBTVkEzTHNBYUs3dGFTalhEL0wwUld2WWJqQ0JzU2Z2RU15
+        aVxuSVVpTHhJVkJ0VXhKdXZXWHlXZ0ZTc0xmRFRZTDRHMGhWQ01DUVFDNUlw
+        UlJEMkpWU0xzL0J5dlVjUkpTUTNVT1xueVFlRWNMZVJWSHBXT3lWbWZWUEw1
+        UFI2VzB5NytyeUNiN2ZuZ0x6RFk1TVY5Yll4dWJxTC9OQS9RbzZ4QWtFQVxu
+        bkZwanJQRGwySTZsR3BUV3JDQlFrc1NsdjhxYlVSdVhlczk0ekhnU2VDYkJH
+        UklFdlpMYzFJeHl0RDVJMHJuU1xuRUdRYVJzV01hNnFoYk1EMHFickJRd0pC
+        QUtUeVpPb3BQYUxMYnJOTER6RG82OWZiR0JRQ0Jvbzc1SjYrY0hLeFxudGNj
+        dHZsVndSenUrRk95TXBuVytNTndES0VVVEZGTVREaEErMFFLZ3NXa05tSE09
+        XG4tLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLVxuLS0tLS1CRUdJTiBD
+        RVJUSUZJQ0FURS0tLS0tXG5NSUlDMERDQ0FiZ0NBVVF3RFFZSktvWklodmNO
+        QVFFRkJRQXdnWVl4Q3pBSkJnTlZCQVlUQWxWVE1SY3dGUVlEXG5WUVFJRXc1
+        T2IzSjBhQ0JEWVhKdmJHbHVZVEVRTUE0R0ExVUVCeE1IVW1Gc1pXbG5hREVR
+        TUE0R0ExVUVDaE1IXG5TMkYwWld4c2J6RVVNQklHQTFVRUN4TUxVMjl0WlU5
+        eVoxVnVhWFF4SkRBaUJnTlZCQU1URzJ0aGRHVnNiRzh0XG5NaTA0TFdSbGRp
+        NWxlR0Z0Y0d4bExtTnZiVEFlRncweE5qQXlNRFV4TkRBMU1UUmFGdzB5TmpB
+        eU1ESXhOREExXG5NVFJhTUZreExUQXJCZ05WQkFNVEpEQXhNRVU1T1VNd0xU
+        TXlOell0TVRGRk1pMDRNVU14TFRBNE1EQXlNREJEXG5PVUUyTmpFb01DWUdD
+        Z21TSm9tVDhpeGtBUUVUR0RVMllqUmhZekZoWXpjNE1qRmlNek13TldObE5U
+        Qm1ZakNCXG5uekFOQmdrcWhraUc5dzBCQVFFRkFBT0JqUUF3Z1lrQ2dZRUF2
+        RldqT3A5Ump6blVKZER4bVp2MTVNaXc2am9mXG5oaVorbTMrMjdTTGtYTk12
+        ZktwbzJiT09GZG5qSGhqakNmZVkvU1JKL2Q5NGQ2U05tSGZlTmh4aEIwdE1n
+        TUZOXG5NN29QUGQ1dGg1aGMxV0VvV1daS0ZteUNGL1ZGWFJ6YXg1OEpNbSsy
+        WGNSSFZycjBobk5nb3FRQlJmRzZhVGFYXG51aEdzdVFBOGRYMExqVE1DQXdF
+        QUFUQU5CZ2txaGtpRzl3MEJBUVVGQUFPQ0FRRUFjcGhSV0ZGRUdZaWg4ZG1j
+        XG5ob2V3d0dPdmVyQUQvOVljb0hsN2RnQ3gwNjhqaGVaVHp2NkR3dlpTMFo1
+        by9lSEhKVW96TURJT2Q0MU9YaG5qXG5yMzhmREZYZ0IvY2luZnJSQ0dsTURS
+        NzlKQks0cEtvT1hwc2pkSlgrSnNBRGFCeDRQTkRPWGxIMUtHUlphOWowXG5j
+        WHFOQzlHc1NrSGlLbkpra0MyTUZUUWdsejJtQ2hVQ1RDRVdVbUh1Tng4NDJQ
+        TEhRTlhuY3gzS0h2VXBEK0t4XG55NkkwOC82RlZucU85Y2Exd1JycGxLVzRj
+        UmF6dVNJREtrejdBNmlaelVaRU5DMnI5eVgrYVBtWjJxUUZyK1loXG45b2Qz
+        RDJPQngySkVvTTc3ekM2YWd3T0t5Ull4R3RGUzNsNDF2cFY4dmJ0c0xheWtQ
+        WnR3RkdKOHQ1ZnZCajVWXG5KRkp4aUE9PVxuLS0tLS1FTkQgQ0VSVElGSUNB
+        VEUtLS0tLSJ9
     http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:22 GMT
+  recorded_at: Fri, 05 Feb 2016 14:05:14 GMT
 - request:
     method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -114,9 +114,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="9RI3c3bS9fi1bg908i88v8hgXPzEvAmYyIj1ZnL6c",
-        oauth_signature="lwE1LTUtjpzDhvnvZZ7BaTVZCJw%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628862", oauth_version="1.0"
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="eeyyIWz109XeiqbDEnPgrH2TZ0Zis6YujP6H5hpxNk",
+        oauth_signature="OZtl7yby8Qbqitv4QT1swKakNF4%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681114", oauth_version="1.0"
       Pulp-User:
       - admin
       User-Agent:
@@ -127,7 +127,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 Feb 2016 23:34:22 GMT
+      - Fri, 05 Feb 2016 14:05:14 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -135,11 +135,11 @@ http_interactions:
       Connection:
       - close
       Content-Type:
-      - application/json
+      - application/json; charset=utf-8
     body:
       encoding: UTF-8
       base64_string: |
         bnVsbA==
     http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:22 GMT
+  recorded_at: Fri, 05 Feb 2016 14:05:14 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/pulp/consumer/delete.yml
+++ b/test/fixtures/vcr_cassettes/pulp/consumer/delete.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/
     body:
       encoding: UTF-8
       base64_string: |
@@ -17,9 +17,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="uWudnam8ztUJdRByASmVtjWIQc2J3dnnmXJv1om7tM", oauth_signature="QxOwdhHC4m87B4aA3ix6rwnzwLA%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628862", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="gBBj1uM8oymmn02E7BdXbbQanOp3dwVddq4IKPdLqgk", oauth_signature="lFg0e%2F%2BP1IhPK1J96uG560eCPJ8%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681114", oauth_version="1.0"
       Pulp-User:
       - admin
       Content-Length:
@@ -29,20 +29,20 @@ http_interactions:
   response:
     status:
       code: 201
-      message: Created
+      message: CREATED
     headers:
       Date:
-      - Thu, 04 Feb 2016 23:34:22 GMT
+      - Fri, 05 Feb 2016 14:05:14 GMT
       Server:
       - Apache/2.4.6 (CentOS)
-      Location:
-      - "/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/"
       Content-Length:
-      - '2311'
+      - '2300'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
       Connection:
       - close
       Content-Type:
-      - application/json
+      - application/json; charset=utf-8
     body:
       encoding: UTF-8
       base64_string: |
@@ -50,59 +50,59 @@ http_interactions:
         MTFFMi04MUMxLTA4MDAyMDBDOUE2NiIsICJkZXNjcmlwdGlvbiI6IG51bGws
         ICJfbnMiOiAiY29uc3VtZXJzIiwgIm5vdGVzIjoge30sICJyc2FfcHViIjog
         bnVsbCwgImNhcGFiaWxpdGllcyI6IHt9LCAiX2lkIjogeyIkb2lkIjogIjU2
-        YjNkZmZlODRhMDljMDcwNjM0MzI2ZiJ9LCAiaWQiOiAiMDEwRTk5QzAtMzI3
-        Ni0xMUUyLTgxQzEtMDgwMDIwMEM5QTY2IiwgIl9ocmVmIjogeyJfaHJlZiI6
-        ICIvcHVscC9hcGkvdjIvY29uc3VtZXJzLzAxMEU5OUMwLTMyNzYtMTFFMi04
-        MUMxLTA4MDAyMDBDOUE2Ni8ifX0sICJjZXJ0aWZpY2F0ZSI6ICItLS0tLUJF
-        R0lOIFJTQSBQUklWQVRFIEtFWS0tLS0tXG5NSUlDWEFJQkFBS0JnUUMvSXpM
-        azlGaitVYW5OeHpuYlBEK2xmeUlydW1LTFR6U3JvUUNhRXl6RytoamxwN1Rs
-        XG5vNUVtcTZkSWJNWW9iK243U1c1dDlHeDJwdmpWVzlsMlJvZ0VVSzZLNHRz
-        ZlBjTnIvQkNuTEZZUmpmakNEVVpqXG5QQWgram1kYXVBZFF5OE9KbEF4UkpB
-        VnlTd2FuSkVnMUt5T3hrUnBGNGF1bndGRzBhb01yU2wwWkJ3SURBUUFCXG5B
-        b0dBZlFBY0RMZndhNElrdHJzUUQxeTdreFF0Mk1Nd0owTkpndVRzYTljV2Ra
-        cWlKYThrRXZxQnR2U1RsajNzXG42ZzBtekh3ZGlETk5xOXRPNk5vRXdlRW1t
-        ZWhaUUNGRC9ONmUvMHp1RGlXWVdZc0VqVjdyVVFLOTBXSDZuNGNQXG5ZUHBQ
-        Z0lSQXBWYkpXZWpyWHRPSjFRUVlOMDVTMEhyZHNEeWhZblZ2L0pPZG5BRUNR
-        UUQ2QktZNVBWTUR6QkVzXG5FZXJTMlRpYXNRQ2lPQnFXK1JJSmltVTJBeFgz
-        QVU4NUFTZDdQMzNqMnB6R05XekpCdEhKckpoOTY3UkM3cS9jXG5mc1Q0UlR1
-        QkFrRUF3N1hvYkNScU94Y0dFYVEzSjdyc1lNbWExaEFUZVMyWk1xQ3g3cFpO
-        dmtZUjBCVVJlL1hPXG5RaHU1VlUwWlkzMjhIZ3dXTVZORjRPajc5ZlNlZmhh
-        NGh3SkFIUFo4NnhTWGtWRUtqRGhuSTVYV1lOVXdaWnBxXG5PaU1RVzlxVWJ2
-        VmNqZ2l3ek1HOWVTR1p5OU4vWmRhNmkyOG16bDRZTEQ0cDI3Y2EyRWczT1N1
-        TUFRSkFQMlg0XG5Lc0FKSWFjdHNoMU9PTEtXekN2QzJzRk9iWnpWMmM2d2xT
-        ZGZlOW5hLzFzejFNSWwxTWlDV3gya3NkUVRVbkI3XG41L0tmMm1IZTdTZ1hC
-        NlY0bFFKQkFOcmVzU3Rrb3dmWmllU1lRWU5ORVB6STdhRWp2MkFEc01hSXN4
-        dFVSSFlDXG5GMjRta0kxdTNVdkRkc0hvdWhxWVRHbm1xZ1RHaEV1TTg3T2Fr
-        VEtJQ09BPVxuLS0tLS1FTkQgUlNBIFBSSVZBVEUgS0VZLS0tLS1cbi0tLS0t
-        QkVHSU4gQ0VSVElGSUNBVEUtLS0tLVxuTUlJQzBEQ0NBYmdDQWdJYU1BMEdD
-        U3FHU0liM0RRRUJCUVVBTUlHRk1Rc3dDUVlEVlFRR0V3SlZVekVYTUJVR1xu
-        QTFVRUNCTU9UbTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9CZ05WQkFjVEIxSmhi
-        R1ZwWjJneEVEQU9CZ05WQkFvVFxuQjB0aGRHVnNiRzh4RkRBU0JnTlZCQXNU
-        QzFOdmJXVlBjbWRWYm1sME1TTXdJUVlEVlFRREV4cHJZWFJsYkd4dlxuTFdS
-        bGRtSnZlQzVsZUdGdGNHeGxMbU52YlRBZUZ3MHhOakF5TURReU16TTBNak5h
-        RncweU5qQXlNREV5TXpNMFxuTWpOYU1Ga3hMVEFyQmdOVkJBTVRKREF4TUVV
-        NU9VTXdMVE15TnpZdE1URkZNaTA0TVVNeExUQTRNREF5TURCRFxuT1VFMk5q
-        RW9NQ1lHQ2dtU0pvbVQ4aXhrQVFFVEdEVTJZak5rWm1abE9EUmhNRGxqTURj
-        d05qTTBNekkyWmpDQlxubnpBTkJna3Foa2lHOXcwQkFRRUZBQU9CalFBd2dZ
-        a0NnWUVBdnlNeTVQUlkvbEdwemNjNTJ6dy9wWDhpSzdwaVxuaTA4MHE2RUFt
-        aE1zeHZvWTVhZTA1YU9SSnF1blNHekdLRy9wKzBsdWJmUnNkcWI0MVZ2WmRr
-        YUlCRkN1aXVMYlxuSHozRGEvd1FweXhXRVkzNHdnMUdZendJZm81bldyZ0hV
-        TXZEaVpRTVVTUUZja3NHcHlSSU5Tc2pzWkVhUmVHclxucDhCUnRHcURLMHBk
-        R1FjQ0F3RUFBVEFOQmdrcWhraUc5dzBCQVFVRkFBT0NBUUVBTlZkMjdsQW1N
-        R2x1eUVBSlxuSlVwbytQNUpKcDI2ZVdmMHRlekRtNVF5UTcxYW5CK3lMZHBV
-        UEZ2ckhHTGlnVWVaM2FlYTI0M2lhMlRGRVZkYVxuMDJ4bGZONjJSTG1PRkJ0
-        Y1FUS2NmNERXdkFZQ3dOQUVNc05IVlNZbUZQd3FySUpaZWEwNVBEeHVmTkdL
-        VW1jOFxuOWM0d3lpdGp0aU0wUnQ3b1U4dFZGTUlTblFtb3Y1c1dlZWdKWnQz
-        ckNNWFltWnlwREF6K3NqWDg2YWRNbzRpUVxuNlNUTXlDNUJvZzFCUjVaQktU
-        WCtWaWRlbk5vbFp6RXV6SUI2L0l1Q2VjRlQyN2V1cXNhUVF5R29jaUZ2K1V5
-        NlxuZjZVSFlTWTBSZ3B4VnpRUmlsZkQvWFVEMUFwTjNPc0xSUGQ2Tzl5bG9x
-        aVVyT2xuRWQvQ0dEdndGWXAxRTE0NVxuZkhYYjNnPT1cbi0tLS0tRU5EIENF
-        UlRJRklDQVRFLS0tLS0ifQ==
+        YjRhYzFhYzc4MjFiMzMwNDJkOWRkMSJ9LCAiaWQiOiAiMDEwRTk5QzAtMzI3
+        Ni0xMUUyLTgxQzEtMDgwMDIwMEM5QTY2IiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi9jb25zdW1lcnMvMDEwRTk5QzAtMzI3Ni0xMUUyLTgxQzEtMDgwMDIw
+        MEM5QTY2LyJ9LCAiY2VydGlmaWNhdGUiOiAiLS0tLS1CRUdJTiBSU0EgUFJJ
+        VkFURSBLRVktLS0tLVxuTUlJQ1hBSUJBQUtCZ1FEWlVNTE43MjExUXQ1WjBk
+        QzFsYkFJMm5oMlBGaVhVRDE3RVJOMnA1ZDg5TjhhY2JzZFxuS0hXck9nU2M5
+        WDlNa0lIc3MwTTFFcUhlbHc2T1NHS3lER1RFSkFtRDBOTy94VFpXZ3RKZlZu
+        MkZmUHFTdFJ1dVxudTRBbVNJUVhJRG9XeVF3UFQvZkc0bWF1b1JSMk9kcXp5
+        WjVRQytwMlo4VitiK1FLdkhuWWJIOGU5d0lEQVFBQlxuQW9HQkFNbUtxT0Fz
+        cVNzVE5QdkFKdndCTXgxQzRHMW5VaElqREtIU0dHYjJ6dnZJYmhFc1lRaU51
+        WE52ZjAvQ1xuTHFsbmE5ZUYrVktEVVRRS2pDbFE0SmVYL3VwanJVTm43c1d4
+        TlVMZ3pSM1J4dzY4cTFZT0RzU2o4eW0xYWhNWVxucjh3d0VWblVLV3dRVHo4
+        cDMvTlp0bEwyVnpBeEgxVUF0M2t4NHVrT0tOQlJiODBoQWtFQTdoT01nNE02
+        VS90Q1xuTFVYZktuUFE5VFZPdFNUTmF0R3haSk0waDM1SWlSSUl0K3NvQXhM
+        d3orK1NYVER4SXJIcklkS1NpYlREQjJwMVxuZW1BTjNSUE9UUUpCQU9tdEZr
+        TlFrS0VWSHc2MFdlWVpnWkUvUDNxVC9Xd2sydG1Vb0JJS2xPSmRXZnZCdjZy
+        ZFxuejJhMFUyYzZYR0pQakh6OWJpdHBNT1hhekdWamdaRVdMRk1DUUZ5OFVL
+        ZUpubGJJTUdiaUtLT29xV1JhZDJZb1xuQjd2c0ltVkMwZHRWWFh2SEFvNWhr
+        eHhmYkY0U3U3aUJMK3lMMFVORGVzRVpJRDdyUVFlQ0V1UmlxcUVDUUZFRlxu
+        TFhucmZpb0x5N2ZxZWwwWXJON3lnZ3o3TU53RkwwaFBpdXlXZEtiRDNVWTRH
+        RCtqSnAwaW11Um96TTFkYllXTVxuelYwSjNPVmxab2NrNkRDbzhuY0NRSDlW
+        TnZuTDVBUncvSVBDSnVXNjJYejVnL0RLd0M2RU12VDg0cDZZYmhLV1xueFFB
+        a004YlVIeTRoNUdXeTV3Nm4rVHk0T25zTE42MkpLWFNzRWRxYndnOD1cbi0t
+        LS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tXG4tLS0tLUJFR0lOIENFUlRJ
+        RklDQVRFLS0tLS1cbk1JSUMwRENDQWJnQ0FVVXdEUVlKS29aSWh2Y05BUUVG
+        QlFBd2dZWXhDekFKQmdOVkJBWVRBbFZUTVJjd0ZRWURcblZRUUlFdzVPYjNK
+        MGFDQkRZWEp2YkdsdVlURVFNQTRHQTFVRUJ4TUhVbUZzWldsbmFERVFNQTRH
+        QTFVRUNoTUhcblMyRjBaV3hzYnpFVU1CSUdBMVVFQ3hNTFUyOXRaVTl5WjFW
+        dWFYUXhKREFpQmdOVkJBTVRHMnRoZEdWc2JHOHRcbk1pMDRMV1JsZGk1bGVH
+        RnRjR3hsTG1OdmJUQWVGdzB4TmpBeU1EVXhOREExTVRSYUZ3MHlOakF5TURJ
+        eE5EQTFcbk1UUmFNRmt4TFRBckJnTlZCQU1USkRBeE1FVTVPVU13TFRNeU56
+        WXRNVEZGTWkwNE1VTXhMVEE0TURBeU1EQkRcbk9VRTJOakVvTUNZR0NnbVNK
+        b21UOGl4a0FRRVRHRFUyWWpSaFl6RmhZemM0TWpGaU16TXdOREprT1dSa01U
+        Q0Jcbm56QU5CZ2txaGtpRzl3MEJBUUVGQUFPQmpRQXdnWWtDZ1lFQTJWREN6
+        ZTl0ZFVMZVdkSFF0Wld3Q05wNGRqeFlcbmwxQTlleEVUZHFlWGZQVGZHbkc3
+        SFNoMXF6b0VuUFYvVEpDQjdMTkROUktoM3BjT2praGlzZ3hreENRSmc5RFRc
+        bnY4VTJWb0xTWDFaOWhYejZrclVicnJ1QUpraUVGeUE2RnNrTUQwLzN4dUpt
+        cnFFVWRqbmFzOG1lVUF2cWRtZkZcbmZtL2tDcng1Mkd4L0h2Y0NBd0VBQVRB
+        TkJna3Foa2lHOXcwQkFRVUZBQU9DQVFFQUpGNTBpdVFEUWRMSDJwMUZcbitr
+        ak5QdzlEK2h3VlQxZkVEbFBDNUtSbm1KRVNyc0JWTkc3VlpnZ2pGcExLTkdx
+        aUwrbnc5T2NMRzJ3NzhhRzZcbll3c25tSnpKVEJDazVWNjU3cHBEZDNOOWhq
+        U1JENWR3TXRMM1NuVk40RjJ0NWc3Y1I1MVJCN3Z1M2xYUThGRXpcbmNTSDRr
+        V2dkemxQUWk4WUw2ZW1OWGwrd1pyZlpwNk5KSXFZcUpHSEVISy9SL1E2NU9o
+        NndYUDEwVENZUlNwTVVcbmk1bkN6ZWMvaDg4R3E3anV4S0pJbk1DY1R3MDVk
+        SFF6MUQwY3pBWVRNMXNnZG5GSGdXSENNSHZuelFtWklOUHVcbm81TkgyV0pi
+        bkh4NjZiWERQeDY3RG5tcFUzUnM4b3hYMUJCSVE3dytwOVMrTHpBQm1BaEVI
+        elhENzlydDVCNElcbjhRdXBTdz09XG4tLS0tLUVORCBDRVJUSUZJQ0FURS0t
+        LS0tIn0=
     http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:23 GMT
+  recorded_at: Fri, 05 Feb 2016 14:05:14 GMT
 - request:
     method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/consumers/010E99C0-3276-11E2-81C1-0800200C9A66/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -114,9 +114,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="G5edlZoqBHum5BOzfUA8vaZFPf194l7gf3RJyorMAXA",
-        oauth_signature="vNREOrO1brdTUnMjH%2FKp3cJy00Q%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628863", oauth_version="1.0"
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="W5h6P2fgtNWCzRk2amvfNpyNtKjKIaOWgvFK8kiqtM",
+        oauth_signature="CWiUMmWqJtSCTAonM5to15eJEz8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681114", oauth_version="1.0"
       Pulp-User:
       - admin
       User-Agent:
@@ -127,7 +127,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 Feb 2016 23:34:23 GMT
+      - Fri, 05 Feb 2016 14:05:14 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -135,11 +135,11 @@ http_interactions:
       Connection:
       - close
       Content-Type:
-      - application/json
+      - application/json; charset=utf-8
     body:
       encoding: UTF-8
       base64_string: |
         bnVsbA==
     http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:23 GMT
+  recorded_at: Fri, 05 Feb 2016 14:05:14 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/pulp/repository/contents.yml
+++ b/test/fixtures/vcr_cassettes/pulp/repository/contents.yml
@@ -819,126 +819,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:35:12 GMT
 - request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwiZmlsdGVycyI6eyJ1
-        bml0Ijp7IiRhbmQiOlt7Im5hbWUiOiJlbGVwaGFudCJ9XX19LCJzb3J0Ijp7
-        InVuaXQiOltbIm5hbWUiLCJhc2NlbmRpbmciXSxbInZlcnNpb24iLCJkZXNj
-        ZW5kaW5nIl1dfX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="uD8DQCbjzJ52nkCZ9oin4zN7dqcbYPtjBnCu3yo", oauth_signature="lXjRgGG01X2LM1TftFbO%2BIiEf04%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628912", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '147'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:35:12 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '3280'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W3sidXBkYXRlZCI6ICIyMDE2LTAyLTA0VDIzOjM1OjExWiIsICJyZXBvX2lk
-        IjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTYtMDItMDRUMjM6MzU6
-        MTFaIiwgIl9ucyI6ICJyZXBvX2NvbnRlbnRfdW5pdHMiLCAidW5pdF9pZCI6
-        ICIyOTcxZWZjYS05N2U3LTQwZDAtOTE5OS01MTU4YWQ4MmM2MDAiLCAibWV0
-        YWRhdGEiOiB7ImJ1aWxkX3RpbWUiOiAxMzA4MjU3NDY2LCAiYnVpbGRob3N0
-        IjogImRoY3AtMjYtMTE4LmJycS5yZWRoYXQuY29tIiwgIl9jb250ZW50X3R5
-        cGVfaWQiOiAicnBtIiwgInZlbmRvciI6IG51bGwsICJjaGVja3N1bSI6ICIz
-        ZTFjNzBjZDFiNDIxMzI4YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFi
-        MDk1ZmMzMTM3MmEwYTcwMWYzIiwgInNpemUiOiAyMjQ0LCAiZ3JvdXAiOiAi
-        SW50ZXJuZXQvQXBwbGljYXRpb25zIiwgIl9ucyI6ICJ1bml0c19ycG0iLCAi
-        YmFzZV91cmwiOiBudWxsLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAu
-        OC5ub2FyY2gucnBtIiwgInJlbGF0aXZlX3VybF9wYXRoIjogbnVsbCwgImVw
-        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAidmVyc2lvbl9zb3J0X2lu
-        ZGV4IjogIjAxLTAuMDEtMyIsICJwcm92aWRlcyI6IFt7InJlbGVhc2UiOiAi
-        MC44IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiZmxhZ3Mi
-        OiAiRVEiLCAibmFtZSI6ICJlbGVwaGFudCJ9XSwgImZpbGVzIjogeyJmaWxl
-        IjogWyIvL2VsZXBoYW50LnR4dCJdLCAiZGlyIjogW119LCAicmVwb2RhdGEi
-        OiB7ImZpbGVsaXN0cyI6ICI8cGFja2FnZSBhcmNoPVwibm9hcmNoXCIgbmFt
-        ZT1cImVsZXBoYW50XCIgcGtnaWQ9XCIzZTFjNzBjZDFiNDIxMzI4YWNhZjYz
-        OTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3MmEwYTcwMWYzXCI+
-        XG4gICAgPHZlcnNpb24gZXBvY2g9XCIwXCIgcmVsPVwiMC44XCIgdmVyPVwi
-        MC4zXCIgLz5cblxuICAgIDxmaWxlPi8vZWxlcGhhbnQudHh0PC9maWxlPlxu
-        PC9wYWNrYWdlPlxuXG4iLCAib3RoZXIiOiAiPHBhY2thZ2UgYXJjaD1cIm5v
-        YXJjaFwiIG5hbWU9XCJlbGVwaGFudFwiIHBrZ2lkPVwiM2UxYzcwY2QxYjQy
-        MTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5NWY2NWQxYjA5NWZjMzEzNzJh
-        MGE3MDFmM1wiPlxuICAgIDx2ZXJzaW9uIGVwb2NoPVwiMFwiIHJlbD1cIjAu
-        OFwiIHZlcj1cIjAuM1wiIC8+XG5cbjwvcGFja2FnZT5cblxuIiwgInByaW1h
-        cnkiOiAiPHBhY2thZ2UgdHlwZT1cInJwbVwiPlxuICA8bmFtZT5lbGVwaGFu
-        dDwvbmFtZT5cbiAgPGFyY2g+bm9hcmNoPC9hcmNoPlxuICA8dmVyc2lvbiBl
-        cG9jaD1cIjBcIiByZWw9XCIwLjhcIiB2ZXI9XCIwLjNcIiAvPlxuICA8Y2hl
-        Y2tzdW0gcGtnaWQ9XCJZRVNcIiB0eXBlPVwic2hhMjU2XCI+M2UxYzcwY2Qx
-        YjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5NWY2NWQxYjA5NWZjMzEz
-        NzJhMGE3MDFmMzwvY2hlY2tzdW0+XG4gIDxzdW1tYXJ5PkEgZHVtbXkgcGFj
-        a2FnZSBvZiBlbGVwaGFudDwvc3VtbWFyeT5cbiAgPGRlc2NyaXB0aW9uPkEg
-        ZHVtbXkgcGFja2FnZSBvZiBlbGVwaGFudDwvZGVzY3JpcHRpb24+XG4gIDxw
-        YWNrYWdlciAvPlxuICA8dXJsPmh0dHA6Ly90c3RyYWNob3RhLmZlZG9yYXBl
-        b3BsZS5vcmc8L3VybD5cbiAgPHRpbWUgYnVpbGQ9XCIxMzA4MjU3NDY2XCIg
-        ZmlsZT1cIjEzMjE4OTEwMjdcIiAvPlxuICA8c2l6ZSBhcmNoaXZlPVwiMjk2
-        XCIgaW5zdGFsbGVkPVwiNDJcIiBwYWNrYWdlPVwiMjI0NFwiIC8+XG48bG9j
-        YXRpb24gaHJlZj1cImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbVwiLz5c
-        biAgPGZvcm1hdD5cbiAgICA8cnBtOmxpY2Vuc2U+R1BMdjI8L3JwbTpsaWNl
-        bnNlPlxuICAgIDxycG06dmVuZG9yIC8+XG4gICAgPHJwbTpncm91cD5JbnRl
-        cm5ldC9BcHBsaWNhdGlvbnM8L3JwbTpncm91cD5cbiAgICA8cnBtOmJ1aWxk
-        aG9zdD5kaGNwLTI2LTExOC5icnEucmVkaGF0LmNvbTwvcnBtOmJ1aWxkaG9z
-        dD5cbiAgICA8cnBtOnNvdXJjZXJwbT5lbGVwaGFudC0wLjMtMC44LnNyYy5y
-        cG08L3JwbTpzb3VyY2VycG0+XG4gICAgPHJwbTpoZWFkZXItcmFuZ2UgZW5k
-        PVwiMjAyOFwiIHN0YXJ0PVwiMjgwXCIgLz5cbiAgICA8cnBtOnByb3ZpZGVz
-        PlxuICAgICAgPHJwbTplbnRyeSBlcG9jaD1cIjBcIiBmbGFncz1cIkVRXCIg
-        bmFtZT1cImVsZXBoYW50XCIgcmVsPVwiMC44XCIgdmVyPVwiMC4zXCIgLz5c
-        biAgICA8L3JwbTpwcm92aWRlcz5cbiAgICA8cnBtOnJlcXVpcmVzPlxuICAg
-        ICAgPHJwbTplbnRyeSBuYW1lPVwiL2Jpbi9zaFwiIHByZT1cIjFcIiAvPlxu
-        ICAgIDwvcnBtOnJlcXVpcmVzPlxuICA8L2Zvcm1hdD5cbjwvcGFja2FnZT5c
-        biJ9LCAiZGVzY3JpcHRpb24iOiAiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBo
-        YW50IiwgIl9sYXN0X3VwZGF0ZWQiOiAxNDU0NjI4OTExLCAidGltZSI6IDEz
-        MjE4OTEwMjcsICJoZWFkZXJfcmFuZ2UiOiB7InN0YXJ0IjogMjgwLCAiZW5k
-        IjogMjAyOH0sICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAi
-        c2hhMjU2IiwgIl9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVscC9jb250
-        ZW50L3JwbS9lbGVwaGFudC8wLjMvMC44L25vYXJjaC8zZTFjNzBjZDFiNDIx
-        MzI4YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3MmEw
-        YTcwMWYzL2VsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsICJzb3VyY2Vy
-        cG0iOiAiZWxlcGhhbnQtMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAiZWxl
-        cGhhbnQiLCAibGljZW5zZSI6ICJHUEx2MiIsICJjaGFuZ2Vsb2ciOiBbXSwg
-        InVybCI6ICJodHRwOi8vdHN0cmFjaG90YS5mZWRvcmFwZW9wbGUub3JnIiwg
-        InJlbGVhc2Vfc29ydF9pbmRleCI6ICIwMS0wLjAxLTgiLCAic3VtbWFyeSI6
-        ICJBIGR1bW15IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCAicmVsYXRpdmVwYXRo
-        IjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsICJyZWxlYXNlIjog
-        IjAuOCIsICJfaWQiOiAiMjk3MWVmY2EtOTdlNy00MGQwLTkxOTktNTE1OGFk
-        ODJjNjAwIiwgInJlcXVpcmVzIjogW3sicmVsZWFzZSI6IG51bGwsICJlcG9j
-        aCI6IG51bGwsICJ2ZXJzaW9uIjogbnVsbCwgImZsYWdzIjogbnVsbCwgIm5h
-        bWUiOiAiL2Jpbi9zaCJ9XX0sICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgIm93
-        bmVyX3R5cGUiOiAiaW1wb3J0ZXIiLCAiX2lkIjogeyIkb2lkIjogIjU2YjNl
-        MDJmODRhMDljMDdkYTk3OWJiYSJ9LCAiaWQiOiAiNTZiM2UwMmY4NGEwOWMw
-        N2RhOTc5YmJhIiwgIm93bmVyX2lkIjogInl1bV9pbXBvcnRlciJ9XQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:35:12 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/6fa8f72e-47a2-47e7-a551-21e5236cffbd/
     body:
@@ -1244,127 +1124,6 @@ http_interactions:
         NGEwOWMwN2RhOTc5YmU3IiwgInJlc3VsdCI6ICJzdWNjZXNzIn0sICJlcnJv
         ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiM2UwMzE4NjgwYjVjYTVj
         ODQyMzYyIn0sICJpZCI6ICI1NmIzZTAzMjg0YTA5YzA3ZGJmNGRhMWEifQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:35:15 GMT
-- request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwiZmlsdGVycyI6eyJ1
-        bml0Ijp7IiRhbmQiOlt7Im5hbWUiOiJlbGVwaGFudCJ9LHsidmVyc2lvbiI6
-        IjAuMyJ9LHsicmVsZWFzZSI6IjAuOCJ9LHsiZXBvY2giOiIwIn1dfX0sInNv
-        cnQiOnsidW5pdCI6W1sibmFtZSIsImFzY2VuZGluZyJdLFsidmVyc2lvbiIs
-        ImRlc2NlbmRpbmciXV19fX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="6hP8MenjQWaUaqc4nq3dQBTgGY4spFdtzcAMkzElCcM", oauth_signature="JFoRDL4yi85dTwih8dLMJP1G0PM%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628915", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '197'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:35:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '3280'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W3sidXBkYXRlZCI6ICIyMDE2LTAyLTA0VDIzOjM1OjE0WiIsICJyZXBvX2lk
-        IjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTYtMDItMDRUMjM6MzU6
-        MTRaIiwgIl9ucyI6ICJyZXBvX2NvbnRlbnRfdW5pdHMiLCAidW5pdF9pZCI6
-        ICIyOTcxZWZjYS05N2U3LTQwZDAtOTE5OS01MTU4YWQ4MmM2MDAiLCAibWV0
-        YWRhdGEiOiB7ImJ1aWxkX3RpbWUiOiAxMzA4MjU3NDY2LCAiYnVpbGRob3N0
-        IjogImRoY3AtMjYtMTE4LmJycS5yZWRoYXQuY29tIiwgIl9jb250ZW50X3R5
-        cGVfaWQiOiAicnBtIiwgInZlbmRvciI6IG51bGwsICJjaGVja3N1bSI6ICIz
-        ZTFjNzBjZDFiNDIxMzI4YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFi
-        MDk1ZmMzMTM3MmEwYTcwMWYzIiwgInNpemUiOiAyMjQ0LCAiZ3JvdXAiOiAi
-        SW50ZXJuZXQvQXBwbGljYXRpb25zIiwgIl9ucyI6ICJ1bml0c19ycG0iLCAi
-        YmFzZV91cmwiOiBudWxsLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAu
-        OC5ub2FyY2gucnBtIiwgInJlbGF0aXZlX3VybF9wYXRoIjogbnVsbCwgImVw
-        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAidmVyc2lvbl9zb3J0X2lu
-        ZGV4IjogIjAxLTAuMDEtMyIsICJwcm92aWRlcyI6IFt7InJlbGVhc2UiOiAi
-        MC44IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiZmxhZ3Mi
-        OiAiRVEiLCAibmFtZSI6ICJlbGVwaGFudCJ9XSwgImZpbGVzIjogeyJmaWxl
-        IjogWyIvL2VsZXBoYW50LnR4dCJdLCAiZGlyIjogW119LCAicmVwb2RhdGEi
-        OiB7ImZpbGVsaXN0cyI6ICI8cGFja2FnZSBhcmNoPVwibm9hcmNoXCIgbmFt
-        ZT1cImVsZXBoYW50XCIgcGtnaWQ9XCIzZTFjNzBjZDFiNDIxMzI4YWNhZjYz
-        OTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3MmEwYTcwMWYzXCI+
-        XG4gICAgPHZlcnNpb24gZXBvY2g9XCIwXCIgcmVsPVwiMC44XCIgdmVyPVwi
-        MC4zXCIgLz5cblxuICAgIDxmaWxlPi8vZWxlcGhhbnQudHh0PC9maWxlPlxu
-        PC9wYWNrYWdlPlxuXG4iLCAib3RoZXIiOiAiPHBhY2thZ2UgYXJjaD1cIm5v
-        YXJjaFwiIG5hbWU9XCJlbGVwaGFudFwiIHBrZ2lkPVwiM2UxYzcwY2QxYjQy
-        MTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5NWY2NWQxYjA5NWZjMzEzNzJh
-        MGE3MDFmM1wiPlxuICAgIDx2ZXJzaW9uIGVwb2NoPVwiMFwiIHJlbD1cIjAu
-        OFwiIHZlcj1cIjAuM1wiIC8+XG5cbjwvcGFja2FnZT5cblxuIiwgInByaW1h
-        cnkiOiAiPHBhY2thZ2UgdHlwZT1cInJwbVwiPlxuICA8bmFtZT5lbGVwaGFu
-        dDwvbmFtZT5cbiAgPGFyY2g+bm9hcmNoPC9hcmNoPlxuICA8dmVyc2lvbiBl
-        cG9jaD1cIjBcIiByZWw9XCIwLjhcIiB2ZXI9XCIwLjNcIiAvPlxuICA8Y2hl
-        Y2tzdW0gcGtnaWQ9XCJZRVNcIiB0eXBlPVwic2hhMjU2XCI+M2UxYzcwY2Qx
-        YjQyMTMyOGFjYWY2Mzk3Y2IzZDE2MTQ1MzA2YmI5NWY2NWQxYjA5NWZjMzEz
-        NzJhMGE3MDFmMzwvY2hlY2tzdW0+XG4gIDxzdW1tYXJ5PkEgZHVtbXkgcGFj
-        a2FnZSBvZiBlbGVwaGFudDwvc3VtbWFyeT5cbiAgPGRlc2NyaXB0aW9uPkEg
-        ZHVtbXkgcGFja2FnZSBvZiBlbGVwaGFudDwvZGVzY3JpcHRpb24+XG4gIDxw
-        YWNrYWdlciAvPlxuICA8dXJsPmh0dHA6Ly90c3RyYWNob3RhLmZlZG9yYXBl
-        b3BsZS5vcmc8L3VybD5cbiAgPHRpbWUgYnVpbGQ9XCIxMzA4MjU3NDY2XCIg
-        ZmlsZT1cIjEzMjE4OTEwMjdcIiAvPlxuICA8c2l6ZSBhcmNoaXZlPVwiMjk2
-        XCIgaW5zdGFsbGVkPVwiNDJcIiBwYWNrYWdlPVwiMjI0NFwiIC8+XG48bG9j
-        YXRpb24gaHJlZj1cImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbVwiLz5c
-        biAgPGZvcm1hdD5cbiAgICA8cnBtOmxpY2Vuc2U+R1BMdjI8L3JwbTpsaWNl
-        bnNlPlxuICAgIDxycG06dmVuZG9yIC8+XG4gICAgPHJwbTpncm91cD5JbnRl
-        cm5ldC9BcHBsaWNhdGlvbnM8L3JwbTpncm91cD5cbiAgICA8cnBtOmJ1aWxk
-        aG9zdD5kaGNwLTI2LTExOC5icnEucmVkaGF0LmNvbTwvcnBtOmJ1aWxkaG9z
-        dD5cbiAgICA8cnBtOnNvdXJjZXJwbT5lbGVwaGFudC0wLjMtMC44LnNyYy5y
-        cG08L3JwbTpzb3VyY2VycG0+XG4gICAgPHJwbTpoZWFkZXItcmFuZ2UgZW5k
-        PVwiMjAyOFwiIHN0YXJ0PVwiMjgwXCIgLz5cbiAgICA8cnBtOnByb3ZpZGVz
-        PlxuICAgICAgPHJwbTplbnRyeSBlcG9jaD1cIjBcIiBmbGFncz1cIkVRXCIg
-        bmFtZT1cImVsZXBoYW50XCIgcmVsPVwiMC44XCIgdmVyPVwiMC4zXCIgLz5c
-        biAgICA8L3JwbTpwcm92aWRlcz5cbiAgICA8cnBtOnJlcXVpcmVzPlxuICAg
-        ICAgPHJwbTplbnRyeSBuYW1lPVwiL2Jpbi9zaFwiIHByZT1cIjFcIiAvPlxu
-        ICAgIDwvcnBtOnJlcXVpcmVzPlxuICA8L2Zvcm1hdD5cbjwvcGFja2FnZT5c
-        biJ9LCAiZGVzY3JpcHRpb24iOiAiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBo
-        YW50IiwgIl9sYXN0X3VwZGF0ZWQiOiAxNDU0NjI4OTE0LCAidGltZSI6IDEz
-        MjE4OTEwMjcsICJoZWFkZXJfcmFuZ2UiOiB7InN0YXJ0IjogMjgwLCAiZW5k
-        IjogMjAyOH0sICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAi
-        c2hhMjU2IiwgIl9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVscC9jb250
-        ZW50L3JwbS9lbGVwaGFudC8wLjMvMC44L25vYXJjaC8zZTFjNzBjZDFiNDIx
-        MzI4YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3MmEw
-        YTcwMWYzL2VsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsICJzb3VyY2Vy
-        cG0iOiAiZWxlcGhhbnQtMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAiZWxl
-        cGhhbnQiLCAibGljZW5zZSI6ICJHUEx2MiIsICJjaGFuZ2Vsb2ciOiBbXSwg
-        InVybCI6ICJodHRwOi8vdHN0cmFjaG90YS5mZWRvcmFwZW9wbGUub3JnIiwg
-        InJlbGVhc2Vfc29ydF9pbmRleCI6ICIwMS0wLjAxLTgiLCAic3VtbWFyeSI6
-        ICJBIGR1bW15IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCAicmVsYXRpdmVwYXRo
-        IjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsICJyZWxlYXNlIjog
-        IjAuOCIsICJfaWQiOiAiMjk3MWVmY2EtOTdlNy00MGQwLTkxOTktNTE1OGFk
-        ODJjNjAwIiwgInJlcXVpcmVzIjogW3sicmVsZWFzZSI6IG51bGwsICJlcG9j
-        aCI6IG51bGwsICJ2ZXJzaW9uIjogbnVsbCwgImZsYWdzIjogbnVsbCwgIm5h
-        bWUiOiAiL2Jpbi9zaCJ9XX0sICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgIm93
-        bmVyX3R5cGUiOiAiaW1wb3J0ZXIiLCAiX2lkIjogeyIkb2lkIjogIjU2YjNl
-        MDMyODRhMDljMDdkYTk3OWJkOCJ9LCAiaWQiOiAiNTZiM2UwMzI4NGEwOWMw
-        N2RhOTc5YmQ4IiwgIm93bmVyX2lkIjogInl1bV9pbXBvcnRlciJ9XQ==
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:35:15 GMT
 - request:
@@ -1678,102 +1437,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:35:17 GMT
 - request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkaXN0cmlidXRpb24iXX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="COwSfZhGIV49BGUaiT8kXIRrmKzcLCIf1xYKgufT0", oauth_signature="OrvKk5FCAQAN3p8ha8eUlTOAhqo%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628918", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '42'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:35:18 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '2308'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W3sidXBkYXRlZCI6ICIyMDE2LTAyLTA0VDIzOjM1OjE3WiIsICJyZXBvX2lk
-        IjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTYtMDItMDRUMjM6MzU6
-        MTdaIiwgIl9ucyI6ICJyZXBvX2NvbnRlbnRfdW5pdHMiLCAidW5pdF9pZCI6
-        ICJlMDBjNWYwNS1iYmVlLTRhMWUtYTI0My0zNmU4NTA0OWMxZjciLCAibWV0
-        YWRhdGEiOiB7ImZpbGVzIjogW3siY2hlY2tzdW10eXBlIjogInNoYTI1NiIs
-        ICJjaGVja3N1bSI6ICJlM2IwYzQ0Mjk4ZmMxYzE0OWFmYmY0Yzg5OTZmYjky
-        NDI3YWU0MWU0NjQ5YjkzNGNhNDk1OTkxYjc4NTJiODU1IiwgImZpbGVOYW1l
-        IjogInRlc3QyLmltZyIsICJkb3dubG9hZHVybCI6ICJmaWxlOi8vL3Zhci93
-        d3cvdGVzdF9yZXBvcy96b28vaW1hZ2VzL3Rlc3QyLmltZyIsICJpdGVtX3R5
-        cGUiOiAiZGlzdHJpYnV0aW9uIiwgInNhdmVwYXRoIjogIi92YXIvbGliL3B1
-        bHAvd29ya2luZy9yZXBvcy9GZWRvcmFfMTcvaW1wb3J0ZXJzL3l1bV9pbXBv
-        cnRlci90bXB2aUdxMVkvdG1wd3o1YXBxL2ltYWdlcy90ZXN0Mi5pbWciLCAi
-        cmVsYXRpdmVwYXRoIjogImltYWdlcy90ZXN0Mi5pbWciLCAiZmlsZW5hbWUi
-        OiAidGVzdDIuaW1nIiwgInBrZ3BhdGgiOiAiL3Zhci9saWIvcHVscC9jb250
-        ZW50L2Rpc3RyaWJ1dGlvbi9rcy1UZXN0IEZhbWlseS1UZXN0VmFyaWFudC0x
-        Ni14ODZfNjQvaW1hZ2VzIiwgInNpemUiOiBudWxsfSwgeyJjaGVja3N1bXR5
-        cGUiOiAic2hhMjU2IiwgImNoZWNrc3VtIjogImUzYjBjNDQyOThmYzFjMTQ5
-        YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4
-        NTUiLCAiZmlsZU5hbWUiOiAiZW1wdHkuaXNvIiwgImRvd25sb2FkdXJsIjog
-        ImZpbGU6Ly8vdmFyL3d3dy90ZXN0X3JlcG9zL3pvby9lbXB0eS5pc28iLCAi
-        aXRlbV90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJzYXZlcGF0aCI6ICIvdmFy
-        L2xpYi9wdWxwL3dvcmtpbmcvcmVwb3MvRmVkb3JhXzE3L2ltcG9ydGVycy95
-        dW1faW1wb3J0ZXIvdG1wdmlHcTFZL3RtcHd6NWFwcS9lbXB0eS5pc28iLCAi
-        cmVsYXRpdmVwYXRoIjogImVtcHR5LmlzbyIsICJmaWxlbmFtZSI6ICJlbXB0
-        eS5pc28iLCAicGtncGF0aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQvZGlz
-        dHJpYnV0aW9uL2tzLVRlc3QgRmFtaWx5LVRlc3RWYXJpYW50LTE2LXg4Nl82
-        NC8iLCAic2l6ZSI6IG51bGx9LCB7ImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYi
-        LCAiY2hlY2tzdW0iOiAiZTNiMGM0NDI5OGZjMWMxNDlhZmJmNGM4OTk2ZmI5
-        MjQyN2FlNDFlNDY0OWI5MzRjYTQ5NTk5MWI3ODUyYjg1NSIsICJmaWxlTmFt
-        ZSI6ICJ0ZXN0MS5pbWciLCAiZG93bmxvYWR1cmwiOiAiZmlsZTovLy92YXIv
-        d3d3L3Rlc3RfcmVwb3Mvem9vL2ltYWdlcy90ZXN0MS5pbWciLCAiaXRlbV90
-        eXBlIjogImRpc3RyaWJ1dGlvbiIsICJzYXZlcGF0aCI6ICIvdmFyL2xpYi9w
-        dWxwL3dvcmtpbmcvcmVwb3MvRmVkb3JhXzE3L2ltcG9ydGVycy95dW1faW1w
-        b3J0ZXIvdG1wdmlHcTFZL3RtcHd6NWFwcS9pbWFnZXMvdGVzdDEuaW1nIiwg
-        InJlbGF0aXZlcGF0aCI6ICJpbWFnZXMvdGVzdDEuaW1nIiwgImZpbGVuYW1l
-        IjogInRlc3QxLmltZyIsICJwa2dwYXRoIjogIi92YXIvbGliL3B1bHAvY29u
-        dGVudC9kaXN0cmlidXRpb24va3MtVGVzdCBGYW1pbHktVGVzdFZhcmlhbnQt
-        MTYteDg2XzY0L2ltYWdlcyIsICJzaXplIjogbnVsbH1dLCAiX3N0b3JhZ2Vf
-        cGF0aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQvZGlzdHJpYnV0aW9uL2tz
-        LVRlc3QgRmFtaWx5LVRlc3RWYXJpYW50LTE2LXg4Nl82NCIsICJmYW1pbHki
-        OiAiVGVzdCBGYW1pbHkiLCAidGltZXN0YW1wIjogMTMyMzExMjE1My4wOSwg
-        Il9sYXN0X3VwZGF0ZWQiOiAxNDU0NjI4OTE3LCAiX2NvbnRlbnRfdHlwZV9p
-        ZCI6ICJkaXN0cmlidXRpb24iLCAidmFyaWFudCI6ICJUZXN0VmFyaWFudCIs
-        ICJpZCI6ICJrcy1UZXN0IEZhbWlseS1UZXN0VmFyaWFudC0xNi14ODZfNjQi
-        LCAidmVyc2lvbiI6ICIxNiIsICJ2ZXJzaW9uX3NvcnRfaW5kZXgiOiAiMDIt
-        MTYiLCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogImUwMGM1ZjA1LWJiZWUt
-        NGExZS1hMjQzLTM2ZTg1MDQ5YzFmNyIsICJhcmNoIjogIng4Nl82NCIsICJf
-        bnMiOiAidW5pdHNfZGlzdHJpYnV0aW9uIn0sICJ1bml0X3R5cGVfaWQiOiAi
-        ZGlzdHJpYnV0aW9uIiwgIm93bmVyX3R5cGUiOiAiaW1wb3J0ZXIiLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YjNlMDM1ODRhMDljMDdkYTk3OWJmZSJ9LCAiaWQi
-        OiAiNTZiM2UwMzU4NGEwOWMwN2RhOTc5YmZlIiwgIm93bmVyX2lkIjogInl1
-        bV9pbXBvcnRlciJ9XQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:35:18 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/b8100045-0bdd-4350-a154-76381965ac7f/
     body:
@@ -2085,66 +1748,6 @@ http_interactions:
   recorded_at: Thu, 04 Feb 2016 23:35:20 GMT
 - request:
     method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJlcnJhdHVtIl0sImZpZWxkcyI6
-        eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="61A9JvNaCKhqVtT6HqiXGwqiCWhmHXJVNJKX71AvStM", oauth_signature="6GcYokYqimGpG%2FtkwNrOty33jV8%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628921", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '84'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:35:21 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '651'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIzMWIyNDEzZS0xOTMzLTRiMTktYjU4
-        OS1iZTNmNmY3YWU4Y2UiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
-        In0sICJfaWQiOiB7IiRvaWQiOiAiNTZiM2UwMzg4NGEwOWMwN2RhOTc5YzFk
-        In0sICJ1bml0X2lkIjogIjMxYjI0MTNlLTE5MzMtNGIxOS1iNTg5LWJlM2Y2
-        ZjdhZThjZSIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
-        YXRhIjogeyJfaWQiOiAiODYxZDlmODctNjcwMi00YjhlLWJlNGQtNWI4ZTZh
-        NDhiOGJjIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
-        IjogeyIkb2lkIjogIjU2YjNlMDM4ODRhMDljMDdkYTk3OWMxZiJ9LCAidW5p
-        dF9pZCI6ICI4NjFkOWY4Ny02NzAyLTRiOGUtYmU0ZC01YjhlNmE0OGI4YmMi
-        LCAidW5pdF90eXBlX2lkIjogImVycmF0dW0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogImNjY2ZkYzFlLWFiMWEtNDBhNS1hMTYzLTNjMjE5ZmEzMWE4ZSIs
-        ICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0ifSwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmIzZTAzODg0YTA5YzA3ZGE5NzljMWUifSwgInVuaXRfaWQiOiAi
-        Y2NjZmRjMWUtYWIxYS00MGE1LWExNjMtM2MyMTlmYTMxYThlIiwgInVuaXRf
-        dHlwZV9pZCI6ICJlcnJhdHVtIn1d
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:35:21 GMT
-- request:
-    method: post
     uri: https://katello-devbox.example.com/pulp/api/v2/content/units/erratum/search/
     body:
       encoding: UTF-8
@@ -2293,66 +1896,6 @@ http_interactions:
         cGFja2FnZXMgdGhhdCBmaXggb25lIHNlY3VyaXR5IGlzc3VlIiwgInJlbGVh
         c2UiOiAiIiwgIl9pZCI6ICJjY2NmZGMxZS1hYjFhLTQwYTUtYTE2My0zYzIx
         OWZhMzFhOGUifV0=
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:35:21 GMT
-- request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJlcnJhdHVtIl0sImZpZWxkcyI6
-        eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="Ue22RHFf4oB22elvBfv0zoDjhJG3ZHGlDItErvbXi94", oauth_signature="FdZ8sTwITVpdvgHwsksatDd%2BkOA%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628921", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '84'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:35:21 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '651'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIzMWIyNDEzZS0xOTMzLTRiMTktYjU4
-        OS1iZTNmNmY3YWU4Y2UiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
-        In0sICJfaWQiOiB7IiRvaWQiOiAiNTZiM2UwMzg4NGEwOWMwN2RhOTc5YzFk
-        In0sICJ1bml0X2lkIjogIjMxYjI0MTNlLTE5MzMtNGIxOS1iNTg5LWJlM2Y2
-        ZjdhZThjZSIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
-        YXRhIjogeyJfaWQiOiAiODYxZDlmODctNjcwMi00YjhlLWJlNGQtNWI4ZTZh
-        NDhiOGJjIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
-        IjogeyIkb2lkIjogIjU2YjNlMDM4ODRhMDljMDdkYTk3OWMxZiJ9LCAidW5p
-        dF9pZCI6ICI4NjFkOWY4Ny02NzAyLTRiOGUtYmU0ZC01YjhlNmE0OGI4YmMi
-        LCAidW5pdF90eXBlX2lkIjogImVycmF0dW0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogImNjY2ZkYzFlLWFiMWEtNDBhNS1hMTYzLTNjMjE5ZmEzMWE4ZSIs
-        ICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0ifSwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmIzZTAzODg0YTA5YzA3ZGE5NzljMWUifSwgInVuaXRfaWQiOiAi
-        Y2NjZmRjMWUtYWIxYS00MGE1LWExNjMtM2MyMTlmYTMxYThlIiwgInVuaXRf
-        dHlwZV9pZCI6ICJlcnJhdHVtIn1d
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:35:21 GMT
 - request:
@@ -2978,67 +2521,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:35:26 GMT
 - request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwYWNrYWdlX2NhdGVnb3J5Il19
-        fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="qCYKVoMNpeaIH9v9WAbO5FKpl2MatShuM9N2DqQWjA", oauth_signature="PQXs20XePdgHMayihGC4wIu5bpw%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628927", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '46'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:35:27 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '717'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W3sidXBkYXRlZCI6ICIyMDE2LTAyLTA0VDIzOjM1OjI2WiIsICJyZXBvX2lk
-        IjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTYtMDItMDRUMjM6MzU6
-        MjZaIiwgIl9ucyI6ICJyZXBvX2NvbnRlbnRfdW5pdHMiLCAidW5pdF9pZCI6
-        ICJkOGM0MmYzMy0zMjQ0LTRlNjgtYjNmMy1iOWU5YTBiMDA1ZjMiLCAibWV0
-        YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiBudWxsLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAiZGVzY3JpcHRpb24iOiBudWxsLCAiX25zIjogInVuaXRz
-        X3BhY2thZ2VfY2F0ZWdvcnkiLCAiX2xhc3RfdXBkYXRlZCI6IDE0NTQ2Mjg5
-        MjYsICJkaXNwbGF5X29yZGVyIjogOTksICJ0cmFuc2xhdGVkX25hbWUiOiB7
-        fSwgInBhY2thZ2Vncm91cGlkcyI6IFsibWFtbWFsIiwgImJpcmQiXSwgInRy
-        YW5zbGF0ZWRfZGVzY3JpcHRpb24iOiB7fSwgIl9jb250ZW50X3R5cGVfaWQi
-        OiAicGFja2FnZV9jYXRlZ29yeSIsICJfaWQiOiAiZDhjNDJmMzMtMzI0NC00
-        ZTY4LWIzZjMtYjllOWEwYjAwNWYzIiwgImlkIjogImFsbCIsICJuYW1lIjog
-        ImFsbCJ9LCAidW5pdF90eXBlX2lkIjogInBhY2thZ2VfY2F0ZWdvcnkiLCAi
-        b3duZXJfdHlwZSI6ICJpbXBvcnRlciIsICJfaWQiOiB7IiRvaWQiOiAiNTZi
-        M2UwM2U4NGEwOWMwN2RhOTc5YzVlIn0sICJpZCI6ICI1NmIzZTAzZTg0YTA5
-        YzA3ZGE5NzljNWUiLCAib3duZXJfaWQiOiAieXVtX2ltcG9ydGVyIn1d
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:35:27 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/69aff01a-c60f-4108-9280-f896a6533608/
     body:
@@ -3662,89 +3144,6 @@ http_interactions:
   recorded_at: Thu, 04 Feb 2016 23:35:33 GMT
 - request:
     method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwiZmllbGRzIjp7InVu
-        aXQiOltdLCJhc3NvY2lhdGlvbiI6WyJ1bml0X2lkIl19fX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="14AkTnRuVzF3kzPO9t9IWmjF3Hb5HajJugAdzIdUvVM", oauth_signature="PALM3TT1I5xWusFQejdQv%2Bym2yg%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628933", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '80'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:35:33 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '1672'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICI5MmJmMDE0ZC0wYTg0LTQwZWEtYWMw
-        Yy1kZGM1ZDUyZDFiNWMiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
-        Il9pZCI6IHsiJG9pZCI6ICI1NmIzZTA0NDg0YTA5YzA3ZGE5NzljOTAifSwg
-        InVuaXRfaWQiOiAiOTJiZjAxNGQtMGE4NC00MGVhLWFjMGMtZGRjNWQ1MmQx
-        YjVjIiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogIjI5NzFlZmNhLTk3ZTctNDBkMC05MTk5LTUxNThhZDgyYzYwMCIs
-        ICJfY29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjog
-        IjU2YjNlMDQ0ODRhMDljMDdkYTk3OWM4YyJ9LCAidW5pdF9pZCI6ICIyOTcx
-        ZWZjYS05N2U3LTQwZDAtOTE5OS01MTU4YWQ4MmM2MDAiLCAidW5pdF90eXBl
-        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiYmZmZTdjZTgt
-        ZTc4ZS00MWYwLWE0MjktMjkyODM2NjE0YTJlIiwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiM2UwNDQ4NGEwOWMw
-        N2RhOTc5YzhiIn0sICJ1bml0X2lkIjogImJmZmU3Y2U4LWU3OGUtNDFmMC1h
-        NDI5LTI5MjgzNjYxNGEyZSIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
-        bWV0YWRhdGEiOiB7Il9pZCI6ICJiNWE2M2UyZS0zMzRjLTRlZDgtYjNjZi0w
-        YzE5YmI5N2Y0NTIiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1NmIzZTA0NDg0YTA5YzA3ZGE5NzljOGQifSwgInVu
-        aXRfaWQiOiAiYjVhNjNlMmUtMzM0Yy00ZWQ4LWIzY2YtMGMxOWJiOTdmNDUy
-        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lk
-        IjogImUwMmRjZTRhLTIwMWEtNDA5Ny04YmY0LTQ0ZTZhMzAyYjRiZCIsICJf
-        Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2
-        YjNlMDQ0ODRhMDljMDdkYTk3OWM4ZSJ9LCAidW5pdF9pZCI6ICJlMDJkY2U0
-        YS0yMDFhLTQwOTctOGJmNC00NGU2YTMwMmI0YmQiLCAidW5pdF90eXBlX2lk
-        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNjkzOTE3YTAtYTRm
-        ZS00OTg5LTk4ZmMtOTlkMmZkY2ZmN2ViIiwgIl9jb250ZW50X3R5cGVfaWQi
-        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiM2UwNDQ4NGEwOWMwN2Rh
-        OTc5YzhmIn0sICJ1bml0X2lkIjogIjY5MzkxN2EwLWE0ZmUtNDk4OS05OGZj
-        LTk5ZDJmZGNmZjdlYiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
-        YWRhdGEiOiB7Il9pZCI6ICI3NmFlZTViMi03ZTc4LTQ2NzQtOGZhMy05Zjhl
-        ZDE1NDBiZTIiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NmIzZTA0NDg0YTA5YzA3ZGE5NzljOTIifSwgInVuaXRf
-        aWQiOiAiNzZhZWU1YjItN2U3OC00Njc0LThmYTMtOWY4ZWQxNTQwYmUyIiwg
-        InVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjog
-        ImIzNThlMDA3LTA0ZWQtNGE5Yi05Mzc1LWRiMTllYTA3Y2VhMSIsICJfY29u
-        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2YjNl
-        MDQ0ODRhMDljMDdkYTk3OWM5MSJ9LCAidW5pdF9pZCI6ICJiMzU4ZTAwNy0w
-        NGVkLTRhOWItOTM3NS1kYjE5ZWEwN2NlYTEiLCAidW5pdF90eXBlX2lkIjog
-        InJwbSJ9XQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:35:33 GMT
-- request:
-    method: post
     uri: https://katello-devbox.example.com/pulp/api/v2/content/units/rpm/search/
     body:
       encoding: UTF-8
@@ -3880,89 +3279,6 @@ http_interactions:
         YXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjogIi9w
         dWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS9lMDJkY2U0YS0yMDFhLTQw
         OTctOGJmNC00NGU2YTMwMmI0YmQvIn1d
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:35:33 GMT
-- request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwiZmllbGRzIjp7InVu
-        aXQiOltdLCJhc3NvY2lhdGlvbiI6WyJ1bml0X2lkIl19fX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="lVEJVBmrdAyxxbF6PEDpiS3Pf1axApZsl9mK1RbJEY", oauth_signature="XEDI%2B4Po6k%2Bin66nN9oHrfwCqhU%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628933", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '80'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:35:33 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '1672'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICI5MmJmMDE0ZC0wYTg0LTQwZWEtYWMw
-        Yy1kZGM1ZDUyZDFiNWMiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
-        Il9pZCI6IHsiJG9pZCI6ICI1NmIzZTA0NDg0YTA5YzA3ZGE5NzljOTAifSwg
-        InVuaXRfaWQiOiAiOTJiZjAxNGQtMGE4NC00MGVhLWFjMGMtZGRjNWQ1MmQx
-        YjVjIiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogIjI5NzFlZmNhLTk3ZTctNDBkMC05MTk5LTUxNThhZDgyYzYwMCIs
-        ICJfY29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjog
-        IjU2YjNlMDQ0ODRhMDljMDdkYTk3OWM4YyJ9LCAidW5pdF9pZCI6ICIyOTcx
-        ZWZjYS05N2U3LTQwZDAtOTE5OS01MTU4YWQ4MmM2MDAiLCAidW5pdF90eXBl
-        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiYmZmZTdjZTgt
-        ZTc4ZS00MWYwLWE0MjktMjkyODM2NjE0YTJlIiwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiM2UwNDQ4NGEwOWMw
-        N2RhOTc5YzhiIn0sICJ1bml0X2lkIjogImJmZmU3Y2U4LWU3OGUtNDFmMC1h
-        NDI5LTI5MjgzNjYxNGEyZSIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
-        bWV0YWRhdGEiOiB7Il9pZCI6ICJiNWE2M2UyZS0zMzRjLTRlZDgtYjNjZi0w
-        YzE5YmI5N2Y0NTIiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1NmIzZTA0NDg0YTA5YzA3ZGE5NzljOGQifSwgInVu
-        aXRfaWQiOiAiYjVhNjNlMmUtMzM0Yy00ZWQ4LWIzY2YtMGMxOWJiOTdmNDUy
-        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lk
-        IjogImUwMmRjZTRhLTIwMWEtNDA5Ny04YmY0LTQ0ZTZhMzAyYjRiZCIsICJf
-        Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2
-        YjNlMDQ0ODRhMDljMDdkYTk3OWM4ZSJ9LCAidW5pdF9pZCI6ICJlMDJkY2U0
-        YS0yMDFhLTQwOTctOGJmNC00NGU2YTMwMmI0YmQiLCAidW5pdF90eXBlX2lk
-        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNjkzOTE3YTAtYTRm
-        ZS00OTg5LTk4ZmMtOTlkMmZkY2ZmN2ViIiwgIl9jb250ZW50X3R5cGVfaWQi
-        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiM2UwNDQ4NGEwOWMwN2Rh
-        OTc5YzhmIn0sICJ1bml0X2lkIjogIjY5MzkxN2EwLWE0ZmUtNDk4OS05OGZj
-        LTk5ZDJmZGNmZjdlYiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
-        YWRhdGEiOiB7Il9pZCI6ICI3NmFlZTViMi03ZTc4LTQ2NzQtOGZhMy05Zjhl
-        ZDE1NDBiZTIiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NmIzZTA0NDg0YTA5YzA3ZGE5NzljOTIifSwgInVuaXRf
-        aWQiOiAiNzZhZWU1YjItN2U3OC00Njc0LThmYTMtOWY4ZWQxNTQwYmUyIiwg
-        InVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjog
-        ImIzNThlMDA3LTA0ZWQtNGE5Yi05Mzc1LWRiMTllYTA3Y2VhMSIsICJfY29u
-        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2YjNl
-        MDQ0ODRhMDljMDdkYTk3OWM5MSJ9LCAidW5pdF9pZCI6ICJiMzU4ZTAwNy0w
-        NGVkLTRhOWItOTM3NS1kYjE5ZWEwN2NlYTEiLCAidW5pdF90eXBlX2lkIjog
-        InJwbSJ9XQ==
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:35:33 GMT
 - request:
@@ -5704,56 +5020,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:35:50 GMT
 - request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjR9fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="spKoJIKQavceScpJtcWDAeiG0Fc1Uj6Qetu2YMURUE", oauth_signature="3TmQk2I0NdvMc5UXXg4xhsk%2FL0c%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628950", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '37'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:35:50 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2ZhMDQ2YzQyLWM4YjctNDVkZS1hZDAzLTJjNjY0MTJkMzgyZS8iLCAi
-        dGFza19pZCI6ICJmYTA0NmM0Mi1jOGI3LTQ1ZGUtYWQwMy0yYzY2NDEyZDM4
-        MmUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:35:50 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/fa046c42-c8b7-45de-ad03-2c66412d382e/
     body:
@@ -5958,3112 +5224,6 @@ http_interactions:
   recorded_at: Thu, 04 Feb 2016 23:35:51 GMT
 - request:
     method: get
-    uri: https://katello-devbox.example.com/pulp/api/v2/tasks/?tag=pulp:action:sync
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="2T1zmVNLa5r5VmZg0pIVYkIxWQGzltzc80gtS3edvFY",
-        oauth_signature="j0sMi9J7h92bxMt3HJEaAdMY5qo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628951", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:35:51 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '135810'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W3siZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZl
-        ci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMzEwNGFkYzItNWIxZC00MmQxLThjMTUtZDI3ODc3N2Q0
-        NmE2LyIsICJ0YXNrX2lkIjogIjMxMDRhZGMyLTViMWQtNDJkMS04YzE1LWQy
-        Nzg3NzdkNDZhNiIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3Jh
-        XzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIw
-        MTYtMDItMDRUMjM6MDM6MzFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
-        dGFydF90aW1lIjogIjIwMTYtMDItMDRUMjM6MDM6MzBaIiwgInRyYWNlYmFj
-        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAv
-        YXBpL3YyL3Rhc2tzLzRiZGE2NDAxLWM4NmEtNDM3ZS04NzU2LTNmNDU4YmVk
-        ODdmZS8iLCAidGFza19pZCI6ICI0YmRhNjQwMS1jODZhLTQzN2UtODc1Ni0z
-        ZjQ1OGJlZDg3ZmUifSwgeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3Mv
-        MGU0MWZiY2UtNDQ4OS00MzVkLWE0MDUtMWRjODU3ZWViMTQ0LyIsICJ0YXNr
-        X2lkIjogIjBlNDFmYmNlLTQ0ODktNDM1ZC1hNDA1LTFkYzg1N2VlYjE0NCJ9
-        XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVyIjogeyJjb250
-        ZW50IjogeyJzaXplX3RvdGFsIjogMTc4NzIsICJpdGVtc19sZWZ0IjogMCwg
-        Iml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVf
-        bGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiA4LCAicnBtX2Rv
-        bmUiOiA4LCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVy
-        cm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNf
-        bGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjog
-        ImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
-        X3dvcmtlci0wQGthdGVsbG8tZGV2Ym94LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IHsiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiaW1w
-        b3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJyZW1vdmVkX2NvdW50IjogMCwg
-        InN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMzowMzozMFoiLCAiX25zIjogInJl
-        cG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA0VDIz
-        OjAzOjMxWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3VtbWFyeSI6IHsiY29u
-        dGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiAxNSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAidXBkYXRlZF9jb3Vu
-        dCI6IDAsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjog
-        MTc4NzIsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogOCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiA4LCAicnBtX2RvbmUiOiA4LCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
-        IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn19LCAiaWQiOiAiNTZiM2Q4YzM4NGEwOWMwN2RhOTc5NjE5
-        IiwgInJlc3VsdCI6ICJzdWNjZXNzIn0sICJlcnJvciI6IG51bGwsICJfaWQi
-        OiB7IiRvaWQiOiAiNTZiM2Q4YzE4NjgwYjVjYTVjODQxZjZkIn0sICJpZCI6
-        ICI1NmIzZDhjMTg0YTA5YzA3ZGJmNGQ0NTEifSwgeyJleGNlcHRpb24iOiBu
-        dWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVyLm1hbmFnZXJzLnJlcG8u
-        c3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84NWUw
-        NmE3YS1lMWY4LTRkM2ItYmVlNS0xNmU2Yjg0M2Q4OGMvIiwgInRhc2tfaWQi
-        OiAiODVlMDZhN2EtZTFmOC00ZDNiLWJlZTUtMTZlNmI4NDNkODhjIiwgInRh
-        Z3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFfMTciLCAicHVscDphY3Rp
-        b246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0wNFQyMzowMzo1
-        MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAx
-        Ni0wMi0wNFQyMzowMzo1MFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXdu
-        ZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvY2M2
-        MTVmYTktY2ZlZi00MGJjLWEwYmEtNzU2MmJmZTE2NjkxLyIsICJ0YXNrX2lk
-        IjogImNjNjE1ZmE5LWNmZWYtNDBiYy1hMGJhLTc1NjJiZmUxNjY5MSJ9LCB7
-        Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9hMDVjYjlhMS03Yzc3LTRl
-        NTUtYmJhZi1iZDFiNzg3ZDc5MTIvIiwgInRhc2tfaWQiOiAiYTA1Y2I5YTEt
-        N2M3Ny00ZTU1LWJiYWYtYmQxYjc4N2Q3OTEyIn1dLCAicHJvZ3Jlc3NfcmVw
-        b3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90
-        YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6
-        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
-        OiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAi
-        Y29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
-        OiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRlbGxvLWRl
-        dmJveC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7ImltcG9ydGVyX3R5cGVf
-        aWQiOiAieXVtX2ltcG9ydGVyIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFf
-        MTciLCAicmVtb3ZlZF9jb3VudCI6IDAsICJzdGFydGVkIjogIjIwMTYtMDIt
-        MDRUMjM6MDM6NTBaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJj
-        b21wbGV0ZWQiOiAiMjAxNi0wMi0wNFQyMzowMzo1MFoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
-        c3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMCwgImVycm9yX21lc3Nh
-        Z2UiOiBudWxsLCAidXBkYXRlZF9jb3VudCI6IDE1LCAiZGV0YWlscyI6IHsi
-        Y29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwg
-        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVf
-        bGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2Rv
-        bmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVy
-        cm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNf
-        bGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiaWQiOiAiNTZi
-        M2Q4ZDY4NGEwOWMwN2RhOTc5NjM5IiwgInJlc3VsdCI6ICJzdWNjZXNzIn0s
-        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiM2Q4ZDY4Njgw
-        YjVjYTVjODQxZjk4In0sICJpZCI6ICI1NmIzZDhkNjg0YTA5YzA3ZGJmNGQ0
-        ODYifSwgeyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAu
-        c2VydmVyLm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9jZWFiODI2ZS00Y2RmLTQwMzAtOWIyNS0yOTZl
-        ZTRlYTk4ZWEvIiwgInRhc2tfaWQiOiAiY2VhYjgyNmUtNGNkZi00MDMwLTli
-        MjUtMjk2ZWU0ZWE5OGVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUi
-        OiAiMjAxNi0wMi0wNFQyMzowMzo1NFoiLCAiX25zIjogInRhc2tfc3RhdHVz
-        IiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNFQyMzowMzo1NFoiLCAidHJh
-        Y2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIv
-        cHVscC9hcGkvdjIvdGFza3MvNTY0MmNmZTMtN2Y3MS00YzJiLTkwM2EtNjJj
-        ODgzMTNiN2YxLyIsICJ0YXNrX2lkIjogIjU2NDJjZmUzLTdmNzEtNGMyYi05
-        MDNhLTYyYzg4MzEzYjdmMSJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90
-        YXNrcy8zNWExOWNkZi0zZGM4LTQyMmEtOTkzOS1mNDBlNjdhOGExNGMvIiwg
-        InRhc2tfaWQiOiAiMzVhMTljZGYtM2RjOC00MjJhLTk5MzktZjQwZTY3YThh
-        MTRjIn1dLCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7
-        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
-        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
-        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
-        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1z
-        X2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6
-        ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBrYXRlbGxvLWRldmJveC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiB7ImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImlt
-        cG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAicmVtb3ZlZF9jb3VudCI6IDAs
-        ICJzdGFydGVkIjogIjIwMTYtMDItMDRUMjM6MDM6NTRaIiwgIl9ucyI6ICJy
-        ZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNFQy
-        MzowMzo1NFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInN1bW1hcnkiOiB7ImNv
-        bnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2Nv
-        dW50IjogMCwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAidXBkYXRlZF9jb3Vu
-        dCI6IDE1LCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19LCAiaWQiOiAiNTZiM2Q4ZGE4NGEwOWMwN2RhOTc5NjVmIiwg
-        InJlc3VsdCI6ICJzdWNjZXNzIn0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNTZiM2Q4ZGE4NjgwYjVjYTVjODQxZmFjIn0sICJpZCI6ICI1
-        NmIzZDhkYTg0YTA5YzA3ZGJmNGQ0YTYifSwgeyJleGNlcHRpb24iOiBudWxs
-        LCAidGFza190eXBlIjogInB1bHAuc2VydmVyLm1hbmFnZXJzLnJlcG8uc3lu
-        Yy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9lZjkyZTMy
-        ZS0wNTkwLTRkMDQtYTk1ZS1kYWRhNWU2YzVkY2YvIiwgInRhc2tfaWQiOiAi
-        ZWY5MmUzMmUtMDU5MC00ZDA0LWE5NWUtZGFkYTVlNmM1ZGNmIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246
-        c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0wNFQyMzowMzo1OFoi
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Mi0wNFQyMzowMzo1N1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvYjA3N2Iz
-        NTctNGYwYy00OGUzLTkyY2MtZTkxYzRmZWNkYTM2LyIsICJ0YXNrX2lkIjog
-        ImIwNzdiMzU3LTRmMGMtNDhlMy05MmNjLWU5MWM0ZmVjZGEzNiJ9LCB7Il9o
-        cmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82MTdjN2UzZS1iYTcyLTRmZjQt
-        ODAwNC0yM2Q2MDkxMzFmZjkvIiwgInRhc2tfaWQiOiAiNjE3YzdlM2UtYmE3
-        Mi00ZmY0LTgwMDQtMjNkNjA5MTMxZmY5In1dLCAicHJvZ3Jlc3NfcmVwb3J0
-        IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwi
-        OiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsi
-        cnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAw
-        LCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29t
-        cHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFt
-        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRlbGxvLWRldmJv
-        eC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7ImltcG9ydGVyX3R5cGVfaWQi
-        OiAieXVtX2ltcG9ydGVyIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRl
-        ciIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAicmVtb3ZlZF9jb3VudCI6IDAsICJzdGFydGVkIjogIjIwMTYtMDItMDRU
-        MjM6MDM6NTdaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21w
-        bGV0ZWQiOiAiMjAxNi0wMi0wNFQyMzowMzo1OFoiLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3Ry
-        aWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMCwgImVycm9yX21lc3NhZ2Ui
-        OiBudWxsLCAidXBkYXRlZF9jb3VudCI6IDE1LCAiZGV0YWlscyI6IHsiY29u
-        dGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVm
-        dCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUi
-        OiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9y
-        X2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVm
-        dCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0
-        YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiaWQiOiAiNTZiM2Q4
-        ZGU4NGEwOWMwN2RhOTc5NjdkIiwgInJlc3VsdCI6ICJzdWNjZXNzIn0sICJl
-        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiM2Q4ZGQ4NjgwYjVj
-        YTVjODQxZmJkIn0sICJpZCI6ICI1NmIzZDhkZDg0YTA5YzA3ZGJmNGQ0YmMi
-        fSwgeyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2Vy
-        dmVyLm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxw
-        L2FwaS92Mi90YXNrcy8zMGZjYzRiOS1kOTkxLTRjY2UtODg0Ny1hMTU1YmRm
-        ODNmZDcvIiwgInRhc2tfaWQiOiAiMzBmY2M0YjktZDk5MS00Y2NlLTg4NDct
-        YTE1NWJkZjgzZmQ3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRv
-        cmFfMTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAi
-        MjAxNi0wMi0wNFQyMzowNDowMVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwg
-        InN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNFQyMzowNDowMVoiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVs
-        cC9hcGkvdjIvdGFza3MvOWJlZDJlNGYtYjg5MC00MGE1LTlhN2QtMDEzMGYz
-        ZDdmMzM4LyIsICJ0YXNrX2lkIjogIjliZWQyZTRmLWI4OTAtNDBhNS05YTdk
-        LTAxMzBmM2Q3ZjMzOCJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNr
-        cy9hYWZhOTdmMi1iMWUzLTQzNzQtODg5MC0yNzc1ZGZjMjRjYzEvIiwgInRh
-        c2tfaWQiOiAiYWFmYTk3ZjItYjFlMy00Mzc0LTg4OTAtMjc3NWRmYzI0Y2Mx
-        In1dLCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNv
-        bnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJp
-        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xl
-        ZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
-        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJv
-        cl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xl
-        ZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
-        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJm
-        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
-        b3JrZXItMEBrYXRlbGxvLWRldmJveC5leGFtcGxlLmNvbSIsICJyZXN1bHQi
-        OiB7ImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImltcG9y
-        dGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxsLCAi
-        cmVwb19pZCI6ICJGZWRvcmFfMTciLCAicmVtb3ZlZF9jb3VudCI6IDAsICJz
-        dGFydGVkIjogIjIwMTYtMDItMDRUMjM6MDQ6MDFaIiwgIl9ucyI6ICJyZXBv
-        X3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNFQyMzow
-        NDowMVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRl
-        bnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
-        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50
-        IjogMCwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAidXBkYXRlZF9jb3VudCI6
-        IDE1LCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAs
-        ICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjog
-        IkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1f
-        dG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJk
-        cnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn19LCAiaWQiOiAiNTZiM2Q4ZTE4NGEwOWMwN2RhOTc5NjliIiwgInJl
-        c3VsdCI6ICJzdWNjZXNzIn0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRv
-        aWQiOiAiNTZiM2Q4ZTE4NjgwYjVjYTVjODQxZmNlIn0sICJpZCI6ICI1NmIz
-        ZDhlMTg0YTA5YzA3ZGJmNGQ0ZDIifSwgeyJleGNlcHRpb24iOiBudWxsLCAi
-        dGFza190eXBlIjogInB1bHAuc2VydmVyLm1hbmFnZXJzLnJlcG8uc3luYy5z
-        eW5jIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy80ZjcwYzA5MC1k
-        NjljLTQ1YzMtOGQzOS0zMzBmMzE1NzY0NzQvIiwgInRhc2tfaWQiOiAiNGY3
-        MGMwOTAtZDY5Yy00NWMzLThkMzktMzMwZjMxNTc2NDc0IiwgInRhZ3MiOiBb
-        InB1bHA6cmVwb3NpdG9yeTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246c3lu
-        YyJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0wNFQyMzowNDowNFoiLCAi
-        X25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0w
-        NFQyMzowNDowNFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFz
-        a3MiOiBbeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvYzljMjAzNWEt
-        YjI3Ny00ZDJiLThlM2UtODI0MDFiODhmYTY3LyIsICJ0YXNrX2lkIjogImM5
-        YzIwMzVhLWIyNzctNGQyYi04ZTNlLTgyNDAxYjg4ZmE2NyJ9LCB7Il9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi90YXNrcy82ODBhZmJjNS0yMTZhLTQwZGYtODg0
-        ZC01MDg0ZjUwMTViNjYvIiwgInRhc2tfaWQiOiAiNjgwYWZiYzUtMjE2YS00
-        MGRmLTg4NGQtNTA4NGY1MDE1YjY2In1dLCAicHJvZ3Jlc3NfcmVwb3J0Ijog
-        eyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAw
-        LCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBt
-        X3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAi
-        ZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0
-        ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRlbGxvLWRldmJveC5l
-        eGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7ImltcG9ydGVyX3R5cGVfaWQiOiAi
-        eXVtX2ltcG9ydGVyIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
-        cmVtb3ZlZF9jb3VudCI6IDAsICJzdGFydGVkIjogIjIwMTYtMDItMDRUMjM6
-        MDQ6MDRaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0
-        ZWQiOiAiMjAxNi0wMi0wNFQyMzowNDowNFoiLCAidHJhY2ViYWNrIjogbnVs
-        bCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
-        dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMCwgImVycm9yX21lc3NhZ2UiOiBu
-        dWxsLCAidXBkYXRlZF9jb3VudCI6IDE1LCAiZGV0YWlscyI6IHsiY29udGVu
-        dCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1z
-        X3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6
-        IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAw
-        LCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2Rl
-        dGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        ImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6
-        IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiaWQiOiAiNTZiM2Q4ZTQ4
-        NGEwOWMwN2RhOTc5NmI5IiwgInJlc3VsdCI6ICJzdWNjZXNzIn0sICJlcnJv
-        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiM2Q4ZTQ4NjgwYjVjYTVj
-        ODQxZmRmIn0sICJpZCI6ICI1NmIzZDhlNDg0YTA5YzA3ZGJmNGQ0ZWIifSwg
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85Y2VkMmY4Ny04ZWVkLTQ2NTctOWYzZC1jNzhhOTU4Zjcw
-        ZTMvIiwgInRhc2tfaWQiOiAiOWNlZDJmODctOGVlZC00NjU3LTlmM2QtYzc4
-        YTk1OGY3MGUzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wMi0wNFQyMzowNDowOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNFQyMzowNDowN1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvN2I4NDRmZjktODBlMi00ZGNmLThhZmItZTUzYWE0MGE5
-        MTk1LyIsICJ0YXNrX2lkIjogIjdiODQ0ZmY5LTgwZTItNGRjZi04YWZiLWU1
-        M2FhNDBhOTE5NSJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9i
-        NTc4YTc1MS00MGEyLTQ5MTQtOTI4Yi1iNDI2YzdlZmFkOTMvIiwgInRhc2tf
-        aWQiOiAiYjU3OGE3NTEtNDBhMi00OTE0LTkyOGItYjQyNmM3ZWZhZDkzIn1d
-        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBrYXRlbGxvLWRldmJveC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7
-        ImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImltcG9ydGVy
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxsLCAicmVw
-        b19pZCI6ICJGZWRvcmFfMTciLCAicmVtb3ZlZF9jb3VudCI6IDAsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDRUMjM6MDQ6MDdaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNFQyMzowNDow
-        OFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50Ijog
-        MCwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAidXBkYXRlZF9jb3VudCI6IDE1
-        LCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJp
-        dGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
-        TklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90
-        YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBt
-        X2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNf
-        dG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In19LCAiaWQiOiAiNTZiM2Q4ZTg4NGEwOWMwN2RhOTc5NmQ3IiwgInJlc3Vs
-        dCI6ICJzdWNjZXNzIn0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNTZiM2Q4ZTc4NjgwYjVjYTVjODQxZmYwIn0sICJpZCI6ICI1NmIzZDhl
-        Nzg0YTA5YzA3ZGJmNGQ1MDQifSwgeyJleGNlcHRpb24iOiBudWxsLCAidGFz
-        a190eXBlIjogInB1bHAuc2VydmVyLm1hbmFnZXJzLnJlcG8uc3luYy5zeW5j
-        IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81OTk5ZjMyYS05ZDlm
-        LTRhOWMtODE3OC05MDZiNGI1NTgzMGIvIiwgInRhc2tfaWQiOiAiNTk5OWYz
-        MmEtOWQ5Zi00YTljLTgxNzgtOTA2YjRiNTU4MzBiIiwgInRhZ3MiOiBbInB1
-        bHA6cmVwb3NpdG9yeTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246c3luYyJd
-        LCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0wNFQyMzowNDoxMVoiLCAiX25z
-        IjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNFQy
-        MzowNDoxMVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3Mi
-        OiBbeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMDhmZmYzODgtOTM0
-        Yy00MGE0LWJhOTQtZmVhMjk2ODc5YjVkLyIsICJ0YXNrX2lkIjogIjA4ZmZm
-        Mzg4LTkzNGMtNDBhNC1iYTk0LWZlYTI5Njg3OWI1ZCJ9LCB7Il9ocmVmIjog
-        Ii9wdWxwL2FwaS92Mi90YXNrcy8yN2JiYTg0OS02MGM2LTQ5YTItOTBkYi0w
-        NTMzOTM5ODE1NWEvIiwgInRhc2tfaWQiOiAiMjdiYmE4NDktNjBjNi00OWEy
-        LTkwZGItMDUzMzkzOTgxNTVhIn1dLCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5
-        dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAi
-        aXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3Rv
-        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
-        bV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
-        X3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJy
-        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBrYXRlbGxvLWRldmJveC5leGFt
-        cGxlLmNvbSIsICJyZXN1bHQiOiB7ImltcG9ydGVyX3R5cGVfaWQiOiAieXVt
-        X2ltcG9ydGVyIiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJl
-        eGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAicmVt
-        b3ZlZF9jb3VudCI6IDAsICJzdGFydGVkIjogIjIwMTYtMDItMDRUMjM6MDQ6
-        MTFaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQi
-        OiAiMjAxNi0wMi0wNFQyMzowNDoxMVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImFkZGVkX2NvdW50IjogMCwgImVycm9yX21lc3NhZ2UiOiBudWxs
-        LCAidXBkYXRlZF9jb3VudCI6IDE1LCAiZGV0YWlscyI6IHsiY29udGVudCI6
-        IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3Rv
-        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAs
-        ICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAi
-        ZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFp
-        bHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
-        c3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklO
-        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9
-        LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiaWQiOiAiNTZiM2Q4ZWI4NGEw
-        OWMwN2RhOTc5NmY1IiwgInJlc3VsdCI6ICJzdWNjZXNzIn0sICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiM2Q4ZWI4NjgwYjVjYTVjODQy
-        MDAxIn0sICJpZCI6ICI1NmIzZDhlYjg0YTA5YzA3ZGJmNGQ1MWQifSwgeyJl
-        eGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVyLm1h
-        bmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92
-        Mi90YXNrcy80ZmM1ZWQ2Yy1jYTIxLTQ3Y2EtOTQ1Ni04YTEwMDUyN2FkODkv
-        IiwgInRhc2tfaWQiOiAiNGZjNWVkNmMtY2EyMS00N2NhLTk0NTYtOGExMDA1
-        MjdhZDg5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFfMTci
-        LCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0w
-        Mi0wNFQyMzowNDoyNloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0
-        X3RpbWUiOiAiMjAxNi0wMi0wNFQyMzowNDoyNloiLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9hcGkv
-        djIvdGFza3MvMzdlYjA2NjctZjI1Ny00NWNkLTgzOTAtYzhjMzdmMzJlNzBm
-        LyIsICJ0YXNrX2lkIjogIjM3ZWIwNjY3LWYyNTctNDVjZC04MzkwLWM4YzM3
-        ZjMyZTcwZiJ9LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8wOTQx
-        ZGU4OC1jZDc3LTRmZjgtOTFiYy1iNDhjM2UyYWFiZmUvIiwgInRhc2tfaWQi
-        OiAiMDk0MWRlODgtY2Q3Ny00ZmY4LTkxYmMtYjQ4YzNlMmFhYmZlIn1dLCAi
-        cHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAxNzg3MiwgIml0ZW1zX2xlZnQiOiAwLCAiaXRl
-        bXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0
-        IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDgsICJycG1fZG9uZSI6
-        IDgsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0
-        IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
-        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAic3RhdGUiOiAiZmlu
-        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTBAa2F0ZWxsby1kZXZib3guZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
-        eyJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJpbXBvcnRl
-        cl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInJlbW92ZWRfY291bnQiOiAwLCAic3Rh
-        cnRlZCI6ICIyMDE2LTAyLTA0VDIzOjA0OjI2WiIsICJfbnMiOiAicmVwb19z
-        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMDRUMjM6MDQ6
-        MjZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
-        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6
-        IDE1LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJ1cGRhdGVkX2NvdW50Ijog
-        MCwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAxNzg3
-        MiwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJw
-        bV90b3RhbCI6IDgsICJycG1fZG9uZSI6IDgsICJkcnBtX3RvdGFsIjogMCwg
-        ImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBz
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJp
-        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifX0sICJpZCI6ICI1NmIzZDhmYTg0YTA5YzA3ZGE5Nzk3MTMiLCAi
-        cmVzdWx0IjogInN1Y2Nlc3MifSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
-        JG9pZCI6ICI1NmIzZDhmOTg2ODBiNWNhNWM4NDIwMzcifSwgImlkIjogIjU2
-        YjNkOGY5ODRhMDljMDdkYmY0ZDU2YiJ9LCB7ImV4Y2VwdGlvbiI6IG51bGws
-        ICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5j
-        LnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzI4ZDE1NmE1
-        LTVlNzQtNDVjYy04NTUzLWVlNDE4ZjdmNjEwMC8iLCAidGFza19pZCI6ICIy
-        OGQxNTZhNS01ZTc0LTQ1Y2MtODU1My1lZTQxOGY3ZjYxMDAiLCAidGFncyI6
-        IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpz
-        eW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjA0OjMyWiIs
-        ICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAy
-        LTA0VDIzOjA0OjMyWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90
-        YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8yYmI2ZmFl
-        MC01ODYyLTRkY2MtOWJhNy0wMjQ2Y2UxZTE5MGYvIiwgInRhc2tfaWQiOiAi
-        MmJiNmZhZTAtNTg2Mi00ZGNjLTliYTctMDI0NmNlMWUxOTBmIn0sIHsiX2hy
-        ZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2U0NDE3OWVlLThjNjEtNGYzNy1i
-        ZjkzLTc4MmE5OTZkMTVlYy8iLCAidGFza19pZCI6ICJlNDQxNzllZS04YzYx
-        LTRmMzctYmY5My03ODJhOTk2ZDE1ZWMifV0sICJwcm9ncmVzc19yZXBvcnQi
-        OiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tZGV2Ym94
-        LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsiaW1wb3J0ZXJfdHlwZV9pZCI6
-        ICJ5dW1faW1wb3J0ZXIiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
-        ICJyZW1vdmVkX2NvdW50IjogMCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQy
-        MzowNDozMloiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTA0VDIzOjA0OjMyWiIsICJ0cmFjZWJhY2siOiBu
-        dWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
-        YnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAiZXJyb3JfbWVzc2FnZSI6
-        IG51bGwsICJ1cGRhdGVkX2NvdW50IjogMTUsICJkZXRhaWxzIjogeyJjb250
-        ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRl
-        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0
-        IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6
-        IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0
-        IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
-        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJpZCI6ICI1NmIzZDkw
-        MDg0YTA5YzA3ZGE5Nzk3MzEiLCAicmVzdWx0IjogInN1Y2Nlc3MifSwgImVy
-        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzZDhmZjg2ODBiNWNh
-        NWM4NDIwNGYifSwgImlkIjogIjU2YjNkOGZmODRhMDljMDdkYmY0ZDU5MiJ9
-        LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2
-        ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAv
-        YXBpL3YyL3Rhc2tzL2RlY2YwYjAxLTNhMTctNDc3Yy1hYmZjLWY1YWQ2OTJl
-        NjBjMC8iLCAidGFza19pZCI6ICJkZWNmMGIwMS0zYTE3LTQ3N2MtYWJmYy1m
-        NWFkNjkyZTYwYzAiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9y
-        YV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA0VDIzOjA0OjM1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjA0OjM0WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxw
-        L2FwaS92Mi90YXNrcy8wNzg4YmVkMy04MzNiLTRmODUtOWMyNy1iMDk4Nzhj
-        MmU1ZTIvIiwgInRhc2tfaWQiOiAiMDc4OGJlZDMtODMzYi00Zjg1LTljMjct
-        YjA5ODc4YzJlNWUyIn0sIHsiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tz
-        LzI4M2ZlMzVkLWYxZjQtNDlhYS05NzEyLWNjNWRlYjE2ZTM5OC8iLCAidGFz
-        a19pZCI6ICIyODNmZTM1ZC1mMWY0LTQ5YWEtOTcxMi1jYzVkZWIxNmUzOTgi
-        fV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29u
-        dGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVm
-        dCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUi
-        OiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9y
-        X2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVm
-        dCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0
-        YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZp
-        bmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
-        cmtlci0wQGthdGVsbG8tZGV2Ym94LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
-        IHsiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiaW1wb3J0
-        ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJy
-        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJyZW1vdmVkX2NvdW50IjogMCwgInN0
-        YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMzowNDozNFoiLCAiX25zIjogInJlcG9f
-        c3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA0VDIzOjA0
-        OjM1WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVu
-        dCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0
-        YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQi
-        OiAwLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJ1cGRhdGVkX2NvdW50Ijog
-        MTUsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwg
-        Iml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90
-        b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRy
-        cG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVt
-        c190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifX0sICJpZCI6ICI1NmIzZDkwMzg0YTA5YzA3ZGE5Nzk3NGYiLCAicmVz
-        dWx0IjogInN1Y2Nlc3MifSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmIzZDkwMjg2ODBiNWNhNWM4NDIwNWYifSwgImlkIjogIjU2YjNk
-        OTAyODRhMDljMDdkYmY0ZDVhYiJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0
-        YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5
-        bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2M0ZDEyZmM5LTBj
-        YjctNDVlYy05Y2I4LWUwZmJlNjUxZmZkYi8iLCAidGFza19pZCI6ICJjNGQx
-        MmZjOS0wY2I3LTQ1ZWMtOWNiOC1lMGZiZTY1MWZmZGIiLCAidGFncyI6IFsi
-        cHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5j
-        Il0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjA0OjM4WiIsICJf
-        bnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0
-        VDIzOjA0OjM3WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNr
-        cyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9kODY0ZWYxYy0z
-        MzJkLTRjOTYtYjNmNS00YTJiMjFlN2Q5NTEvIiwgInRhc2tfaWQiOiAiZDg2
-        NGVmMWMtMzMyZC00Yzk2LWIzZjUtNGEyYjIxZTdkOTUxIn0sIHsiX2hyZWYi
-        OiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2UxOWMzNmEzLTI1YmUtNDlhNi04OTgx
-        LTRkZjYyN2U0YjVkYy8iLCAidGFza19pZCI6ICJlMTljMzZhMy0yNWJlLTQ5
-        YTYtODk4MS00ZGY2MjdlNGI1ZGMifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAs
-        ICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjog
-        IkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1f
-        dG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJk
-        cnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tZGV2Ym94LmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5
-        dW1faW1wb3J0ZXIiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwg
-        ImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMzow
-        NDozN1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDE2LTAyLTA0VDIzOjA0OjM4WiIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
-        aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAiZXJyb3JfbWVzc2FnZSI6IG51
-        bGwsICJ1cGRhdGVkX2NvdW50IjogMTUsICJkZXRhaWxzIjogeyJjb250ZW50
-        IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNf
-        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0Ijog
-        MCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAs
-        ICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0
-        YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJpZCI6ICI1NmIzZDkwNjg0
-        YTA5YzA3ZGE5Nzk3NmQiLCAicmVzdWx0IjogInN1Y2Nlc3MifSwgImVycm9y
-        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzZDkwNTg2ODBiNWNhNWM4
-        NDIwNmYifSwgImlkIjogIjU2YjNkOTA1ODRhMDljMDdkYmY0ZDVjMSJ9LCB7
-        ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIu
-        bWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
-        L3YyL3Rhc2tzLzA0NWZhOTFkLWI4NDgtNDI3Ni1hNzM4LTBiNTNlYzRlYmIz
-        Ni8iLCAidGFza19pZCI6ICIwNDVmYTkxZC1iODQ4LTQyNzYtYTczOC0wYjUz
-        ZWM0ZWJiMzYiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8x
-        NyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2
-        LTAyLTA0VDIzOjA0OjQxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3Rh
-        cnRfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjA0OjQwWiIsICJ0cmFjZWJhY2si
-        OiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81MGM0MmEyNS1lYmU3LTRiODYtYmM4Ni02MWNmZmYzMGZh
-        ZDAvIiwgInRhc2tfaWQiOiAiNTBjNDJhMjUtZWJlNy00Yjg2LWJjODYtNjFj
-        ZmZmMzBmYWQwIn0sIHsiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzc4
-        YWU0OTBkLTM5ODgtNGZlNC05OTNmLWUzYjhjYTlmNmNiZS8iLCAidGFza19p
-        ZCI6ICI3OGFlNDkwZC0zOTg4LTRmZTQtOTkzZi1lM2I4Y2E5ZjZjYmUifV0s
-        ICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVu
-        dCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1z
-        X3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6
-        IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAw
-        LCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2Rl
-        dGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        ImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6
-        IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0wQGthdGVsbG8tZGV2Ym94LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
-        aW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiaW1wb3J0ZXJf
-        aWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJyZW1vdmVkX2NvdW50IjogMCwgInN0YXJ0
-        ZWQiOiAiMjAxNi0wMi0wNFQyMzowNDo0MFoiLCAiX25zIjogInJlcG9fc3lu
-        Y19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA0VDIzOjA0OjQx
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAw
-        LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJ1cGRhdGVkX2NvdW50IjogMTUs
-        ICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0
-        ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklO
-        SVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3Rh
-        bCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1f
-        ZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
-        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX0sICJpZCI6ICI1NmIzZDkwOTg0YTA5YzA3ZGE5Nzk3OGIiLCAicmVzdWx0
-        IjogInN1Y2Nlc3MifSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
-        ICI1NmIzZDkwODg2ODBiNWNhNWM4NDIwN2YifSwgImlkIjogIjU2YjNkOTA4
-        ODRhMDljMDdkYmY0ZDVkYSJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNr
-        X3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMi
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzI3Nzg2NTgzLTJiYTIt
-        NGUyMi04MGU0LTQxMzhmMTU2YTUwNC8iLCAidGFza19pZCI6ICIyNzc4NjU4
-        My0yYmEyLTRlMjItODBlNC00MTM4ZjE1NmE1MDQiLCAidGFncyI6IFsicHVs
-        cDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0s
-        ICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjA0OjQ0WiIsICJfbnMi
-        OiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0VDIz
-        OjA0OjQzWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6
-        IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy80OWRkNmMyOC1mZWJi
-        LTRkYjYtODgzNy0wZTUwMzZmZGE3N2EvIiwgInRhc2tfaWQiOiAiNDlkZDZj
-        MjgtZmViYi00ZGI2LTg4MzctMGU1MDM2ZmRhNzdhIn0sIHsiX2hyZWYiOiAi
-        L3B1bHAvYXBpL3YyL3Rhc2tzLzA5YmFiYjIyLWExMWUtNDZiYS1iNzkyLWFj
-        OWZiNDRmMDFhNy8iLCAidGFza19pZCI6ICIwOWJhYmIyMi1hMTFlLTQ2YmEt
-        Yjc5Mi1hYzlmYjQ0ZjAxYTcifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1
-        bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJp
-        dGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
-        TklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90
-        YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBt
-        X2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNf
-        dG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
-        c2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tZGV2Ym94LmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
-        aW1wb3J0ZXIiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4
-        Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMzowNDo0
-        M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6
-        ICIyMDE2LTAyLTA0VDIzOjA0OjQ0WiIsICJ0cmFjZWJhY2siOiBudWxsLCAi
-        c3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In19LCAiYWRkZWRfY291bnQiOiAwLCAiZXJyb3JfbWVzc2FnZSI6IG51bGws
-        ICJ1cGRhdGVkX2NvdW50IjogMTUsICJkZXRhaWxzIjogeyJjb250ZW50Ijog
-        eyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90
-        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwg
-        ImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJk
-        cnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWls
-        cyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJpZCI6ICI1NmIzZDkwYzg0YTA5
-        YzA3ZGE5Nzk3YTkiLCAicmVzdWx0IjogInN1Y2Nlc3MifSwgImVycm9yIjog
-        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzZDkwYjg2ODBiNWNhNWM4NDIw
-        OGYifSwgImlkIjogIjU2YjNkOTBiODRhMDljMDdkYmY0ZDVmMyJ9LCB7ImV4
-        Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFu
-        YWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
-        L3Rhc2tzLzE4ZTNmMjAxLTRkZjAtNDhjMC1iMjY2LWE0ZWUwZTUyZTkzZC8i
-        LCAidGFza19pZCI6ICIxOGUzZjIwMS00ZGYwLTQ4YzAtYjI2Ni1hNGVlMGU1
-        MmU5M2QiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIs
-        ICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAy
-        LTA0VDIzOjA0OjQ3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRf
-        dGltZSI6ICIyMDE2LTAyLTA0VDIzOjA0OjQ2WiIsICJ0cmFjZWJhY2siOiBu
-        dWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92
-        Mi90YXNrcy84NDM4MTk3Yy1lNjM1LTQ4MmYtODA5MC1iODJhZGQ3ZmU1MTIv
-        IiwgInRhc2tfaWQiOiAiODQzODE5N2MtZTYzNS00ODJmLTgwOTAtYjgyYWRk
-        N2ZlNTEyIn0sIHsiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzIwYWIx
-        YWQwLTEwNDUtNDVmMS05ODc5LTZkNDU4MDFmMmE4Yi8iLCAidGFza19pZCI6
-        ICIyMGFiMWFkMC0xMDQ1LTQ1ZjEtOTg3OS02ZDQ1ODAxZjJhOGIifV0sICJw
-        cm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6
-        IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3Rv
-        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAs
-        ICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAi
-        ZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFp
-        bHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
-        c3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklO
-        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9
-        LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVk
-        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0w
-        QGthdGVsbG8tZGV2Ym94LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsiaW1w
-        b3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiaW1wb3J0ZXJfaWQi
-        OiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lk
-        IjogIkZlZG9yYV8xNyIsICJyZW1vdmVkX2NvdW50IjogMCwgInN0YXJ0ZWQi
-        OiAiMjAxNi0wMi0wNFQyMzowNDo0NloiLCAiX25zIjogInJlcG9fc3luY19y
-        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA0VDIzOjA0OjQ3WiIs
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAi
-        ZXJyb3JfbWVzc2FnZSI6IG51bGwsICJ1cGRhdGVkX2NvdW50IjogMTUsICJk
-        ZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1z
-        X2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
-        bCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0s
-        ICJpZCI6ICI1NmIzZDkwZjg0YTA5YzA3ZGE5Nzk3YzciLCAicmVzdWx0Ijog
-        InN1Y2Nlc3MifSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmIzZDkwZTg2ODBiNWNhNWM4NDIwOWYifSwgImlkIjogIjU2YjNkOTBlODRh
-        MDljMDdkYmY0ZDYwYyJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5
-        cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAi
-        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2FlMzMxN2ZjLTM4ZjEtNGFm
-        My05MDEyLWQ4ZWI3OGMzOGM4Yy8iLCAidGFza19pZCI6ICJhZTMzMTdmYy0z
-        OGYxLTRhZjMtOTAxMi1kOGViNzhjMzhjOGMiLCAidGFncyI6IFsicHVscDpy
-        ZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJm
-        aW5pc2hfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjA0OjUwWiIsICJfbnMiOiAi
-        dGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjA0
-        OjQ5WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7
-        Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8wYjAyMDI5Ni00NDc3LTQ1
-        NmQtODA5Ni1lM2FhNjZjMmY1MTYvIiwgInRhc2tfaWQiOiAiMGIwMjAyOTYt
-        NDQ3Ny00NTZkLTgwOTYtZTNhYTY2YzJmNTE2In0sIHsiX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzLzFiMWRlZjJjLWNjY2YtNDYxZS05YjcwLTlhMDcx
-        NzZjNWNmZC8iLCAidGFza19pZCI6ICIxYjFkZWYyYy1jY2NmLTQ2MWUtOWI3
-        MC05YTA3MTc2YzVjZmQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
-        bXBvcnRlciI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVt
-        c19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwi
-        OiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2Rv
-        bmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
-        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19
-        fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tZGV2Ym94LmV4YW1wbGUu
-        Y29tIiwgInJlc3VsdCI6IHsiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2Vw
-        dGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJyZW1vdmVk
-        X2NvdW50IjogMCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMzowNDo0OVoi
-        LCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIy
-        MDE2LTAyLTA0VDIzOjA0OjUwWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Vt
-        bWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNv
-        bXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19
-        LCAiYWRkZWRfY291bnQiOiAwLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJ1
-        cGRhdGVkX2NvdW50IjogMTUsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJz
-        aXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwi
-        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRl
-        dGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBt
-        X3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6
-        IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
-        YnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJl
-        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifX0sICJpZCI6ICI1NmIzZDkxMjg0YTA5YzA3
-        ZGE5Nzk3ZTUiLCAicmVzdWx0IjogInN1Y2Nlc3MifSwgImVycm9yIjogbnVs
-        bCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzZDkxMTg2ODBiNWNhNWM4NDIwYWYi
-        fSwgImlkIjogIjU2YjNkOTExODRhMDljMDdkYmY0ZDYyNSJ9LCB7ImV4Y2Vw
-        dGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdl
-        cnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2Q5MGQ2NTgwLTZjZTktNGU4ZS04YTRmLTgwYWI4YTRlZjE4Mi8iLCAi
-        dGFza19pZCI6ICJkOTBkNjU4MC02Y2U5LTRlOGUtOGE0Zi04MGFiOGE0ZWYx
-        ODIiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJw
-        dWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA0
-        VDIzOjA0OjUzWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGlt
-        ZSI6ICIyMDE2LTAyLTA0VDIzOjA0OjUzWiIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90
-        YXNrcy9hOWYyYTZlNC05NzRmLTQzMWUtYTUxMS02NGNlMzU1OWU2ODYvIiwg
-        InRhc2tfaWQiOiAiYTlmMmE2ZTQtOTc0Zi00MzFlLWE1MTEtNjRjZTM1NTll
-        Njg2In0sIHsiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzUzOTY1NGQy
-        LWM3YTgtNDg1ZC05YmRjLWI0ZTg1MDcxNDY1OC8iLCAidGFza19pZCI6ICI1
-        Mzk2NTRkMi1jN2E4LTQ4NWQtOWJkYy1iNGU4NTA3MTQ2NTgifV0sICJwcm9n
-        cmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsi
-        c2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFs
-        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJk
-        ZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJw
-        bV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMi
-        OiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3Ry
-        aWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGth
-        dGVsbG8tZGV2Ym94LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsiaW1wb3J0
-        ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiaW1wb3J0ZXJfaWQiOiAi
-        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
-        IkZlZG9yYV8xNyIsICJyZW1vdmVkX2NvdW50IjogMCwgInN0YXJ0ZWQiOiAi
-        MjAxNi0wMi0wNFQyMzowNDo1M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1
-        bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA0VDIzOjA0OjUzWiIsICJ0
-        cmFjZWJhY2siOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJ1cGRhdGVkX2NvdW50IjogMTUsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJp
-        ZCI6ICI1NmIzZDkxNTg0YTA5YzA3ZGE5Nzk4MDMiLCAicmVzdWx0IjogInN1
-        Y2Nlc3MifSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIz
-        ZDkxNTg2ODBiNWNhNWM4NDIwYmYifSwgImlkIjogIjU2YjNkOTE1ODRhMDlj
-        MDdkYmY0ZDYzZSJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUi
-        OiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hy
-        ZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzQxMGJlYmNjLWYxZWItNDIxNi05
-        NWMwLTcxOTE2ZThkZDEzMS8iLCAidGFza19pZCI6ICI0MTBiZWJjYy1mMWVi
-        LTQyMTYtOTVjMC03MTkxNmU4ZGQxMzEiLCAidGFncyI6IFsicHVscDpyZXBv
-        c2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjA0OjU2WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjA0OjU2
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9o
-        cmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8zZWZkYjJjNS1iM2ZjLTRiN2Et
-        YTEyYi0zMTkzNGMxZDVkMmMvIiwgInRhc2tfaWQiOiAiM2VmZGIyYzUtYjNm
-        Yy00YjdhLWExMmItMzE5MzRjMWQ1ZDJjIn0sIHsiX2hyZWYiOiAiL3B1bHAv
-        YXBpL3YyL3Rhc2tzLzcwMDE5YWQ4LTk3ZWItNGIzZC05ZTkyLWIyZDdiZGZi
-        NWJkZS8iLCAidGFza19pZCI6ICI3MDAxOWFkOC05N2ViLTRiM2QtOWU5Mi1i
-        MmQ3YmRmYjViZGUifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
-        cnRlciI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
-        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
-        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
-        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwi
-        OiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwg
-        InN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVk
-        X3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tZGV2Ym94LmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IHsiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
-        ZXIiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlv
-        biI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJyZW1vdmVkX2Nv
-        dW50IjogMCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMzowNDo1NloiLCAi
-        X25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2
-        LTAyLTA0VDIzOjA0OjU2WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3VtbWFy
-        eSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBz
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAi
-        YWRkZWRfY291bnQiOiAwLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJ1cGRh
-        dGVkX2NvdW50IjogMTUsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXpl
-        X3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
-        bHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3Rv
-        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
-        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
-        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJpZCI6ICI1NmIzZDkxODg0YTA5YzA3ZGE5
-        Nzk4MjEiLCAicmVzdWx0IjogInN1Y2Nlc3MifSwgImVycm9yIjogbnVsbCwg
-        Il9pZCI6IHsiJG9pZCI6ICI1NmIzZDkxODg2ODBiNWNhNWM4NDIwY2YifSwg
-        ImlkIjogIjU2YjNkOTE4ODRhMDljMDdkYmY0ZDY1NCJ9LCB7ImV4Y2VwdGlv
-        biI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMu
-        cmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tz
-        L2E5YWUwZGZiLTY1NzctNGI1Yi1iYzA4LTUzZDQxMWM3MGY1ZC8iLCAidGFz
-        a19pZCI6ICJhOWFlMGRmYi02NTc3LTRiNWItYmMwOC01M2Q0MTFjNzBmNWQi
-        LCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxw
-        OmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA0VDIz
-        OjA0OjU5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6
-        ICIyMDE2LTAyLTA0VDIzOjA0OjU5WiIsICJ0cmFjZWJhY2siOiBudWxsLCAi
-        c3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNr
-        cy8zMDkwNmY1ZC02NDdkLTQ1ZDYtYjAwZC0zOTU3OTZjMzRhYzcvIiwgInRh
-        c2tfaWQiOiAiMzA5MDZmNWQtNjQ3ZC00NWQ2LWIwMGQtMzk1Nzk2YzM0YWM3
-        In0sIHsiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzVlYzhmODI5LTg3
-        NGItNDJjMi1hMjhlLTU2NWExNTMwNmJmOC8iLCAidGFza19pZCI6ICI1ZWM4
-        ZjgyOS04NzRiLTQyYzItYTI4ZS01NjVhMTUzMDZiZjgifV0sICJwcm9ncmVz
-        c19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsic2l6
-        ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjog
-        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRh
-        aWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90
-        b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBb
-        XX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
-        dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJy
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
-        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVs
-        bG8tZGV2Ym94LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsiaW1wb3J0ZXJf
-        dHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiaW1wb3J0ZXJfaWQiOiAieXVt
-        X2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZl
-        ZG9yYV8xNyIsICJyZW1vdmVkX2NvdW50IjogMCwgInN0YXJ0ZWQiOiAiMjAx
-        Ni0wMi0wNFQyMzowNDo1OVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRz
-        IiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA0VDIzOjA0OjU5WiIsICJ0cmFj
-        ZWJhY2siOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJy
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAiZXJyb3Jf
-        bWVzc2FnZSI6IG51bGwsICJ1cGRhdGVkX2NvdW50IjogMTUsICJkZXRhaWxz
-        IjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQi
-        OiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        c2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJy
-        cG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
-        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJpZCI6
-        ICI1NmIzZDkxYjg0YTA5YzA3ZGE5Nzk4M2YiLCAicmVzdWx0IjogInN1Y2Nl
-        c3MifSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzZDkx
-        Yjg2ODBiNWNhNWM4NDIwZGYifSwgImlkIjogIjU2YjNkOTFiODRhMDljMDdk
-        YmY0ZDY2ZCJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAi
-        cHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYi
-        OiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2RmMjdiNzY5LWFiMTgtNGM2NC04NjJl
-        LTQ1Zjc1ZGI0ZTllMS8iLCAidGFza19pZCI6ICJkZjI3Yjc2OS1hYjE4LTRj
-        NjQtODYyZS00NWY3NWRiNGU5ZTEiLCAidGFncyI6IFsicHVscDpyZXBvc2l0
-        b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hf
-        dGltZSI6ICIyMDE2LTAyLTA0VDIzOjA1OjAyWiIsICJfbnMiOiAidGFza19z
-        dGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjA1OjAyWiIs
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi90YXNrcy8zMzE0NWFmZC04MDU5LTRkM2MtOTM1
-        Ny0wNTE1ZGEyZDVkZWEvIiwgInRhc2tfaWQiOiAiMzMxNDVhZmQtODA1OS00
-        ZDNjLTkzNTctMDUxNWRhMmQ1ZGVhIn0sIHsiX2hyZWYiOiAiL3B1bHAvYXBp
-        L3YyL3Rhc2tzL2FiYzc3NTdhLWU5ZTktNGY5OC1hNGRmLTg0MjU0ZTQ5Y2Q4
-        Ny8iLCAidGFza19pZCI6ICJhYmM3NzU3YS1lOWU5LTRmOTgtYTRkZi04NDI1
-        NGU0OWNkODcifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRl
-        ciI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0
-        IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        InNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAi
-        cnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAw
-        fSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0
-        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
-        c291cmNlX3dvcmtlci0wQGthdGVsbG8tZGV2Ym94LmV4YW1wbGUuY29tIiwg
-        InJlc3VsdCI6IHsiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIi
-        LCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6
-        IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJyZW1vdmVkX2NvdW50
-        IjogMCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMzowNTowMloiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAy
-        LTA0VDIzOjA1OjAyWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3VtbWFyeSI6
-        IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
-        ZWRfY291bnQiOiAwLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJ1cGRhdGVk
-        X2NvdW50IjogMTUsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3Rv
-        dGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAi
-        c3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMi
-        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
-        IjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwg
-        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX0sICJpZCI6ICI1NmIzZDkxZTg0YTA5YzA3ZGE5Nzk4
-        NWQiLCAicmVzdWx0IjogInN1Y2Nlc3MifSwgImVycm9yIjogbnVsbCwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1NmIzZDkxZTg2ODBiNWNhNWM4NDIwZWYifSwgImlk
-        IjogIjU2YjNkOTFlODRhMDljMDdkYmY0ZDY4NiJ9LCB7ImV4Y2VwdGlvbiI6
-        IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVw
-        by5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzFh
-        ZTJhMmI0LTA2NGItNDc2Yi1iMmVlLWQ0NTQzMjUwYTczZC8iLCAidGFza19p
-        ZCI6ICIxYWUyYTJiNC0wNjRiLTQ3NmItYjJlZS1kNDU0MzI1MGE3M2QiLCAi
-        dGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFj
-        dGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjA1
-        OjA1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIy
-        MDE2LTAyLTA0VDIzOjA1OjA1WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bh
-        d25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9k
-        YjM0N2JiMS01MDRmLTRkYmItOTJjZi1lN2NlOGRhNGRmNzgvIiwgInRhc2tf
-        aWQiOiAiZGIzNDdiYjEtNTA0Zi00ZGJiLTkyY2YtZTdjZThkYTRkZjc4In0s
-        IHsiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzNiMzJiZjVjLTE1MTgt
-        NDA1NS04ZTMyLTk0MzVmMzNjNzBmMi8iLCAidGFza19pZCI6ICIzYjMyYmY1
-        Yy0xNTE4LTQwNTUtOGUzMi05NDM1ZjMzYzcwZjIifV0sICJwcm9ncmVzc19y
-        ZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsic2l6ZV90
-        b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxz
-        IjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3Rh
-        bCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8t
-        ZGV2Ym94LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsiaW1wb3J0ZXJfdHlw
-        ZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2lt
-        cG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9y
-        YV8xNyIsICJyZW1vdmVkX2NvdW50IjogMCwgInN0YXJ0ZWQiOiAiMjAxNi0w
-        Mi0wNFQyMzowNTowNVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwg
-        ImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA0VDIzOjA1OjA1WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAiZXJyb3JfbWVz
-        c2FnZSI6IG51bGwsICJ1cGRhdGVkX2NvdW50IjogMTUsICJkZXRhaWxzIjog
-        eyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAw
-        LCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6
-        ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1f
-        ZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVt
-        c19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJpZCI6ICI1
-        NmIzZDkyMTg0YTA5YzA3ZGE5Nzk4N2IiLCAicmVzdWx0IjogInN1Y2Nlc3Mi
-        fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzZDkyMTg2
-        ODBiNWNhNWM4NDIwZmYifSwgImlkIjogIjU2YjNkOTIxODRhMDljMDdkYmY0
-        ZDY5YyJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVs
-        cC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAi
-        L3B1bHAvYXBpL3YyL3Rhc2tzLzdhMzQ0ZDVkLTkyOWEtNGVmMy04ZjA1LWVh
-        ZWYzZDIyZmY4Yi8iLCAidGFza19pZCI6ICI3YTM0NGQ1ZC05MjlhLTRlZjMt
-        OGYwNS1lYWVmM2QyMmZmOGIiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5
-        OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGlt
-        ZSI6ICIyMDE2LTAyLTA0VDIzOjA1OjA4WiIsICJfbnMiOiAidGFza19zdGF0
-        dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjA1OjA4WiIsICJ0
-        cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjog
-        Ii9wdWxwL2FwaS92Mi90YXNrcy8yYzAyMGQ4Ni1hNTZiLTQ4YTAtOGMwOS0w
-        Mzc1YTNjZjFjZTUvIiwgInRhc2tfaWQiOiAiMmMwMjBkODYtYTU2Yi00OGEw
-        LThjMDktMDM3NWEzY2YxY2U1In0sIHsiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
-        L3Rhc2tzLzUxYzdkYTI1LTM1N2MtNGIxMi1iODQzLTIxYzQyNjY1NmRiZC8i
-        LCAidGFza19pZCI6ICI1MWM3ZGEyNS0zNTdjLTRiMTItYjg0My0yMWM0MjY2
-        NTZkYmQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6
-        IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0Ijog
-        MCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNp
-        emVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBt
-        X2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwg
-        ImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAi
-        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0wQGthdGVsbG8tZGV2Ym94LmV4YW1wbGUuY29tIiwgInJl
-        c3VsdCI6IHsiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJyZW1vdmVkX2NvdW50Ijog
-        MCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMzowNTowOFoiLCAiX25zIjog
-        InJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA0
-        VDIzOjA1OjA4WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3VtbWFyeSI6IHsi
-        Y29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRf
-        Y291bnQiOiAwLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJ1cGRhdGVkX2Nv
-        dW50IjogMTUsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFs
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7
-        InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjog
-        MCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNv
-        bXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjog
-        eyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifX0sICJpZCI6ICI1NmIzZDkyNDg0YTA5YzA3ZGE5Nzk4OTki
-        LCAicmVzdWx0IjogInN1Y2Nlc3MifSwgImVycm9yIjogbnVsbCwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NmIzZDkyNDg2ODBiNWNhNWM4NDIxMGYifSwgImlkIjog
-        IjU2YjNkOTI0ODRhMDljMDdkYmY0ZDZiNSJ9LCB7ImV4Y2VwdGlvbiI6IG51
-        bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5z
-        eW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzdmOWUw
-        MTMyLTMyMjUtNDEwZi04MzMzLTQzYzhmNDM2NTUzNC8iLCAidGFza19pZCI6
-        ICI3ZjllMDEzMi0zMjI1LTQxMGYtODMzMy00M2M4ZjQzNjU1MzQiLCAidGFn
-        cyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlv
-        bjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjA1OjEy
-        WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
-        LTAyLTA0VDIzOjA1OjExWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
-        ZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8yNGRh
-        NjgxMi1lNDI0LTQ3NWItOTNjZC1iNDIzMmM3NDU1ODIvIiwgInRhc2tfaWQi
-        OiAiMjRkYTY4MTItZTQyNC00NzViLTkzY2QtYjQyMzJjNzQ1NTgyIn0sIHsi
-        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2Q1YTE0ZWUwLWM5MDctNDJl
-        OC1iNzA5LWY4OTU0NWRhNjNlZi8iLCAidGFza19pZCI6ICJkNWExNGVlMC1j
-        OTA3LTQyZTgtYjcwOS1mODk1NDVkYTYzZWYifV0sICJwcm9ncmVzc19yZXBv
-        cnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
-        IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9u
-        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tZGV2
-        Ym94LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsiaW1wb3J0ZXJfdHlwZV9p
-        ZCI6ICJ5dW1faW1wb3J0ZXIiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9y
-        dGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8x
-        NyIsICJyZW1vdmVkX2NvdW50IjogMCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0w
-        NFQyMzowNToxMVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
-        bXBsZXRlZCI6ICIyMDE2LTAyLTA0VDIzOjA1OjEyWiIsICJ0cmFjZWJhY2si
-        OiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAiZXJyb3JfbWVzc2Fn
-        ZSI6IG51bGwsICJ1cGRhdGVkX2NvdW50IjogMTUsICJkZXRhaWxzIjogeyJj
-        b250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAi
-        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9s
-        ZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9u
-        ZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJy
-        b3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
-        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJpZCI6ICI1NmIz
-        ZDkyODg0YTA5YzA3ZGE5Nzk4YjciLCAicmVzdWx0IjogInN1Y2Nlc3MifSwg
-        ImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzZDkyNzg2ODBi
-        NWNhNWM4NDIxMWYifSwgImlkIjogIjU2YjNkOTI3ODRhMDljMDdkYmY0ZDZj
-        YiJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5z
-        ZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzLzFhMjdiY2U4LTI3OWEtNDhhNS05NTE0LWVkZWNm
-        ZTllNThkZC8iLCAidGFza19pZCI6ICIxYTI3YmNlOC0yNzlhLTQ4YTUtOTUx
-        NC1lZGVjZmU5ZTU4ZGQiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZl
-        ZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6
-        ICIyMDE2LTAyLTA0VDIzOjA1OjE1WiIsICJfbnMiOiAidGFza19zdGF0dXMi
-        LCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjA1OjE0WiIsICJ0cmFj
-        ZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9mNDNmYzdhOC0yNGJiLTQ1YjMtYWZhOC02OWNk
-        YWIwYTE3ZTAvIiwgInRhc2tfaWQiOiAiZjQzZmM3YTgtMjRiYi00NWIzLWFm
-        YTgtNjljZGFiMGExN2UwIn0sIHsiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzg2YzQxMDlkLTIzYzUtNDc4My1hMjk3LWYxZDU4YWRhODZiMy8iLCAi
-        dGFza19pZCI6ICI4NmM0MTA5ZC0yM2M1LTQ3ODMtYTI5Ny1mMWQ1OGFkYTg2
-        YjMifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsi
-        Y29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwg
-        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVf
-        bGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2Rv
-        bmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVy
-        cm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNf
-        bGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjog
-        ImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
-        X3dvcmtlci0wQGthdGVsbG8tZGV2Ym94LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IHsiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiaW1w
-        b3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJyZW1vdmVkX2NvdW50IjogMCwg
-        InN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMzowNToxNFoiLCAiX25zIjogInJl
-        cG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA0VDIz
-        OjA1OjE1WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3VtbWFyeSI6IHsiY29u
-        dGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiAwLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJ1cGRhdGVkX2NvdW50
-        IjogMTUsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjog
-        MCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJw
-        bV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwg
-        ImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBz
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJp
-        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifX0sICJpZCI6ICI1NmIzZDkyYjg0YTA5YzA3ZGE5Nzk4ZDUiLCAi
-        cmVzdWx0IjogInN1Y2Nlc3MifSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
-        JG9pZCI6ICI1NmIzZDkyYTg2ODBiNWNhNWM4NDIxMmYifSwgImlkIjogIjU2
-        YjNkOTJhODRhMDljMDdkYmY0ZDZlNCJ9LCB7ImV4Y2VwdGlvbiI6IG51bGws
-        ICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5j
-        LnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzdhZWI1ZTVl
-        LWU3MzgtNGI4ZC1iMGZlLTUwZTE3YzUwZGM5ZS8iLCAidGFza19pZCI6ICI3
-        YWViNWU1ZS1lNzM4LTRiOGQtYjBmZS01MGUxN2M1MGRjOWUiLCAidGFncyI6
-        IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpz
-        eW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjA1OjE4WiIs
-        ICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAy
-        LTA0VDIzOjA1OjE4WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90
-        YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82NzQ5MmIx
-        Zi0xNGVlLTQyODgtOTEyZC00MTdlMWU2OTE2YzcvIiwgInRhc2tfaWQiOiAi
-        Njc0OTJiMWYtMTRlZS00Mjg4LTkxMmQtNDE3ZTFlNjkxNmM3In0sIHsiX2hy
-        ZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2E5NWYwMTE2LTdiNTEtNDU3My1h
-        ZWIwLTk4M2RlMjVkNjA3Yi8iLCAidGFza19pZCI6ICJhOTVmMDExNi03YjUx
-        LTQ1NzMtYWViMC05ODNkZTI1ZDYwN2IifV0sICJwcm9ncmVzc19yZXBvcnQi
-        OiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tZGV2Ym94
-        LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsiaW1wb3J0ZXJfdHlwZV9pZCI6
-        ICJ5dW1faW1wb3J0ZXIiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
-        ICJyZW1vdmVkX2NvdW50IjogMCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQy
-        MzowNToxOFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTA0VDIzOjA1OjE4WiIsICJ0cmFjZWJhY2siOiBu
-        dWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
-        YnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAiZXJyb3JfbWVzc2FnZSI6
-        IG51bGwsICJ1cGRhdGVkX2NvdW50IjogMTUsICJkZXRhaWxzIjogeyJjb250
-        ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRl
-        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0
-        IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6
-        IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0
-        IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
-        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJpZCI6ICI1NmIzZDky
-        ZTg0YTA5YzA3ZGE5Nzk4ZjMiLCAicmVzdWx0IjogInN1Y2Nlc3MifSwgImVy
-        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzZDkyZTg2ODBiNWNh
-        NWM4NDIxM2YifSwgImlkIjogIjU2YjNkOTJlODRhMDljMDdkYmY0ZDZmZCJ9
-        LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2
-        ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAv
-        YXBpL3YyL3Rhc2tzLzIxN2ViNzZiLWIxZDUtNDE2Zi04NmQyLTI1YWU3MGRh
-        NTVlYS8iLCAidGFza19pZCI6ICIyMTdlYjc2Yi1iMWQ1LTQxNmYtODZkMi0y
-        NWFlNzBkYTU1ZWEiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9y
-        YV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA0VDIzOjA1OjIxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjA1OjIxWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxw
-        L2FwaS92Mi90YXNrcy82MzM1N2ZmZC1kNWI1LTRhMmUtYTAzMC05NzcxMDA3
-        YjE4ZTYvIiwgInRhc2tfaWQiOiAiNjMzNTdmZmQtZDViNS00YTJlLWEwMzAt
-        OTc3MTAwN2IxOGU2In0sIHsiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tz
-        LzQ5Yjg4YTRmLTNiNzgtNDU1Mi1iNTY4LTM5MGNiYmJjYTJkOC8iLCAidGFz
-        a19pZCI6ICI0OWI4OGE0Zi0zYjc4LTQ1NTItYjU2OC0zOTBjYmJiY2EyZDgi
-        fV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29u
-        dGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVm
-        dCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUi
-        OiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9y
-        X2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVm
-        dCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0
-        YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZp
-        bmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
-        cmtlci0wQGthdGVsbG8tZGV2Ym94LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
-        IHsiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiaW1wb3J0
-        ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJy
-        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJyZW1vdmVkX2NvdW50IjogMCwgInN0
-        YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMzowNToyMVoiLCAiX25zIjogInJlcG9f
-        c3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA0VDIzOjA1
-        OjIxWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVu
-        dCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0
-        YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQi
-        OiAwLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJ1cGRhdGVkX2NvdW50Ijog
-        MTUsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwg
-        Iml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90
-        b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRy
-        cG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVt
-        c190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifX0sICJpZCI6ICI1NmIzZDkzMTg0YTA5YzA3ZGE5Nzk5MTEiLCAicmVz
-        dWx0IjogInN1Y2Nlc3MifSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmIzZDkzMTg2ODBiNWNhNWM4NDIxNGYifSwgImlkIjogIjU2YjNk
-        OTMxODRhMDljMDdkYmY0ZDcxNiJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0
-        YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5
-        bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzk4YzliNDkxLWRi
-        Y2UtNGExMy1iNTVjLWFjZmRmNmE0N2IzOS8iLCAidGFza19pZCI6ICI5OGM5
-        YjQ5MS1kYmNlLTRhMTMtYjU1Yy1hY2ZkZjZhNDdiMzkiLCAidGFncyI6IFsi
-        cHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5j
-        Il0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjA1OjI4WiIsICJf
-        bnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0
-        VDIzOjA1OjI4WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNr
-        cyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8xZDBjMGUwYy1l
-        ZWM4LTRlZmUtOGFhNy05NDkyYTRmZTJlZmMvIiwgInRhc2tfaWQiOiAiMWQw
-        YzBlMGMtZWVjOC00ZWZlLThhYTctOTQ5MmE0ZmUyZWZjIn0sIHsiX2hyZWYi
-        OiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2Y3NWNhNWRhLTQ1OGYtNDI1YS05OGNm
-        LTgzMmZhZGU1YzNiYy8iLCAidGFza19pZCI6ICJmNzVjYTVkYS00NThmLTQy
-        NWEtOThjZi04MzJmYWRlNWMzYmMifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAs
-        ICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjog
-        IkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1f
-        dG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJk
-        cnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tZGV2Ym94LmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5
-        dW1faW1wb3J0ZXIiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwg
-        ImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMzow
-        NToyOFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDE2LTAyLTA0VDIzOjA1OjI4WiIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
-        aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAiZXJyb3JfbWVzc2FnZSI6IG51
-        bGwsICJ1cGRhdGVkX2NvdW50IjogMTUsICJkZXRhaWxzIjogeyJjb250ZW50
-        IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNf
-        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0Ijog
-        MCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAs
-        ICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0
-        YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJpZCI6ICI1NmIzZDkzODg0
-        YTA5YzA3ZGE5Nzk5M2YiLCAicmVzdWx0IjogInN1Y2Nlc3MifSwgImVycm9y
-        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzZDkzODg2ODBiNWNhNWM4
-        NDIxNzMifSwgImlkIjogIjU2YjNkOTM4ODRhMDljMDdkYmY0ZDc0YyJ9LCB7
-        ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIu
-        bWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
-        L3YyL3Rhc2tzLzYyMmJmNDBkLWYzNjEtNDRkNy1iZDBlLTk0ZTM1ZTNiNDgw
-        My8iLCAidGFza19pZCI6ICI2MjJiZjQwZC1mMzYxLTQ0ZDctYmQwZS05NGUz
-        NWUzYjQ4MDMiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8x
-        NyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2
-        LTAyLTA0VDIzOjA2OjAzWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3Rh
-        cnRfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjA2OjAyWiIsICJ0cmFjZWJhY2si
-        OiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lZjhhZjU3Yi1lZDhiLTQ0MmEtOWM1My1lOGU0YjZlMjhi
-        ODQvIiwgInRhc2tfaWQiOiAiZWY4YWY1N2ItZWQ4Yi00NDJhLTljNTMtZThl
-        NGI2ZTI4Yjg0In0sIHsiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2Nl
-        NDk2NGEzLTNiNWMtNDhkYS04OTEwLWEzNmI3MGQ0MDRjZS8iLCAidGFza19p
-        ZCI6ICJjZTQ5NjRhMy0zYjVjLTQ4ZGEtODkxMC1hMzZiNzBkNDA0Y2UifV0s
-        ICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVu
-        dCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1z
-        X3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6
-        IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAw
-        LCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2Rl
-        dGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        ImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6
-        IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0wQGthdGVsbG8tZGV2Ym94LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
-        aW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiaW1wb3J0ZXJf
-        aWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJyZW1vdmVkX2NvdW50IjogMCwgInN0YXJ0
-        ZWQiOiAiMjAxNi0wMi0wNFQyMzowNjowMloiLCAiX25zIjogInJlcG9fc3lu
-        Y19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA0VDIzOjA2OjAz
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAw
-        LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJ1cGRhdGVkX2NvdW50IjogMTUs
-        ICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0
-        ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklO
-        SVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3Rh
-        bCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1f
-        ZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
-        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX0sICJpZCI6ICI1NmIzZDk1Yjg0YTA5YzA3ZGE5Nzk5NWQiLCAicmVzdWx0
-        IjogInN1Y2Nlc3MifSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
-        ICI1NmIzZDk1YTg2ODBiNWNhNWM4NDIxODMifSwgImlkIjogIjU2YjNkOTVh
-        ODRhMDljMDdkYmY0ZDc2MiJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNr
-        X3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMi
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzRhNTc1ZTcxLWUwOTkt
-        NGNlZS04OGJlLWMzNzYzOGZkYzFhZC8iLCAidGFza19pZCI6ICI0YTU3NWU3
-        MS1lMDk5LTRjZWUtODhiZS1jMzc2MzhmZGMxYWQiLCAidGFncyI6IFsicHVs
-        cDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0s
-        ICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjA2OjA2WiIsICJfbnMi
-        OiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0VDIz
-        OjA2OjA1WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6
-        IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9kNTBlYmRmYS01OGVi
-        LTRkNGEtYWNhZS1jNzY2OWRkMGVmNmUvIiwgInRhc2tfaWQiOiAiZDUwZWJk
-        ZmEtNThlYi00ZDRhLWFjYWUtYzc2NjlkZDBlZjZlIn0sIHsiX2hyZWYiOiAi
-        L3B1bHAvYXBpL3YyL3Rhc2tzL2UxZmQ0NGIzLTAyODgtNDllMy1hZThmLTcw
-        N2JiYWU1M2QzZC8iLCAidGFza19pZCI6ICJlMWZkNDRiMy0wMjg4LTQ5ZTMt
-        YWU4Zi03MDdiYmFlNTNkM2QifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1
-        bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJp
-        dGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
-        TklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90
-        YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBt
-        X2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNf
-        dG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
-        c2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tZGV2Ym94LmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
-        aW1wb3J0ZXIiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4
-        Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMzowNjow
-        NVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6
-        ICIyMDE2LTAyLTA0VDIzOjA2OjA2WiIsICJ0cmFjZWJhY2siOiBudWxsLCAi
-        c3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In19LCAiYWRkZWRfY291bnQiOiAwLCAiZXJyb3JfbWVzc2FnZSI6IG51bGws
-        ICJ1cGRhdGVkX2NvdW50IjogMTUsICJkZXRhaWxzIjogeyJjb250ZW50Ijog
-        eyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90
-        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwg
-        ImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJk
-        cnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWls
-        cyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJpZCI6ICI1NmIzZDk1ZTg0YTA5
-        YzA3ZGE5Nzk5N2IiLCAicmVzdWx0IjogInN1Y2Nlc3MifSwgImVycm9yIjog
-        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzZDk1ZDg2ODBiNWNhNWM4NDIx
-        OTMifSwgImlkIjogIjU2YjNkOTVkODRhMDljMDdkYmY0ZDc3YiJ9LCB7ImV4
-        Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFu
-        YWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
-        L3Rhc2tzLzc2ZDI5NmM1LWYzOTUtNDM2Yi05YmM0LWY2MjU5ZWY4OGIxNi8i
-        LCAidGFza19pZCI6ICI3NmQyOTZjNS1mMzk1LTQzNmItOWJjNC1mNjI1OWVm
-        ODhiMTYiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIs
-        ICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAy
-        LTA0VDIzOjA2OjA5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRf
-        dGltZSI6ICIyMDE2LTAyLTA0VDIzOjA2OjA4WiIsICJ0cmFjZWJhY2siOiBu
-        dWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92
-        Mi90YXNrcy9iMTFmMGM0MC1mMzU3LTRhMGUtOTQxMy1mYzE1ODkyYWVmNzQv
-        IiwgInRhc2tfaWQiOiAiYjExZjBjNDAtZjM1Ny00YTBlLTk0MTMtZmMxNTg5
-        MmFlZjc0In0sIHsiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzIyNGZj
-        M2NhLTIzZDAtNGE0YS05ZGI2LTBmMGJkZjYyMmY1My8iLCAidGFza19pZCI6
-        ICIyMjRmYzNjYS0yM2QwLTRhNGEtOWRiNi0wZjBiZGY2MjJmNTMifV0sICJw
-        cm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6
-        IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3Rv
-        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAs
-        ICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAi
-        ZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFp
-        bHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
-        c3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklO
-        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9
-        LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVk
-        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0w
-        QGthdGVsbG8tZGV2Ym94LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsiaW1w
-        b3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiaW1wb3J0ZXJfaWQi
-        OiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lk
-        IjogIkZlZG9yYV8xNyIsICJyZW1vdmVkX2NvdW50IjogMCwgInN0YXJ0ZWQi
-        OiAiMjAxNi0wMi0wNFQyMzowNjowOFoiLCAiX25zIjogInJlcG9fc3luY19y
-        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA0VDIzOjA2OjA5WiIs
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAi
-        ZXJyb3JfbWVzc2FnZSI6IG51bGwsICJ1cGRhdGVkX2NvdW50IjogMTUsICJk
-        ZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1z
-        X2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
-        bCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0s
-        ICJpZCI6ICI1NmIzZDk2MTg0YTA5YzA3ZGE5Nzk5OTkiLCAicmVzdWx0Ijog
-        InN1Y2Nlc3MifSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmIzZDk2MDg2ODBiNWNhNWM4NDIxYTMifSwgImlkIjogIjU2YjNkOTYwODRh
-        MDljMDdkYmY0ZDc5NCJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5
-        cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAi
-        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzQ0ZmM0NjNlLTJlMTMtNGEx
-        Mi04N2RmLTFkYjAzNWU0MDI1Mi8iLCAidGFza19pZCI6ICI0NGZjNDYzZS0y
-        ZTEzLTRhMTItODdkZi0xZGIwMzVlNDAyNTIiLCAidGFncyI6IFsicHVscDpy
-        ZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJm
-        aW5pc2hfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjA2OjEyWiIsICJfbnMiOiAi
-        dGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjA2
-        OjExWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7
-        Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8zNzI0ODRmOS0wNjA4LTRi
-        MDQtYmMwMi1mMDIzODcxYmExODkvIiwgInRhc2tfaWQiOiAiMzcyNDg0Zjkt
-        MDYwOC00YjA0LWJjMDItZjAyMzg3MWJhMTg5In0sIHsiX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzL2I5OGQ3NDA4LTY2NTQtNDAzNS05M2RmLWFjZDdk
-        MDQ2ZWY5Ny8iLCAidGFza19pZCI6ICJiOThkNzQwOC02NjU0LTQwMzUtOTNk
-        Zi1hY2Q3ZDA0NmVmOTcifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
-        bXBvcnRlciI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVt
-        c19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwi
-        OiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2Rv
-        bmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
-        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19
-        fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tZGV2Ym94LmV4YW1wbGUu
-        Y29tIiwgInJlc3VsdCI6IHsiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2Vw
-        dGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJyZW1vdmVk
-        X2NvdW50IjogMCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMzowNjoxMVoi
-        LCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIy
-        MDE2LTAyLTA0VDIzOjA2OjEyWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Vt
-        bWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNv
-        bXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19
-        LCAiYWRkZWRfY291bnQiOiAwLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJ1
-        cGRhdGVkX2NvdW50IjogMTUsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJz
-        aXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwi
-        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRl
-        dGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBt
-        X3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6
-        IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
-        YnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJl
-        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifX0sICJpZCI6ICI1NmIzZDk2NDg0YTA5YzA3
-        ZGE5Nzk5YjciLCAicmVzdWx0IjogInN1Y2Nlc3MifSwgImVycm9yIjogbnVs
-        bCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzZDk2Mzg2ODBiNWNhNWM4NDIxYjMi
-        fSwgImlkIjogIjU2YjNkOTYzODRhMDljMDdkYmY0ZDdhZCJ9LCB7ImV4Y2Vw
-        dGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdl
-        cnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzVhOWNhNGYzLWRhZjgtNGZjZi04YjcwLTFkMWVlYzJkZGFiMi8iLCAi
-        dGFza19pZCI6ICI1YTljYTRmMy1kYWY4LTRmY2YtOGI3MC0xZDFlZWMyZGRh
-        YjIiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJw
-        dWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA0
-        VDIzOjA2OjE0WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGlt
-        ZSI6ICIyMDE2LTAyLTA0VDIzOjA2OjE0WiIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90
-        YXNrcy83NzdhYTFlNC1jMjQyLTRkM2YtOWRjYS1iY2Q0OWI3M2M5MWYvIiwg
-        InRhc2tfaWQiOiAiNzc3YWExZTQtYzI0Mi00ZDNmLTlkY2EtYmNkNDliNzNj
-        OTFmIn0sIHsiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2EyNDNkOGVk
-        LTJkNTctNGZiZS04MWZiLWE1NjI1YzU2MmE2NC8iLCAidGFza19pZCI6ICJh
-        MjQzZDhlZC0yZDU3LTRmYmUtODFmYi1hNTYyNWM1NjJhNjQifV0sICJwcm9n
-        cmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsi
-        c2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFs
-        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJk
-        ZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJw
-        bV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMi
-        OiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3Ry
-        aWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGth
-        dGVsbG8tZGV2Ym94LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsiaW1wb3J0
-        ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiaW1wb3J0ZXJfaWQiOiAi
-        eXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
-        IkZlZG9yYV8xNyIsICJyZW1vdmVkX2NvdW50IjogMCwgInN0YXJ0ZWQiOiAi
-        MjAxNi0wMi0wNFQyMzowNjoxNFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1
-        bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA0VDIzOjA2OjE0WiIsICJ0
-        cmFjZWJhY2siOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJ1cGRhdGVkX2NvdW50IjogMTUsICJkZXRh
-        aWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJp
-        ZCI6ICI1NmIzZDk2Njg0YTA5YzA3ZGE5Nzk5ZDUiLCAicmVzdWx0IjogInN1
-        Y2Nlc3MifSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIz
-        ZDk2Njg2ODBiNWNhNWM4NDIxYzMifSwgImlkIjogIjU2YjNkOTY2ODRhMDlj
-        MDdkYmY0ZDdjMyJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUi
-        OiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hy
-        ZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2ZkOWY3MWUyLTgzZjctNGM2Zi1i
-        YzU0LWYzNjU5YWE2YzliZS8iLCAidGFza19pZCI6ICJmZDlmNzFlMi04M2Y3
-        LTRjNmYtYmM1NC1mMzY1OWFhNmM5YmUiLCAidGFncyI6IFsicHVscDpyZXBv
-        c2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjA2OjE3WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjA2OjE3
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9o
-        cmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8zYThmZjJmZS0yNmJiLTQ5ZjUt
-        YmJmOS1lNzI2M2FhNDRiNWEvIiwgInRhc2tfaWQiOiAiM2E4ZmYyZmUtMjZi
-        Yi00OWY1LWJiZjktZTcyNjNhYTQ0YjVhIn0sIHsiX2hyZWYiOiAiL3B1bHAv
-        YXBpL3YyL3Rhc2tzLzcyMGQyY2E1LTQ2N2MtNGVlYy05NGFlLWVmYTE1MTRh
-        YTMyZi8iLCAidGFza19pZCI6ICI3MjBkMmNhNS00NjdjLTRlZWMtOTRhZS1l
-        ZmExNTE0YWEzMmYifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
-        cnRlciI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19s
-        ZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
-        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
-        OiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwi
-        OiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwg
-        InN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVk
-        X3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tZGV2Ym94LmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IHsiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
-        ZXIiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlv
-        biI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJyZW1vdmVkX2Nv
-        dW50IjogMCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMzowNjoxN1oiLCAi
-        X25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2
-        LTAyLTA0VDIzOjA2OjE3WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3VtbWFy
-        eSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBz
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAi
-        YWRkZWRfY291bnQiOiAwLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJ1cGRh
-        dGVkX2NvdW50IjogMTUsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXpl
-        X3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
-        bHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3Rv
-        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
-        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
-        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJpZCI6ICI1NmIzZDk2OTg0YTA5YzA3ZGE5
-        Nzk5ZjMiLCAicmVzdWx0IjogInN1Y2Nlc3MifSwgImVycm9yIjogbnVsbCwg
-        Il9pZCI6IHsiJG9pZCI6ICI1NmIzZDk2OTg2ODBiNWNhNWM4NDIxZDMifSwg
-        ImlkIjogIjU2YjNkOTY5ODRhMDljMDdkYmY0ZDdkYyJ9LCB7ImV4Y2VwdGlv
-        biI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMu
-        cmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tz
-        LzgzY2UyODFiLTgzM2ItNDFlYy1iY2ZjLTZlNDE5MWZmZjEzYy8iLCAidGFz
-        a19pZCI6ICI4M2NlMjgxYi04MzNiLTQxZWMtYmNmYy02ZTQxOTFmZmYxM2Mi
-        LCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxw
-        OmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA0VDIz
-        OjA2OjUyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6
-        ICIyMDE2LTAyLTA0VDIzOjA2OjUyWiIsICJ0cmFjZWJhY2siOiBudWxsLCAi
-        c3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNr
-        cy8yODFjMzQ5NC1lMTJlLTRhODYtOTQ0Yi1iMmU5MzQ4ODM0MmQvIiwgInRh
-        c2tfaWQiOiAiMjgxYzM0OTQtZTEyZS00YTg2LTk0NGItYjJlOTM0ODgzNDJk
-        In0sIHsiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2FjY2U0OGU5LWQ0
-        ZGMtNGUxNi1iZDhkLTAzMWY2ZmQ0MGFiNC8iLCAidGFza19pZCI6ICJhY2Nl
-        NDhlOS1kNGRjLTRlMTYtYmQ4ZC0wMzFmNmZkNDBhYjQifV0sICJwcm9ncmVz
-        c19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsic2l6
-        ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjog
-        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRh
-        aWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90
-        b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBb
-        XX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
-        dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJy
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
-        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVs
-        bG8tZGV2Ym94LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsiaW1wb3J0ZXJf
-        dHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiaW1wb3J0ZXJfaWQiOiAieXVt
-        X2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZl
-        ZG9yYV8xNyIsICJyZW1vdmVkX2NvdW50IjogMCwgInN0YXJ0ZWQiOiAiMjAx
-        Ni0wMi0wNFQyMzowNjo1MloiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRz
-        IiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA0VDIzOjA2OjUyWiIsICJ0cmFj
-        ZWJhY2siOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJy
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAiZXJyb3Jf
-        bWVzc2FnZSI6IG51bGwsICJ1cGRhdGVkX2NvdW50IjogMTUsICJkZXRhaWxz
-        IjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQi
-        OiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        c2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJy
-        cG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
-        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJpZCI6
-        ICI1NmIzZDk4Yzg0YTA5YzA3ZGE5NzlhMWYiLCAicmVzdWx0IjogInN1Y2Nl
-        c3MifSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzZDk4
-        Yzg2ODBiNWNhNWM4NDIxZjcifSwgImlkIjogIjU2YjNkOThjODRhMDljMDdk
-        YmY0ZDgxMiJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAi
-        cHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYi
-        OiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzlkZTA0YjY2LWNmOTItNGI5Ni1iY2Zl
-        LWI3ZWIxYjAxMDg1Yi8iLCAidGFza19pZCI6ICI5ZGUwNGI2Ni1jZjkyLTRi
-        OTYtYmNmZS1iN2ViMWIwMTA4NWIiLCAidGFncyI6IFsicHVscDpyZXBvc2l0
-        b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hf
-        dGltZSI6ICIyMDE2LTAyLTA0VDIzOjA2OjU1WiIsICJfbnMiOiAidGFza19z
-        dGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjA2OjU1WiIs
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi90YXNrcy8yNTJiNjFmNy02ZmQ4LTRiZDgtOTk4
-        NC0yYjRhNzFhM2NkZTQvIiwgInRhc2tfaWQiOiAiMjUyYjYxZjctNmZkOC00
-        YmQ4LTk5ODQtMmI0YTcxYTNjZGU0In0sIHsiX2hyZWYiOiAiL3B1bHAvYXBp
-        L3YyL3Rhc2tzL2QyYTBiYTU4LTRjMDEtNDIzMi1hNDUzLTkwNzAyMzYxMGQ5
-        NC8iLCAidGFza19pZCI6ICJkMmEwYmE1OC00YzAxLTQyMzItYTQ1My05MDcw
-        MjM2MTBkOTQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRl
-        ciI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0
-        IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        InNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAi
-        cnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAw
-        fSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0
-        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
-        c291cmNlX3dvcmtlci0wQGthdGVsbG8tZGV2Ym94LmV4YW1wbGUuY29tIiwg
-        InJlc3VsdCI6IHsiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIi
-        LCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6
-        IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJyZW1vdmVkX2NvdW50
-        IjogMCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMzowNjo1NVoiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAy
-        LTA0VDIzOjA2OjU1WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3VtbWFyeSI6
-        IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
-        ZWRfY291bnQiOiAwLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJ1cGRhdGVk
-        X2NvdW50IjogMTUsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3Rv
-        dGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAi
-        c3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMi
-        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
-        IjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwg
-        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX0sICJpZCI6ICI1NmIzZDk4Zjg0YTA5YzA3ZGE5Nzlh
-        M2QiLCAicmVzdWx0IjogInN1Y2Nlc3MifSwgImVycm9yIjogbnVsbCwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1NmIzZDk4Zjg2ODBiNWNhNWM4NDIyMDcifSwgImlk
-        IjogIjU2YjNkOThmODRhMDljMDdkYmY0ZDgyYiJ9LCB7ImV4Y2VwdGlvbiI6
-        IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVw
-        by5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2Yx
-        YzdjZjkyLWYzOWUtNGVlNi1hZTZhLWNmODEyOGQ2YzRhZC8iLCAidGFza19p
-        ZCI6ICJmMWM3Y2Y5Mi1mMzllLTRlZTYtYWU2YS1jZjgxMjhkNmM0YWQiLCAi
-        dGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFj
-        dGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjA2
-        OjU4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIy
-        MDE2LTAyLTA0VDIzOjA2OjU4WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bh
-        d25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9l
-        MDcxM2UwZC04YzEzLTQyMTYtODUxOS1kNjA5MjkxYTk5MjcvIiwgInRhc2tf
-        aWQiOiAiZTA3MTNlMGQtOGMxMy00MjE2LTg1MTktZDYwOTI5MWE5OTI3In0s
-        IHsiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzM0M2UzMjEzLTAxYTkt
-        NDE0My04YTMzLTM4OTQ4N2QyZTQ1ZS8iLCAidGFza19pZCI6ICIzNDNlMzIx
-        My0wMWE5LTQxNDMtOGEzMy0zODk0ODdkMmU0NWUifV0sICJwcm9ncmVzc19y
-        ZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsic2l6ZV90
-        b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxz
-        IjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3Rh
-        bCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0s
-        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
-        biI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8t
-        ZGV2Ym94LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsiaW1wb3J0ZXJfdHlw
-        ZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2lt
-        cG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9y
-        YV8xNyIsICJyZW1vdmVkX2NvdW50IjogMCwgInN0YXJ0ZWQiOiAiMjAxNi0w
-        Mi0wNFQyMzowNjo1OFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwg
-        ImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA0VDIzOjA2OjU4WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAiZXJyb3JfbWVz
-        c2FnZSI6IG51bGwsICJ1cGRhdGVkX2NvdW50IjogMTUsICJkZXRhaWxzIjog
-        eyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAw
-        LCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6
-        ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1f
-        ZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVt
-        c19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJpZCI6ICI1
-        NmIzZDk5Mjg0YTA5YzA3ZGE5NzlhNWIiLCAicmVzdWx0IjogInN1Y2Nlc3Mi
-        fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzZDk5Mjg2
-        ODBiNWNhNWM4NDIyMTcifSwgImlkIjogIjU2YjNkOTkyODRhMDljMDdkYmY0
-        ZDg0NCJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVs
-        cC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAi
-        L3B1bHAvYXBpL3YyL3Rhc2tzLzlmODUyMGZkLWQ3NzktNDRlNS1hODdjLTQz
-        MTI5NjY4YmVmNC8iLCAidGFza19pZCI6ICI5Zjg1MjBmZC1kNzc5LTQ0ZTUt
-        YTg3Yy00MzEyOTY2OGJlZjQiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5
-        OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGlt
-        ZSI6ICIyMDE2LTAyLTA0VDIzOjM0OjA3WiIsICJfbnMiOiAidGFza19zdGF0
-        dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjM0OjA3WiIsICJ0
-        cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjog
-        Ii9wdWxwL2FwaS92Mi90YXNrcy8zOTk2ZGE3ZC01ZGM5LTQ5ZTAtYjU2Ny1k
-        ZWFmMThjZjI0MmIvIiwgInRhc2tfaWQiOiAiMzk5NmRhN2QtNWRjOS00OWUw
-        LWI1NjctZGVhZjE4Y2YyNDJiIn0sIHsiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
-        L3Rhc2tzL2UyZjQ3MDI5LTQ4NDEtNGIzNy05OTk5LTM5ZDAyOGRjMjUyNy8i
-        LCAidGFza19pZCI6ICJlMmY0NzAyOS00ODQxLTRiMzctOTk5OS0zOWQwMjhk
-        YzI1MjcifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6
-        IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0Ijog
-        MCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNp
-        emVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBt
-        X2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwg
-        ImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAi
-        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0wQGthdGVsbG8tZGV2Ym94LmV4YW1wbGUuY29tIiwgInJl
-        c3VsdCI6IHsiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJyZW1vdmVkX2NvdW50Ijog
-        MCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMzozNDowN1oiLCAiX25zIjog
-        InJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA0
-        VDIzOjM0OjA3WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3VtbWFyeSI6IHsi
-        Y29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRf
-        Y291bnQiOiAwLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJ1cGRhdGVkX2Nv
-        dW50IjogMTUsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFs
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7
-        InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjog
-        MCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNv
-        bXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjog
-        eyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifX0sICJpZCI6ICI1NmIzZGZlZjg0YTA5YzA3ZGE5NzlhNzki
-        LCAicmVzdWx0IjogInN1Y2Nlc3MifSwgImVycm9yIjogbnVsbCwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NmIzZGZlZjg2ODBiNWNhNWM4NDIyNTYifSwgImlkIjog
-        IjU2YjNkZmVmODRhMDljMDdkYmY0ZDg4NyJ9LCB7ImV4Y2VwdGlvbiI6IG51
-        bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5z
-        eW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzBkZTdh
-        ZmZlLWUwYjYtNDc4YS1hYzdhLWQ5YmY5NzI1NzAwZi8iLCAidGFza19pZCI6
-        ICIwZGU3YWZmZS1lMGI2LTQ3OGEtYWM3YS1kOWJmOTcyNTcwMGYiLCAidGFn
-        cyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlv
-        bjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjM0OjI1
-        WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
-        LTAyLTA0VDIzOjM0OjI1WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
-        ZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy80NTUz
-        ZjBhMy0zMTJkLTRjYTQtYmFmMC05NmI1YjQxNjRhNTAvIiwgInRhc2tfaWQi
-        OiAiNDU1M2YwYTMtMzEyZC00Y2E0LWJhZjAtOTZiNWI0MTY0YTUwIn0sIHsi
-        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzZkMTY2NWMxLWRjNjctNGNm
-        Ny04MjRlLTQyNDIyZTdhNTQzOS8iLCAidGFza19pZCI6ICI2ZDE2NjVjMS1k
-        YzY3LTRjZjctODI0ZS00MjQyMmU3YTU0MzkifV0sICJwcm9ncmVzc19yZXBv
-        cnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsic2l6ZV90b3Rh
-        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
-        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
-        IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9u
-        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tZGV2
-        Ym94LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsiaW1wb3J0ZXJfdHlwZV9p
-        ZCI6ICJ5dW1faW1wb3J0ZXIiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9y
-        dGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8x
-        NyIsICJyZW1vdmVkX2NvdW50IjogMCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0w
-        NFQyMzozNDoyNVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
-        bXBsZXRlZCI6ICIyMDE2LTAyLTA0VDIzOjM0OjI1WiIsICJ0cmFjZWJhY2si
-        OiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAiZXJyb3JfbWVzc2Fn
-        ZSI6IG51bGwsICJ1cGRhdGVkX2NvdW50IjogMTUsICJkZXRhaWxzIjogeyJj
-        b250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAi
-        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9s
-        ZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9u
-        ZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJy
-        b3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
-        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJpZCI6ICI1NmIz
-        ZTAwMTg0YTA5YzA3ZGE5NzlhOWIiLCAicmVzdWx0IjogInN1Y2Nlc3MifSwg
-        ImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzZTAwMDg2ODBi
-        NWNhNWM4NDIyN2UifSwgImlkIjogIjU2YjNlMDAwODRhMDljMDdkYmY0ZDhj
-        MyJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5z
-        ZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzLzRiNTg3MmU1LTdiYzMtNDcxNS1iYTU2LWM3M2I1
-        NmRhMTJmOS8iLCAidGFza19pZCI6ICI0YjU4NzJlNS03YmMzLTQ3MTUtYmE1
-        Ni1jNzNiNTZkYTEyZjkiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZl
-        ZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6
-        ICIyMDE2LTAyLTA0VDIzOjM0OjI4WiIsICJfbnMiOiAidGFza19zdGF0dXMi
-        LCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjM0OjI4WiIsICJ0cmFj
-        ZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9kODlmOTJjZi1iYTdkLTRmMDYtYWI2OS0xZWU1
-        ZDFhOGUzZTQvIiwgInRhc2tfaWQiOiAiZDg5ZjkyY2YtYmE3ZC00ZjA2LWFi
-        NjktMWVlNWQxYThlM2U0In0sIHsiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzg4ZjRmZGQxLWY2MmYtNGEwYi04YWE4LWYwMTM4YjMyMzM1OC8iLCAi
-        dGFza19pZCI6ICI4OGY0ZmRkMS1mNjJmLTRhMGItOGFhOC1mMDEzOGIzMjMz
-        NTgifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsi
-        Y29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwg
-        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVf
-        bGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2Rv
-        bmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVy
-        cm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNf
-        bGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjog
-        ImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
-        X3dvcmtlci0wQGthdGVsbG8tZGV2Ym94LmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IHsiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiaW1w
-        b3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGws
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJyZW1vdmVkX2NvdW50IjogMCwg
-        InN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMzozNDoyOFoiLCAiX25zIjogInJl
-        cG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA0VDIz
-        OjM0OjI4WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3VtbWFyeSI6IHsiY29u
-        dGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
-        bnQiOiAwLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJ1cGRhdGVkX2NvdW50
-        IjogMTUsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjog
-        MCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJw
-        bV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwg
-        ImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBz
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJp
-        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifX0sICJpZCI6ICI1NmIzZTAwNDg0YTA5YzA3ZGE5NzlhYjkiLCAi
-        cmVzdWx0IjogInN1Y2Nlc3MifSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
-        JG9pZCI6ICI1NmIzZTAwNDg2ODBiNWNhNWM4NDIyOGYifSwgImlkIjogIjU2
-        YjNlMDA0ODRhMDljMDdkYmY0ZDhkOSJ9LCB7ImV4Y2VwdGlvbiI6IG51bGws
-        ICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5j
-        LnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzU2OTQ3NjFj
-        LWYwZTAtNGM1YS04NDc1LWQ4NmNjNDMyYmM1YS8iLCAidGFza19pZCI6ICI1
-        Njk0NzYxYy1mMGUwLTRjNWEtODQ3NS1kODZjYzQzMmJjNWEiLCAidGFncyI6
-        IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpz
-        eW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjM0OjMxWiIs
-        ICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAy
-        LTA0VDIzOjM0OjMxWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90
-        YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82NjhmMGU4
-        Zi1iZGFkLTQ2ZjctODJjYi1lY2M5ZjE5MjE2NDQvIiwgInRhc2tfaWQiOiAi
-        NjY4ZjBlOGYtYmRhZC00NmY3LTgyY2ItZWNjOWYxOTIxNjQ0In0sIHsiX2hy
-        ZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2FlZTUxYmU3LTFlZWItNDMzMy1i
-        MDA3LWMzMjYxNmZlNTIxMy8iLCAidGFza19pZCI6ICJhZWU1MWJlNy0xZWVi
-        LTQzMzMtYjAwNy1jMzI2MTZmZTUyMTMifV0sICJwcm9ncmVzc19yZXBvcnQi
-        OiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6
-        IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21w
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
-        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tZGV2Ym94
-        LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsiaW1wb3J0ZXJfdHlwZV9pZCI6
-        ICJ5dW1faW1wb3J0ZXIiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
-        ICJyZW1vdmVkX2NvdW50IjogMCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQy
-        MzozNDozMVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBs
-        ZXRlZCI6ICIyMDE2LTAyLTA0VDIzOjM0OjMxWiIsICJ0cmFjZWJhY2siOiBu
-        dWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
-        YnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAiZXJyb3JfbWVzc2FnZSI6
-        IG51bGwsICJ1cGRhdGVkX2NvdW50IjogMTUsICJkZXRhaWxzIjogeyJjb250
-        ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRl
-        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0
-        IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6
-        IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0
-        IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
-        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJpZCI6ICI1NmIzZTAw
-        Nzg0YTA5YzA3ZGE5NzlhZDciLCAicmVzdWx0IjogInN1Y2Nlc3MifSwgImVy
-        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzZTAwNzg2ODBiNWNh
-        NWM4NDIyYTAifSwgImlkIjogIjU2YjNlMDA3ODRhMDljMDdkYmY0ZDhmMiJ9
-        LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2
-        ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAv
-        YXBpL3YyL3Rhc2tzLzNkNDJmODE2LWU4YmQtNGFiZS05Njc0LWMzNDVlNzEz
-        MjUwZC8iLCAidGFza19pZCI6ICIzZDQyZjgxNi1lOGJkLTRhYmUtOTY3NC1j
-        MzQ1ZTcxMzI1MGQiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9y
-        YV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTAyLTA0VDIzOjM0OjM0WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjM0OjM0WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxw
-        L2FwaS92Mi90YXNrcy81ODhkZDM3MS01NTBlLTQ1ZWUtOGNhMi1lMzNhODM0
-        YTBhMjIvIiwgInRhc2tfaWQiOiAiNTg4ZGQzNzEtNTUwZS00NWVlLThjYTIt
-        ZTMzYTgzNGEwYTIyIn0sIHsiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tz
-        LzJhZjc5MWZhLWQ5ODctNDJhMC05MzM1LWNjYzk5Y2M1NzhkNy8iLCAidGFz
-        a19pZCI6ICIyYWY3OTFmYS1kOTg3LTQyYTAtOTMzNS1jY2M5OWNjNTc4ZDci
-        fV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29u
-        dGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVm
-        dCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUi
-        OiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9y
-        X2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVm
-        dCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0
-        YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZp
-        bmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
-        cmtlci0wQGthdGVsbG8tZGV2Ym94LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
-        IHsiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiaW1wb3J0
-        ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJy
-        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJyZW1vdmVkX2NvdW50IjogMCwgInN0
-        YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMzozNDozNFoiLCAiX25zIjogInJlcG9f
-        c3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA0VDIzOjM0
-        OjM0WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVu
-        dCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0
-        YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQi
-        OiAwLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJ1cGRhdGVkX2NvdW50Ijog
-        MTUsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwg
-        Iml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90
-        b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRy
-        cG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVt
-        c190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifX0sICJpZCI6ICI1NmIzZTAwYTg0YTA5YzA3ZGE5NzlhZjUiLCAicmVz
-        dWx0IjogInN1Y2Nlc3MifSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmIzZTAwYTg2ODBiNWNhNWM4NDIyYjEifSwgImlkIjogIjU2YjNl
-        MDBhODRhMDljMDdkYmY0ZDkwYiJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0
-        YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5
-        bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzExNWIzNzVmLTk2
-        YWItNDI5Yy1iN2MyLWU3YzVhOTFmM2MwMC8iLCAidGFza19pZCI6ICIxMTVi
-        Mzc1Zi05NmFiLTQyOWMtYjdjMi1lN2M1YTkxZjNjMDAiLCAidGFncyI6IFsi
-        cHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5j
-        Il0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjM0OjM4WiIsICJf
-        bnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0
-        VDIzOjM0OjM3WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNr
-        cyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy80Y2UxYzYyZi00
-        MGQ1LTQ2NDYtYWQzOS1lOGY0Yzg2MzQ0YmUvIiwgInRhc2tfaWQiOiAiNGNl
-        MWM2MmYtNDBkNS00NjQ2LWFkMzktZThmNGM4NjM0NGJlIn0sIHsiX2hyZWYi
-        OiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2IzNGM2M2NiLWY4YmItNGUxZi04ZDY0
-        LTUzMjA1ZDY5OTI5OS8iLCAidGFza19pZCI6ICJiMzRjNjNjYi1mOGJiLTRl
-        MWYtOGQ2NC01MzIwNWQ2OTkyOTkifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAs
-        ICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjog
-        IkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1f
-        dG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJk
-        cnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRl
-        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tZGV2Ym94LmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5
-        dW1faW1wb3J0ZXIiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwg
-        ImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJy
-        ZW1vdmVkX2NvdW50IjogMCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMzoz
-        NDozN1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDE2LTAyLTA0VDIzOjM0OjM4WiIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
-        aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAiZXJyb3JfbWVzc2FnZSI6IG51
-        bGwsICJ1cGRhdGVkX2NvdW50IjogMTUsICJkZXRhaWxzIjogeyJjb250ZW50
-        IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNf
-        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0Ijog
-        MCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAs
-        ICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0
-        YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJpZCI6ICI1NmIzZTAwZTg0
-        YTA5YzA3ZGE5NzliMTMiLCAicmVzdWx0IjogInN1Y2Nlc3MifSwgImVycm9y
-        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzZTAwZDg2ODBiNWNhNWM4
-        NDIyYzIifSwgImlkIjogIjU2YjNlMDBkODRhMDljMDdkYmY0ZDkyNCJ9LCB7
-        ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIu
-        bWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
-        L3YyL3Rhc2tzL2Y1ZTAzNDZjLTJlZjctNDFmOS1hNzVmLTIyNzlmY2U0ODNi
-        ZS8iLCAidGFza19pZCI6ICJmNWUwMzQ2Yy0yZWY3LTQxZjktYTc1Zi0yMjc5
-        ZmNlNDgzYmUiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8x
-        NyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2
-        LTAyLTA0VDIzOjM0OjQxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3Rh
-        cnRfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjM0OjQxWiIsICJ0cmFjZWJhY2si
-        OiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80MTVkMTYzYS1lMDA1LTQwN2QtYjlhZC0yZWY4ZDNiNzM4
-        M2UvIiwgInRhc2tfaWQiOiAiNDE1ZDE2M2EtZTAwNS00MDdkLWI5YWQtMmVm
-        OGQzYjczODNlIn0sIHsiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzE4
-        ZDZmNDFlLWQyZGItNGY4ZC05ZDBmLTQwYTgzODI0ZDg0Yi8iLCAidGFza19p
-        ZCI6ICIxOGQ2ZjQxZS1kMmRiLTRmOGQtOWQwZi00MGE4MzgyNGQ4NGIifV0s
-        ICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVu
-        dCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1z
-        X3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6
-        IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAw
-        LCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2Rl
-        dGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        ImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6
-        IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0wQGthdGVsbG8tZGV2Ym94LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
-        aW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiaW1wb3J0ZXJf
-        aWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJyZW1vdmVkX2NvdW50IjogMCwgInN0YXJ0
-        ZWQiOiAiMjAxNi0wMi0wNFQyMzozNDo0MVoiLCAiX25zIjogInJlcG9fc3lu
-        Y19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA0VDIzOjM0OjQx
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAw
-        LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJ1cGRhdGVkX2NvdW50IjogMTUs
-        ICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0
-        ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklO
-        SVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3Rh
-        bCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1f
-        ZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
-        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX0sICJpZCI6ICI1NmIzZTAxMTg0YTA5YzA3ZGE5NzliMzEiLCAicmVzdWx0
-        IjogInN1Y2Nlc3MifSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
-        ICI1NmIzZTAxMTg2ODBiNWNhNWM4NDIyZDMifSwgImlkIjogIjU2YjNlMDEx
-        ODRhMDljMDdkYmY0ZDkzZCJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNr
-        X3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMi
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzRhODk2MjcwLWM0NTkt
-        NDQzMS05ZmI2LTQzYzY5ODk3MDdjNC8iLCAidGFza19pZCI6ICI0YTg5NjI3
-        MC1jNDU5LTQ0MzEtOWZiNi00M2M2OTg5NzA3YzQiLCAidGFncyI6IFsicHVs
-        cDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0s
-        ICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA0VDIzOjM0OjQ0WiIsICJfbnMi
-        OiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0VDIz
-        OjM0OjQ0WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6
-        IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9kYzI1NmU5Yi1jNTVi
-        LTQ1MDgtODlkNi03NGEzZDA5NWY4NWIvIiwgInRhc2tfaWQiOiAiZGMyNTZl
-        OWItYzU1Yi00NTA4LTg5ZDYtNzRhM2QwOTVmODViIn0sIHsiX2hyZWYiOiAi
-        L3B1bHAvYXBpL3YyL3Rhc2tzLzA5ZjUzNTBhLWVjMTUtNDFiNi05MmEyLTY3
-        N2YxNGM4MmQ0MC8iLCAidGFza19pZCI6ICIwOWY1MzUwYS1lYzE1LTQxYjYt
-        OTJhMi02NzdmMTRjODJkNDAifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1
-        bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJp
-        dGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
-        TklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90
-        YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBt
-        X2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNf
-        dG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
-        c2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGthdGVsbG8tZGV2Ym94LmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
-        aW1wb3J0ZXIiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4
-        Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJyZW1v
-        dmVkX2NvdW50IjogMCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMzozNDo0
-        NFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6
-        ICIyMDE2LTAyLTA0VDIzOjM0OjQ0WiIsICJ0cmFjZWJhY2siOiBudWxsLCAi
-        c3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In19LCAiYWRkZWRfY291bnQiOiAwLCAiZXJyb3JfbWVzc2FnZSI6IG51bGws
-        ICJ1cGRhdGVkX2NvdW50IjogMTUsICJkZXRhaWxzIjogeyJjb250ZW50Ijog
-        eyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90
-        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwg
-        ImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJk
-        cnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWls
-        cyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJpZCI6ICI1NmIzZTAxNDg0YTA5
-        YzA3ZGE5NzliNGYiLCAicmVzdWx0IjogInN1Y2Nlc3MifSwgImVycm9yIjog
-        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzZTAxNDg2ODBiNWNhNWM4NDIy
-        ZTQifSwgImlkIjogIjU2YjNlMDE0ODRhMDljMDdkYmY0ZDk1NiJ9LCB7ImV4
-        Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFu
-        YWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
-        L3Rhc2tzL2RlYjdiYjkwLTg5MDItNDExYS04YTNlLTNjM2Q5ZDk2NmNhZS8i
-        LCAidGFza19pZCI6ICJkZWI3YmI5MC04OTAyLTQxMWEtOGEzZS0zYzNkOWQ5
-        NjZjYWUiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIs
-        ICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAy
-        LTA0VDIzOjM0OjU5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRf
-        dGltZSI6ICIyMDE2LTAyLTA0VDIzOjM0OjU4WiIsICJ0cmFjZWJhY2siOiBu
-        dWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92
-        Mi90YXNrcy85MzdmYzAyYS04NDg5LTRlNWItOTA5OS01OWNkMDgyODUxMDkv
-        IiwgInRhc2tfaWQiOiAiOTM3ZmMwMmEtODQ4OS00ZTViLTkwOTktNTljZDA4
-        Mjg1MTA5In0sIHsiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzkxYmM1
-        ZDVhLTI3NjQtNDk5NC04Nzk5LWEyMWVkNmJmNTMyNi8iLCAidGFza19pZCI6
-        ICI5MWJjNWQ1YS0yNzY0LTQ5OTQtODc5OS1hMjFlZDZiZjUzMjYifV0sICJw
-        cm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6
-        IHsic2l6ZV90b3RhbCI6IDE3ODcyLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjog
-        OCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5p
-        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBrYXRlbGxvLWRldmJveC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7
-        ImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImltcG9ydGVy
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxsLCAicmVw
-        b19pZCI6ICJGZWRvcmFfMTciLCAicmVtb3ZlZF9jb3VudCI6IDAsICJzdGFy
-        dGVkIjogIjIwMTYtMDItMDRUMjM6MzQ6NTlaIiwgIl9ucyI6ICJyZXBvX3N5
-        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNFQyMzozNDo1
-        OVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50Ijog
-        MTUsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInVwZGF0ZWRfY291bnQiOiAw
-        LCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDE3ODcy
-        LCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBt
-        X3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1fdG90YWwiOiAwLCAi
-        ZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0
-        ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9fSwgImlkIjogIjU2YjNlMDIzODRhMDljMDdkYTk3OWI2ZCIsICJy
-        ZXN1bHQiOiAic3VjY2VzcyJ9LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
-        b2lkIjogIjU2YjNlMDIyODY4MGI1Y2E1Yzg0MjMxNiJ9LCAiaWQiOiAiNTZi
-        M2UwMjI4NGEwOWMwN2RiZjRkOWE0In0sIHsiZXhjZXB0aW9uIjogbnVsbCwg
-        InRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMu
-        c3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMjUwODc4ODkt
-        MzliZC00MGI2LWFkMGEtMTgwMWZkZDRlOGY3LyIsICJ0YXNrX2lkIjogIjI1
-        MDg3ODg5LTM5YmQtNDBiNi1hZDBhLTE4MDFmZGQ0ZThmNyIsICJ0YWdzIjog
-        WyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5
-        bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMDRUMjM6MzU6MDVaIiwg
-        Il9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDIt
-        MDRUMjM6MzU6MDVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rh
-        c2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzI3YjhhODIy
-        LWJlNzctNGIzMC1hZGZkLTVkOTE3MzU4OGUxNi8iLCAidGFza19pZCI6ICIy
-        N2I4YTgyMi1iZTc3LTRiMzAtYWRmZC01ZDkxNzM1ODhlMTYifSwgeyJfaHJl
-        ZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNWIyZDU4ZTQtMTRhOS00ZTZlLWIy
-        ZWUtYzQzZDdlNjk4NGRmLyIsICJ0YXNrX2lkIjogIjViMmQ1OGU0LTE0YTkt
-        NGU2ZS1iMmVlLWM0M2Q3ZTY5ODRkZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6
-        IHsieXVtX2ltcG9ydGVyIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjog
-        MCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJw
-        bV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwg
-        ImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBz
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJp
-        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifX19LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
-        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1kZXZib3gu
-        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJpbXBvcnRlcl90eXBlX2lkIjog
-        Inl1bV9pbXBvcnRlciIsICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIi
-        LCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        InJlbW92ZWRfY291bnQiOiAwLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA0VDIz
-        OjM1OjA1WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxl
-        dGVkIjogIjIwMTYtMDItMDRUMjM6MzU6MDVaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
-        dXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJlcnJvcl9tZXNzYWdlIjog
-        bnVsbCwgInVwZGF0ZWRfY291bnQiOiAxNSwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImlkIjogIjU2YjNlMDI5
-        ODRhMDljMDdkYTk3OWI4ZCIsICJyZXN1bHQiOiAic3VjY2VzcyJ9LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjNlMDI5ODY4MGI1Y2E1
-        Yzg0MjMzMiJ9LCAiaWQiOiAiNTZiM2UwMjk4NGEwOWMwN2RiZjRkOWQyIn0s
-        IHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZl
-        ci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvOGE4YWI5MjAtODVmNC00Mjk1LWJlNmEtNjUwMWZiZDMw
-        NjZlLyIsICJ0YXNrX2lkIjogIjhhOGFiOTIwLTg1ZjQtNDI5NS1iZTZhLTY1
-        MDFmYmQzMDY2ZSIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3Jh
-        XzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIw
-        MTYtMDItMDRUMjM6MzU6MDhaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
-        dGFydF90aW1lIjogIjIwMTYtMDItMDRUMjM6MzU6MDhaIiwgInRyYWNlYmFj
-        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAv
-        YXBpL3YyL3Rhc2tzLzEyY2E2NGQzLWEyYzUtNGMxNC1hMjc5LWNmMjZiYzE0
-        NWQ5NS8iLCAidGFza19pZCI6ICIxMmNhNjRkMy1hMmM1LTRjMTQtYTI3OS1j
-        ZjI2YmMxNDVkOTUifSwgeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3Mv
-        YThmNWFmYjYtYmRlYy00ZTA4LThjMWMtOTNjY2IwYjg3YmQyLyIsICJ0YXNr
-        X2lkIjogImE4ZjVhZmI2LWJkZWMtNGUwOC04YzFjLTkzY2NiMGI4N2JkMiJ9
-        XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVyIjogeyJjb250
-        ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRl
-        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0
-        IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6
-        IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0
-        IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
-        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAic3RhdGUiOiAiZmlu
-        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTBAa2F0ZWxsby1kZXZib3guZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
-        eyJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJpbXBvcnRl
-        cl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
-        cG9faWQiOiAiRmVkb3JhXzE3IiwgInJlbW92ZWRfY291bnQiOiAwLCAic3Rh
-        cnRlZCI6ICIyMDE2LTAyLTA0VDIzOjM1OjA4WiIsICJfbnMiOiAicmVwb19z
-        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMDRUMjM6MzU6
-        MDhaIiwgInRyYWNlYmFjayI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
-        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6
-        IDAsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInVwZGF0ZWRfY291bnQiOiAx
-        NSwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAi
-        aXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3Rv
-        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
-        bV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
-        X3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9fSwgImlkIjogIjU2YjNlMDJjODRhMDljMDdkYTk3OWJhYiIsICJyZXN1
-        bHQiOiAic3VjY2VzcyJ9LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjU2YjNlMDJjODY4MGI1Y2E1Yzg0MjM0MiJ9LCAiaWQiOiAiNTZiM2Uw
-        MmM4NGEwOWMwN2RiZjRkOWViIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRh
-        c2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3lu
-        YyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvOGRlZmNjYzYtNDIz
-        OS00MjEyLWI5MGYtOGIwMmVjZmY3Njc1LyIsICJ0YXNrX2lkIjogIjhkZWZj
-        Y2M2LTQyMzktNDIxMi1iOTBmLThiMDJlY2ZmNzY3NSIsICJ0YWdzIjogWyJw
-        dWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMi
-        XSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMDRUMjM6MzU6MTFaIiwgIl9u
-        cyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMDRU
-        MjM6MzU6MTFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
-        IjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2FmOTgxM2VlLWEz
-        MDItNGJjNS05MmE2LTIyNjM1NzgyYTkwMC8iLCAidGFza19pZCI6ICJhZjk4
-        MTNlZS1hMzAyLTRiYzUtOTJhNi0yMjYzNTc4MmE5MDAifSwgeyJfaHJlZiI6
-        ICIvcHVscC9hcGkvdjIvdGFza3MvMmNjNmUxNzUtYzU4YS00OGIyLWJiYzAt
-        MGRiNTdlMDI3MGVkLyIsICJ0YXNrX2lkIjogIjJjYzZlMTc1LWM1OGEtNDhi
-        Mi1iYmMwLTBkYjU3ZTAyNzBlZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsi
-        eXVtX2ltcG9ydGVyIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwg
-        Iml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90
-        b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRy
-        cG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVt
-        c190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifX19LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1kZXZib3guZXhh
-        bXBsZS5jb20iLCAicmVzdWx0IjogeyJpbXBvcnRlcl90eXBlX2lkIjogInl1
-        bV9pbXBvcnRlciIsICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
-        ZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInJl
-        bW92ZWRfY291bnQiOiAwLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA0VDIzOjM1
-        OjExWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVk
-        IjogIjIwMTYtMDItMDRUMjM6MzU6MTFaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRp
-        b24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJlcnJvcl9tZXNzYWdlIjogbnVs
-        bCwgInVwZGF0ZWRfY291bnQiOiAxNSwgImRldGFpbHMiOiB7ImNvbnRlbnQi
-        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
-        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
-        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
-        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJk
-        aXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJ
-        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAw
-        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImlkIjogIjU2YjNlMDJmODRh
-        MDljMDdkYTk3OWJjOSIsICJyZXN1bHQiOiAic3VjY2VzcyJ9LCAiZXJyb3Ii
-        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjNlMDJmODY4MGI1Y2E1Yzg0
-        MjM1MiJ9LCAiaWQiOiAiNTZiM2UwMmY4NGEwOWMwN2RiZjRkYTAxIn0sIHsi
-        ZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5t
-        YW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkv
-        djIvdGFza3MvOWJkZWQ1ZTUtOWZlZi00Yzg5LTkxMTMtNDI2ZGQ2MjRjMGVl
-        LyIsICJ0YXNrX2lkIjogIjliZGVkNWU1LTlmZWYtNGM4OS05MTEzLTQyNmRk
-        NjI0YzBlZSIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3
-        IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYt
-        MDItMDRUMjM6MzU6MTRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFy
-        dF90aW1lIjogIjIwMTYtMDItMDRUMjM6MzU6MTRaIiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBp
-        L3YyL3Rhc2tzL2M5M2VjMzkxLTNhMTQtNDBjMS05ZTgzLThkNDc2Y2VmMGY5
-        NS8iLCAidGFza19pZCI6ICJjOTNlYzM5MS0zYTE0LTQwYzEtOWU4My04ZDQ3
-        NmNlZjBmOTUifSwgeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNzU1
-        NmUxNWUtNTQzYy00NDZkLWIyNzEtZDllZjNkNDkzZmQ5LyIsICJ0YXNrX2lk
-        IjogIjc1NTZlMTVlLTU0M2MtNDQ2ZC1iMjcxLWQ5ZWYzZDQ5M2ZkOSJ9XSwg
-        InByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVyIjogeyJjb250ZW50
-        IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNf
-        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0Ijog
-        MCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAs
-        ICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0
-        YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
-        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAic3RhdGUiOiAiZmluaXNo
-        ZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTBAa2F0ZWxsby1kZXZib3guZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJp
-        bXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJpbXBvcnRlcl9p
-        ZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9f
-        aWQiOiAiRmVkb3JhXzE3IiwgInJlbW92ZWRfY291bnQiOiAwLCAic3RhcnRl
-        ZCI6ICIyMDE2LTAyLTA0VDIzOjM1OjE0WiIsICJfbnMiOiAicmVwb19zeW5j
-        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMDRUMjM6MzU6MTRa
-        IiwgInRyYWNlYmFjayI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50Ijog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAs
-        ICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInVwZGF0ZWRfY291bnQiOiAxNSwg
-        ImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
-        IjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9k
-        b25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
-        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        fSwgImlkIjogIjU2YjNlMDMyODRhMDljMDdkYTk3OWJlNyIsICJyZXN1bHQi
-        OiAic3VjY2VzcyJ9LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjog
-        IjU2YjNlMDMxODY4MGI1Y2E1Yzg0MjM2MiJ9LCAiaWQiOiAiNTZiM2UwMzI4
-        NGEwOWMwN2RiZjRkYTFhIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tf
-        dHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIs
-        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZGIyMzM4NDYtNjNmMS00
-        YzA2LWI0MTQtNTUyYjVkOTZmNWY0LyIsICJ0YXNrX2lkIjogImRiMjMzODQ2
-        LTYzZjEtNGMwNi1iNDE0LTU1MmI1ZDk2ZjVmNCIsICJ0YWdzIjogWyJwdWxw
-        OnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwg
-        ImZpbmlzaF90aW1lIjogIjIwMTYtMDItMDRUMjM6MzU6MTdaIiwgIl9ucyI6
-        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMDRUMjM6
-        MzU6MTdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
-        W3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2Q2NTQ3ZmY0LTAxMjgt
-        NGY5Zi04MDc3LTczMmZhMWUyMTFiYy8iLCAidGFza19pZCI6ICJkNjU0N2Zm
-        NC0wMTI4LTRmOWYtODA3Ny03MzJmYTFlMjExYmMifSwgeyJfaHJlZiI6ICIv
-        cHVscC9hcGkvdjIvdGFza3MvNjY4MDY1ZjUtNmJiYy00OTgyLTliMzktNWJm
-        YTVhYTQ1NGFjLyIsICJ0YXNrX2lkIjogIjY2ODA2NWY1LTZiYmMtNDk4Mi05
-        YjM5LTViZmE1YWE0NTRhYyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVt
-        X2ltcG9ydGVyIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0
-        ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklO
-        SVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3Rh
-        bCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1f
-        ZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
-        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX19LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVz
-        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1kZXZib3guZXhhbXBs
-        ZS5jb20iLCAicmVzdWx0IjogeyJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9p
-        bXBvcnRlciIsICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhj
-        ZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInJlbW92
-        ZWRfY291bnQiOiAwLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA0VDIzOjM1OjE3
-        WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjog
-        IjIwMTYtMDItMDRUMjM6MzU6MTdaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
-        dW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        Y29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX0sICJhZGRlZF9jb3VudCI6IDAsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwg
-        InVwZGF0ZWRfY291bnQiOiAxNSwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7
-        InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3Rh
-        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAi
-        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
-        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxz
-        IjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
-        cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwg
-        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImlkIjogIjU2YjNlMDM1ODRhMDlj
-        MDdkYTk3OWMwNSIsICJyZXN1bHQiOiAic3VjY2VzcyJ9LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjNlMDM0ODY4MGI1Y2E1Yzg0MjM3
-        MiJ9LCAiaWQiOiAiNTZiM2UwMzQ4NGEwOWMwN2RiZjRkYTMwIn0sIHsiZXhj
-        ZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5h
-        Z2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIv
-        dGFza3MvYTFkYTJjN2MtNzhjNi00YjM0LThlMzYtMTg4ZTBmZGMzNjM5LyIs
-        ICJ0YXNrX2lkIjogImExZGEyYzdjLTc4YzYtNGIzNC04ZTM2LTE4OGUwZmRj
-        MzYzOSIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3Iiwg
-        InB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDIt
-        MDRUMjM6MzU6MjBaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTYtMDItMDRUMjM6MzU6MTlaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
-        L3Rhc2tzLzIwNjE4NGNhLTFkMjctNDk2ZS05ZDIyLTljNjEwNDAxYjdiZC8i
-        LCAidGFza19pZCI6ICIyMDYxODRjYS0xZDI3LTQ5NmUtOWQyMi05YzYxMDQw
-        MWI3YmQifSwgeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMGRhYmNh
-        ZWEtZTQwZS00YWFjLWI3NzAtMDgyNWIyZWYyNzRmLyIsICJ0YXNrX2lkIjog
-        IjBkYWJjYWVhLWU0MGUtNGFhYy1iNzcwLTA4MjViMmVmMjc0ZiJ9XSwgInBy
-        b2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVyIjogeyJjb250ZW50Ijog
-        eyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90
-        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwg
-        ImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJk
-        cnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWls
-        cyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
-        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAic3RhdGUiOiAiZmluaXNoZWQi
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
-        a2F0ZWxsby1kZXZib3guZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJpbXBv
-        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJpbXBvcnRlcl9pZCI6
-        ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQi
-        OiAiRmVkb3JhXzE3IiwgInJlbW92ZWRfY291bnQiOiAwLCAic3RhcnRlZCI6
-        ICIyMDE2LTAyLTA0VDIzOjM1OjE5WiIsICJfbnMiOiAicmVwb19zeW5jX3Jl
-        c3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMDRUMjM6MzU6MjBaIiwg
-        InRyYWNlYmFjayI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJl
-        cnJvcl9tZXNzYWdlIjogbnVsbCwgInVwZGF0ZWRfY291bnQiOiAxNSwgImRl
-        dGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNf
-        bGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjog
-        MCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25l
-        IjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwg
-        ImlkIjogIjU2YjNlMDM4ODRhMDljMDdkYTk3OWMyMyIsICJyZXN1bHQiOiAi
-        c3VjY2VzcyJ9LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2
-        YjNlMDM3ODY4MGI1Y2E1Yzg0MjM4MiJ9LCAiaWQiOiAiNTZiM2UwMzc4NGEw
-        OWMwN2RiZjRkYTQ5In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlw
-        ZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJf
-        aHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvYzYwNjM0NTMtNjNiMS00ZGM3
-        LTg5MzMtMDczNjNmNjg5ZjM5LyIsICJ0YXNrX2lkIjogImM2MDYzNDUzLTYz
-        YjEtNGRjNy04OTMzLTA3MzYzZjY4OWYzOSIsICJ0YWdzIjogWyJwdWxwOnJl
-        cG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZp
-        bmlzaF90aW1lIjogIjIwMTYtMDItMDRUMjM6MzU6MjNaIiwgIl9ucyI6ICJ0
-        YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMDRUMjM6MzU6
-        MjNaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3si
-        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzU2ODA5ZWE0LTZiYzQtNGJk
-        OC05ZmE0LTU2MTllYjQ0NDM5Ni8iLCAidGFza19pZCI6ICI1NjgwOWVhNC02
-        YmM0LTRiZDgtOWZhNC01NjE5ZWI0NDQzOTYifSwgeyJfaHJlZiI6ICIvcHVs
-        cC9hcGkvdjIvdGFza3MvZTZmNjVhYjQtMmJiZC00MjMyLThmYWQtYTRiMDBl
-        NzYzOTVjLyIsICJ0YXNrX2lkIjogImU2ZjY1YWI0LTJiYmQtNDIzMi04ZmFk
-        LWE0YjAwZTc2Mzk1YyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2lt
-        cG9ydGVyIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1z
-        X2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
-        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
-        ZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
-        bCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
-        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
-        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1kZXZib3guZXhhbXBsZS5j
-        b20iLCAicmVzdWx0IjogeyJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0
-        aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInJlbW92ZWRf
-        Y291bnQiOiAwLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA0VDIzOjM1OjIzWiIs
-        ICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
-        MTYtMDItMDRUMjM6MzU6MjNaIiwgInRyYWNlYmFjayI6IG51bGwsICJzdW1t
-        YXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29t
-        cHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0s
-        ICJhZGRlZF9jb3VudCI6IDAsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInVw
-        ZGF0ZWRfY291bnQiOiAxNSwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNp
-        emVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6
-        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0
-        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
-        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjog
-        W119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
-        dXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVy
-        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImlkIjogIjU2YjNlMDNiODRhMDljMDdk
-        YTk3OWM0MSIsICJyZXN1bHQiOiAic3VjY2VzcyJ9LCAiZXJyb3IiOiBudWxs
-        LCAiX2lkIjogeyIkb2lkIjogIjU2YjNlMDNhODY4MGI1Y2E1Yzg0MjM5MiJ9
-        LCAiaWQiOiAiNTZiM2UwM2E4NGEwOWMwN2RiZjRkYTVmIn0sIHsiZXhjZXB0
-        aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vy
-        cy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFz
-        a3MvMzczZGNkMTctNWI1Yy00MmUwLWIyZWUtYTliYzI0N2U5ZWJiLyIsICJ0
-        YXNrX2lkIjogIjM3M2RjZDE3LTViNWMtNDJlMC1iMmVlLWE5YmMyNDdlOWVi
-        YiIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1
-        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMDRU
-        MjM6MzU6MjZaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
-        IjogIjIwMTYtMDItMDRUMjM6MzU6MjVaIiwgInRyYWNlYmFjayI6IG51bGws
-        ICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzcwMGI4MWJmLTA5ZWYtNDNhYy04ZDI3LWE5MjVkMDI0NGY0ZS8iLCAi
-        dGFza19pZCI6ICI3MDBiODFiZi0wOWVmLTQzYWMtOGQyNy1hOTI1ZDAyNDRm
-        NGUifSwgeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZThiMTFjZDYt
-        N2RiOS00YmQ1LTllYzUtNzYwNjJhZDAzOTc0LyIsICJ0YXNrX2lkIjogImU4
-        YjExY2Q2LTdkYjktNGJkNS05ZWM1LTc2MDYyYWQwMzk3NCJ9XSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVyIjogeyJjb250ZW50IjogeyJz
-        aXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwi
-        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRl
-        dGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBt
-        X3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6
-        IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
-        YnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJl
-        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifX19LCAic3RhdGUiOiAiZmluaXNoZWQiLCAi
-        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAa2F0
-        ZWxsby1kZXZib3guZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJpbXBvcnRl
-        cl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJpbXBvcnRlcl9pZCI6ICJ5
-        dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAi
-        RmVkb3JhXzE3IiwgInJlbW92ZWRfY291bnQiOiAwLCAic3RhcnRlZCI6ICIy
-        MDE2LTAyLTA0VDIzOjM1OjI1WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3Vs
-        dHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMDRUMjM6MzU6MjZaIiwgInRy
-        YWNlYmFjayI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJl
-        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJlcnJv
-        cl9tZXNzYWdlIjogbnVsbCwgInVwZGF0ZWRfY291bnQiOiAxNSwgImRldGFp
-        bHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVm
-        dCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwg
-        InJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
-        MH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
-        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImlk
-        IjogIjU2YjNlMDNlODRhMDljMDdkYTk3OWM1ZiIsICJyZXN1bHQiOiAic3Vj
-        Y2VzcyJ9LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjNl
-        MDNkODY4MGI1Y2E1Yzg0MjNhMiJ9LCAiaWQiOiAiNTZiM2UwM2Q4NGEwOWMw
-        N2RiZjRkYTc4In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6
-        ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJl
-        ZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvYTg1ZTI2NWEtOTk3NS00ZTRmLTg2
-        MTItOTY5ODhmNDI5OGExLyIsICJ0YXNrX2lkIjogImE4NWUyNjVhLTk5NzUt
-        NGU0Zi04NjEyLTk2OTg4ZjQyOThhMSIsICJ0YWdzIjogWyJwdWxwOnJlcG9z
-        aXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlz
-        aF90aW1lIjogIjIwMTYtMDItMDRUMjM6MzU6MjlaIiwgIl9ucyI6ICJ0YXNr
-        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMDRUMjM6MzU6Mjha
-        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hy
-        ZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzY3NDI5NmJlLWU5ODUtNDcwYS1h
-        ODZiLTJhYzIyNjU1NGNmNC8iLCAidGFza19pZCI6ICI2NzQyOTZiZS1lOTg1
-        LTQ3MGEtYTg2Yi0yYWMyMjY1NTRjZjQifSwgeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNzBjMzgwMWUtMDQ2Zi00YmUyLThlYzktYTg3M2M0NDBh
-        YzliLyIsICJ0YXNrX2lkIjogIjcwYzM4MDFlLTA0NmYtNGJlMi04ZWM5LWE4
-        NzNjNDQwYWM5YiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xl
-        ZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
-        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
-        IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
-        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
-        c3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRf
-        cmVzb3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1kZXZib3guZXhhbXBsZS5jb20i
-        LCAicmVzdWx0IjogeyJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRl
-        ciIsICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9u
-        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInJlbW92ZWRfY291
-        bnQiOiAwLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA0VDIzOjM1OjI5WiIsICJf
-        bnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYt
-        MDItMDRUMjM6MzU6MjlaIiwgInRyYWNlYmFjayI6IG51bGwsICJzdW1tYXJ5
-        IjogeyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJh
-        ZGRlZF9jb3VudCI6IDAsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInVwZGF0
-        ZWRfY291bnQiOiAxNSwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRp
-        b24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0
-        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9fSwgImlkIjogIjU2YjNlMDQxODRhMDljMDdkYTk3
-        OWM3ZCIsICJyZXN1bHQiOiAic3VjY2VzcyJ9LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjU2YjNlMDQwODY4MGI1Y2E1Yzg0MjNiMiJ9LCAi
-        aWQiOiAiNTZiM2UwNDA4NGEwOWMwN2RiZjRkYTkxIn0sIHsiZXhjZXB0aW9u
-        IjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5y
-        ZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3Mv
-        ODEzMzcyM2UtZDlmYi00YmY4LThlMmEtNGY0MDZmN2YwM2RjLyIsICJ0YXNr
-        X2lkIjogIjgxMzM3MjNlLWQ5ZmItNGJmOC04ZTJhLTRmNDA2ZjdmMDNkYyIs
-        ICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6
-        YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMDRUMjM6
-        MzU6MzJaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
-        IjIwMTYtMDItMDRUMjM6MzU6MzJaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
-        cGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tz
-        LzQxNGNmYzg2LWVhMmQtNGM3OC04OGRlLWYzMGM2YWQyZGVkMy8iLCAidGFz
-        a19pZCI6ICI0MTRjZmM4Ni1lYTJkLTRjNzgtODhkZS1mMzBjNmFkMmRlZDMi
-        fSwgeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvYzFiOGY1YzQtNmE4
-        Zi00M2I2LTljNmMtNTgwNzAwOWIzZDg5LyIsICJ0YXNrX2lkIjogImMxYjhm
-        NWM0LTZhOGYtNDNiNi05YzZjLTU4MDcwMDliM2Q4OSJ9XSwgInByb2dyZXNz
-        X3JlcG9ydCI6IHsieXVtX2ltcG9ydGVyIjogeyJjb250ZW50IjogeyJzaXpl
-        X3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
-        bHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3Rv
-        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
-        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
-        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX19LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29y
-        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAa2F0ZWxs
-        by1kZXZib3guZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJpbXBvcnRlcl90
-        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJpbXBvcnRlcl9pZCI6ICJ5dW1f
-        aW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVk
-        b3JhXzE3IiwgInJlbW92ZWRfY291bnQiOiAwLCAic3RhcnRlZCI6ICIyMDE2
-        LTAyLTA0VDIzOjM1OjMyWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMi
-        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMDRUMjM6MzU6MzJaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJlcnJvcl9t
-        ZXNzYWdlIjogbnVsbCwgInVwZGF0ZWRfY291bnQiOiAxNSwgImRldGFpbHMi
-        OiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6
-        IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJz
-        aXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJw
-        bV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0s
-        ICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0
-        ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImlkIjog
-        IjU2YjNlMDQ0ODRhMDljMDdkYTk3OWM5YiIsICJyZXN1bHQiOiAic3VjY2Vz
-        cyJ9LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjNlMDQz
-        ODY4MGI1Y2E1Yzg0MjNjMiJ9LCAiaWQiOiAiNTZiM2UwNDM4NGEwOWMwN2Ri
-        ZjRkYWE3In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJw
-        dWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6
-        ICIvcHVscC9hcGkvdjIvdGFza3MvNGM4YTkwNmMtMmY3OS00NzEzLWE3ZmUt
-        YzUxZDFiNDA4ODgxLyIsICJ0YXNrX2lkIjogIjRjOGE5MDZjLTJmNzktNDcx
-        My1hN2ZlLWM1MWQxYjQwODg4MSIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRv
-        cnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90
-        aW1lIjogIjIwMTYtMDItMDRUMjM6MzU6MzVaIiwgIl9ucyI6ICJ0YXNrX3N0
-        YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMDRUMjM6MzU6MzVaIiwg
-        InRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYi
-        OiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2E3NGQ2M2Q2LTgzNmEtNDA2MS04YzQw
-        LTQ5NjFmYzlmZDJkZi8iLCAidGFza19pZCI6ICJhNzRkNjNkNi04MzZhLTQw
-        NjEtOGM0MC00OTYxZmM5ZmQyZGYifSwgeyJfaHJlZiI6ICIvcHVscC9hcGkv
-        djIvdGFza3MvNWEwMGQ1MjctOGQ1Ny00NWRjLWE2MTAtMWU1N2UwYmNhZTYx
-        LyIsICJ0YXNrX2lkIjogIjVhMDBkNTI3LThkNTctNDVkYy1hNjEwLTFlNTdl
-        MGJjYWU2MSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQi
-        OiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        c2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJy
-        cG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
-        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAic3Rh
-        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1kZXZib3guZXhhbXBsZS5jb20iLCAi
-        cmVzdWx0IjogeyJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjog
-        bnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInJlbW92ZWRfY291bnQi
-        OiAwLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA0VDIzOjM1OjM1WiIsICJfbnMi
-        OiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDIt
-        MDRUMjM6MzU6MzVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzdW1tYXJ5Ijog
-        eyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRl
-        ZF9jb3VudCI6IDAsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInVwZGF0ZWRf
-        Y291bnQiOiAxNSwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90
-        YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6
-        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
-        OiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAi
-        Y29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
-        OiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6
-        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9fSwgImlkIjogIjU2YjNlMDQ3ODRhMDljMDdkYTk3OWNi
-        OSIsICJyZXN1bHQiOiAic3VjY2VzcyJ9LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjU2YjNlMDQ3ODY4MGI1Y2E1Yzg0MjNkMiJ9LCAiaWQi
-        OiAiNTZiM2UwNDc4NGEwOWMwN2RiZjRkYWMwIn0sIHsiZXhjZXB0aW9uIjog
-        bnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBv
-        LnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvODg0
-        NjQ3MzYtYmU3MS00MmU5LWIwODEtYjQ2OGNkY2Y1NjNkLyIsICJ0YXNrX2lk
-        IjogIjg4NDY0NzM2LWJlNzEtNDJlOS1iMDgxLWI0NjhjZGNmNTYzZCIsICJ0
-        YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0
-        aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMDRUMjM6MzU6
-        MzhaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTYtMDItMDRUMjM6MzU6MzhaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
-        bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzcz
-        MTRlNjU4LTYxNjgtNDI3My05MDRhLTcyM2M3MzJmOTEwYS8iLCAidGFza19p
-        ZCI6ICI3MzE0ZTY1OC02MTY4LTQyNzMtOTA0YS03MjNjNzMyZjkxMGEifSwg
-        eyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvODE0OTIxOGUtNzdjMC00
-        NjgxLThkYjItNzY5MjY0ZDFjOWUyLyIsICJ0YXNrX2lkIjogIjgxNDkyMThl
-        LTc3YzAtNDY4MS04ZGIyLTc2OTI2NGQxYzllMiJ9XSwgInByb2dyZXNzX3Jl
-        cG9ydCI6IHsieXVtX2ltcG9ydGVyIjogeyJjb250ZW50IjogeyJzaXplX3Rv
-        dGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAi
-        c3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMi
-        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
-        IjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwg
-        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2Vy
-        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1k
-        ZXZib3guZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJpbXBvcnRlcl90eXBl
-        X2lkIjogInl1bV9pbXBvcnRlciIsICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1w
-        b3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgInJlbW92ZWRfY291bnQiOiAwLCAic3RhcnRlZCI6ICIyMDE2LTAy
-        LTA0VDIzOjM1OjM4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAi
-        Y29tcGxldGVkIjogIjIwMTYtMDItMDRUMjM6MzU6MzhaIiwgInRyYWNlYmFj
-        ayI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJk
-        aXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJlcnJvcl9tZXNz
-        YWdlIjogbnVsbCwgInVwZGF0ZWRfY291bnQiOiAxNSwgImRldGFpbHMiOiB7
-        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
-        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
-        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
-        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1z
-        X2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImlkIjogIjU2
-        YjNlMDRhODRhMDljMDdkYTk3OWNkNyIsICJyZXN1bHQiOiAic3VjY2VzcyJ9
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjNlMDRhODY4
-        MGI1Y2E1Yzg0MjNlMiJ9LCAiaWQiOiAiNTZiM2UwNGE4NGEwOWMwN2RiZjRk
-        YWQ5In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxw
-        LnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIv
-        cHVscC9hcGkvdjIvdGFza3MvMGQ0ZmMyMzAtNWJhZi00Njk2LWE1Y2MtOGRm
-        NWYxZGExZWNlLyIsICJ0YXNrX2lkIjogIjBkNGZjMjMwLTViYWYtNDY5Ni1h
-        NWNjLThkZjVmMWRhMWVjZSIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6
-        RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1l
-        IjogIjIwMTYtMDItMDRUMjM6MzU6NDFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1
-        cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMDRUMjM6MzU6NDFaIiwgInRy
-        YWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAi
-        L3B1bHAvYXBpL3YyL3Rhc2tzL2VmNDA0NTQzLWNhMzQtNDI2NS1iOTBkLWMy
-        ZWFjZTE4MWIyOS8iLCAidGFza19pZCI6ICJlZjQwNDU0My1jYTM0LTQyNjUt
-        YjkwZC1jMmVhY2UxODFiMjkifSwgeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIv
-        dGFza3MvZjUxYzNjYmItNzAwMy00MmNiLWEyOTAtZDA1OTJiMWM1ZTc3LyIs
-        ICJ0YXNrX2lkIjogImY1MWMzY2JiLTcwMDMtNDJjYi1hMjkwLWQwNTkyYjFj
-        NWU3NyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVyIjog
-        eyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAw
-        LCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6
-        ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1f
-        ZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVt
-        c19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAic3RhdGUi
-        OiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
-        Y2Vfd29ya2VyLTBAa2F0ZWxsby1kZXZib3guZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJp
-        bXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVs
-        bCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInJlbW92ZWRfY291bnQiOiAw
-        LCAic3RhcnRlZCI6ICIyMDE2LTAyLTA0VDIzOjM1OjQxWiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMDRU
-        MjM6MzU6NDFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzdW1tYXJ5IjogeyJj
-        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
-        b3VudCI6IDAsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInVwZGF0ZWRfY291
-        bnQiOiAxNSwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwi
-        OiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsi
-        cnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAw
-        LCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29t
-        cHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9fSwgImlkIjogIjU2YjNlMDRkODRhMDljMDdkYTk3OWNmNSIs
-        ICJyZXN1bHQiOiAic3VjY2VzcyJ9LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjU2YjNlMDRkODY4MGI1Y2E1Yzg0MjNmMiJ9LCAiaWQiOiAi
-        NTZiM2UwNGQ4NGEwOWMwN2RiZjRkYWYyIn0sIHsiZXhjZXB0aW9uIjogbnVs
-        bCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5
-        bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNjk3ZmVj
-        MzAtOWE5OC00ODZkLWIzMDMtNWY1NGNkMjY1NWVhLyIsICJ0YXNrX2lkIjog
-        IjY5N2ZlYzMwLTlhOTgtNDg2ZC1iMzAzLTVmNTRjZDI2NTVlYSIsICJ0YWdz
-        IjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9u
-        OnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMDRUMjM6MzU6NDRa
-        IiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYt
-        MDItMDRUMjM6MzU6NDRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
-        X3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzFhMGU4
-        YzFlLWUwOWUtNGZjZS04NGRkLTgyOTc2NzYzMGVlOC8iLCAidGFza19pZCI6
-        ICIxYTBlOGMxZS1lMDllLTRmY2UtODRkZC04Mjk3Njc2MzBlZTgifSwgeyJf
-        aHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNDc1MmI5ZDgtNTU1MS00Yjlj
-        LThjZjMtZmVlZGRiNWJmMjgyLyIsICJ0YXNrX2lkIjogIjQ3NTJiOWQ4LTU1
-        NTEtNGI5Yy04Y2YzLWZlZWRkYjViZjI4MiJ9XSwgInByb2dyZXNzX3JlcG9y
-        dCI6IHsieXVtX2ltcG9ydGVyIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFs
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7
-        InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjog
-        MCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNv
-        bXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjog
-        eyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifX19LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25h
-        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1kZXZi
-        b3guZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJpbXBvcnRlcl90eXBlX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0
-        ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3
-        IiwgInJlbW92ZWRfY291bnQiOiAwLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA0
-        VDIzOjM1OjQ0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29t
-        cGxldGVkIjogIjIwMTYtMDItMDRUMjM6MzU6NDRaIiwgInRyYWNlYmFjayI6
-        IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
-        cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJlcnJvcl9tZXNzYWdl
-        IjogbnVsbCwgInVwZGF0ZWRfY291bnQiOiAxNSwgImRldGFpbHMiOiB7ImNv
-        bnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJp
-        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xl
-        ZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
-        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJv
-        cl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xl
-        ZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
-        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImlkIjogIjU2YjNl
-        MDUwODRhMDljMDdkYTk3OWQxMyIsICJyZXN1bHQiOiAic3VjY2VzcyJ9LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjNlMDUwODY4MGI1
-        Y2E1Yzg0MjQwMiJ9LCAiaWQiOiAiNTZiM2UwNTA4NGEwOWMwN2RiZjRkYjBi
-        In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNl
-        cnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVs
-        cC9hcGkvdjIvdGFza3MvNzczMDkzZDYtYzQ1MS00OGY3LTk1MDUtMTVjYTYw
-        MzgzYWM5LyIsICJ0YXNrX2lkIjogIjc3MzA5M2Q2LWM0NTEtNDhmNy05NTA1
-        LTE1Y2E2MDM4M2FjOSIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVk
-        b3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTYtMDItMDRUMjM6MzU6NDdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTYtMDItMDRUMjM6MzU6NDdaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzL2JhNjdiNWFjLTU5YWEtNGUwNi05ZDc5LWFjNDYz
-        NjI4MzExYi8iLCAidGFza19pZCI6ICJiYTY3YjVhYy01OWFhLTRlMDYtOWQ3
-        OS1hYzQ2MzYyODMxMWIifSwgeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFz
-        a3MvY2I4NDE2MTktZWMzMy00ZjViLTgyMWYtYTQxNGQwMDUxMGEwLyIsICJ0
-        YXNrX2lkIjogImNiODQxNjE5LWVjMzMtNGY1Yi04MjFmLWE0MTRkMDA1MTBh
-        MCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVyIjogeyJj
-        b250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAi
-        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9s
-        ZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9u
-        ZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJy
-        b3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
-        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAic3RhdGUiOiAi
-        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAa2F0ZWxsby1kZXZib3guZXhhbXBsZS5jb20iLCAicmVzdWx0
-        IjogeyJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJpbXBv
-        cnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwg
-        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInJlbW92ZWRfY291bnQiOiAwLCAi
-        c3RhcnRlZCI6ICIyMDE2LTAyLTA0VDIzOjM1OjQ3WiIsICJfbnMiOiAicmVw
-        b19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMDRUMjM6
-        MzU6NDdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250
-        ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3Vu
-        dCI6IDAsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInVwZGF0ZWRfY291bnQi
-        OiAxNSwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAw
-        LCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBt
-        X3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAi
-        ZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0
-        ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9fSwgImlkIjogIjU2YjNlMDUzODRhMDljMDdkYTk3OWQzMSIsICJy
-        ZXN1bHQiOiAic3VjY2VzcyJ9LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
-        b2lkIjogIjU2YjNlMDUzODY4MGI1Y2E1Yzg0MjQxMiJ9LCAiaWQiOiAiNTZi
-        M2UwNTM4NGEwOWMwN2RiZjRkYjI0In0sIHsiZXhjZXB0aW9uIjogbnVsbCwg
-        InRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMu
-        c3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZmEwNDZjNDIt
-        YzhiNy00NWRlLWFkMDMtMmM2NjQxMmQzODJlLyIsICJ0YXNrX2lkIjogImZh
-        MDQ2YzQyLWM4YjctNDVkZS1hZDAzLTJjNjY0MTJkMzgyZSIsICJ0YWdzIjog
-        WyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5
-        bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMDRUMjM6MzU6NTBaIiwg
-        Il9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDIt
-        MDRUMjM6MzU6NTBaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rh
-        c2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2UxZmZkZmNl
-        LTFkZWUtNGE3My04MjgwLTFmYTc3MWE4Mzg2ZS8iLCAidGFza19pZCI6ICJl
-        MWZmZGZjZS0xZGVlLTRhNzMtODI4MC0xZmE3NzFhODM4NmUifSwgeyJfaHJl
-        ZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMjVkZDNlOWQtYTNjOC00ZWFhLWIz
-        YmItYmNmNzQzZmI2NzE0LyIsICJ0YXNrX2lkIjogIjI1ZGQzZTlkLWEzYzgt
-        NGVhYS1iM2JiLWJjZjc0M2ZiNjcxNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6
-        IHsieXVtX2ltcG9ydGVyIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjog
-        MCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJw
-        bV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwg
-        ImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBz
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJp
-        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifX19LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
-        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAa2F0ZWxsby1kZXZib3gu
-        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJpbXBvcnRlcl90eXBlX2lkIjog
-        Inl1bV9pbXBvcnRlciIsICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIi
-        LCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        InJlbW92ZWRfY291bnQiOiAwLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA0VDIz
-        OjM1OjUwWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxl
-        dGVkIjogIjIwMTYtMDItMDRUMjM6MzU6NTBaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
-        dXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJlcnJvcl9tZXNzYWdlIjog
-        bnVsbCwgInVwZGF0ZWRfY291bnQiOiAxNSwgImRldGFpbHMiOiB7ImNvbnRl
-        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
-        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
-        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
-        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImlkIjogIjU2YjNlMDU2
-        ODRhMDljMDdkYTk3OWQ0ZiIsICJyZXN1bHQiOiAic3VjY2VzcyJ9LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjNlMDU2ODY4MGI1Y2E1
-        Yzg0MjQyMiJ9LCAiaWQiOiAiNTZiM2UwNTY4NGEwOWMwN2RiZjRkYjNhIn1d
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:35:51 GMT
-- request:
-    method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="pm9bu5sz47v5ZPWAYytzpAsm2D9epF7UmgxJPcsU",
-        oauth_signature="p8CMe8LtfVa8ac7cBTcPdBdurpI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628952", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:35:52 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzdlOTdkYWNiLWJjNjItNGUyNC1hNGNjLTk1MmNmMWJmNWNiMy8iLCAi
-        dGFza19pZCI6ICI3ZTk3ZGFjYi1iYzYyLTRlMjQtYTRjYy05NTJjZjFiZjVj
-        YjMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:35:52 GMT
-- request:
-    method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/7e97dacb-bc62-4e24-a4cc-952cf1bf5cb3/
     body:
       encoding: US-ASCII
@@ -9172,4 +5332,9280 @@ http_interactions:
         N2RiZjRkYjRjIn0=
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:35:52 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/bf061ba2-e159-482a-9017-5106a6dff387/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="pIvKlFk6OMLPpGg0Y3AneVAQD71rtFTu8ljGLhXFfw",
+        oauth_signature="Xs3H74z3rSPVMhb%2Fhw4Z6PVquKM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681181", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iZjA2MWJhMi1lMTU5LTQ4MmEtOTAxNy01MTA2YTZkZmYz
+        ODcvIiwgInRhc2tfaWQiOiAiYmYwNjFiYTItZTE1OS00ODJhLTkwMTctNTEw
+        NmE2ZGZmMzg3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNWQ4
+        YWRhNDBkYjA0ZWUwYTVlIn0sICJpZCI6ICI1NmI0YWM1ZDhhZGE0MGRiMDRl
+        ZTBhNWUifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:21 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/bf061ba2-e159-482a-9017-5106a6dff387/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="cykFodA1ZdGA9H6BAhFhbkgo5oifRIiEBTRqhhRKY",
+        oauth_signature="7PXQSN8lGLgvFuydp877nxHbKL0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681181", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '649'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iZjA2MWJhMi1lMTU5LTQ4MmEtOTAxNy01MTA2YTZkZmYz
+        ODcvIiwgInRhc2tfaWQiOiAiYmYwNjFiYTItZTE1OS00ODJhLTkwMTctNTEw
+        NmE2ZGZmMzg3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0
+        YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwg
+        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNTZiNGFjNWQ4YWRhNDBkYjA0ZWUwYTVlIn0sICJpZCI6ICI1NmI0YWM1
+        ZDhhZGE0MGRiMDRlZTBhNWUifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:21 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/bf061ba2-e159-482a-9017-5106a6dff387/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="9nQQgHijkBheUnkoJab0Dq2ohbpw5r3W0oOVxwWtw",
+        oauth_signature="uPmlG4mqcdjpg6%2FhcvB1g3od2i0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681182", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:22 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iZjA2MWJhMi1lMTU5LTQ4MmEtOTAxNy01MTA2YTZkZmYz
+        ODcvIiwgInRhc2tfaWQiOiAiYmYwNjFiYTItZTE1OS00ODJhLTkwMTctNTEw
+        NmE2ZGZmMzg3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNjoyMVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNjoyMVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNWEwNzQ0ZjctOTcxMi00MGRmLWI2MmYtZWUwY2ZlYzhm
+        M2M3LyIsICJ0YXNrX2lkIjogIjVhMDc0NGY3LTk3MTItNDBkZi1iNjJmLWVl
+        MGNmZWM4ZjNjNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzVkYzc4MjFiMzMwNWNlNTEyNyJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDY6MjFaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNjoy
+        MVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjNWRjNzgyMWIzNDQ0ZmNjMjg2IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNWQ4YWRhNDBkYjA0ZWUwYTVlIn0s
+        ICJpZCI6ICI1NmI0YWM1ZDhhZGE0MGRiMDRlZTBhNWUifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:22 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/54722c8b-f0f1-4405-ba5d-51baa447e2bd/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="xZ9XWjRjWeJhniaDZS0rxN9ngQ2QWmoYjX76ADpW8",
+        oauth_signature="1%2FLWOKFap9%2Bj%2Fl%2B%2By4r%2B6IDyCsE%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681183", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:23 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NDcyMmM4Yi1mMGYxLTQ0MDUtYmE1ZC01MWJhYTQ0N2Uy
+        YmQvIiwgInRhc2tfaWQiOiAiNTQ3MjJjOGItZjBmMS00NDA1LWJhNWQtNTFi
+        YWE0NDdlMmJkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM1
+        ZjhhZGE0MGRiMDRlZTBhNmYifSwgImlkIjogIjU2YjRhYzVmOGFkYTQwZGIw
+        NGVlMGE2ZiJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:23 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/54722c8b-f0f1-4405-ba5d-51baa447e2bd/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="5ImBOls4aLtgNKHfshXAecZhwBTiKvub2CbrVk",
+        oauth_signature="QNelgBMDCZRmGS3UpoeH7Rr6qiw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681183", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:23 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NDcyMmM4Yi1mMGYxLTQ0MDUtYmE1ZC01MWJhYTQ0N2Uy
+        YmQvIiwgInRhc2tfaWQiOiAiNTQ3MjJjOGItZjBmMS00NDA1LWJhNWQtNTFi
+        YWE0NDdlMmJkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA2OjIzWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA2OjIzWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjNWY4YWRhNDBkYjA0ZWUwYTZmIn0sICJpZCI6ICI1NmI0YWM1ZjhhZGE0
+        MGRiMDRlZTBhNmYifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:23 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/630433a9-3861-49f8-8e01-364436512b34/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="86HG0spXSWEf8atL487kCANe43Iv3DKvywTldncpE",
+        oauth_signature="J2PB6n8MJwbtybc%2BReEMR6C8sJs%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681184", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82MzA0MzNhOS0zODYxLTQ5ZjgtOGUwMS0zNjQ0MzY1MTJi
+        MzQvIiwgInRhc2tfaWQiOiAiNjMwNDMzYTktMzg2MS00OWY4LThlMDEtMzY0
+        NDM2NTEyYjM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNjA4
+        YWRhNDBkYjA0ZWUwYTcwIn0sICJpZCI6ICI1NmI0YWM2MDhhZGE0MGRiMDRl
+        ZTBhNzAifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:24 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/630433a9-3861-49f8-8e01-364436512b34/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="VKJk3usFuxmzVZjqkmXOcIL2PBgQZqnRtNvcCt4",
+        oauth_signature="rOokjtCan%2B57bxACTh%2BfJYtUSy8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681185", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:25 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '649'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82MzA0MzNhOS0zODYxLTQ5ZjgtOGUwMS0zNjQ0MzY1MTJi
+        MzQvIiwgInRhc2tfaWQiOiAiNjMwNDMzYTktMzg2MS00OWY4LThlMDEtMzY0
+        NDM2NTEyYjM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0
+        YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwg
+        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNTZiNGFjNjA4YWRhNDBkYjA0ZWUwYTcwIn0sICJpZCI6ICI1NmI0YWM2
+        MDhhZGE0MGRiMDRlZTBhNzAifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:25 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/630433a9-3861-49f8-8e01-364436512b34/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="sn6krud1nCB1ivqWuDJIBsv3y3domC5brUN9nLN7A2M",
+        oauth_signature="NrsOrnl62ck1TxStWk1lAc9h3Ew%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681186", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:26 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82MzA0MzNhOS0zODYxLTQ5ZjgtOGUwMS0zNjQ0MzY1MTJi
+        MzQvIiwgInRhc2tfaWQiOiAiNjMwNDMzYTktMzg2MS00OWY4LThlMDEtMzY0
+        NDM2NTEyYjM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNjoyNVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNjoyNVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvODIzY2ZlMTQtYmNjYS00OTRlLWI1NzYtMDAxY2JmMjBi
+        MDI2LyIsICJ0YXNrX2lkIjogIjgyM2NmZTE0LWJjY2EtNDk0ZS1iNTc2LTAw
+        MWNiZjIwYjAyNiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzYwYzc4MjFiMzMwNWNlNTEyYyJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDY6MjVaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNjoy
+        NVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjNjFjNzgyMWIzNDQ0ZmNjMjhiIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNjA4YWRhNDBkYjA0ZWUwYTcwIn0s
+        ICJpZCI6ICI1NmI0YWM2MDhhZGE0MGRiMDRlZTBhNzAifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:26 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/5e68542f-ab2f-4edb-ac03-660353f10771/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="GcSzpYHIoxpQ1Qe3TmrvdVX1iO5pCKg5mws004W1U",
+        oauth_signature="HC0e6mjjW5HgRDswufu2LbVtTb0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681186", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:27 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81ZTY4NTQyZi1hYjJmLTRlZGItYWMwMy02NjAzNTNmMTA3
+        NzEvIiwgInRhc2tfaWQiOiAiNWU2ODU0MmYtYWIyZi00ZWRiLWFjMDMtNjYw
+        MzUzZjEwNzcxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM2
+        MjhhZGE0MGRiMDRlZTBhODEifSwgImlkIjogIjU2YjRhYzYyOGFkYTQwZGIw
+        NGVlMGE4MSJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:27 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/5e68542f-ab2f-4edb-ac03-660353f10771/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="tBotCfCEwAAC1V7J7z71T7hRZaXhpwdeiBROOt79gN8",
+        oauth_signature="KdDg1vgZOuWjTJVB3mXWZg6QhC4%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681187", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:27 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81ZTY4NTQyZi1hYjJmLTRlZGItYWMwMy02NjAzNTNmMTA3
+        NzEvIiwgInRhc2tfaWQiOiAiNWU2ODU0MmYtYWIyZi00ZWRiLWFjMDMtNjYw
+        MzUzZjEwNzcxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA2OjI3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA2OjI3WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjNjI4YWRhNDBkYjA0ZWUwYTgxIn0sICJpZCI6ICI1NmI0YWM2MjhhZGE0
+        MGRiMDRlZTBhODEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:27 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ddf4677e-6116-4ec1-bd6b-3ae3c1a4b8f3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Xh0CioVeVTZCPRIbdI50OGsW8jqPkdK1VD4vARLRLaM",
+        oauth_signature="6IjVbBMQlrq80Lll3rITYujhd1M%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681188", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:28 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kZGY0Njc3ZS02MTE2LTRlYzEtYmQ2Yi0zYWUzYzFhNGI4
+        ZjMvIiwgInRhc2tfaWQiOiAiZGRmNDY3N2UtNjExNi00ZWMxLWJkNmItM2Fl
+        M2MxYTRiOGYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNjQ4
+        YWRhNDBkYjA0ZWUwYTgyIn0sICJpZCI6ICI1NmI0YWM2NDhhZGE0MGRiMDRl
+        ZTBhODIifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:28 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ddf4677e-6116-4ec1-bd6b-3ae3c1a4b8f3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="4Wd3Da6RKpkDNQhV6nZURVpGnyjAbOCm9f1B3SX9qP8",
+        oauth_signature="j9pfBvqXun7D2YtPySyikFIjMVA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681189", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:29 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '649'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kZGY0Njc3ZS02MTE2LTRlYzEtYmQ2Yi0zYWUzYzFhNGI4
+        ZjMvIiwgInRhc2tfaWQiOiAiZGRmNDY3N2UtNjExNi00ZWMxLWJkNmItM2Fl
+        M2MxYTRiOGYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0
+        YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwg
+        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNTZiNGFjNjQ4YWRhNDBkYjA0ZWUwYTgyIn0sICJpZCI6ICI1NmI0YWM2
+        NDhhZGE0MGRiMDRlZTBhODIifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:29 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ddf4677e-6116-4ec1-bd6b-3ae3c1a4b8f3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="EttCCnOYlAwG62VikjrtDXdtIXp1wxDMldv2SAhiw",
+        oauth_signature="w3ge9EYFIaeaJuaxFKSYsklmo4M%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681190", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:30 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kZGY0Njc3ZS02MTE2LTRlYzEtYmQ2Yi0zYWUzYzFhNGI4
+        ZjMvIiwgInRhc2tfaWQiOiAiZGRmNDY3N2UtNjExNi00ZWMxLWJkNmItM2Fl
+        M2MxYTRiOGYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNjoyOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNjoyOVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvZmFlODUxMzAtYmU0OS00YWJhLTk5YjgtYWE4ZGViYzk1
+        OWNiLyIsICJ0YXNrX2lkIjogImZhZTg1MTMwLWJlNDktNGFiYS05OWI4LWFh
+        OGRlYmM5NTljYiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzY0Yzc4MjFiMzMwNDJkOWUxOCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDY6MjlaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNjoy
+        OVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjNjVjNzgyMWIzNDQ0ZmNjMjkwIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNjQ4YWRhNDBkYjA0ZWUwYTgyIn0s
+        ICJpZCI6ICI1NmI0YWM2NDhhZGE0MGRiMDRlZTBhODIifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:30 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwiZmlsdGVycyI6eyJ1
+        bml0Ijp7IiRhbmQiOlt7Im5hbWUiOiJlbGVwaGFudCJ9XX19LCJzb3J0Ijp7
+        InVuaXQiOltbIm5hbWUiLCJhc2NlbmRpbmciXSxbInZlcnNpb24iLCJkZXNj
+        ZW5kaW5nIl1dfX19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="bzBazb0sKg4t469QS3fZ9uyxgpR0WN2BtL8d6iwyI", oauth_signature="XKS3V1Tvu%2B9z7NizwuGWkWT6WG8%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681190", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '147'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:30 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '3107'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7ImJ1aWxkX3RpbWUiOiAxMzA4MjU3NDY2LCAiYnVp
+        bGRob3N0IjogImRoY3AtMjYtMTE4LmJycS5yZWRoYXQuY29tIiwgInB1bHBf
+        dXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0i
+        LCAic2l6ZSI6IDIyNDQsICJsaWNlbnNlIjogIkdQTHYyIiwgImdyb3VwIjog
+        IkludGVybmV0L0FwcGxpY2F0aW9ucyIsICJfbnMiOiAidW5pdHNfcnBtIiwg
+        ImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsICJl
+        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInZlcnNpb25fc29ydF9p
+        bmRleCI6ICIwMS0wLjAxLTMiLCAicHJvdmlkZXMiOiBbeyJyZWxlYXNlIjog
+        IjAuOCIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImZsYWdz
+        IjogIkVRIiwgIm5hbWUiOiAiZWxlcGhhbnQifV0sICJmaWxlcyI6IHsiZGly
+        IjogW10sICJmaWxlIjogWyIvL2VsZXBoYW50LnR4dCJdfSwgInJlcG9kYXRh
+        IjogeyJmaWxlbGlzdHMiOiAiPHBhY2thZ2UgYXJjaD1cIm5vYXJjaFwiIG5h
+        bWU9XCJlbGVwaGFudFwiIHBrZ2lkPVwiM2UxYzcwY2QxYjQyMTMyOGFjYWY2
+        Mzk3Y2IzZDE2MTQ1MzA2YmI5NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmM1wi
+        PlxuICAgIDx2ZXJzaW9uIGVwb2NoPVwiMFwiIHJlbD1cIjAuOFwiIHZlcj1c
+        IjAuM1wiIC8+XG5cbiAgICA8ZmlsZT4vL2VsZXBoYW50LnR4dDwvZmlsZT5c
+        bjwvcGFja2FnZT5cblxuIiwgIm90aGVyIjogIjxwYWNrYWdlIGFyY2g9XCJu
+        b2FyY2hcIiBuYW1lPVwiZWxlcGhhbnRcIiBwa2dpZD1cIjNlMWM3MGNkMWI0
+        MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcy
+        YTBhNzAxZjNcIj5cbiAgICA8dmVyc2lvbiBlcG9jaD1cIjBcIiByZWw9XCIw
+        LjhcIiB2ZXI9XCIwLjNcIiAvPlxuXG48L3BhY2thZ2U+XG5cbiIsICJwcmlt
+        YXJ5IjogIjxwYWNrYWdlIHR5cGU9XCJycG1cIj5cbiAgPG5hbWU+ZWxlcGhh
+        bnQ8L25hbWU+XG4gIDxhcmNoPm5vYXJjaDwvYXJjaD5cbiAgPHZlcnNpb24g
+        ZXBvY2g9XCIwXCIgcmVsPVwiMC44XCIgdmVyPVwiMC4zXCIgLz5cbiAgPGNo
+        ZWNrc3VtIHBrZ2lkPVwiWUVTXCIgdHlwZT1cInNoYTI1NlwiPjNlMWM3MGNk
+        MWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMx
+        MzcyYTBhNzAxZjM8L2NoZWNrc3VtPlxuICA8c3VtbWFyeT5BIGR1bW15IHBh
+        Y2thZ2Ugb2YgZWxlcGhhbnQ8L3N1bW1hcnk+XG4gIDxkZXNjcmlwdGlvbj5B
+        IGR1bW15IHBhY2thZ2Ugb2YgZWxlcGhhbnQ8L2Rlc2NyaXB0aW9uPlxuICA8
+        cGFja2FnZXIgLz5cbiAgPHVybD5odHRwOi8vdHN0cmFjaG90YS5mZWRvcmFw
+        ZW9wbGUub3JnPC91cmw+XG4gIDx0aW1lIGJ1aWxkPVwiMTMwODI1NzQ2Nlwi
+        IGZpbGU9XCIxMzIxODkxMDI3XCIgLz5cbiAgPHNpemUgYXJjaGl2ZT1cIjI5
+        NlwiIGluc3RhbGxlZD1cIjQyXCIgcGFja2FnZT1cIjIyNDRcIiAvPlxuPGxv
+        Y2F0aW9uIGhyZWY9XCJlbGVwaGFudC0wLjMtMC44Lm5vYXJjaC5ycG1cIi8+
+        XG4gIDxmb3JtYXQ+XG4gICAgPHJwbTpsaWNlbnNlPkdQTHYyPC9ycG06bGlj
+        ZW5zZT5cbiAgICA8cnBtOnZlbmRvciAvPlxuICAgIDxycG06Z3JvdXA+SW50
+        ZXJuZXQvQXBwbGljYXRpb25zPC9ycG06Z3JvdXA+XG4gICAgPHJwbTpidWls
+        ZGhvc3Q+ZGhjcC0yNi0xMTguYnJxLnJlZGhhdC5jb208L3JwbTpidWlsZGhv
+        c3Q+XG4gICAgPHJwbTpzb3VyY2VycG0+ZWxlcGhhbnQtMC4zLTAuOC5zcmMu
+        cnBtPC9ycG06c291cmNlcnBtPlxuICAgIDxycG06aGVhZGVyLXJhbmdlIGVu
+        ZD1cIjIwMjhcIiBzdGFydD1cIjI4MFwiIC8+XG4gICAgPHJwbTpwcm92aWRl
+        cz5cbiAgICAgIDxycG06ZW50cnkgZXBvY2g9XCIwXCIgZmxhZ3M9XCJFUVwi
+        IG5hbWU9XCJlbGVwaGFudFwiIHJlbD1cIjAuOFwiIHZlcj1cIjAuM1wiIC8+
+        XG4gICAgPC9ycG06cHJvdmlkZXM+XG4gICAgPHJwbTpyZXF1aXJlcz5cbiAg
+        ICAgIDxycG06ZW50cnkgbmFtZT1cIi9iaW4vc2hcIiBwcmU9XCIxXCIgLz5c
+        biAgICA8L3JwbTpyZXF1aXJlcz5cbiAgPC9mb3JtYXQ+XG48L3BhY2thZ2U+
+        XG4ifSwgImRlc2NyaXB0aW9uIjogIkEgZHVtbXkgcGFja2FnZSBvZiBlbGVw
+        aGFudCIsICJfbGFzdF91cGRhdGVkIjogMTQ1NDY4MTE3MiwgInRpbWUiOiAx
+        MzIxODkxMDI3LCAiZG93bmxvYWRlZCI6IHRydWUsICJoZWFkZXJfcmFuZ2Ui
+        OiB7InN0YXJ0IjogMjgwLCAiZW5kIjogMjAyOH0sICJhcmNoIjogIm5vYXJj
+        aCIsICJuYW1lIjogImVsZXBoYW50IiwgIl9zdG9yYWdlX3BhdGgiOiAiL3Zh
+        ci9saWIvcHVscC9jb250ZW50L3VuaXRzL3JwbS9hYzgyL2FjODJiM2ZkLWRj
+        ZDItNGJhZi1iODY0LTAyNTNlYmQyM2IyNy9lbGVwaGFudC0wLjMtMC44Lm5v
+        YXJjaC5ycG0iLCAic291cmNlcnBtIjogImVsZXBoYW50LTAuMy0wLjguc3Jj
+        LnJwbSIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2IiwgInJlbGVhc2Vfc29y
+        dF9pbmRleCI6ICIwMS0wLjAxLTgiLCAiY2hhbmdlbG9nIjogW10sICJ1cmwi
+        OiAiaHR0cDovL3RzdHJhY2hvdGEuZmVkb3JhcGVvcGxlLm9yZyIsICJjaGVj
+        a3N1bSI6ICIzZTFjNzBjZDFiNDIxMzI4YWNhZjYzOTdjYjNkMTYxNDUzMDZi
+        Yjk1ZjY1ZDFiMDk1ZmMzMTM3MmEwYTcwMWYzIiwgInN1bW1hcnkiOiAiQSBk
+        dW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwgInJlbGF0aXZlcGF0aCI6ICJl
+        bGVwaGFudC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAicmVsZWFzZSI6ICIwLjgi
+        LCAiX2lkIjogImFjODJiM2ZkLWRjZDItNGJhZi1iODY0LTAyNTNlYmQyM2Iy
+        NyIsICJyZXF1aXJlcyI6IFt7InJlbGVhc2UiOiBudWxsLCAiZXBvY2giOiBu
+        dWxsLCAidmVyc2lvbiI6IG51bGwsICJmbGFncyI6IG51bGwsICJuYW1lIjog
+        Ii9iaW4vc2gifV19LCAidXBkYXRlZCI6ICIyMDE2LTAyLTA1VDE0OjA2OjI5
+        WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTYt
+        MDItMDVUMTQ6MDY6MjlaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5p
+        dF9pZCI6ICJhYzgyYjNmZC1kY2QyLTRiYWYtYjg2NC0wMjUzZWJkMjNiMjci
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YjRhYzY1OGFkYTQwZGIwNGVlMGE4OCJ9
+        fV0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:30 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/1a0007fd-1f48-47f3-9e6f-8477f694a294/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="xVHUdKDUkhOfrWtYezEVtuuyxjg5JkzmOqZy3br1Y",
+        oauth_signature="ZM01xKINokfzCJVFBIAZlAG7uXU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681191", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:31 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xYTAwMDdmZC0xZjQ4LTQ3ZjMtOWU2Zi04NDc3ZjY5NGEy
+        OTQvIiwgInRhc2tfaWQiOiAiMWEwMDA3ZmQtMWY0OC00N2YzLTllNmYtODQ3
+        N2Y2OTRhMjk0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM2
+        NzhhZGE0MGRiMDRlZTBhOTMifSwgImlkIjogIjU2YjRhYzY3OGFkYTQwZGIw
+        NGVlMGE5MyJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:31 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/1a0007fd-1f48-47f3-9e6f-8477f694a294/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="bvjjEb3cSKc14Ltof8oyt8E4zc0vkbPsWqEQr76hUM",
+        oauth_signature="fYf03nmVqKT1bxUOxBAWf4mL%2F2Y%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681191", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:31 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xYTAwMDdmZC0xZjQ4LTQ3ZjMtOWU2Zi04NDc3ZjY5NGEy
+        OTQvIiwgInRhc2tfaWQiOiAiMWEwMDA3ZmQtMWY0OC00N2YzLTllNmYtODQ3
+        N2Y2OTRhMjk0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA2OjMxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA2OjMxWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjNjc4YWRhNDBkYjA0ZWUwYTkzIn0sICJpZCI6ICI1NmI0YWM2NzhhZGE0
+        MGRiMDRlZTBhOTMifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:31 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/5601bfcc-a102-4fce-9a6c-a3c746688e47/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="uyQ5fAVMPMiHqKnsIjZXeRuFB4g7AHo3SSeNLB895h4",
+        oauth_signature="12GUKj8KFTFstBof%2BsneWM0YTsg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681193", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:33 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '649'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NjAxYmZjYy1hMTAyLTRmY2UtOWE2Yy1hM2M3NDY2ODhl
+        NDcvIiwgInRhc2tfaWQiOiAiNTYwMWJmY2MtYTEwMi00ZmNlLTlhNmMtYTNj
+        NzQ2Njg4ZTQ3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0
+        YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwg
+        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNTZiNGFjNjk4YWRhNDBkYjA0ZWUwYTk0In0sICJpZCI6ICI1NmI0YWM2
+        OThhZGE0MGRiMDRlZTBhOTQifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:33 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/5601bfcc-a102-4fce-9a6c-a3c746688e47/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="pDa8LBSQliXtVBpB1CB2HROw2xwCXWwd3rjwvDno",
+        oauth_signature="3KritxvzamPNo2IMcD8AqKdJYqs%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681193", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:33 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1093'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NjAxYmZjYy1hMTAyLTRmY2UtOWE2Yy1hM2M3NDY2ODhl
+        NDcvIiwgInRhc2tfaWQiOiAiNTYwMWJmY2MtYTEwMi00ZmNlLTlhNmMtYTNj
+        NzQ2Njg4ZTQ3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0wNVQxNDowNjozM1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
+        bCI6IDAsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiSU5fUFJP
+        R1JFU1MifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjNjk4YWRhNDBkYjA0ZWUwYTk0In0sICJpZCI6ICI1NmI0YWM2OThhZGE0
+        MGRiMDRlZTBhOTQifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:33 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/5601bfcc-a102-4fce-9a6c-a3c746688e47/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="ZnkenN2S68rK4WY6SpC9Jrm92iqgFA7Hzh04uZZwSWc",
+        oauth_signature="tLYCC2U%2BUOLqpOSrxRnk%2BdWbeJI%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681194", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:34 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NjAxYmZjYy1hMTAyLTRmY2UtOWE2Yy1hM2M3NDY2ODhl
+        NDcvIiwgInRhc2tfaWQiOiAiNTYwMWJmY2MtYTEwMi00ZmNlLTlhNmMtYTNj
+        NzQ2Njg4ZTQ3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNjozM1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNjozM1oiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvYzY0YTAzN2QtN2JmYy00MjViLWEwZGUtOTJiYzlkOGI0
+        ZTI5LyIsICJ0YXNrX2lkIjogImM2NGEwMzdkLTdiZmMtNDI1Yi1hMGRlLTky
+        YmM5ZDhiNGUyOSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzY4Yzc4MjFiMzMwNWNlNTEzMSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDY6MzNaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNjoz
+        M1oiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjNjljNzgyMWIzNDQ0ZmNjMjk1IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNjk4YWRhNDBkYjA0ZWUwYTk0In0s
+        ICJpZCI6ICI1NmI0YWM2OThhZGE0MGRiMDRlZTBhOTQifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:34 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwiZmlsdGVycyI6eyJ1
+        bml0Ijp7IiRhbmQiOlt7Im5hbWUiOiJlbGVwaGFudCJ9LHsidmVyc2lvbiI6
+        IjAuMyJ9LHsicmVsZWFzZSI6IjAuOCJ9LHsiZXBvY2giOiIwIn1dfX0sInNv
+        cnQiOnsidW5pdCI6W1sibmFtZSIsImFzY2VuZGluZyJdLFsidmVyc2lvbiIs
+        ImRlc2NlbmRpbmciXV19fX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="c0uMSBAnf8zjsqvEALvx2CE1tdeSGVf11FHUdRV7ZI", oauth_signature="7pe93AffczxCxkJOAsRu8W8YGeQ%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681194", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '197'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:34 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '3107'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7ImJ1aWxkX3RpbWUiOiAxMzA4MjU3NDY2LCAiYnVp
+        bGRob3N0IjogImRoY3AtMjYtMTE4LmJycS5yZWRoYXQuY29tIiwgInB1bHBf
+        dXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0i
+        LCAic2l6ZSI6IDIyNDQsICJsaWNlbnNlIjogIkdQTHYyIiwgImdyb3VwIjog
+        IkludGVybmV0L0FwcGxpY2F0aW9ucyIsICJfbnMiOiAidW5pdHNfcnBtIiwg
+        ImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsICJl
+        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInZlcnNpb25fc29ydF9p
+        bmRleCI6ICIwMS0wLjAxLTMiLCAicHJvdmlkZXMiOiBbeyJyZWxlYXNlIjog
+        IjAuOCIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImZsYWdz
+        IjogIkVRIiwgIm5hbWUiOiAiZWxlcGhhbnQifV0sICJmaWxlcyI6IHsiZGly
+        IjogW10sICJmaWxlIjogWyIvL2VsZXBoYW50LnR4dCJdfSwgInJlcG9kYXRh
+        IjogeyJmaWxlbGlzdHMiOiAiPHBhY2thZ2UgYXJjaD1cIm5vYXJjaFwiIG5h
+        bWU9XCJlbGVwaGFudFwiIHBrZ2lkPVwiM2UxYzcwY2QxYjQyMTMyOGFjYWY2
+        Mzk3Y2IzZDE2MTQ1MzA2YmI5NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmM1wi
+        PlxuICAgIDx2ZXJzaW9uIGVwb2NoPVwiMFwiIHJlbD1cIjAuOFwiIHZlcj1c
+        IjAuM1wiIC8+XG5cbiAgICA8ZmlsZT4vL2VsZXBoYW50LnR4dDwvZmlsZT5c
+        bjwvcGFja2FnZT5cblxuIiwgIm90aGVyIjogIjxwYWNrYWdlIGFyY2g9XCJu
+        b2FyY2hcIiBuYW1lPVwiZWxlcGhhbnRcIiBwa2dpZD1cIjNlMWM3MGNkMWI0
+        MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcy
+        YTBhNzAxZjNcIj5cbiAgICA8dmVyc2lvbiBlcG9jaD1cIjBcIiByZWw9XCIw
+        LjhcIiB2ZXI9XCIwLjNcIiAvPlxuXG48L3BhY2thZ2U+XG5cbiIsICJwcmlt
+        YXJ5IjogIjxwYWNrYWdlIHR5cGU9XCJycG1cIj5cbiAgPG5hbWU+ZWxlcGhh
+        bnQ8L25hbWU+XG4gIDxhcmNoPm5vYXJjaDwvYXJjaD5cbiAgPHZlcnNpb24g
+        ZXBvY2g9XCIwXCIgcmVsPVwiMC44XCIgdmVyPVwiMC4zXCIgLz5cbiAgPGNo
+        ZWNrc3VtIHBrZ2lkPVwiWUVTXCIgdHlwZT1cInNoYTI1NlwiPjNlMWM3MGNk
+        MWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMx
+        MzcyYTBhNzAxZjM8L2NoZWNrc3VtPlxuICA8c3VtbWFyeT5BIGR1bW15IHBh
+        Y2thZ2Ugb2YgZWxlcGhhbnQ8L3N1bW1hcnk+XG4gIDxkZXNjcmlwdGlvbj5B
+        IGR1bW15IHBhY2thZ2Ugb2YgZWxlcGhhbnQ8L2Rlc2NyaXB0aW9uPlxuICA8
+        cGFja2FnZXIgLz5cbiAgPHVybD5odHRwOi8vdHN0cmFjaG90YS5mZWRvcmFw
+        ZW9wbGUub3JnPC91cmw+XG4gIDx0aW1lIGJ1aWxkPVwiMTMwODI1NzQ2Nlwi
+        IGZpbGU9XCIxMzIxODkxMDI3XCIgLz5cbiAgPHNpemUgYXJjaGl2ZT1cIjI5
+        NlwiIGluc3RhbGxlZD1cIjQyXCIgcGFja2FnZT1cIjIyNDRcIiAvPlxuPGxv
+        Y2F0aW9uIGhyZWY9XCJlbGVwaGFudC0wLjMtMC44Lm5vYXJjaC5ycG1cIi8+
+        XG4gIDxmb3JtYXQ+XG4gICAgPHJwbTpsaWNlbnNlPkdQTHYyPC9ycG06bGlj
+        ZW5zZT5cbiAgICA8cnBtOnZlbmRvciAvPlxuICAgIDxycG06Z3JvdXA+SW50
+        ZXJuZXQvQXBwbGljYXRpb25zPC9ycG06Z3JvdXA+XG4gICAgPHJwbTpidWls
+        ZGhvc3Q+ZGhjcC0yNi0xMTguYnJxLnJlZGhhdC5jb208L3JwbTpidWlsZGhv
+        c3Q+XG4gICAgPHJwbTpzb3VyY2VycG0+ZWxlcGhhbnQtMC4zLTAuOC5zcmMu
+        cnBtPC9ycG06c291cmNlcnBtPlxuICAgIDxycG06aGVhZGVyLXJhbmdlIGVu
+        ZD1cIjIwMjhcIiBzdGFydD1cIjI4MFwiIC8+XG4gICAgPHJwbTpwcm92aWRl
+        cz5cbiAgICAgIDxycG06ZW50cnkgZXBvY2g9XCIwXCIgZmxhZ3M9XCJFUVwi
+        IG5hbWU9XCJlbGVwaGFudFwiIHJlbD1cIjAuOFwiIHZlcj1cIjAuM1wiIC8+
+        XG4gICAgPC9ycG06cHJvdmlkZXM+XG4gICAgPHJwbTpyZXF1aXJlcz5cbiAg
+        ICAgIDxycG06ZW50cnkgbmFtZT1cIi9iaW4vc2hcIiBwcmU9XCIxXCIgLz5c
+        biAgICA8L3JwbTpyZXF1aXJlcz5cbiAgPC9mb3JtYXQ+XG48L3BhY2thZ2U+
+        XG4ifSwgImRlc2NyaXB0aW9uIjogIkEgZHVtbXkgcGFja2FnZSBvZiBlbGVw
+        aGFudCIsICJfbGFzdF91cGRhdGVkIjogMTQ1NDY4MTE3MiwgInRpbWUiOiAx
+        MzIxODkxMDI3LCAiZG93bmxvYWRlZCI6IHRydWUsICJoZWFkZXJfcmFuZ2Ui
+        OiB7InN0YXJ0IjogMjgwLCAiZW5kIjogMjAyOH0sICJhcmNoIjogIm5vYXJj
+        aCIsICJuYW1lIjogImVsZXBoYW50IiwgIl9zdG9yYWdlX3BhdGgiOiAiL3Zh
+        ci9saWIvcHVscC9jb250ZW50L3VuaXRzL3JwbS9hYzgyL2FjODJiM2ZkLWRj
+        ZDItNGJhZi1iODY0LTAyNTNlYmQyM2IyNy9lbGVwaGFudC0wLjMtMC44Lm5v
+        YXJjaC5ycG0iLCAic291cmNlcnBtIjogImVsZXBoYW50LTAuMy0wLjguc3Jj
+        LnJwbSIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2IiwgInJlbGVhc2Vfc29y
+        dF9pbmRleCI6ICIwMS0wLjAxLTgiLCAiY2hhbmdlbG9nIjogW10sICJ1cmwi
+        OiAiaHR0cDovL3RzdHJhY2hvdGEuZmVkb3JhcGVvcGxlLm9yZyIsICJjaGVj
+        a3N1bSI6ICIzZTFjNzBjZDFiNDIxMzI4YWNhZjYzOTdjYjNkMTYxNDUzMDZi
+        Yjk1ZjY1ZDFiMDk1ZmMzMTM3MmEwYTcwMWYzIiwgInN1bW1hcnkiOiAiQSBk
+        dW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwgInJlbGF0aXZlcGF0aCI6ICJl
+        bGVwaGFudC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAicmVsZWFzZSI6ICIwLjgi
+        LCAiX2lkIjogImFjODJiM2ZkLWRjZDItNGJhZi1iODY0LTAyNTNlYmQyM2Iy
+        NyIsICJyZXF1aXJlcyI6IFt7InJlbGVhc2UiOiBudWxsLCAiZXBvY2giOiBu
+        dWxsLCAidmVyc2lvbiI6IG51bGwsICJmbGFncyI6IG51bGwsICJuYW1lIjog
+        Ii9iaW4vc2gifV19LCAidXBkYXRlZCI6ICIyMDE2LTAyLTA1VDE0OjA2OjMz
+        WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTYt
+        MDItMDVUMTQ6MDY6MzNaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5p
+        dF9pZCI6ICJhYzgyYjNmZC1kY2QyLTRiYWYtYjg2NC0wMjUzZWJkMjNiMjci
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YjRhYzY5OGFkYTQwZGIwNGVlMGE5YSJ9
+        fV0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:34 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f2387d65-c3af-429f-8aff-5dfb8c8e4ac1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="NEQ1q4KBTN4UKtefvdKQrS2fnamQSfKL1m8TlFqIoUc",
+        oauth_signature="5aSeV7xPvhQI8rtrNIUKWT6fetA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681195", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:35 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mMjM4N2Q2NS1jM2FmLTQyOWYtOGFmZi01ZGZiOGM4ZTRh
+        YzEvIiwgInRhc2tfaWQiOiAiZjIzODdkNjUtYzNhZi00MjlmLThhZmYtNWRm
+        YjhjOGU0YWMxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM2
+        YjhhZGE0MGRiMDRlZTBhYTUifSwgImlkIjogIjU2YjRhYzZiOGFkYTQwZGIw
+        NGVlMGFhNSJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:35 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f2387d65-c3af-429f-8aff-5dfb8c8e4ac1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="pHeJPspZeQUyS9sxL86fbjAUb09edOkTM6vKOj5Y",
+        oauth_signature="xQKAgmNyNIr8BfJEtixXCFe7Ggo%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681195", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:35 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mMjM4N2Q2NS1jM2FmLTQyOWYtOGFmZi01ZGZiOGM4ZTRh
+        YzEvIiwgInRhc2tfaWQiOiAiZjIzODdkNjUtYzNhZi00MjlmLThhZmYtNWRm
+        YjhjOGU0YWMxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA2OjM1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA2OjM1WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjNmI4YWRhNDBkYjA0ZWUwYWE1In0sICJpZCI6ICI1NmI0YWM2YjhhZGE0
+        MGRiMDRlZTBhYTUifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:35 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/87889ccf-e7ef-4ef0-96ad-345cecc7df36/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="7UeVBBDpZrMEpxBF5Aia1o6IKXpCFz7nDePcMTsv9s",
+        oauth_signature="krpC90i6lcY%2FFfF%2BoQDCScHsR4Y%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681196", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:36 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84Nzg4OWNjZi1lN2VmLTRlZjAtOTZhZC0zNDVjZWNjN2Rm
+        MzYvIiwgInRhc2tfaWQiOiAiODc4ODljY2YtZTdlZi00ZWYwLTk2YWQtMzQ1
+        Y2VjYzdkZjM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNmM4
+        YWRhNDBkYjA0ZWUwYWE2In0sICJpZCI6ICI1NmI0YWM2YzhhZGE0MGRiMDRl
+        ZTBhYTYifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:37 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/87889ccf-e7ef-4ef0-96ad-345cecc7df36/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="8GBWjtjJjpZPKzKiV1WTmkZLjoEQyx6e8ReEnT9RQ4",
+        oauth_signature="b4D6266il7FlzUrhqVZnpwpt1x0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681197", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:37 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '649'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84Nzg4OWNjZi1lN2VmLTRlZjAtOTZhZC0zNDVjZWNjN2Rm
+        MzYvIiwgInRhc2tfaWQiOiAiODc4ODljY2YtZTdlZi00ZWYwLTk2YWQtMzQ1
+        Y2VjYzdkZjM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0
+        YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwg
+        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNTZiNGFjNmM4YWRhNDBkYjA0ZWUwYWE2In0sICJpZCI6ICI1NmI0YWM2
+        YzhhZGE0MGRiMDRlZTBhYTYifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:37 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/87889ccf-e7ef-4ef0-96ad-345cecc7df36/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="4B0z3BIjo6873YfhYOZy0E81lUWpNepGrVfWZCBQY",
+        oauth_signature="kMWCIE3saAt1XnP3aV73C8uirVI%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681198", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:38 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84Nzg4OWNjZi1lN2VmLTRlZjAtOTZhZC0zNDVjZWNjN2Rm
+        MzYvIiwgInRhc2tfaWQiOiAiODc4ODljY2YtZTdlZi00ZWYwLTk2YWQtMzQ1
+        Y2VjYzdkZjM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNjozN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNjozN1oiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNzE3OGVjMTctODIwOS00OWIzLWE0M2QtNjY3ZTBjNzk5
+        MmMxLyIsICJ0YXNrX2lkIjogIjcxNzhlYzE3LTgyMDktNDliMy1hNDNkLTY2
+        N2UwYzc5OTJjMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzZjYzc4MjFiMzMwMzRiYWU0NCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDY6MzdaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNjoz
+        N1oiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjNmRjNzgyMWIzNDQ0ZmNjMjlhIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNmM4YWRhNDBkYjA0ZWUwYWE2In0s
+        ICJpZCI6ICI1NmI0YWM2YzhhZGE0MGRiMDRlZTBhYTYifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:38 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkaXN0cmlidXRpb24iXX19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="BvLCqvnKj2nZzMgCkgUyWBOfCutX8KPn2TgTcvi1s", oauth_signature="MIc9w828MIhOg1skJ4kU6YIQ0qw%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681198", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '42'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:38 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1173'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7ImZpbGVzIjogW3sicmVsYXRpdmVwYXRoIjogImlt
+        YWdlcy90ZXN0Mi5pbWciLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiIsICJj
+        aGVja3N1bSI6ICJlM2IwYzQ0Mjk4ZmMxYzE0OWFmYmY0Yzg5OTZmYjkyNDI3
+        YWU0MWU0NjQ5YjkzNGNhNDk1OTkxYjc4NTJiODU1In0sIHsicmVsYXRpdmVw
+        YXRoIjogImVtcHR5LmlzbyIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2Iiwg
+        ImNoZWNrc3VtIjogImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0
+        MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifSwgeyJyZWxhdGl2
+        ZXBhdGgiOiAiaW1hZ2VzL3Rlc3QxLmltZyIsICJjaGVja3N1bXR5cGUiOiAi
+        c2hhMjU2IiwgImNoZWNrc3VtIjogImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRj
+        ODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifV0s
+        ICJfc3RvcmFnZV9wYXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0
+        cy9kaXN0cmlidXRpb24vNmI5ZC82YjlkNmY4Yy01YzFjLTQ1MmItYTJhYi02
+        ODhmZmI1ZjlhY2YiLCAiZmFtaWx5IjogIlRlc3QgRmFtaWx5IiwgImRvd25s
+        b2FkZWQiOiB0cnVlLCAidGltZXN0YW1wIjogMTMyMzExMjE1My4wOSwgIl9s
+        YXN0X3VwZGF0ZWQiOiAxNDU0NjgxMTk3LCAiX2NvbnRlbnRfdHlwZV9pZCI6
+        ICJkaXN0cmlidXRpb24iLCAidmFyaWFudCI6ICJUZXN0VmFyaWFudCIsICJp
+        ZCI6ICJrcy1UZXN0IEZhbWlseS1UZXN0VmFyaWFudC0xNi14ODZfNjQiLCAi
+        dmVyc2lvbiI6ICIxNiIsICJ2ZXJzaW9uX3NvcnRfaW5kZXgiOiAiMDItMTYi
+        LCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJwYWNrYWdlZGlyIjogIiIs
+        ICJfaWQiOiAiNmI5ZDZmOGMtNWMxYy00NTJiLWEyYWItNjg4ZmZiNWY5YWNm
+        IiwgImFyY2giOiAieDg2XzY0IiwgIl9ucyI6ICJ1bml0c19kaXN0cmlidXRp
+        b24ifSwgInVwZGF0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNjozN1oiLCAicmVw
+        b19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE2LTAyLTA1VDE0
+        OjA2OjM3WiIsICJ1bml0X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInVu
+        aXRfaWQiOiAiNmI5ZDZmOGMtNWMxYy00NTJiLWEyYWItNjg4ZmZiNWY5YWNm
+        IiwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM2ZDhhZGE0MGRiMDRlZTBhYWYi
+        fX1d
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:38 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/75396a4a-2200-41e1-96b5-6ce443074833/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="mL07Nuf46UIpFP4THQ6unTnjFa2YDBI5V9utlAlyU",
+        oauth_signature="zLpW9wWlr%2BvEil9AgdsXQt03RTw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681199", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:39 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83NTM5NmE0YS0yMjAwLTQxZTEtOTZiNS02Y2U0NDMwNzQ4
+        MzMvIiwgInRhc2tfaWQiOiAiNzUzOTZhNGEtMjIwMC00MWUxLTk2YjUtNmNl
+        NDQzMDc0ODMzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM2
+        ZjhhZGE0MGRiMDRlZTBhYjcifSwgImlkIjogIjU2YjRhYzZmOGFkYTQwZGIw
+        NGVlMGFiNyJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:39 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/75396a4a-2200-41e1-96b5-6ce443074833/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="LAdTKsuguYwxznoVVt9O91sK7WgZmfg8PuUTo9Y12k",
+        oauth_signature="w17h2AdbHZ7xp9UqvMYKiQXJ5Ig%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681199", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:39 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83NTM5NmE0YS0yMjAwLTQxZTEtOTZiNS02Y2U0NDMwNzQ4
+        MzMvIiwgInRhc2tfaWQiOiAiNzUzOTZhNGEtMjIwMC00MWUxLTk2YjUtNmNl
+        NDQzMDc0ODMzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA2OjM5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA2OjM5WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjNmY4YWRhNDBkYjA0ZWUwYWI3In0sICJpZCI6ICI1NmI0YWM2ZjhhZGE0
+        MGRiMDRlZTBhYjcifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:39 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/9b2fb441-1afb-4749-a2e1-6b66f9427fb4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="ddZXwb1Q10i9zJhpxpDTpjpNLjkuXBVDGPhOBGZXFbI",
+        oauth_signature="MF%2FgHmPNHwxVj4dX3Mgd1%2FqijPE%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681200", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:41 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85YjJmYjQ0MS0xYWZiLTQ3NDktYTJlMS02YjY2Zjk0Mjdm
+        YjQvIiwgInRhc2tfaWQiOiAiOWIyZmI0NDEtMWFmYi00NzQ5LWEyZTEtNmI2
+        NmY5NDI3ZmI0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNzA4
+        YWRhNDBkYjA0ZWUwYWI4In0sICJpZCI6ICI1NmI0YWM3MDhhZGE0MGRiMDRl
+        ZTBhYjgifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:41 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/9b2fb441-1afb-4749-a2e1-6b66f9427fb4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="yLkKx5IhUtpPtNEqrGtYA5eX2znswTxjXPwW6CpOWLc",
+        oauth_signature="UsQGXnFap%2FliLy3DhdtLlEnlW5w%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681201", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:41 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85YjJmYjQ0MS0xYWZiLTQ3NDktYTJlMS02YjY2Zjk0Mjdm
+        YjQvIiwgInRhc2tfaWQiOiAiOWIyZmI0NDEtMWFmYi00NzQ5LWEyZTEtNmI2
+        NmY5NDI3ZmI0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNzA4
+        YWRhNDBkYjA0ZWUwYWI4In0sICJpZCI6ICI1NmI0YWM3MDhhZGE0MGRiMDRl
+        ZTBhYjgifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:41 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/9b2fb441-1afb-4749-a2e1-6b66f9427fb4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="pk3TKINMptQDAbV3EPQRCIlEtMiDmz0o6wizcFba2M",
+        oauth_signature="cBVu6DxSKPobEBtOjBo7YN1ogCo%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681202", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:42 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85YjJmYjQ0MS0xYWZiLTQ3NDktYTJlMS02YjY2Zjk0Mjdm
+        YjQvIiwgInRhc2tfaWQiOiAiOWIyZmI0NDEtMWFmYi00NzQ5LWEyZTEtNmI2
+        NmY5NDI3ZmI0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNjo0MVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNjo0MVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvYTU0NGU4MDgtMjM0NS00OGExLWFlNjctYTlkYmY2NDg0
+        ZDFlLyIsICJ0YXNrX2lkIjogImE1NDRlODA4LTIzNDUtNDhhMS1hZTY3LWE5
+        ZGJmNjQ4NGQxZSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzcwYzc4MjFiMzMwNDJkOWUxZSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDY6NDFaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNjo0
+        MVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjNzFjNzgyMWIzNDQ0ZmNjMjlmIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNzA4YWRhNDBkYjA0ZWUwYWI4In0s
+        ICJpZCI6ICI1NmI0YWM3MDhhZGE0MGRiMDRlZTBhYjgifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:42 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJlcnJhdHVtIl0sImZpZWxkcyI6
+        eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="6TLXEK8DZL2Zrtka9b80tev1LjivWCBHcdaHlOM9Vvc", oauth_signature="BgYYCWmuGlIWshXxWcOcGm1jAFw%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681202", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '84'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:42 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '651'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIyNzE1ZGE2Zi0yNTI4LTQ3YmUtODIw
+        MS05ODE0ZWJlMjJmMTgiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
+        In0sICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNzE4YWRhNDBkYjA0ZWUwYWMy
+        In0sICJ1bml0X2lkIjogIjI3MTVkYTZmLTI1MjgtNDdiZS04MjAxLTk4MTRl
+        YmUyMmYxOCIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
+        YXRhIjogeyJfaWQiOiAiNDhjMDlkZGYtNmE5OS00MmU0LTgxZGEtNjYxOTBk
+        Y2IzMGFhIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
+        IjogeyIkb2lkIjogIjU2YjRhYzcxOGFkYTQwZGIwNGVlMGFjNCJ9LCAidW5p
+        dF9pZCI6ICI0OGMwOWRkZi02YTk5LTQyZTQtODFkYS02NjE5MGRjYjMwYWEi
+        LCAidW5pdF90eXBlX2lkIjogImVycmF0dW0ifSwgeyJtZXRhZGF0YSI6IHsi
+        X2lkIjogImU2NmYwNjE1LWJhYzAtNDRjNC1hYzA3LTIzM2NlMDRjODVkYSIs
+        ICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0ifSwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1NmI0YWM3MThhZGE0MGRiMDRlZTBhYzMifSwgInVuaXRfaWQiOiAi
+        ZTY2ZjA2MTUtYmFjMC00NGM0LWFjMDctMjMzY2UwNGM4NWRhIiwgInVuaXRf
+        dHlwZV9pZCI6ICJlcnJhdHVtIn1d
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:42 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/content/units/erratum/search/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMjcxNWRh
+        NmYtMjUyOC00N2JlLTgyMDEtOTgxNGViZTIyZjE4IiwiNDhjMDlkZGYtNmE5
+        OS00MmU0LTgxZGEtNjYxOTBkY2IzMGFhIiwiZTY2ZjA2MTUtYmFjMC00NGM0
+        LWFjMDctMjMzY2UwNGM4NWRhIl19fX0sImluY2x1ZGVfcmVwb3MiOnRydWV9
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="tDXnbgxdS32j4s0bRW6Psq4iPu0uv5OWE2Fvl17JE", oauth_signature="2s3OLUVJ%2Fty72B6W2RNJkbueMMs%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681202", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '180'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:42 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4700'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJf
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9lcnJhdHVtLzI3
+        MTVkYTZmLTI1MjgtNDdiZS04MjAxLTk4MTRlYmUyMmYxOC8iLCAiaXNzdWVk
+        IjogIjIwMTAtMDEtMDEgMDE6MDE6MDEiLCAicmVmZXJlbmNlcyI6IFtdLCAi
+        cHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lkIjog
+        ImVycmF0dW0iLCAiaWQiOiAiUkhFQS0yMDEwOjAwMDEiLCAiZnJvbSI6ICJs
+        emFwK3B1YkByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRsZSI6
+        ICJFbXB0eSBlcnJhdGEiLCAiY2hpbGRyZW4iOiB7fSwgInZlcnNpb24iOiAi
+        MSIsICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3Vy
+        aXR5IiwgInBrZ2xpc3QiOiBbXSwgInN0YXR1cyI6ICJzdGFibGUiLCAidXBk
+        YXRlZCI6ICIiLCAiZGVzY3JpcHRpb24iOiAiRW1wdHkgZXJyYXRhIiwgIl9s
+        YXN0X3VwZGF0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNjo0MVoiLCAicHVzaGNv
+        dW50IjogIiIsICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1t
+        YXJ5IjogIiIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjI3MTVkYTZmLTI1
+        MjgtNDdiZS04MjAxLTk4MTRlYmUyMmYxOCJ9LCB7InJlcG9zaXRvcnlfbWVt
+        YmVyc2hpcHMiOiBbIkZlZG9yYV8xNyJdLCAiX2hyZWYiOiAiL3B1bHAvYXBp
+        L3YyL2NvbnRlbnQvdW5pdHMvZXJyYXR1bS80OGMwOWRkZi02YTk5LTQyZTQt
+        ODFkYS02NjE5MGRjYjMwYWEvIiwgImlzc3VlZCI6ICIyMDEwLTAxLTAxIDAx
+        OjAxOjAxIiwgInJlZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0
+        YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjog
+        IlJIRUEtMjAxMDowMDAyIiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0LmNv
+        bSIsICJzZXZlcml0eSI6ICIiLCAidGl0bGUiOiAiT25lIHBhY2thZ2UgZXJy
+        YXRhIiwgImNoaWxkcmVuIjoge30sICJ2ZXJzaW9uIjogIjEiLCAicmVib290
+        X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2ds
+        aXN0IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRv
+        cmFwcm9qZWN0Lm9yZyIsICJuYW1lIjogImVsZXBoYW50IiwgInN1bSI6IG51
+        bGwsICJmaWxlbmFtZSI6ICJlbGVwaGFudC0wLjMtMC44Lm5vYXJjaC5ycG0i
+        LCAiZXBvY2giOiBudWxsLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6
+        ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogIjEiLCAic2hv
+        cnQiOiAiIn1dLCAic3RhdHVzIjogInN0YWJsZSIsICJ1cGRhdGVkIjogIiIs
+        ICJkZXNjcmlwdGlvbiI6ICJPbmUgcGFja2FnZSBlcnJhdGEiLCAiX2xhc3Rf
+        dXBkYXRlZCI6ICIyMDE2LTAyLTA1VDE0OjA2OjQxWiIsICJwdXNoY291bnQi
+        OiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnki
+        OiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiNDhjMDlkZGYtNmE5OS00
+        MmU0LTgxZGEtNjYxOTBkY2IzMGFhIn0sIHsicmVwb3NpdG9yeV9tZW1iZXJz
+        aGlwcyI6IFsiRmVkb3JhXzE3Il0sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIv
+        Y29udGVudC91bml0cy9lcnJhdHVtL2U2NmYwNjE1LWJhYzAtNDRjNC1hYzA3
+        LTIzM2NlMDRjODVkYS8iLCAiaXNzdWVkIjogIjIwMTAtMTEtMTAgMDA6MDA6
+        MDAiLCAicmVmZXJlbmNlcyI6IFt7ImhyZWYiOiAiaHR0cHM6Ly9yaG4ucmVk
+        aGF0LmNvbS9lcnJhdGEvUkhTQS0yMDEwLTA4NTguaHRtbCIsICJ0eXBlIjog
+        InNlbGYiLCAiaWQiOiBudWxsLCAidGl0bGUiOiBudWxsfSwgeyJocmVmIjog
+        Imh0dHBzOi8vYnVnemlsbGEucmVkaGF0LmNvbS9idWd6aWxsYS9zaG93X2J1
+        Zy5jZ2k/aWQ9NjI3ODgyIiwgInR5cGUiOiAiYnVnemlsbGEiLCAiaWQiOiAi
+        NjI3ODgyIiwgInRpdGxlIjogbnVsbH0sIHsiaHJlZiI6ICJodHRwczovL3d3
+        dy5yZWRoYXQuY29tL3NlY3VyaXR5L2RhdGEvY3ZlL0NWRS0yMDEwLTA0MDUu
+        aHRtbCIsICJ0eXBlIjogImN2ZSIsICJpZCI6ICJDVkUtMjAxMC0wNDA1Iiwg
+        InRpdGxlIjogbnVsbH0sIHsiaHJlZiI6ICJodHRwOi8vd3d3LnJlZGhhdC5j
+        b20vc2VjdXJpdHkvdXBkYXRlcy9jbGFzc2lmaWNhdGlvbi8jaW1wb3J0YW50
+        IiwgInR5cGUiOiAib3RoZXIiLCAiaWQiOiBudWxsLCAidGl0bGUiOiBudWxs
+        fV0sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVf
+        aWQiOiAiZXJyYXR1bSIsICJpZCI6ICJSSFNBLTIwMTA6MDg1OCIsICJmcm9t
+        IjogInNlY3VyaXR5QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiSW1wb3J0
+        YW50IiwgInRpdGxlIjogIkltcG9ydGFudDogYnppcDIgc2VjdXJpdHkgdXBk
+        YXRlIiwgImNoaWxkcmVuIjoge30sICJ2ZXJzaW9uIjogIjMiLCAicmVib290
+        X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2ds
+        aXN0IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiYnppcDItMS4wLjUtNy5l
+        bDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDItZGV2ZWwiLCAic3VtIjog
+        WyJzaGEyNTYiLCAiZWE2N2M2NjRkYTFmZjk2YTZkYzk0ZDMzMDA5YjczZDhm
+        YWIzMWI1OTgyNDE4M2ZiNDVlOWJhMmViZjgyZDU4MyJdLCAiZmlsZW5hbWUi
+        OiAiYnppcDItZGV2ZWwtMS4wLjUtNy5lbDZfMC5pNjg2LnJwbSIsICJlcG9j
+        aCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVs
+        Nl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03
+        LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJzIiwgInN1bSI6
+        IFsic2hhMjU2IiwgImM5ZjA2NGE2ODYyNTczZmI5ZjJhNmFmZjdjMzYyMWYx
+        OTQwYjQ5MmRmMmVkZmMyZWJiZGMwYjgzMDVmNTExNDciXSwgImZpbGVuYW1l
+        IjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC5pNjg2LnJwbSIsICJlcG9j
+        aCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVs
+        Nl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03
+        LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMiIsICJzdW0iOiBbInNo
+        YTI1NiIsICJiOGEzZjcyYmMyYjBkODliYTczNzA5OWFjOThiZjhkMmFmNGJl
+        YTAyZDMxODg0YzAyZGI5N2Y3ZjY2YzNkNWMyIl0sICJmaWxlbmFtZSI6ICJi
+        emlwMi0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0iLCAiZXBvY2giOiAiMCIs
+        ICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJh
+        cmNoIjogIng4Nl82NCJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8w
+        LnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1kZXZlbCIsICJzdW0iOiBbInNo
+        YTI1NiIsICI3ZjYzMTI0ZTQ2NTViN2M5MmQyM2VjNGMzODIyNmY1ZDM3NDY1
+        Njg4NTNkZmY3NTBmYzg1ZTA1OGU3NGI1Y2Y2Il0sICJmaWxlbmFtZSI6ICJi
+        emlwMi1kZXZlbC0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0iLCAiZXBvY2gi
+        OiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZf
+        MCIsICJhcmNoIjogIng4Nl82NCJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03
+        LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJzIiwgInN1bSI6
+        IFsic2hhMjU2IiwgIjgwMmY0Mzk5ZGJkZDAxNDc2ZTI1NGMzYjMyYzQwYWZm
+        NTljZjVkMjNhNDVmYTQ4OGM2OTE3Y2U4OTA0ZDZiNGQiXSwgImZpbGVuYW1l
+        IjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVw
+        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcu
+        ZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQifV0sICJuYW1lIjogIlJlZCBIYXQg
+        RW50ZXJwcmlzZSBMaW51eCBTZXJ2ZXIgKHYuIDYgZm9yIDY0LWJpdCB4ODZf
+        NjQpIiwgInNob3J0IjogInJoZWwteDg2XzY0LXNlcnZlci02In1dLCAic3Rh
+        dHVzIjogImZpbmFsIiwgInVwZGF0ZWQiOiAiMjAxMC0xMS0xMCAwMDowMDow
+        MCIsICJkZXNjcmlwdGlvbiI6ICJiemlwMiBpcyBhIGZyZWVseSBhdmFpbGFi
+        bGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNvbXByZXNzb3IuIEl0IHByb3ZpZGVz
+        IGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11c3QgYmUgcmVzdGFydGVkIGZvciB0
+        aGUgdXBkYXRlIHRvIHRha2UgZWZmZWN0LiIsICJfbGFzdF91cGRhdGVkIjog
+        IjIwMTYtMDItMDVUMTQ6MDY6NDFaIiwgInB1c2hjb3VudCI6ICIiLCAicmln
+        aHRzIjogIkNvcHlyaWdodCAyMDEwIFJlZCBIYXQgSW5jIiwgInNvbHV0aW9u
+        IjogIkJlZm9yZSBhcHBseWluZyB0aGlzIHVwZGF0ZSwgbWFrZSBzdXJlIGFs
+        bCBwcmV2aW91c2x5LXJlbGVhc2VkIGVycmF0YVxucmVsZXZhbnQgdG8geW91
+        ciBzeXN0ZW0gaGF2ZSBiZWVuIGFwcGxpZWQuXG5cblRoaXMgdXBkYXRlIGlz
+        IGF2YWlsYWJsZSB2aWEgdGhlIFJlZCBIYXQgTmV0d29yay4gRGV0YWlscyBv
+        biBob3cgdG9cbnVzZSB0aGUgUmVkIEhhdCBOZXR3b3JrIHRvIGFwcGx5IHRo
+        aXMgdXBkYXRlIGFyZSBhdmFpbGFibGUgYXRcbmh0dHA6Ly9rYmFzZS5yZWRo
+        YXQuY29tL2ZhcS9kb2NzL0RPQy0xMTI1OSIsICJzdW1tYXJ5IjogIlVwZGF0
+        ZWQgYnppcDIgcGFja2FnZXMgdGhhdCBmaXggb25lIHNlY3VyaXR5IGlzc3Vl
+        IiwgInJlbGVhc2UiOiAiIiwgIl9pZCI6ICJlNjZmMDYxNS1iYWMwLTQ0YzQt
+        YWMwNy0yMzNjZTA0Yzg1ZGEifV0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:42 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJlcnJhdHVtIl0sImZpZWxkcyI6
+        eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="fOBP0lXjCwEL7twRmTNTkA9mQ9T6YN4QAGIMuWkSE", oauth_signature="RmqaAqogopMK2aKrE6A6P%2Fzhh7s%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681202", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '84'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:42 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '651'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIyNzE1ZGE2Zi0yNTI4LTQ3YmUtODIw
+        MS05ODE0ZWJlMjJmMTgiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
+        In0sICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNzE4YWRhNDBkYjA0ZWUwYWMy
+        In0sICJ1bml0X2lkIjogIjI3MTVkYTZmLTI1MjgtNDdiZS04MjAxLTk4MTRl
+        YmUyMmYxOCIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
+        YXRhIjogeyJfaWQiOiAiNDhjMDlkZGYtNmE5OS00MmU0LTgxZGEtNjYxOTBk
+        Y2IzMGFhIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
+        IjogeyIkb2lkIjogIjU2YjRhYzcxOGFkYTQwZGIwNGVlMGFjNCJ9LCAidW5p
+        dF9pZCI6ICI0OGMwOWRkZi02YTk5LTQyZTQtODFkYS02NjE5MGRjYjMwYWEi
+        LCAidW5pdF90eXBlX2lkIjogImVycmF0dW0ifSwgeyJtZXRhZGF0YSI6IHsi
+        X2lkIjogImU2NmYwNjE1LWJhYzAtNDRjNC1hYzA3LTIzM2NlMDRjODVkYSIs
+        ICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0ifSwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1NmI0YWM3MThhZGE0MGRiMDRlZTBhYzMifSwgInVuaXRfaWQiOiAi
+        ZTY2ZjA2MTUtYmFjMC00NGM0LWFjMDctMjMzY2UwNGM4NWRhIiwgInVuaXRf
+        dHlwZV9pZCI6ICJlcnJhdHVtIn1d
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:42 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/71f0d702-7cc9-472c-8040-eeb52149ba24/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Z1fnWRd38pZylMf3CjAe1ESmfpuOdqKM0CqDFgmIM",
+        oauth_signature="QxbBTRUXMHMC4llienXotI0abWI%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681203", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:43 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83MWYwZDcwMi03Y2M5LTQ3MmMtODA0MC1lZWI1MjE0OWJh
+        MjQvIiwgInRhc2tfaWQiOiAiNzFmMGQ3MDItN2NjOS00NzJjLTgwNDAtZWVi
+        NTIxNDliYTI0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM3
+        MzhhZGE0MGRiMDRlZTBhYzkifSwgImlkIjogIjU2YjRhYzczOGFkYTQwZGIw
+        NGVlMGFjOSJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:43 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/71f0d702-7cc9-472c-8040-eeb52149ba24/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="fZt4ZZlV2hwuNFOEOwAMs2CXNfH1cP2ISgRSFVZI14",
+        oauth_signature="IBbY3W4d1VlHl8yPLDlpImlareY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681203", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:43 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83MWYwZDcwMi03Y2M5LTQ3MmMtODA0MC1lZWI1MjE0OWJh
+        MjQvIiwgInRhc2tfaWQiOiAiNzFmMGQ3MDItN2NjOS00NzJjLTgwNDAtZWVi
+        NTIxNDliYTI0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA2OjQzWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA2OjQzWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjNzM4YWRhNDBkYjA0ZWUwYWM5In0sICJpZCI6ICI1NmI0YWM3MzhhZGE0
+        MGRiMDRlZTBhYzkifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:43 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/31af2042-62d1-49ad-b845-537fbe170061/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="GCedn1Uzt7hnykRlEqKwsDgHQFK9zaGHWiU42NLujw",
+        oauth_signature="QMGPjHG4nnuJrvHiMtAj0e57fKA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681205", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:45 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zMWFmMjA0Mi02MmQxLTQ5YWQtYjg0NS01MzdmYmUxNzAw
+        NjEvIiwgInRhc2tfaWQiOiAiMzFhZjIwNDItNjJkMS00OWFkLWI4NDUtNTM3
+        ZmJlMTcwMDYxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNzU4
+        YWRhNDBkYjA0ZWUwYWNhIn0sICJpZCI6ICI1NmI0YWM3NThhZGE0MGRiMDRl
+        ZTBhY2EifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:45 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/31af2042-62d1-49ad-b845-537fbe170061/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="rVuzWMasb6epMKKAKz3y1to14sfJMh3fbT19otg",
+        oauth_signature="wvhfwpKB%2BPLCjCtMi8hImDDQcPw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681205", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:45 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '667'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zMWFmMjA0Mi02MmQxLTQ5YWQtYjg0NS01MzdmYmUxNzAw
+        NjEvIiwgInRhc2tfaWQiOiAiMzFhZjIwNDItNjJkMS00OWFkLWI4NDUtNTM3
+        ZmJlMTcwMDYxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0wNVQxNDowNjo0NVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4
+        YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25h
+        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgt
+        ZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51
+        bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNzU4YWRhNDBkYjA0ZWUwYWNh
+        In0sICJpZCI6ICI1NmI0YWM3NThhZGE0MGRiMDRlZTBhY2EifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:45 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/31af2042-62d1-49ad-b845-537fbe170061/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="2F3O5jL8UC938DfM6r9KZO0HcOSqzLBHGym8ZwfBzo",
+        oauth_signature="XshH04Iw7JHVWeyyiTqZNQbrDUs%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681206", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:46 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zMWFmMjA0Mi02MmQxLTQ5YWQtYjg0NS01MzdmYmUxNzAw
+        NjEvIiwgInRhc2tfaWQiOiAiMzFhZjIwNDItNjJkMS00OWFkLWI4NDUtNTM3
+        ZmJlMTcwMDYxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNjo0NloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNjo0NVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvZjVhODBmYmEtMGVkOC00M2UzLWIyMjMtNjdmMWI3ODVm
+        OTUwLyIsICJ0YXNrX2lkIjogImY1YTgwZmJhLTBlZDgtNDNlMy1iMjIzLTY3
+        ZjFiNzg1Zjk1MCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        Yzc1Yzc4MjFiMzMwMzRiYWU0YSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDY6NDVaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNjo0
+        NVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjNzVjNzgyMWIzNDQ0ZmNjMmE0IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNzU4YWRhNDBkYjA0ZWUwYWNhIn0s
+        ICJpZCI6ICI1NmI0YWM3NThhZGE0MGRiMDRlZTBhY2EifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:46 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/d800e284-a40a-478e-ba36-9ee74326c9d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="2MFD0vOtI921Ct28O7hcAwllk4uFj0pYpBQNS0WSU",
+        oauth_signature="rb90QZ6fPWjcAmnC%2B%2BCMg6%2B3eqQ%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681207", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '651'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kODAwZTI4NC1hNDBhLTQ3OGUtYmEzNi05ZWU3NDMyNmM5
+        ZDAvIiwgInRhc2tfaWQiOiAiZDgwMGUyODQtYTQwYS00NzhlLWJhMzYtOWVl
+        NzQzMjZjOWQwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAi
+        c3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
+        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1NmI0YWM3NzhhZGE0MGRiMDRlZTBhZGIifSwgImlkIjogIjU2YjRh
+        Yzc3OGFkYTQwZGIwNGVlMGFkYiJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:47 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/d800e284-a40a-478e-ba36-9ee74326c9d0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="6HGnNW8FU9TRkktwZCEqnMCR1UYVhC8bpOfvuDHKTM",
+        oauth_signature="pZLFujuLJRakkpwIPbS6B0mWv9M%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681208", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:48 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kODAwZTI4NC1hNDBhLTQ3OGUtYmEzNi05ZWU3NDMyNmM5
+        ZDAvIiwgInRhc2tfaWQiOiAiZDgwMGUyODQtYTQwYS00NzhlLWJhMzYtOWVl
+        NzQzMjZjOWQwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA2OjQ3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA2OjQ3WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjNzc4YWRhNDBkYjA0ZWUwYWRiIn0sICJpZCI6ICI1NmI0YWM3NzhhZGE0
+        MGRiMDRlZTBhZGIifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:48 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/bfc5594a-f626-4808-b8dd-e2b72e3e54ea/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="ab57d8QfX1gh57zvkOzz9TdSDR6WHN9n4IcYQ5zo",
+        oauth_signature="4woORviXaQ6dGjQFLZSgsFywZzo%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681209", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:49 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iZmM1NTk0YS1mNjI2LTQ4MDgtYjhkZC1lMmI3MmUzZTU0
+        ZWEvIiwgInRhc2tfaWQiOiAiYmZjNTU5NGEtZjYyNi00ODA4LWI4ZGQtZTJi
+        NzJlM2U1NGVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNzk4
+        YWRhNDBkYjA0ZWUwYWRjIn0sICJpZCI6ICI1NmI0YWM3OThhZGE0MGRiMDRl
+        ZTBhZGMifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:49 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/bfc5594a-f626-4808-b8dd-e2b72e3e54ea/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="PCrBuS6fWvFEt0tjzZE1fTToIuWcdnoCtEMmNTXYs",
+        oauth_signature="rzuHXLMy1NQs%2FVqKkBzv7EF0My0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681209", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:49 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iZmM1NTk0YS1mNjI2LTQ4MDgtYjhkZC1lMmI3MmUzZTU0
+        ZWEvIiwgInRhc2tfaWQiOiAiYmZjNTU5NGEtZjYyNi00ODA4LWI4ZGQtZTJi
+        NzJlM2U1NGVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNzk4
+        YWRhNDBkYjA0ZWUwYWRjIn0sICJpZCI6ICI1NmI0YWM3OThhZGE0MGRiMDRl
+        ZTBhZGMifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:49 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/bfc5594a-f626-4808-b8dd-e2b72e3e54ea/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="i2V4swNy9BQ1Qv0HAzCa72vkZmE1nbJB1OcmrfOq8",
+        oauth_signature="5uYXCLLURB2PE5MMz4sxk3I2tIU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681210", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:50 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1078'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iZmM1NTk0YS1mNjI2LTQ4MDgtYjhkZC1lMmI3MmUzZTU0
+        ZWEvIiwgInRhc2tfaWQiOiAiYmZjNTU5NGEtZjYyNi00ODA4LWI4ZGQtZTJi
+        NzJlM2U1NGVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0wNVQxNDowNjo1MFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
+        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVl
+        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgt
+        ZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29y
+        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
+        by0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJv
+        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNzk4YWRhNDBkYjA0
+        ZWUwYWRjIn0sICJpZCI6ICI1NmI0YWM3OThhZGE0MGRiMDRlZTBhZGMifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:50 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/bfc5594a-f626-4808-b8dd-e2b72e3e54ea/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Q5LFdKvZjEZTNvPHLSdO6UV4ZCgFf7Y46jSDMfs1w",
+        oauth_signature="VEVBskC5A6zabbDSrou07FWHWZA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681211", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:51 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iZmM1NTk0YS1mNjI2LTQ4MDgtYjhkZC1lMmI3MmUzZTU0
+        ZWEvIiwgInRhc2tfaWQiOiAiYmZjNTU5NGEtZjYyNi00ODA4LWI4ZGQtZTJi
+        NzJlM2U1NGVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNjo1MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNjo1MFoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMTA1YzliYTQtOTY3ZC00NjQ4LTgwMTMtNTNlZDQ3YjBi
+        NDE4LyIsICJ0YXNrX2lkIjogIjEwNWM5YmE0LTk2N2QtNDY0OC04MDEzLTUz
+        ZWQ0N2IwYjQxOCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        Yzc5Yzc4MjFiMzMwNWNlNTEzYSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDY6NTBaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNjo1
+        MFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjN2FjNzgyMWIzNDQ0ZmNjMmE5IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNzk4YWRhNDBkYjA0ZWUwYWRjIn0s
+        ICJpZCI6ICI1NmI0YWM3OThhZGE0MGRiMDRlZTBhZGMifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:51 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwYWNrYWdlX2NhdGVnb3J5Il19
+        fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="qTcFXVLk382Kv2rD71yryfi4XyoT1Stak5Oh3zjA", oauth_signature="5x50i46az6xuI4UVqW6KfdQ3fhc%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681212", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '46'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:52 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '582'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5hbWUi
+        OiAiYWxsIiwgIl9ucyI6ICJ1bml0c19wYWNrYWdlX2NhdGVnb3J5IiwgIl9s
+        YXN0X3VwZGF0ZWQiOiAxNDU0NjgxMTczLCAidHJhbnNsYXRlZF9uYW1lIjog
+        e30sICJwYWNrYWdlZ3JvdXBpZHMiOiBbIm1hbW1hbCIsICJiaXJkIl0sICJ0
+        cmFuc2xhdGVkX2Rlc2NyaXB0aW9uIjoge30sICJwdWxwX3VzZXJfbWV0YWRh
+        dGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAicGFja2FnZV9jYXRlZ29y
+        eSIsICJpZCI6ICJhbGwiLCAiX2lkIjogImQ1OWU5MzUxLTJmODgtNDc1ZS1h
+        MTExLTMyOTRiODY0YjYzMiIsICJkaXNwbGF5X29yZGVyIjogOTl9LCAidXBk
+        YXRlZCI6ICIyMDE2LTAyLTA1VDE0OjA2OjUwWiIsICJyZXBvX2lkIjogIkZl
+        ZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTYtMDItMDVUMTQ6MDY6NTBaIiwg
+        InVuaXRfdHlwZV9pZCI6ICJwYWNrYWdlX2NhdGVnb3J5IiwgInVuaXRfaWQi
+        OiAiZDU5ZTkzNTEtMmY4OC00NzVlLWExMTEtMzI5NGI4NjRiNjMyIiwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1NmI0YWM3YThhZGE0MGRiMDRlZTBhZWIifX1d
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:52 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/fb7b3a01-3a0d-454b-aa4a-927840a29217/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="T3xrwMgp3gAUq6AhuYI0RjUnEb2cac5inpoQiO4VUo",
+        oauth_signature="ei8CS3KMDOrLRE%2BvU9A7tVcGcX8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681212", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:52 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mYjdiM2EwMS0zYTBkLTQ1NGItYWE0YS05Mjc4NDBhMjky
+        MTcvIiwgInRhc2tfaWQiOiAiZmI3YjNhMDEtM2EwZC00NTRiLWFhNGEtOTI3
+        ODQwYTI5MjE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM3
+        YzhhZGE0MGRiMDRlZTBhZWQifSwgImlkIjogIjU2YjRhYzdjOGFkYTQwZGIw
+        NGVlMGFlZCJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:52 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/fb7b3a01-3a0d-454b-aa4a-927840a29217/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="vTp1axUOJp1mOAWk5irIdykbtzL9Gm9pWJWw6NQE",
+        oauth_signature="G7yYa67h6KRz3fl9LlkX57lPbSo%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681213", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:53 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mYjdiM2EwMS0zYTBkLTQ1NGItYWE0YS05Mjc4NDBhMjky
+        MTcvIiwgInRhc2tfaWQiOiAiZmI3YjNhMDEtM2EwZC00NTRiLWFhNGEtOTI3
+        ODQwYTI5MjE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA2OjUyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA2OjUyWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjN2M4YWRhNDBkYjA0ZWUwYWVkIn0sICJpZCI6ICI1NmI0YWM3YzhhZGE0
+        MGRiMDRlZTBhZWQifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:53 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/2c6799c0-62a7-4106-ad91-ec387a3f451e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="3ByeYAUKqkT0SmReHCgI7RjsIzzIDJi0DayBWJaoKAI",
+        oauth_signature="vz5lbde%2BmBlXVFytDG1LX3IECS8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681214", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:54 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '649'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yYzY3OTljMC02MmE3LTQxMDYtYWQ5MS1lYzM4N2EzZjQ1
+        MWUvIiwgInRhc2tfaWQiOiAiMmM2Nzk5YzAtNjJhNy00MTA2LWFkOTEtZWMz
+        ODdhM2Y0NTFlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0
+        YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwg
+        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNTZiNGFjN2U4YWRhNDBkYjA0ZWUwYWVlIn0sICJpZCI6ICI1NmI0YWM3
+        ZThhZGE0MGRiMDRlZTBhZWUifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:54 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/2c6799c0-62a7-4106-ad91-ec387a3f451e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="CkCiptpKhC5pqU2RKjPKBZpL5prmGjhIgXcJPOE4",
+        oauth_signature="DZ72oAVQJ%2BaI4h7N6Amml6jTH8o%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681214", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:54 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1093'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yYzY3OTljMC02MmE3LTQxMDYtYWQ5MS1lYzM4N2EzZjQ1
+        MWUvIiwgInRhc2tfaWQiOiAiMmM2Nzk5YzAtNjJhNy00MTA2LWFkOTEtZWMz
+        ODdhM2Y0NTFlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0wNVQxNDowNjo1NFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
+        bCI6IDAsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiSU5fUFJP
+        R1JFU1MifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjN2U4YWRhNDBkYjA0ZWUwYWVlIn0sICJpZCI6ICI1NmI0YWM3ZThhZGE0
+        MGRiMDRlZTBhZWUifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:54 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/2c6799c0-62a7-4106-ad91-ec387a3f451e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="3eeTQCEzkgWgou7Rpmyg9YZfzBcbnMEjfaYm0Y8",
+        oauth_signature="PHgzmo0vebU%2BmkitTwyxMXhFLOQ%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681215", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:55 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yYzY3OTljMC02MmE3LTQxMDYtYWQ5MS1lYzM4N2EzZjQ1
+        MWUvIiwgInRhc2tfaWQiOiAiMmM2Nzk5YzAtNjJhNy00MTA2LWFkOTEtZWMz
+        ODdhM2Y0NTFlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNjo1NVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNjo1NFoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMWMyMjZjZWQtYTU5ZC00MDg5LWI5ZmMtMzQxMDRkOWFh
+        Yjg3LyIsICJ0YXNrX2lkIjogIjFjMjI2Y2VkLWE1OWQtNDA4OS1iOWZjLTM0
+        MTA0ZDlhYWI4NyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzdlYzc4MjFiMzMwMzRiYWU1MSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDY6NTRaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNjo1
+        NVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjN2ZjNzgyMWIzNDQ0ZmNjMmFlIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjN2U4YWRhNDBkYjA0ZWUwYWVlIn0s
+        ICJpZCI6ICI1NmI0YWM3ZThhZGE0MGRiMDRlZTBhZWUifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:55 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/2d94a8d2-6abd-44af-8f37-e96111ea168d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="WT4zf49vaIZDbwhmYSltlW54tTIuuGvNs7ZPoSjGhE",
+        oauth_signature="XRHD2r1bCrMh36XJp68I9HxIbKE%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681216", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '651'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yZDk0YThkMi02YWJkLTQ0YWYtOGYzNy1lOTYxMTFlYTE2
+        OGQvIiwgInRhc2tfaWQiOiAiMmQ5NGE4ZDItNmFiZC00NGFmLThmMzctZTk2
+        MTExZWExNjhkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAi
+        c3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
+        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1NmI0YWM4MDhhZGE0MGRiMDRlZTBhZmYifSwgImlkIjogIjU2YjRh
+        YzgwOGFkYTQwZGIwNGVlMGFmZiJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:56 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/2d94a8d2-6abd-44af-8f37-e96111ea168d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="d0YUHalRDpdBmQYNeG0Fye1qwNEKZoDJDAbpdu1cQHA",
+        oauth_signature="cHz6oEoNb6bYzqNr3zdcbBixF64%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681217", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:57 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yZDk0YThkMi02YWJkLTQ0YWYtOGYzNy1lOTYxMTFlYTE2
+        OGQvIiwgInRhc2tfaWQiOiAiMmQ5NGE4ZDItNmFiZC00NGFmLThmMzctZTk2
+        MTExZWExNjhkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA2OjU2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA2OjU2WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjODA4YWRhNDBkYjA0ZWUwYWZmIn0sICJpZCI6ICI1NmI0YWM4MDhhZGE0
+        MGRiMDRlZTBhZmYifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:57 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/238959b1-3569-44b0-9a9b-780c09842d7a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="pDXrPfiMHFBebFpkTBw3cEU5aa7ws0S0JvvQd8pTWXo",
+        oauth_signature="u9BRPNetWv0jTRxkPXyjje03fC0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681218", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yMzg5NTliMS0zNTY5LTQ0YjAtOWE5Yi03ODBjMDk4NDJk
+        N2EvIiwgInRhc2tfaWQiOiAiMjM4OTU5YjEtMzU2OS00NGIwLTlhOWItNzgw
+        YzA5ODQyZDdhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjODI4
+        YWRhNDBkYjA0ZWUwYjAwIn0sICJpZCI6ICI1NmI0YWM4MjhhZGE0MGRiMDRl
+        ZTBiMDAifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:58 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/238959b1-3569-44b0-9a9b-780c09842d7a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="BYvLqnCiwxR7jAQ02vEsdoX3PIAVWQYpJQJKJMI0",
+        oauth_signature="0JHLtPPjrzvnlo6zAFqKsFr%2FsVU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681218", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '667'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yMzg5NTliMS0zNTY5LTQ0YjAtOWE5Yi03ODBjMDk4NDJk
+        N2EvIiwgInRhc2tfaWQiOiAiMjM4OTU5YjEtMzU2OS00NGIwLTlhOWItNzgw
+        YzA5ODQyZDdhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0wNVQxNDowNjo1OFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4
+        YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25h
+        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgt
+        ZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51
+        bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjODI4YWRhNDBkYjA0ZWUwYjAw
+        In0sICJpZCI6ICI1NmI0YWM4MjhhZGE0MGRiMDRlZTBiMDAifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:58 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/238959b1-3569-44b0-9a9b-780c09842d7a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="ljmEDf6WO9t8tRwhCdqNQeQ3rX20jVJNi0WHkmJa1aQ",
+        oauth_signature="JSywsyNFgX0u4%2FUCdPonAHSgxFc%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681219", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yMzg5NTliMS0zNTY5LTQ0YjAtOWE5Yi03ODBjMDk4NDJk
+        N2EvIiwgInRhc2tfaWQiOiAiMjM4OTU5YjEtMzU2OS00NGIwLTlhOWItNzgw
+        YzA5ODQyZDdhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNjo1OVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNjo1OFoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvYzU2ZWRhOGYtOTY5Yi00MmU3LWE4YzgtOTg4Y2E2NjBh
+        NGM4LyIsICJ0YXNrX2lkIjogImM1NmVkYThmLTk2OWItNDJlNy1hOGM4LTk4
+        OGNhNjYwYTRjOCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzgyYzc4MjFiMzMwNWNlNTEzZiJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDY6NThaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNjo1
+        OVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjODNjNzgyMWIzNDQ0ZmNjMmIzIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjODI4YWRhNDBkYjA0ZWUwYjAwIn0s
+        ICJpZCI6ICI1NmI0YWM4MjhhZGE0MGRiMDRlZTBiMDAifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:59 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwiZmllbGRzIjp7InVu
+        aXQiOltdLCJhc3NvY2lhdGlvbiI6WyJ1bml0X2lkIl19fX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="5ELxLHIuBJAVH28yM4IjFe2pi33OkPTlrb9zu1eRbo", oauth_signature="jpKRXiDXossvzX2Ad5px7UOzT5A%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681220", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '80'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1672'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIwYjUzZGRkMC0yZTk1LTRlMTktOTY4
+        OS02YTdiODIwZGVmNTYiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmI0YWM4MzhhZGE0MGRiMDRlZTBiMDEifSwg
+        InVuaXRfaWQiOiAiMGI1M2RkZDAtMmU5NS00ZTE5LTk2ODktNmE3YjgyMGRl
+        ZjU2IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
+        X2lkIjogIjE2OGQ0N2IxLTEzMTgtNDQ5ZC05MmVhLWZlZDIxZjVjNjJkZCIs
+        ICJfY29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjog
+        IjU2YjRhYzgzOGFkYTQwZGIwNGVlMGIwMiJ9LCAidW5pdF9pZCI6ICIxNjhk
+        NDdiMS0xMzE4LTQ0OWQtOTJlYS1mZWQyMWY1YzYyZGQiLCAidW5pdF90eXBl
+        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNjFkYjdiMjEt
+        YzkxMy00OTlhLTgzYzctYTk3OWExMzE4MDQxIiwgIl9jb250ZW50X3R5cGVf
+        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjODM4YWRhNDBk
+        YjA0ZWUwYjA0In0sICJ1bml0X2lkIjogIjYxZGI3YjIxLWM5MTMtNDk5YS04
+        M2M3LWE5NzlhMTMxODA0MSIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
+        bWV0YWRhdGEiOiB7Il9pZCI6ICI2OGI2N2M5Yy05NzY0LTQ5ZjEtYTZhYy0z
+        NWFiMzcyYWIxMDMiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1NmI0YWM4MzhhZGE0MGRiMDRlZTBiMDMifSwgInVu
+        aXRfaWQiOiAiNjhiNjdjOWMtOTc2NC00OWYxLWE2YWMtMzVhYjM3MmFiMTAz
+        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lk
+        IjogIjdmYTExOGZlLThhZTQtNGJhOC1iZjRmLTZkM2NhOTYwZTZjYSIsICJf
+        Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2
+        YjRhYzgzOGFkYTQwZGIwNGVlMGIwNyJ9LCAidW5pdF9pZCI6ICI3ZmExMThm
+        ZS04YWU0LTRiYTgtYmY0Zi02ZDNjYTk2MGU2Y2EiLCAidW5pdF90eXBlX2lk
+        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiYTg2NGVjZjUtMGZj
+        Ni00ZjIzLWJkODEtNjk2NzA1OThjZGFiIiwgIl9jb250ZW50X3R5cGVfaWQi
+        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjODM4YWRhNDBkYjA0
+        ZWUwYjA1In0sICJ1bml0X2lkIjogImE4NjRlY2Y1LTBmYzYtNGYyMy1iZDgx
+        LTY5NjcwNTk4Y2RhYiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
+        YWRhdGEiOiB7Il9pZCI6ICJhYzgyYjNmZC1kY2QyLTRiYWYtYjg2NC0wMjUz
+        ZWJkMjNiMjciLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
+        IHsiJG9pZCI6ICI1NmI0YWM4MzhhZGE0MGRiMDRlZTBiMDYifSwgInVuaXRf
+        aWQiOiAiYWM4MmIzZmQtZGNkMi00YmFmLWI4NjQtMDI1M2ViZDIzYjI3Iiwg
+        InVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjog
+        ImQ0YTAwMmM0LWJlYjYtNDliYy04ODAxLTQwNDYxNjhhYzRhYiIsICJfY29u
+        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzgzOGFkYTQwZGIwNGVlMGIwOCJ9LCAidW5pdF9pZCI6ICJkNGEwMDJjNC1i
+        ZWI2LTQ5YmMtODgwMS00MDQ2MTY4YWM0YWIiLCAidW5pdF90eXBlX2lkIjog
+        InJwbSJ9XQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:00 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/content/units/rpm/search/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMGI1M2Rk
+        ZDAtMmU5NS00ZTE5LTk2ODktNmE3YjgyMGRlZjU2IiwiMTY4ZDQ3YjEtMTMx
+        OC00NDlkLTkyZWEtZmVkMjFmNWM2MmRkIiwiNjFkYjdiMjEtYzkxMy00OTlh
+        LTgzYzctYTk3OWExMzE4MDQxIiwiNjhiNjdjOWMtOTc2NC00OWYxLWE2YWMt
+        MzVhYjM3MmFiMTAzIiwiN2ZhMTE4ZmUtOGFlNC00YmE4LWJmNGYtNmQzY2E5
+        NjBlNmNhIiwiYTg2NGVjZjUtMGZjNi00ZjIzLWJkODEtNjk2NzA1OThjZGFi
+        IiwiYWM4MmIzZmQtZGNkMi00YmFmLWI4NjQtMDI1M2ViZDIzYjI3IiwiZDRh
+        MDAyYzQtYmViNi00OWJjLTg4MDEtNDA0NjE2OGFjNGFiIl19fSwiZmllbGRz
+        IjpbIm5hbWUiLCJ2ZXJzaW9uIiwicmVsZWFzZSIsImFyY2giLCJlcG9jaCIs
+        InN1bW1hcnkiLCJzb3VyY2VycG0iLCJjaGVja3N1bSIsImZpbGVuYW1lIiwi
+        X2lkIl19LCJpbmNsdWRlX3JlcG9zIjp0cnVlfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="wqyXe6CtmjZHPAdVtKXeaKQeT4lhOM0azCzim23HI", oauth_signature="IHp7jXoXc0aFmpSRjg2HQU9S4DM%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681220", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '478'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '3804'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJz
+        b3VyY2VycG0iOiAibW9ua2V5LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjog
+        Im1vbmtleSIsICJjaGVja3N1bSI6ICIwZThmYTUwZDAxMjhmYmFiYzdjY2M1
+        NjMyZTNmYTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwg
+        InN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIsICJmaWxl
+        bmFtZSI6ICJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjog
+        IjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lk
+        IjogIjBiNTNkZGQwLTJlOTUtNGUxOS05Njg5LTZhN2I4MjBkZWY1NiIsICJh
+        cmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBtLzBiNTNkZGQwLTJlOTUtNGUx
+        OS05Njg5LTZhN2I4MjBkZWY1Ni8ifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNo
+        aXBzIjogWyJGZWRvcmFfMTciXSwgInNvdXJjZXJwbSI6ICJ3YWxydXMtMC4z
+        LTAuOC5zcmMucnBtIiwgIm5hbWUiOiAid2FscnVzIiwgImNoZWNrc3VtIjog
+        IjZlOGQ2ZGMwNTdlM2UyYzk4MTlmMGRjN2U2YzdiN2Y4NmJmMmU4NTcxYmJh
+        NDE0YWRlYzdmYjYyMWE0NjFkZmQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBh
+        Y2thZ2Ugb2Ygd2FscnVzIiwgImZpbGVuYW1lIjogIndhbHJ1cy0wLjMtMC44
+        Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIs
+        ICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiMTY4ZDQ3YjEtMTMxOC00NDlk
+        LTkyZWEtZmVkMjFmNWM2MmRkIiwgImFyY2giOiAibm9hcmNoIiwgImNoaWxk
+        cmVuIjoge30sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0
+        cy9ycG0vMTY4ZDQ3YjEtMTMxOC00NDlkLTkyZWEtZmVkMjFmNWM2MmRkLyJ9
+        LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBbIkZlZG9yYV8xNyJdLCAi
+        c291cmNlcnBtIjogInNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsICJuYW1l
+        IjogInNxdWlycmVsIiwgImNoZWNrc3VtIjogIjI1MTc2OGJkZDE1ZjEzZDc4
+        NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3
+        ZDIiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwi
+        LCAiZmlsZW5hbWUiOiAic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwg
+        ImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIw
+        LjgiLCAiX2lkIjogIjYxZGI3YjIxLWM5MTMtNDk5YS04M2M3LWE5NzlhMTMx
+        ODA0MSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hy
+        ZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBtLzYxZGI3YjIx
+        LWM5MTMtNDk5YS04M2M3LWE5NzlhMTMxODA0MS8ifSwgeyJyZXBvc2l0b3J5
+        X21lbWJlcnNoaXBzIjogWyJGZWRvcmFfMTciXSwgInNvdXJjZXJwbSI6ICJw
+        ZW5ndWluLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogInBlbmd1aW4iLCAi
+        Y2hlY2tzdW0iOiAiM2ZjYjJjOTI3ZGU5ZTEzYmY2ODQ2OTAzMmEyOGIxMzlk
+        M2U1YWQyZTU4NTY0ZmMyMTBmZDZlNDg2MzViZTY5NCIsICJzdW1tYXJ5Ijog
+        IkEgZHVtbXkgcGFja2FnZSBvZiBwZW5ndWluIiwgImZpbGVuYW1lIjogInBl
+        bmd1aW4tMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVy
+        c2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjY4YjY3
+        YzljLTk3NjQtNDlmMS1hNmFjLTM1YWIzNzJhYjEwMyIsICJhcmNoIjogIm5v
+        YXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L2NvbnRlbnQvdW5pdHMvcnBtLzY4YjY3YzljLTk3NjQtNDlmMS1hNmFjLTM1
+        YWIzNzJhYjEwMy8ifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJG
+        ZWRvcmFfMTciXSwgInNvdXJjZXJwbSI6ICJsaW9uLTAuMy0wLjguc3JjLnJw
+        bSIsICJuYW1lIjogImxpb24iLCAiY2hlY2tzdW0iOiAiMTI0MDBkYzk1YzIz
+        YTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2MmVm
+        YTNlNGFlNCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwgImZpbGVuYW1lIjogImxpb24tMC4zLTAuOC5ub2FyY2gucnBtIiwgImVw
+        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgi
+        LCAiX2lkIjogIjdmYTExOGZlLThhZTQtNGJhOC1iZjRmLTZkM2NhOTYwZTZj
+        YSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBtLzdmYTExOGZlLThh
+        ZTQtNGJhOC1iZjRmLTZkM2NhOTYwZTZjYS8ifSwgeyJyZXBvc2l0b3J5X21l
+        bWJlcnNoaXBzIjogWyJGZWRvcmFfMTciXSwgInNvdXJjZXJwbSI6ICJjaGVl
+        dGFoLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogImNoZWV0YWgiLCAiY2hl
+        Y2tzdW0iOiAiNDIyZDBiYWEwY2Q5ZDc3MTNhZTc5NmU4ODZhMjNlMTdmNTc4
+        ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2OGRhZSIsICJzdW1tYXJ5IjogIkEg
+        ZHVtbXkgcGFja2FnZSBvZiBjaGVldGFoIiwgImZpbGVuYW1lIjogImNoZWV0
+        YWgtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lv
+        biI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogImE4NjRlY2Y1
+        LTBmYzYtNGYyMy1iZDgxLTY5NjcwNTk4Y2RhYiIsICJhcmNoIjogIm5vYXJj
+        aCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2Nv
+        bnRlbnQvdW5pdHMvcnBtL2E4NjRlY2Y1LTBmYzYtNGYyMy1iZDgxLTY5Njcw
+        NTk4Y2RhYi8ifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJGZWRv
+        cmFfMTciXSwgInNvdXJjZXJwbSI6ICJlbGVwaGFudC0wLjMtMC44LnNyYy5y
+        cG0iLCAibmFtZSI6ICJlbGVwaGFudCIsICJjaGVja3N1bSI6ICIzZTFjNzBj
+        ZDFiNDIxMzI4YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMz
+        MTM3MmEwYTcwMWYzIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9m
+        IGVsZXBoYW50IiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9h
+        cmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJl
+        bGVhc2UiOiAiMC44IiwgIl9pZCI6ICJhYzgyYjNmZC1kY2QyLTRiYWYtYjg2
+        NC0wMjUzZWJkMjNiMjciLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4i
+        OiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3Jw
+        bS9hYzgyYjNmZC1kY2QyLTRiYWYtYjg2NC0wMjUzZWJkMjNiMjcvIn0sIHsi
+        cmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJzb3Vy
+        Y2VycG0iOiAiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJn
+        aXJhZmZlIiwgImNoZWNrc3VtIjogImYyNWQ2N2QxZDlkYTA0ZjEyZTU3Y2Ez
+        MjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQiLCAi
+        c3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsICJmaWxl
+        bmFtZSI6ICJnaXJhZmZlLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6
+        ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgIl9p
+        ZCI6ICJkNGEwMDJjNC1iZWI2LTQ5YmMtODgwMS00MDQ2MTY4YWM0YWIiLCAi
+        YXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS9kNGEwMDJjNC1iZWI2LTQ5
+        YmMtODgwMS00MDQ2MTY4YWM0YWIvIn1d
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:00 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwiZmllbGRzIjp7InVu
+        aXQiOltdLCJhc3NvY2lhdGlvbiI6WyJ1bml0X2lkIl19fX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="bXMAf72IHwaH5IymY43ccNaMoCroD0YcV1dBlYZHuo", oauth_signature="3TpRAAGqAILTHMYPYdhBFmj0W94%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681220", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '80'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1672'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIwYjUzZGRkMC0yZTk1LTRlMTktOTY4
+        OS02YTdiODIwZGVmNTYiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmI0YWM4MzhhZGE0MGRiMDRlZTBiMDEifSwg
+        InVuaXRfaWQiOiAiMGI1M2RkZDAtMmU5NS00ZTE5LTk2ODktNmE3YjgyMGRl
+        ZjU2IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
+        X2lkIjogIjE2OGQ0N2IxLTEzMTgtNDQ5ZC05MmVhLWZlZDIxZjVjNjJkZCIs
+        ICJfY29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjog
+        IjU2YjRhYzgzOGFkYTQwZGIwNGVlMGIwMiJ9LCAidW5pdF9pZCI6ICIxNjhk
+        NDdiMS0xMzE4LTQ0OWQtOTJlYS1mZWQyMWY1YzYyZGQiLCAidW5pdF90eXBl
+        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNjFkYjdiMjEt
+        YzkxMy00OTlhLTgzYzctYTk3OWExMzE4MDQxIiwgIl9jb250ZW50X3R5cGVf
+        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjODM4YWRhNDBk
+        YjA0ZWUwYjA0In0sICJ1bml0X2lkIjogIjYxZGI3YjIxLWM5MTMtNDk5YS04
+        M2M3LWE5NzlhMTMxODA0MSIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
+        bWV0YWRhdGEiOiB7Il9pZCI6ICI2OGI2N2M5Yy05NzY0LTQ5ZjEtYTZhYy0z
+        NWFiMzcyYWIxMDMiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1NmI0YWM4MzhhZGE0MGRiMDRlZTBiMDMifSwgInVu
+        aXRfaWQiOiAiNjhiNjdjOWMtOTc2NC00OWYxLWE2YWMtMzVhYjM3MmFiMTAz
+        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lk
+        IjogIjdmYTExOGZlLThhZTQtNGJhOC1iZjRmLTZkM2NhOTYwZTZjYSIsICJf
+        Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2
+        YjRhYzgzOGFkYTQwZGIwNGVlMGIwNyJ9LCAidW5pdF9pZCI6ICI3ZmExMThm
+        ZS04YWU0LTRiYTgtYmY0Zi02ZDNjYTk2MGU2Y2EiLCAidW5pdF90eXBlX2lk
+        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiYTg2NGVjZjUtMGZj
+        Ni00ZjIzLWJkODEtNjk2NzA1OThjZGFiIiwgIl9jb250ZW50X3R5cGVfaWQi
+        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjODM4YWRhNDBkYjA0
+        ZWUwYjA1In0sICJ1bml0X2lkIjogImE4NjRlY2Y1LTBmYzYtNGYyMy1iZDgx
+        LTY5NjcwNTk4Y2RhYiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
+        YWRhdGEiOiB7Il9pZCI6ICJhYzgyYjNmZC1kY2QyLTRiYWYtYjg2NC0wMjUz
+        ZWJkMjNiMjciLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
+        IHsiJG9pZCI6ICI1NmI0YWM4MzhhZGE0MGRiMDRlZTBiMDYifSwgInVuaXRf
+        aWQiOiAiYWM4MmIzZmQtZGNkMi00YmFmLWI4NjQtMDI1M2ViZDIzYjI3Iiwg
+        InVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjog
+        ImQ0YTAwMmM0LWJlYjYtNDliYy04ODAxLTQwNDYxNjhhYzRhYiIsICJfY29u
+        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzgzOGFkYTQwZGIwNGVlMGIwOCJ9LCAidW5pdF9pZCI6ICJkNGEwMDJjNC1i
+        ZWI2LTQ5YmMtODgwMS00MDQ2MTY4YWM0YWIiLCAidW5pdF90eXBlX2lkIjog
+        InJwbSJ9XQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:00 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/289d8929-4abd-4367-909e-25777e0ccc13/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="5Hesf5ik9VDfVuTpOcNsZCzHi4jAKEDVeljz4QRxRTQ",
+        oauth_signature="5zVQK%2FZA8yTZympjyNwKmNGGiNo%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681220", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yODlkODkyOS00YWJkLTQzNjctOTA5ZS0yNTc3N2UwY2Nj
+        MTMvIiwgInRhc2tfaWQiOiAiMjg5ZDg5MjktNGFiZC00MzY3LTkwOWUtMjU3
+        NzdlMGNjYzEzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM4
+        NDhhZGE0MGRiMDRlZTBiMTEifSwgImlkIjogIjU2YjRhYzg0OGFkYTQwZGIw
+        NGVlMGIxMSJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:00 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/289d8929-4abd-4367-909e-25777e0ccc13/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="uhVE1HfmOzyYdjDDG8urSy3ePeAQKOXU7ykjBiYM",
+        oauth_signature="xxBj2de7ldtqDeXyCH9q6GCZ0Wc%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681221", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:01 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yODlkODkyOS00YWJkLTQzNjctOTA5ZS0yNTc3N2UwY2Nj
+        MTMvIiwgInRhc2tfaWQiOiAiMjg5ZDg5MjktNGFiZC00MzY3LTkwOWUtMjU3
+        NzdlMGNjYzEzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA3OjAxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA3OjAxWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjODQ4YWRhNDBkYjA0ZWUwYjExIn0sICJpZCI6ICI1NmI0YWM4NDhhZGE0
+        MGRiMDRlZTBiMTEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:01 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/59d6dc6d-bcf6-4899-9b3b-643be2d09189/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="7xeuAL2FyO0BMlzXISu3odtw0qUI8Kjeop8dI4bYco",
+        oauth_signature="SebRIwTyhSkX0qLu1boB%2Bze6ylg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681223", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:03 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81OWQ2ZGM2ZC1iY2Y2LTQ4OTktOWIzYi02NDNiZTJkMDkx
+        ODkvIiwgInRhc2tfaWQiOiAiNTlkNmRjNmQtYmNmNi00ODk5LTliM2ItNjQz
+        YmUyZDA5MTg5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjODY4
+        YWRhNDBkYjA0ZWUwYjEyIn0sICJpZCI6ICI1NmI0YWM4NjhhZGE0MGRiMDRl
+        ZTBiMTIifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:03 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/59d6dc6d-bcf6-4899-9b3b-643be2d09189/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="IhGK0onf4kWyHR8rXwSaOpens4mavEnuoeJCWW4",
+        oauth_signature="Iwi1enkSr7n3KfydaMMRMx37aX8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681223", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:03 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81OWQ2ZGM2ZC1iY2Y2LTQ4OTktOWIzYi02NDNiZTJkMDkx
+        ODkvIiwgInRhc2tfaWQiOiAiNTlkNmRjNmQtYmNmNi00ODk5LTliM2ItNjQz
+        YmUyZDA5MTg5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjODY4
+        YWRhNDBkYjA0ZWUwYjEyIn0sICJpZCI6ICI1NmI0YWM4NjhhZGE0MGRiMDRl
+        ZTBiMTIifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:03 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/59d6dc6d-bcf6-4899-9b3b-643be2d09189/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="GZJfHss7uPmRUi7qVQPL0s2OubMrf6BhyUSgTM4rT4",
+        oauth_signature="UuGuSyDEw%2Fm8PtTRnhySaK2yf70%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681224", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:04 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81OWQ2ZGM2ZC1iY2Y2LTQ4OTktOWIzYi02NDNiZTJkMDkx
+        ODkvIiwgInRhc2tfaWQiOiAiNTlkNmRjNmQtYmNmNi00ODk5LTliM2ItNjQz
+        YmUyZDA5MTg5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNzowM1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNzowM1oiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMjI2ZTVlMDctYTgwMi00ZmYzLWE4NjktMWM4MWVmY2M0
+        MmZmLyIsICJ0YXNrX2lkIjogIjIyNmU1ZTA3LWE4MDItNGZmMy1hODY5LTFj
+        ODFlZmNjNDJmZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        Yzg2Yzc4MjFiMzMwMzRiYWU1NiJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDc6MDNaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNzow
+        M1oiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjODdjNzgyMWIzNDQ0ZmNjMmI4IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjODY4YWRhNDBkYjA0ZWUwYjEyIn0s
+        ICJpZCI6ICI1NmI0YWM4NjhhZGE0MGRiMDRlZTBiMTIifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:04 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/43be0688-c646-4903-b638-1c15bec153f0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="P5vx7D0ERR6bU13mAdadn7jidAawCPE14qZQ32pDAE",
+        oauth_signature="j142kbgAN7pXkAgvqmBz6J5gXgE%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681225", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:05 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy80M2JlMDY4OC1jNjQ2LTQ5MDMtYjYzOC0xYzE1YmVjMTUz
+        ZjAvIiwgInRhc2tfaWQiOiAiNDNiZTA2ODgtYzY0Ni00OTAzLWI2MzgtMWMx
+        NWJlYzE1M2YwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM4
+        OThhZGE0MGRiMDRlZTBiMjMifSwgImlkIjogIjU2YjRhYzg5OGFkYTQwZGIw
+        NGVlMGIyMyJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:05 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/43be0688-c646-4903-b638-1c15bec153f0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="344LGLId6KZ1CP0SRDz3PYZdijpmYwkkPFRosxz98w",
+        oauth_signature="PpDXpjoi4N1d9aDlvAIUjfTpEBQ%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681225", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:05 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy80M2JlMDY4OC1jNjQ2LTQ5MDMtYjYzOC0xYzE1YmVjMTUz
+        ZjAvIiwgInRhc2tfaWQiOiAiNDNiZTA2ODgtYzY0Ni00OTAzLWI2MzgtMWMx
+        NWJlYzE1M2YwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA3OjA1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA3OjA1WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjODk4YWRhNDBkYjA0ZWUwYjIzIn0sICJpZCI6ICI1NmI0YWM4OThhZGE0
+        MGRiMDRlZTBiMjMifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:05 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/c954a18b-c001-4a4f-8106-9bee696fe9da/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="UoVg25FyjPy8brVs86o75tOOgNsOX6wA0s0bs1SQaQ",
+        oauth_signature="sop7WsOsXl9EUtHonZL6VOFIrcQ%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681227", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:07 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jOTU0YTE4Yi1jMDAxLTRhNGYtODEwNi05YmVlNjk2ZmU5
+        ZGEvIiwgInRhc2tfaWQiOiAiYzk1NGExOGItYzAwMS00YTRmLTgxMDYtOWJl
+        ZTY5NmZlOWRhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjOGI4
+        YWRhNDBkYjA0ZWUwYjI0In0sICJpZCI6ICI1NmI0YWM4YjhhZGE0MGRiMDRl
+        ZTBiMjQifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:07 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/c954a18b-c001-4a4f-8106-9bee696fe9da/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="McmYvqMvVRAJKzci6zx2AvBkYyr3X69xkqal60Sw",
+        oauth_signature="LI99uWj60Hl8Kmy%2FNw8gaa%2FdMVQ%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681227", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:07 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '649'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jOTU0YTE4Yi1jMDAxLTRhNGYtODEwNi05YmVlNjk2ZmU5
+        ZGEvIiwgInRhc2tfaWQiOiAiYzk1NGExOGItYzAwMS00YTRmLTgxMDYtOWJl
+        ZTY5NmZlOWRhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0
+        YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwg
+        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNTZiNGFjOGI4YWRhNDBkYjA0ZWUwYjI0In0sICJpZCI6ICI1NmI0YWM4
+        YjhhZGE0MGRiMDRlZTBiMjQifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:07 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/c954a18b-c001-4a4f-8106-9bee696fe9da/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="mP7iG4qrQFEbaHa29gYXOq8BsvDTpY7ymhxnXxwOhc",
+        oauth_signature="yapqibPKVrtMpk4qbsCtWW86P%2Bc%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681228", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:08 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jOTU0YTE4Yi1jMDAxLTRhNGYtODEwNi05YmVlNjk2ZmU5
+        ZGEvIiwgInRhc2tfaWQiOiAiYzk1NGExOGItYzAwMS00YTRmLTgxMDYtOWJl
+        ZTY5NmZlOWRhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNzowOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNzowN1oiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMzM3MzUzZmYtOTYwNy00NzVjLWE4MDMtZmM5YWNlZTg1
+        OWE3LyIsICJ0YXNrX2lkIjogIjMzNzM1M2ZmLTk2MDctNDc1Yy1hODAzLWZj
+        OWFjZWU4NTlhNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzhiYzc4MjFiMzMwMzRiYWU1YiJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDc6MDdaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNzow
+        OFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjOGNjNzgyMWIzNDQ0ZmNjMmJkIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjOGI4YWRhNDBkYjA0ZWUwYjI0In0s
+        ICJpZCI6ICI1NmI0YWM4YjhhZGE0MGRiMDRlZTBiMjQifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:08 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/bb676a4a-8793-42d1-b5ee-e1c28dc71339/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="NCs6N9VQoOtwiLHEKu4w9vuDxW9luB6A6b8TIaj4H0",
+        oauth_signature="nq2xunbhwp6nSGd8BFhkqjabG1U%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681229", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:09 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '651'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iYjY3NmE0YS04NzkzLTQyZDEtYjVlZS1lMWMyOGRjNzEz
+        MzkvIiwgInRhc2tfaWQiOiAiYmI2NzZhNGEtODc5My00MmQxLWI1ZWUtZTFj
+        MjhkYzcxMzM5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAi
+        c3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
+        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1NmI0YWM4ZDhhZGE0MGRiMDRlZTBiMzUifSwgImlkIjogIjU2YjRh
+        YzhkOGFkYTQwZGIwNGVlMGIzNSJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:09 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/bb676a4a-8793-42d1-b5ee-e1c28dc71339/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="a7jv3NdtP37yYyTM2Ko2YC10OwMqXLZFpkAK2EWehM",
+        oauth_signature="eThwSpe2z6xnwSmqotJUiofPi4Y%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681230", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:10 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iYjY3NmE0YS04NzkzLTQyZDEtYjVlZS1lMWMyOGRjNzEz
+        MzkvIiwgInRhc2tfaWQiOiAiYmI2NzZhNGEtODc5My00MmQxLWI1ZWUtZTFj
+        MjhkYzcxMzM5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA3OjA5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA3OjA5WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjOGQ4YWRhNDBkYjA0ZWUwYjM1In0sICJpZCI6ICI1NmI0YWM4ZDhhZGE0
+        MGRiMDRlZTBiMzUifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:10 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/cd3cf44b-9b35-42a4-9216-2e17785decdb/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="w46N9ngAVdFS6frpt1EqlnuB7aBqEc4w7bTNJUWJI",
+        oauth_signature="FLItXxVosWbF8ULRtd0G%2F1i6ahE%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681231", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:11 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jZDNjZjQ0Yi05YjM1LTQyYTQtOTIxNi0yZTE3Nzg1ZGVj
+        ZGIvIiwgInRhc2tfaWQiOiAiY2QzY2Y0NGItOWIzNS00MmE0LTkyMTYtMmUx
+        Nzc4NWRlY2RiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjOGY4
+        YWRhNDBkYjA0ZWUwYjM2In0sICJpZCI6ICI1NmI0YWM4ZjhhZGE0MGRiMDRl
+        ZTBiMzYifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:11 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/cd3cf44b-9b35-42a4-9216-2e17785decdb/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="2Xlm2lqfIgXIIfdJZ3XsFqswji0ALDcDv1H2ZIknw",
+        oauth_signature="AkwbGQtw4w90MBx6h%2Fo9lRW5yfA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681231", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:11 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '649'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jZDNjZjQ0Yi05YjM1LTQyYTQtOTIxNi0yZTE3Nzg1ZGVj
+        ZGIvIiwgInRhc2tfaWQiOiAiY2QzY2Y0NGItOWIzNS00MmE0LTkyMTYtMmUx
+        Nzc4NWRlY2RiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0
+        YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwg
+        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNTZiNGFjOGY4YWRhNDBkYjA0ZWUwYjM2In0sICJpZCI6ICI1NmI0YWM4
+        ZjhhZGE0MGRiMDRlZTBiMzYifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:11 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/cd3cf44b-9b35-42a4-9216-2e17785decdb/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="CI2Ed6JHjD6ItUYWBR3MEYsCsTX3FLcZvxQLLHElK58",
+        oauth_signature="zOJRPF%2FE%2Fg99GBI7nxm2FRBZ27g%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681233", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:13 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jZDNjZjQ0Yi05YjM1LTQyYTQtOTIxNi0yZTE3Nzg1ZGVj
+        ZGIvIiwgInRhc2tfaWQiOiAiY2QzY2Y0NGItOWIzNS00MmE0LTkyMTYtMmUx
+        Nzc4NWRlY2RiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNzoxMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNzoxMloiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvOTUyZjQxMmMtOGE5Ni00MjAyLTg0YTMtZDM4Y2JlNjE1
+        OWFlLyIsICJ0YXNrX2lkIjogIjk1MmY0MTJjLThhOTYtNDIwMi04NGEzLWQz
+        OGNiZTYxNTlhZSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzhmYzc4MjFiMzMwNDJkOWUyNiJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDc6MTJaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNzox
+        MloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjOTBjNzgyMWIzNDQ0ZmNjMmMyIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjOGY4YWRhNDBkYjA0ZWUwYjM2In0s
+        ICJpZCI6ICI1NmI0YWM4ZjhhZGE0MGRiMDRlZTBiMzYifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:13 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/099b8b10-c803-4842-a20c-d837c46be38e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="3CfehFanR2HL0gJq2Wka6COBHmWSSvXg0OXht4lZo4",
+        oauth_signature="W6%2FEby6MOhh%2FepOgkuootYNSqNs%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681234", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:14 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wOTliOGIxMC1jODAzLTQ4NDItYTIwYy1kODM3YzQ2YmUz
+        OGUvIiwgInRhc2tfaWQiOiAiMDk5YjhiMTAtYzgwMy00ODQyLWEyMGMtZDgz
+        N2M0NmJlMzhlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM5
+        MjhhZGE0MGRiMDRlZTBiNDcifSwgImlkIjogIjU2YjRhYzkyOGFkYTQwZGIw
+        NGVlMGI0NyJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:14 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/099b8b10-c803-4842-a20c-d837c46be38e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Xq8LUeOSemuplDM7Q3VoYSFn0qLfTtfAg8H11a26DM",
+        oauth_signature="TPuwzabvlo5qql10l77AD0fI6Xg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681234", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:14 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wOTliOGIxMC1jODAzLTQ4NDItYTIwYy1kODM3YzQ2YmUz
+        OGUvIiwgInRhc2tfaWQiOiAiMDk5YjhiMTAtYzgwMy00ODQyLWEyMGMtZDgz
+        N2M0NmJlMzhlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA3OjE0WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA3OjE0WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjOTI4YWRhNDBkYjA0ZWUwYjQ3In0sICJpZCI6ICI1NmI0YWM5MjhhZGE0
+        MGRiMDRlZTBiNDcifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:14 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/505dd45f-08eb-4082-8a2b-c699f0ad7067/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="cGO71pNt6wsnA3BdshRntwaza3RmWPBPeSRpJHKUhfc",
+        oauth_signature="a9hKMF8jYzKezTLjJJAKu2mj9J4%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681236", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:16 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81MDVkZDQ1Zi0wOGViLTQwODItOGEyYi1jNjk5ZjBhZDcw
+        NjcvIiwgInRhc2tfaWQiOiAiNTA1ZGQ0NWYtMDhlYi00MDgyLThhMmItYzY5
+        OWYwYWQ3MDY3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjOTQ4
+        YWRhNDBkYjA0ZWUwYjQ4In0sICJpZCI6ICI1NmI0YWM5NDhhZGE0MGRiMDRl
+        ZTBiNDgifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:16 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/505dd45f-08eb-4082-8a2b-c699f0ad7067/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="MR8Y3A3o74wg9y4weKHcxBdM0tGKOAUwrpYbXC6HRX0",
+        oauth_signature="7T%2FNbj4moITe7zygvQvafJ001n4%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681236", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:16 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '649'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81MDVkZDQ1Zi0wOGViLTQwODItOGEyYi1jNjk5ZjBhZDcw
+        NjcvIiwgInRhc2tfaWQiOiAiNTA1ZGQ0NWYtMDhlYi00MDgyLThhMmItYzY5
+        OWYwYWQ3MDY3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0
+        YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwg
+        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNTZiNGFjOTQ4YWRhNDBkYjA0ZWUwYjQ4In0sICJpZCI6ICI1NmI0YWM5
+        NDhhZGE0MGRiMDRlZTBiNDgifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:16 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/505dd45f-08eb-4082-8a2b-c699f0ad7067/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="hplRjpxgjNIZEtbleecIa27i3oNF6Uirh6DbUK3dU",
+        oauth_signature="iHt26Jp3ZreQNN2tHA%2B5gmkEmKI%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681237", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81MDVkZDQ1Zi0wOGViLTQwODItOGEyYi1jNjk5ZjBhZDcw
+        NjcvIiwgInRhc2tfaWQiOiAiNTA1ZGQ0NWYtMDhlYi00MDgyLThhMmItYzY5
+        OWYwYWQ3MDY3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNzoxN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNzoxNloiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvN2JiZWYzMzgtZWUwYy00NTUwLWE4NjEtNjczNzk1YmEz
+        ZGQ2LyIsICJ0YXNrX2lkIjogIjdiYmVmMzM4LWVlMGMtNDU1MC1hODYxLTY3
+        Mzc5NWJhM2RkNiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        Yzk0Yzc4MjFiMzMwMzRiYWU2MCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDc6MTZaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNzox
+        N1oiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjOTVjNzgyMWIzNDQ0ZmNjMmM3IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjOTQ4YWRhNDBkYjA0ZWUwYjQ4In0s
+        ICJpZCI6ICI1NmI0YWM5NDhhZGE0MGRiMDRlZTBiNDgifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:17 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/83bbb4f8-ba18-4861-9db1-e9dad2142cf6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="tDPTP0eMlKgWu3Ni94aCGPIjVgKOqRdf3cLuCHmxpI",
+        oauth_signature="Y3FNibO%2FaRutr4GdwfwX5%2FqmP3s%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681238", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:18 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84M2JiYjRmOC1iYTE4LTQ4NjEtOWRiMS1lOWRhZDIxNDJj
+        ZjYvIiwgInRhc2tfaWQiOiAiODNiYmI0ZjgtYmExOC00ODYxLTlkYjEtZTlk
+        YWQyMTQyY2Y2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM5
+        NjhhZGE0MGRiMDRlZTBiNTkifSwgImlkIjogIjU2YjRhYzk2OGFkYTQwZGIw
+        NGVlMGI1OSJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:18 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/83bbb4f8-ba18-4861-9db1-e9dad2142cf6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="kHphjJD74zLU0V8AZRSsZM797MK74sLjIEilaOE2Uc",
+        oauth_signature="bsGohx1MMIBYc2iDRDK9Wz%2BwsUY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681239", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:19 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84M2JiYjRmOC1iYTE4LTQ4NjEtOWRiMS1lOWRhZDIxNDJj
+        ZjYvIiwgInRhc2tfaWQiOiAiODNiYmI0ZjgtYmExOC00ODYxLTlkYjEtZTlk
+        YWQyMTQyY2Y2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA3OjE4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA3OjE4WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjOTY4YWRhNDBkYjA0ZWUwYjU5In0sICJpZCI6ICI1NmI0YWM5NjhhZGE0
+        MGRiMDRlZTBiNTkifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:19 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/b766eb24-163c-4217-8bd6-45f90a830999/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="RH9c5iVRO81QfLLu9flQ4hR2KWoiYZkYOMRtIjuC0yM",
+        oauth_signature="1x3Yd%2FaqXeEFCMUBrW4VQwSjv5M%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681240", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:20 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iNzY2ZWIyNC0xNjNjLTQyMTctOGJkNi00NWY5MGE4MzA5
+        OTkvIiwgInRhc2tfaWQiOiAiYjc2NmViMjQtMTYzYy00MjE3LThiZDYtNDVm
+        OTBhODMwOTk5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjOTg4
+        YWRhNDBkYjA0ZWUwYjVhIn0sICJpZCI6ICI1NmI0YWM5ODhhZGE0MGRiMDRl
+        ZTBiNWEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:20 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/b766eb24-163c-4217-8bd6-45f90a830999/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Io1So70XWQWKVpFc33VyoCYMyAdIlIF2AbyZVTU1k",
+        oauth_signature="6XOgdX%2FQ5NEosfSUG034A7EWCh0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681240", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:20 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iNzY2ZWIyNC0xNjNjLTQyMTctOGJkNi00NWY5MGE4MzA5
+        OTkvIiwgInRhc2tfaWQiOiAiYjc2NmViMjQtMTYzYy00MjE3LThiZDYtNDVm
+        OTBhODMwOTk5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjOTg4
+        YWRhNDBkYjA0ZWUwYjVhIn0sICJpZCI6ICI1NmI0YWM5ODhhZGE0MGRiMDRl
+        ZTBiNWEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:20 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/b766eb24-163c-4217-8bd6-45f90a830999/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="PjcJzkltfqgXRJGbmnnLDItV712E3nc4jy6LLs7PxU",
+        oauth_signature="%2BLun0MoZs6GXCHd8UjeZZ5uLapQ%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681241", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iNzY2ZWIyNC0xNjNjLTQyMTctOGJkNi00NWY5MGE4MzA5
+        OTkvIiwgInRhc2tfaWQiOiAiYjc2NmViMjQtMTYzYy00MjE3LThiZDYtNDVm
+        OTBhODMwOTk5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNzoyMVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNzoyMVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvOTlhOTg1YjgtM2NmNS00NGExLWE3M2UtMWYwMDBlN2Ex
+        OGEyLyIsICJ0YXNrX2lkIjogIjk5YTk4NWI4LTNjZjUtNDRhMS1hNzNlLTFm
+        MDAwZTdhMThhMiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        Yzk4Yzc4MjFiMzMwMzRiYWU2NSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDc6MjFaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNzoy
+        MVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjOTljNzgyMWIzNDQ0ZmNjMmNjIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjOTg4YWRhNDBkYjA0ZWUwYjVhIn0s
+        ICJpZCI6ICI1NmI0YWM5ODhhZGE0MGRiMDRlZTBiNWEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:22 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/5e3ef41f-e43f-4a9c-90af-46ec5a636907/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="PiuVIJCvhiHTORMjWpRsSkQ97ffi8DioBa2IFa9xyE",
+        oauth_signature="bPO5iyWvp0jGBvA5VjTxYuCnKOI%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681243", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:23 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81ZTNlZjQxZi1lNDNmLTRhOWMtOTBhZi00NmVjNWE2MzY5
+        MDcvIiwgInRhc2tfaWQiOiAiNWUzZWY0MWYtZTQzZi00YTljLTkwYWYtNDZl
+        YzVhNjM2OTA3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM5
+        YjhhZGE0MGRiMDRlZTBiNmIifSwgImlkIjogIjU2YjRhYzliOGFkYTQwZGIw
+        NGVlMGI2YiJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:23 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/5e3ef41f-e43f-4a9c-90af-46ec5a636907/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="hgYFo3fX855dLqkbdSg9qUnKihSJXcXntWSvAQEY4",
+        oauth_signature="hO9bkt8X7pS1FrMJxbMgOViss8I%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681243", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:23 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81ZTNlZjQxZi1lNDNmLTRhOWMtOTBhZi00NmVjNWE2MzY5
+        MDcvIiwgInRhc2tfaWQiOiAiNWUzZWY0MWYtZTQzZi00YTljLTkwYWYtNDZl
+        YzVhNjM2OTA3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA3OjIzWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA3OjIzWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjOWI4YWRhNDBkYjA0ZWUwYjZiIn0sICJpZCI6ICI1NmI0YWM5YjhhZGE0
+        MGRiMDRlZTBiNmIifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:23 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
+        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
+        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
+        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
+        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
+        LXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1
+        dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9j
+        b25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoLyIsImh0dHAiOmZh
+        bHNlLCJodHRwcyI6dHJ1ZSwicHJvdGVjdGVkIjp0cnVlLCJjaGVja3N1bV90
+        eXBlIjpudWxsfSwiYXV0b19wdWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9p
+        ZCI6IkZlZG9yYV8xNyJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9j
+        bG9uZV9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJkZXN0
+        aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6IkZlZG9yYV8xNyJ9LCJhdXRvX3B1
+        Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRvcl9pZCI6IkZlZG9yYV8xN19jbG9u
+        ZSJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ImV4cG9ydF9kaXN0cmlidXRv
+        ciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJodHRwIjpmYWxzZSwiaHR0cHMi
+        OmZhbHNlLCJyZWxhdGl2ZV91cmwiOm51bGx9LCJhdXRvX3B1Ymxpc2giOmZh
+        bHNlLCJkaXN0cmlidXRvcl9pZCI6ImV4cG9ydF9kaXN0cmlidXRvciJ9XX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="5VidRM1eauoDG0cejGLHE0lxbEkDzgWOvayG5nVPgZQ", oauth_signature="bYlQZan9%2FUfWAL3uDm4%2BjmqADF8%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681245", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '809'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:25 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '320'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
+        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
+        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NTZiNGFjOWRjNzgyMWIzMzA1Y2U1MTQ3In0sICJpZCI6ICJGZWRvcmFfMTci
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
+        MTcvIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:25 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjR9fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="PEEiGm0pDFWrxO12TwjLjfKQURGo3ur1ZuosiWlrk", oauth_signature="PMQM3yGR5f8h6YHa5mdy7KHiLdQ%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681245", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '37'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:25 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzgxZDdjMzhjLWU5MWMtNDdlZS1hMzE1LTdjM2U0YTViOWNkMi8iLCAi
+        dGFza19pZCI6ICI4MWQ3YzM4Yy1lOTFjLTQ3ZWUtYTMxNS03YzNlNGE1Yjlj
+        ZDIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:25 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/81d7c38c-e91c-47ee-a315-7c3e4a5b9cd2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="06Hxe2H28p0I5nMAdwrOkKckC8qVV9vRzRwYHzz1M",
+        oauth_signature="yjbKdqu8Fjw5MnlciEKwEEtkQfY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681245", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:25 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84MWQ3YzM4Yy1lOTFjLTQ3ZWUtYTMxNS03YzNlNGE1Yjlj
+        ZDIvIiwgInRhc2tfaWQiOiAiODFkN2MzOGMtZTkxYy00N2VlLWEzMTUtN2Mz
+        ZTRhNWI5Y2QyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjOWQ4
+        YWRhNDBkYjA0ZWUwYjZjIn0sICJpZCI6ICI1NmI0YWM5ZDhhZGE0MGRiMDRl
+        ZTBiNmMifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:25 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/81d7c38c-e91c-47ee-a315-7c3e4a5b9cd2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="uW7iyY8GYnjxVdp1gGmL6tQnA1stEURt73MtWDg",
+        oauth_signature="IJ2ViLaKyRloAXuRblphMYXjMhM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681245", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:25 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '667'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84MWQ3YzM4Yy1lOTFjLTQ3ZWUtYTMxNS03YzNlNGE1Yjlj
+        ZDIvIiwgInRhc2tfaWQiOiAiODFkN2MzOGMtZTkxYy00N2VlLWEzMTUtN2Mz
+        ZTRhNWI5Y2QyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0wNVQxNDowNzoyNVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4
+        YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25h
+        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgt
+        ZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51
+        bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjOWQ4YWRhNDBkYjA0ZWUwYjZj
+        In0sICJpZCI6ICI1NmI0YWM5ZDhhZGE0MGRiMDRlZTBiNmMifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:25 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/81d7c38c-e91c-47ee-a315-7c3e4a5b9cd2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="hda0SuTg9npwGlm0TbSyLHYwTCEZ1TABmzrW0X6Q",
+        oauth_signature="sEcof%2FHU329ELP8%2FoJLc705bcac%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681246", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:26 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84MWQ3YzM4Yy1lOTFjLTQ3ZWUtYTMxNS03YzNlNGE1Yjlj
+        ZDIvIiwgInRhc2tfaWQiOiAiODFkN2MzOGMtZTkxYy00N2VlLWEzMTUtN2Mz
+        ZTRhNWI5Y2QyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNzoyNloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNzoyNVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMmUzMTRmNGQtODUwYy00YjJjLWIzMWYtMTU0ZDRlNmMx
+        YTljLyIsICJ0YXNrX2lkIjogIjJlMzE0ZjRkLTg1MGMtNGIyYy1iMzFmLTE1
+        NGQ0ZTZjMWE5YyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzlkYzc4MjFiMzMwNWNlNTE0OCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDc6MjVaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNzoy
+        NloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjOWVjNzgyMWIzNDQ0ZmNjMmQxIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjOWQ4YWRhNDBkYjA0ZWUwYjZjIn0s
+        ICJpZCI6ICI1NmI0YWM5ZDhhZGE0MGRiMDRlZTBiNmMifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:26 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/?tag=pulp:action:sync
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="avgxb6U1E7tpZpB4euJQrpc7rL3mepeCRj5jSrtGS4",
+        oauth_signature="8R5XZhMlX2cwA%2BbzryG8vqLLOpc%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681247", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:27 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '129710'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3siZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZl
+        ci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvZGYyYzBkY2ItOTU5NC00NGRlLTg1ZDMtNTg3MWU2NTg2
+        YTk2LyIsICJ0YXNrX2lkIjogImRmMmMwZGNiLTk1OTQtNDRkZS04NWQzLTU4
+        NzFlNjU4NmE5NiIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3Jh
+        XzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIw
+        MTYtMDItMDRUMjE6NDE6MTNaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
+        dGFydF90aW1lIjogIjIwMTYtMDItMDRUMjE6NDE6MTJaIiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAv
+        YXBpL3YyL3Rhc2tzLzM0YzUxNWIzLTkwNzMtNDZlZS1iNmJlLWYxNjhkZTgy
+        NTQyMi8iLCAidGFza19pZCI6ICIzNGM1MTViMy05MDczLTQ2ZWUtYjZiZS1m
+        MTY4ZGU4MjU0MjIifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIsICJz
+        aXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBs
+        ZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBv
+        cnRlcl9pZCI6IHsiJG9pZCI6ICI1NmIzYzU3OGM3ODIxYjMzMDM0YmFkN2Mi
+        fSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA0VDIx
+        OjQxOjEyWiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxl
+        dGVkIjogIjIwMTYtMDItMDRUMjE6NDE6MTNaIiwgImltcG9ydGVyX3R5cGVf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAi
+        c3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In19LCAiYWRkZWRfY291bnQiOiAwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1
+        cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YjNjNTc5Yzc4MjFiMzQ0NGZj
+        YzE4OCIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjog
+        MTc4NzIsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogOCwgInN0
+        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiA4LCAicnBtX2RvbmUiOiA4LCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
+        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1NmIzYzU3ODhhZGE0MGRiMDRlZTA2YjAifSwgImlkIjogIjU2YjNjNTc4
+        OGFkYTQwZGIwNGVlMDZiMCJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNr
+        X3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMi
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzEwYWEwYWNhLTc3OWIt
+        NGJlYi1hMmI0LTE3MmFkZDI3Nzg5MC8iLCAidGFza19pZCI6ICIxMGFhMGFj
+        YS03NzliLTRiZWItYTJiNC0xNzJhZGQyNzc4OTAiLCAidGFncyI6IFsicHVs
+        cDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0s
+        ICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA0VDIxOjQxOjQxWiIsICJfbnMi
+        OiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0VDIx
+        OjQxOjQwWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6
+        IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy85NmU0MTdhNy1kMjMy
+        LTQwNGQtOGYxNS0wNTIwNzBjZmFiZDUvIiwgInRhc2tfaWQiOiAiOTZlNDE3
+        YTctZDIzMi00MDRkLThmMTUtMDUyMDcwY2ZhYmQ1In1dLCAicHJvZ3Jlc3Nf
+        cmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQiOiB7Iml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9u
+        ZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAic2l6
+        ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9
+        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRp
+        b24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
+        c3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmIzYzU5NGM3
+        ODIxYjMzMDVjZTUwNzEifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lk
+        IjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6
+        ICIyMDE2LTAyLTA0VDIxOjQxOjQwWiIsICJfbnMiOiAicmVwb19zeW5jX3Jl
+        c3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMDRUMjE6NDE6NDFaIiwg
+        ImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21l
+        c3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJy
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAicmVtb3Zl
+        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YjNj
+        NTk1Yzc4MjFiMzQ0NGZjYzE4ZSIsICJkZXRhaWxzIjogeyJjb250ZW50Ijog
+        eyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwg
+        ImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJk
+        cnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWls
+        cyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
+        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjU2YjNjNTk0OGFkYTQwZGIwNGVlMDZjYyJ9LCAiaWQi
+        OiAiNTZiM2M1OTQ4YWRhNDBkYjA0ZWUwNmNjIn0sIHsiZXhjZXB0aW9uIjog
+        bnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBv
+        LnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMzcz
+        MjhkYTQtMzc3Ni00OGJiLTg0YWItMWE0N2VjYTEwNThkLyIsICJ0YXNrX2lk
+        IjogIjM3MzI4ZGE0LTM3NzYtNDhiYi04NGFiLTFhNDdlY2ExMDU4ZCIsICJ0
+        YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0
+        aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMDRUMjE6NDE6
+        NDZaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTYtMDItMDRUMjE6NDE6NDVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzI0
+        NjNhNzUwLWQ5NDctNDZmYS04MWIwLTcwYzcxYjM1ODQ5My8iLCAidGFza19p
+        ZCI6ICIyNDYzYTc1MC1kOTQ3LTQ2ZmEtODFiMC03MGM3MWIzNTg0OTMifV0s
+        ICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVu
+        dCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjog
+        MCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25l
+        IjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVt
+        c19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6
+        IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlz
+        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0xQGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7
+        InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjog
+        IjU2YjNjNTk5Yzc4MjFiMzMwNDJkOWQyZCJ9LCAiZXhjZXB0aW9uIjogbnVs
+        bCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGws
+        ICJzdGFydGVkIjogIjIwMTYtMDItMDRUMjE6NDE6NDVaIiwgIl9ucyI6ICJy
+        ZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNFQy
+        MTo0MTo0NloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIi
+        LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
+        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6
+        IDAsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAi
+        aWQiOiAiNTZiM2M1OWFjNzgyMWIzNDQ0ZmNjMTkzIiwgImRldGFpbHMiOiB7
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0
+        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1z
+        X2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiM2M1OTk4YWRhNDBkYjA0ZWUw
+        NmRmIn0sICJpZCI6ICI1NmIzYzU5OThhZGE0MGRiMDRlZTA2ZGYifSwgeyJl
+        eGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVyLm1h
+        bmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92
+        Mi90YXNrcy85ZDRmZjY4MC00MjhjLTRhMGUtYWFiZS0wYzY3NGExNmM0OWMv
+        IiwgInRhc2tfaWQiOiAiOWQ0ZmY2ODAtNDI4Yy00YTBlLWFhYmUtMGM2NzRh
+        MTZjNDljIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFfMTci
+        LCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0w
+        Mi0wNFQyMTo0MTo1MVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0
+        X3RpbWUiOiAiMjAxNi0wMi0wNFQyMTo0MTo1MVoiLCAidHJhY2ViYWNrIjog
+        bnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9hcGkv
+        djIvdGFza3MvZjBlNTBlODktYjBkNS00ODUyLWIyMmYtNjliNDJkZjY2ZmI2
+        LyIsICJ0YXNrX2lkIjogImYwZTUwZTg5LWIwZDUtNDg1Mi1iMjJmLTY5YjQy
+        ZGY2NmZiNiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
+        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAic3Rh
+        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwg
+        InJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQi
+        OiB7IiRvaWQiOiAiNTZiM2M1OWVjNzgyMWIzMzA0MmQ5ZDNhIn0sICJleGNl
+        cHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2Vi
+        YWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMTo0MTo1MVoi
+        LCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIy
+        MDE2LTAyLTA0VDIxOjQxOjUxWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1
+        bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnki
+        OiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb21wcyI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFk
+        ZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1NmIzYzU5ZmM3ODIxYjM0NDRmY2MxOTgiLCAi
+        ZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVt
+        c19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwi
+        OiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2Rv
+        bmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19
+        fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzYzU5ZThh
+        ZGE0MGRiMDRlZTA2ZjIifSwgImlkIjogIjU2YjNjNTllOGFkYTQwZGIwNGVl
+        MDZmMiJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVs
+        cC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAi
+        L3B1bHAvYXBpL3YyL3Rhc2tzLzNlMGVmY2VkLWQwOWYtNDZjMy05NGI0LTRk
+        ZjQ0OTY0ZGIzYS8iLCAidGFza19pZCI6ICIzZTBlZmNlZC1kMDlmLTQ2YzMt
+        OTRiNC00ZGY0NDk2NGRiM2EiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5
+        OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGlt
+        ZSI6ICIyMDE2LTAyLTA0VDIxOjQxOjU2WiIsICJfbnMiOiAidGFza19zdGF0
+        dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0VDIxOjQxOjU1WiIsICJ0
+        cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjog
+        Ii9wdWxwL2FwaS92Mi90YXNrcy8yMjZhZDliNC03OGNmLTRjNDYtYTU1YS0y
+        MTY3NDNjYTI3OTkvIiwgInRhc2tfaWQiOiAiMjI2YWQ5YjQtNzhjZi00YzQ2
+        LWE1NWEtMjE2NzQzY2EyNzk5In1dLCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5
+        dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBt
+        X3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAs
+        ICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhh
+        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJp
+        bXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmIzYzVhM2M3ODIxYjMzMDVjZTUw
+        NzYifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8x
+        NyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA0
+        VDIxOjQxOjU1WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29t
+        cGxldGVkIjogIjIwMTYtMDItMDRUMjE6NDE6NTZaIiwgImltcG9ydGVyX3R5
+        cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxs
+        LCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAicmVtb3ZlZF9jb3VudCI6IDAs
+        ICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YjNjNWE0Yzc4MjFiMzQ0
+        NGZjYzE5ZCIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFs
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7
+        InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjog
+        MCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNv
+        bXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjog
+        eyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjog
+        IjU2YjNjNWEzOGFkYTQwZGIwNGVlMDcwNSJ9LCAiaWQiOiAiNTZiM2M1YTM4
+        YWRhNDBkYjA0ZWUwNzA1In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tf
+        dHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIs
+        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvN2FjMzRkOGItOGM3My00
+        ZDZlLWJmMDUtNGFhOGY3ZjJkYTA5LyIsICJ0YXNrX2lkIjogIjdhYzM0ZDhi
+        LThjNzMtNGQ2ZS1iZjA1LTRhYThmN2YyZGEwOSIsICJ0YWdzIjogWyJwdWxw
+        OnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwg
+        ImZpbmlzaF90aW1lIjogIjIwMTYtMDItMDRUMjE6NDI6MDJaIiwgIl9ucyI6
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMDRUMjE6
+        NDI6MDJaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        W3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzBhYmJkNjJiLTY1NzIt
+        NDAxNC05N2Q2LTY2OWZkNmFhZWE4Mi8iLCAidGFza19pZCI6ICIwYWJiZDYy
+        Yi02NTcyLTQwMTQtOTdkNi02NjlmZDZhYWVhODIifV0sICJwcm9ncmVzc19y
+        ZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNf
+        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
+        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXpl
+        X3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        Mi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJz
+        dWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjNjNWE4Yzc4
+        MjFiMzMwNDJkOWQzZiJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQi
+        OiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjog
+        IjIwMTYtMDItMDRUMjE6NDI6MDJaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVz
+        dWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNFQyMTo0MjowMloiLCAi
+        aW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJyb3JfbWVz
+        c2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJyZW1vdmVk
+        X2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZiM2M1
+        YWFjNzgyMWIzNDQ0ZmNjMWEyIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7
+        InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3Rh
+        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAi
+        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
+        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxz
+        IjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
+        cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQi
+        OiB7IiRvaWQiOiAiNTZiM2M1YTk4YWRhNDBkYjA0ZWUwNzE4In0sICJpZCI6
+        ICI1NmIzYzVhOThhZGE0MGRiMDRlZTA3MTgifSwgeyJleGNlcHRpb24iOiBu
+        dWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVyLm1hbmFnZXJzLnJlcG8u
+        c3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8xN2Jl
+        NDRjYS1mM2E5LTQ2YWYtOTg5Ni01ZTYwNmMyZjAyMzYvIiwgInRhc2tfaWQi
+        OiAiMTdiZTQ0Y2EtZjNhOS00NmFmLTk4OTYtNWU2MDZjMmYwMjM2IiwgInRh
+        Z3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFfMTciLCAicHVscDphY3Rp
+        b246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0wNFQyMTo0Mjow
+        OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAx
+        Ni0wMi0wNFQyMTo0MjowN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXdu
+        ZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMzhl
+        OWI3NjQtMjYzYS00N2VhLTg2NzEtMDhiNGQ1ZjJkNTUwLyIsICJ0YXNrX2lk
+        IjogIjM4ZTliNzY0LTI2M2EtNDdlYS04NjcxLTA4YjRkNWYyZDU1MCJ9XSwg
+        InByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVyIjogeyJjb250ZW50
+        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0IjogMCwgIml0ZW1z
+        X2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAic3RhdGUiOiAiZmluaXNo
+        ZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        cmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAi
+        NTZiM2M1YWVjNzgyMWIzMzAzNGJhZDk2In0sICJleGNlcHRpb24iOiBudWxs
+        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMTo0MjowN1oiLCAiX25zIjogInJl
+        cG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA0VDIx
+        OjQyOjA4WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50Ijog
+        MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJp
+        ZCI6ICI1NmIzYzViMGM3ODIxYjM0NDRmY2MxYTciLCAiZGV0YWlscyI6IHsi
+        Y29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwg
+        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVf
+        bGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2Rv
+        bmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVy
+        cm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNf
+        bGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9yIjog
+        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzYzVhZjhhZGE0MGRiMDRlZTA3
+        MmIifSwgImlkIjogIjU2YjNjNWFmOGFkYTQwZGIwNGVlMDcyYiJ9LCB7ImV4
+        Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFu
+        YWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L3Rhc2tzL2U0YmY1NjBiLWZmYTgtNGVlYi04NWNlLTUxYWQ4MDAxZjc2MC8i
+        LCAidGFza19pZCI6ICJlNGJmNTYwYi1mZmE4LTRlZWItODVjZS01MWFkODAw
+        MWY3NjAiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIs
+        ICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAy
+        LTA0VDIxOjQyOjEzWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRf
+        dGltZSI6ICIyMDE2LTAyLTA0VDIxOjQyOjEzWiIsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92
+        Mi90YXNrcy9lY2U3OGNkZi03NmMxLTQ3NTUtYjQ3Yi0xMDRjMmY4MzgzMTcv
+        IiwgInRhc2tfaWQiOiAiZWNlNzhjZGYtNzZjMS00NzU1LWI0N2ItMTA0YzJm
+        ODM4MzE3In1dLCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIi
+        OiB7ImNvbnRlbnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJw
+        bV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwg
+        ImRycG1fZG9uZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQi
+        OiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0
+        ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0
+        ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6
+        IHsiJG9pZCI6ICI1NmIzYzViNGM3ODIxYjMzMDQyZDlkNGMifSwgImV4Y2Vw
+        dGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA0VDIxOjQyOjEzWiIs
+        ICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
+        MTYtMDItMDRUMjE6NDI6MTNaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVt
+        X2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6
+        IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2Nv
+        dW50IjogMCwgImlkIjogIjU2YjNjNWI1Yzc4MjFiMzQ0NGZjYzFhYyIsICJk
+        ZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1z
+        X2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
+        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
+        ZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
+        bCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjNjNWI1OGFk
+        YTQwZGIwNGVlMDczZSJ9LCAiaWQiOiAiNTZiM2M1YjU4YWRhNDBkYjA0ZWUw
+        NzNlIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxw
+        LnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIv
+        cHVscC9hcGkvdjIvdGFza3MvMGY2ZWRkMWYtNWM4ZS00ZmI5LTgwNWYtMjU1
+        ZDEyN2Q1ZjcwLyIsICJ0YXNrX2lkIjogIjBmNmVkZDFmLTVjOGUtNGZiOS04
+        MDVmLTI1NWQxMjdkNWY3MCIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6
+        RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1l
+        IjogIjIwMTYtMDItMDRUMjE6NDI6MzVaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1
+        cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMDRUMjE6NDI6MzRaIiwgInRy
+        YWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAi
+        L3B1bHAvYXBpL3YyL3Rhc2tzLzA0ODc5OTc3LWQ0NDYtNGZjZC04Yzc0LWQy
+        OGZhMjA0MWNjNC8iLCAidGFza19pZCI6ICIwNDg3OTk3Ny1kNDQ2LTRmY2Qt
+        OGM3NC1kMjhmYTIwNDFjYzQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1
+        bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4
+        NzIsICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0
+        ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmIzYzVjYWM3ODIxYjMzMDQy
+        ZDlkNmEifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9y
+        YV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAy
+        LTA0VDIxOjQyOjM0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAi
+        Y29tcGxldGVkIjogIjIwMTYtMDItMDRUMjE6NDI6MzVaIiwgImltcG9ydGVy
+        X3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBu
+        dWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
+        YnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAicmVtb3ZlZF9jb3VudCI6
+        IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YjNjNWNiYzc4MjFi
+        MzQ0NGZjYzFiOSIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3Rv
+        dGFsIjogMTc4NzIsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjog
+        OCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRh
+        aWxzIjogeyJycG1fdG90YWwiOiA4LCAicnBtX2RvbmUiOiA4LCAiZHJwbV90
+        b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBb
+        XX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJy
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1NmIzYzVjYThhZGE0MGRiMDRlZTA3NWEifSwgImlkIjogIjU2
+        YjNjNWNhOGFkYTQwZGIwNGVlMDc1YSJ9LCB7ImV4Y2VwdGlvbiI6IG51bGws
+        ICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5j
+        LnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2QyYjJhNDQ2
+        LWNhN2EtNDU5OS04YTEzLWVjZmQ0MTgwZTU5MC8iLCAidGFza19pZCI6ICJk
+        MmIyYTQ0Ni1jYTdhLTQ1OTktOGExMy1lY2ZkNDE4MGU1OTAiLCAidGFncyI6
+        IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpz
+        eW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA0VDIxOjQyOjQ0WiIs
+        ICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAy
+        LTA0VDIxOjQyOjQzWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90
+        YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9kYWEzYzk3
+        Zi0zYTBhLTQzMWQtYjY0My02ZjZiZTM2YTE1NGUvIiwgInRhc2tfaWQiOiAi
+        ZGFhM2M5N2YtM2EwYS00MzFkLWI2NDMtNmY2YmUzNmExNTRlIn1dLCAicHJv
+        Z3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQiOiB7
+        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJy
+        cG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9
+        LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVm
+        dCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
+        cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmIz
+        YzVkM2M3ODIxYjMzMDVjZTUwOTIifSwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTAyLTA0VDIxOjQyOjQzWiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMDRUMjE6NDI6
+        NDRaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAi
+        cmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjog
+        IjU2YjNjNWQ0Yzc4MjFiMzQ0NGZjYzFiZiIsICJkZXRhaWxzIjogeyJjb250
+        ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRl
+        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0
+        IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6
+        IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0
+        IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
+        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU2YjNjNWQzOGFkYTQwZGIwNGVlMDc2ZiJ9
+        LCAiaWQiOiAiNTZiM2M1ZDM4YWRhNDBkYjA0ZWUwNzZmIn0sIHsiZXhjZXB0
+        aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vy
+        cy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFz
+        a3MvODAyM2I2OTgtNDZhZi00NGVlLWJlMzQtMGIxNzNiYmRiMWNkLyIsICJ0
+        YXNrX2lkIjogIjgwMjNiNjk4LTQ2YWYtNDRlZS1iZTM0LTBiMTczYmJkYjFj
+        ZCIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1
+        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMDRU
+        MjE6NDI6NDhaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
+        IjogIjIwMTYtMDItMDRUMjE6NDI6NDdaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzljZGEyNTczLTlhZDEtNGE5ZS1iNTZiLTgwY2M1YzIxM2RlZC8iLCAi
+        dGFza19pZCI6ICI5Y2RhMjU3My05YWQxLTRhOWUtYjU2Yi04MGNjNWMyMTNk
+        ZWQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsi
+        Y29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3Rv
+        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
+        bV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAs
+        ICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNf
+        bGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjog
+        ImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
+        X3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1
+        bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIk
+        b2lkIjogIjU2YjNjNWQ3Yzc4MjFiMzMwMzRiYWRhYyJ9LCAiZXhjZXB0aW9u
+        IjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6
+        IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDRUMjE6NDI6NDdaIiwgIl9u
+        cyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0w
+        Mi0wNFQyMTo0Mjo0OFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1w
+        b3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJj
+        b250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9j
+        b3VudCI6IDAsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQi
+        OiAwLCAiaWQiOiAiNTZiM2M1ZDhjNzgyMWIzNDQ0ZmNjMWM0IiwgImRldGFp
+        bHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVm
+        dCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwg
+        InJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
+        MH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiM2M1ZDc4YWRhNDBk
+        YjA0ZWUwNzgxIn0sICJpZCI6ICI1NmIzYzVkNzhhZGE0MGRiMDRlZTA3ODEi
+        fSwgeyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2Vy
+        dmVyLm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxw
+        L2FwaS92Mi90YXNrcy8xODdjYmIxZS0xZGU4LTQ4ODUtYmNmYy0yNWI2M2Nj
+        ODA1MjcvIiwgInRhc2tfaWQiOiAiMTg3Y2JiMWUtMWRlOC00ODg1LWJjZmMt
+        MjViNjNjYzgwNTI3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRv
+        cmFfMTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAi
+        MjAxNi0wMi0wNFQyMTo0Mjo1MloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwg
+        InN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNFQyMTo0Mjo1MVoiLCAidHJhY2Vi
+        YWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVs
+        cC9hcGkvdjIvdGFza3MvOGE1MTA3N2ItNWRhYS00Mzg5LTg4MTQtMGVjN2Ex
+        ODI1ZmU0LyIsICJ0YXNrX2lkIjogIjhhNTEwNzdiLTVkYWEtNDM4OS04ODE0
+        LTBlYzdhMTgyNWZlNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2lt
+        cG9ydGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3Rh
+        bCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6
+        ZV9sZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
+        bCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0
+        ZXJfaWQiOiB7IiRvaWQiOiAiNTZiM2M1ZGJjNzgyMWIzMzAzNGJhZGIxIn0s
+        ICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMTo0
+        Mjo1MVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDE2LTAyLTA0VDIxOjQyOjUxWiIsICJpbXBvcnRlcl90eXBlX2lk
+        IjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1
+        bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJj
+        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBk
+        YXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmIzYzVkYmM3ODIxYjM0NDRmY2Mx
+        YzkiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAs
+        ICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1f
+        dG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJk
+        cnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRl
+        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIz
+        YzVkYjhhZGE0MGRiMDRlZTA3OTMifSwgImlkIjogIjU2YjNjNWRiOGFkYTQw
+        ZGIwNGVlMDc5MyJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUi
+        OiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hy
+        ZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2I5NDJjMzg0LTViYWEtNDdjNi1h
+        MTFiLWJmMjA0NGUzYTVmNy8iLCAidGFza19pZCI6ICJiOTQyYzM4NC01YmFh
+        LTQ3YzYtYTExYi1iZjIwNDRlM2E1ZjciLCAidGFncyI6IFsicHVscDpyZXBv
+        c2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE2LTAyLTA0VDIxOjQyOjU2WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0VDIxOjQyOjU1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9o
+        cmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8xY2IzZjc1Ny01ZTgzLTRmMjAt
+        YjZkNS02NWNjMmZhODcyODYvIiwgInRhc2tfaWQiOiAiMWNiM2Y3NTctNWU4
+        My00ZjIwLWI2ZDUtNjVjYzJmYTg3Mjg2In1dLCAicHJvZ3Jlc3NfcmVwb3J0
+        IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQiOiB7Iml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAs
+        ICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAic2l6ZV90b3Rh
+        bCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29t
+        cHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1k
+        ZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2Vz
+        cyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmIzYzVkZmM3ODIxYjMz
+        MDM0YmFkYjYifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZl
+        ZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2
+        LTAyLTA0VDIxOjQyOjU1WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMi
+        LCAiY29tcGxldGVkIjogIjIwMTYtMDItMDRUMjE6NDI6NTZaIiwgImltcG9y
+        dGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2Ui
+        OiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
+        dHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAicmVtb3ZlZF9jb3Vu
+        dCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YjNjNWUwYzc4
+        MjFiMzQ0NGZjYzFjZSIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXpl
+        X3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
+        bHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3Rv
+        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2YjNjNWRmOGFkYTQwZGIwNGVlMDdhNSJ9LCAiaWQiOiAiNTZi
+        M2M1ZGY4YWRhNDBkYjA0ZWUwN2E1In0sIHsiZXhjZXB0aW9uIjogbnVsbCwg
+        InRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMu
+        c3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvOWYzNGViNTYt
+        NTkzNy00ZmQwLTg0NzQtMTA5YjQwMTRlZjliLyIsICJ0YXNrX2lkIjogIjlm
+        MzRlYjU2LTU5MzctNGZkMC04NDc0LTEwOWI0MDE0ZWY5YiIsICJ0YWdzIjog
+        WyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5
+        bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMDRUMjE6NDM6MDBaIiwg
+        Il9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDIt
+        MDRUMjE6NDI6NTlaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rh
+        c2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2M0NTJjMjFh
+        LTQ0NDktNGViYi1hYTliLWM0NWVjYWJhZjQzMS8iLCAidGFza19pZCI6ICJj
+        NDUyYzIxYS00NDQ5LTRlYmItYWE5Yi1jNDVlY2FiYWY0MzEifV0sICJwcm9n
+        cmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsi
+        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJw
+        bV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0s
+        ICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0
+        IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3Ry
+        aWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAi
+        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjNj
+        NWUzYzc4MjFiMzMwMzRiYWRiYiJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDRUMjE6NDI6NTlaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNFQyMTo0Mjo1
+        OVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiM2M1ZTNjNzgyMWIzNDQ0ZmNjMWQzIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiM2M1ZTM4YWRhNDBkYjA0ZWUwN2I3In0s
+        ICJpZCI6ICI1NmIzYzVlMzhhZGE0MGRiMDRlZTA3YjcifSwgeyJleGNlcHRp
+        b24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVyLm1hbmFnZXJz
+        LnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNr
+        cy9kYzBhMzcyMC04YjBmLTQxYjgtYTE4Yy03M2NkYWJjMzQxZjgvIiwgInRh
+        c2tfaWQiOiAiZGMwYTM3MjAtOGIwZi00MWI4LWExOGMtNzNjZGFiYzM0MWY4
+        IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFfMTciLCAicHVs
+        cDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0wNFQy
+        MTo0MzowNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxNi0wMi0wNFQyMTo0MzowM1oiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFz
+        a3MvYWMyMTMxOWUtZDJmMS00ZGZhLWJlYzUtOTNmZTk2NGM5ZmMyLyIsICJ0
+        YXNrX2lkIjogImFjMjEzMTllLWQyZjEtNGRmYS1iZWM1LTkzZmU5NjRjOWZj
+        MiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVyIjogeyJj
+        b250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJycG1fdG90
+        YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBt
+        X2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0IjogMCwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRv
+        aWQiOiAiNTZiM2M1ZTdjNzgyMWIzMzA0MmQ5ZDc3In0sICJleGNlcHRpb24i
+        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
+        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMTo0MzowM1oiLCAiX25z
+        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAy
+        LTA0VDIxOjQzOjA0WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
+        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7ImNv
+        bnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2Nv
+        dW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1NmIzYzVlOGM3ODIxYjM0NDRmY2MxZDgiLCAiZGV0YWls
+        cyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0
+        IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        InNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAi
+        cnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAw
+        fSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzYzVlNzhhZGE0MGRi
+        MDRlZTA3YzkifSwgImlkIjogIjU2YjNjNWU3OGFkYTQwZGIwNGVlMDdjOSJ9
+        LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2
+        ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAv
+        YXBpL3YyL3Rhc2tzLzU3YTljMjg5LTczNjAtNDJhNi04OWRkLTVmZTI3ZThm
+        NjUwMy8iLCAidGFza19pZCI6ICI1N2E5YzI4OS03MzYwLTQyYTYtODlkZC01
+        ZmUyN2U4ZjY1MDMiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9y
+        YV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA0VDIxOjQzOjA5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0VDIxOjQzOjA4WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxw
+        L2FwaS92Mi90YXNrcy8wNzgxOWJkNS1mMDUwLTQ2N2MtYWE2Yi1mNTBkM2Q2
+        NzJiN2QvIiwgInRhc2tfaWQiOiAiMDc4MTliZDUtZjA1MC00NjdjLWFhNmIt
+        ZjUwZDNkNjcyYjdkIn1dLCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1w
+        b3J0ZXIiOiB7ImNvbnRlbnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
+        IjogMCwgImRycG1fZG9uZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXpl
+        X2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
+        ZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRl
+        cl9pZCI6IHsiJG9pZCI6ICI1NmIzYzVlY2M3ODIxYjMzMDQyZDlkODAifSwg
+        ImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0
+        cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA0VDIxOjQz
+        OjA4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMDRUMjE6NDM6MDlaIiwgImltcG9ydGVyX3R5cGVfaWQi
+        OiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3Vt
+        bWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNv
+        bXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19
+        LCAiYWRkZWRfY291bnQiOiAwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRh
+        dGVkX2NvdW50IjogMCwgImlkIjogIjU2YjNjNWVkYzc4MjFiMzQ0NGZjYzFk
+        ZCIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwg
+        Iml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90
+        b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRy
+        cG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVt
+        c190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjNj
+        NWVjOGFkYTQwZGIwNGVlMDdkYiJ9LCAiaWQiOiAiNTZiM2M1ZWM4YWRhNDBk
+        YjA0ZWUwN2RiIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6
+        ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJl
+        ZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZjNkODEyOTEtMDAyZS00YmE4LTky
+        ODgtYWFkZTZhOGI4ZjU5LyIsICJ0YXNrX2lkIjogImYzZDgxMjkxLTAwMmUt
+        NGJhOC05Mjg4LWFhZGU2YThiOGY1OSIsICJ0YWdzIjogWyJwdWxwOnJlcG9z
+        aXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTYtMDItMDRUMjE6NDM6MTNaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMDRUMjE6NDM6MTNa
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hy
+        ZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzVlMzJiODg5LWYyZWMtNDUzOS04
+        NGI4LThhZmQ2N2RkYjQyNy8iLCAidGFza19pZCI6ICI1ZTMyYjg4OS1mMmVj
+        LTQ1MzktODRiOC04YWZkNjdkZGI0MjcifV0sICJwcm9ncmVzc19yZXBvcnQi
+        OiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
+        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFs
+        IjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21w
+        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
+        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRl
+        di5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
+        IiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjNjNWYwYzc4MjFiMzMw
+        MzRiYWRjMCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVk
+        b3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMTYt
+        MDItMDRUMjE6NDM6MTNaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIs
+        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNFQyMTo0MzoxM1oiLCAiaW1wb3J0
+        ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6
+        IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
+        cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJyZW1vdmVkX2NvdW50
+        IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZiM2M1ZjFjNzgy
+        MWIzNDQ0ZmNjMWUyIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVf
+        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
+        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRp
+        b24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRv
+        aWQiOiAiNTZiM2M1ZjA4YWRhNDBkYjA0ZWUwN2VkIn0sICJpZCI6ICI1NmIz
+        YzVmMDhhZGE0MGRiMDRlZTA3ZWQifSwgeyJleGNlcHRpb24iOiBudWxsLCAi
+        dGFza190eXBlIjogInB1bHAuc2VydmVyLm1hbmFnZXJzLnJlcG8uc3luYy5z
+        eW5jIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9jZGFiOTIwOS03
+        NmQ5LTRkZTQtYTdiOS01NzZmOTVmMmRmNzMvIiwgInRhc2tfaWQiOiAiY2Rh
+        YjkyMDktNzZkOS00ZGU0LWE3YjktNTc2Zjk1ZjJkZjczIiwgInRhZ3MiOiBb
+        InB1bHA6cmVwb3NpdG9yeTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246c3lu
+        YyJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0wNFQyMTo0MzoxN1oiLCAi
+        X25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0w
+        NFQyMTo0MzoxNloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFz
+        a3MiOiBbeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNTkxZGM3ZTgt
+        ZjRjMi00YTIzLWE0Y2YtZTlhM2NkZmFlMjU1LyIsICJ0YXNrX2lkIjogIjU5
+        MWRjN2U4LWY0YzItNGEyMy1hNGNmLWU5YTNjZGZhZTI1NSJ9XSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVyIjogeyJjb250ZW50IjogeyJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBt
+        X2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwg
+        InNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0IjogMCwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
+        YnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJl
+        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifX19LCAic3RhdGUiOiAiZmluaXNoZWQiLCAi
+        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0
+        ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0
+        IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZiM2M1
+        ZjRjNzgyMWIzMzA1Y2U1MDllIn0sICJleGNlcHRpb24iOiBudWxsLCAicmVw
+        b19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0
+        ZWQiOiAiMjAxNi0wMi0wNFQyMTo0MzoxNloiLCAiX25zIjogInJlcG9fc3lu
+        Y19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA0VDIxOjQzOjE3
+        WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJv
+        cl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJl
+        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
+        NmIzYzVmNWM3ODIxYjM0NDRmY2MxZTciLCAiZGV0YWlscyI6IHsiY29udGVu
+        dCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6
+        IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAw
+        LCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2Rl
+        dGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6
+        IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmIzYzVmNDhhZGE0MGRiMDRlZTA3ZmYifSwg
+        ImlkIjogIjU2YjNjNWY0OGFkYTQwZGIwNGVlMDdmZiJ9LCB7ImV4Y2VwdGlv
+        biI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMu
+        cmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tz
+        L2EwMjdlMzlhLWE5NDUtNDY3NS1iNTNjLTNlZTZkMTIzM2Q3NS8iLCAidGFz
+        a19pZCI6ICJhMDI3ZTM5YS1hOTQ1LTQ2NzUtYjUzYy0zZWU2ZDEyMzNkNzUi
+        LCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxw
+        OmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA0VDIx
+        OjQzOjIxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6
+        ICIyMDE2LTAyLTA0VDIxOjQzOjIxWiIsICJ0cmFjZWJhY2siOiBudWxsLCAi
+        c3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNr
+        cy85MmMwOTA1NC0wODE2LTRiOGUtOTUwMS01MzQ2NDU5OTZiNDcvIiwgInRh
+        c2tfaWQiOiAiOTJjMDkwNTQtMDgxNi00YjhlLTk1MDEtNTM0NjQ1OTk2YjQ3
+        In1dLCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNv
+        bnRlbnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3Rh
+        bCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1f
+        ZG9uZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xl
+        ZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
+        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJm
+        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0
+        IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9p
+        ZCI6ICI1NmIzYzVmOGM3ODIxYjMzMDM0YmFkYzYifSwgImV4Y2VwdGlvbiI6
+        IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA0VDIxOjQzOjIxWiIsICJfbnMi
+        OiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDIt
+        MDRUMjE6NDM6MjFaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9y
+        dGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29u
+        dGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiAwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50Ijog
+        MCwgImlkIjogIjU2YjNjNWY5Yzc4MjFiMzQ0NGZjYzFlYyIsICJkZXRhaWxz
+        IjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQi
+        OiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        c2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJy
+        cG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
+        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjNjNWY4OGFkYTQwZGIw
+        NGVlMDgxMSJ9LCAiaWQiOiAiNTZiM2M1Zjg4YWRhNDBkYjA0ZWUwODExIn0s
+        IHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZl
+        ci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNmRiYzEyNjItNGQ2MC00ZDI2LTk2ZWMtNDBkZTEyMDAy
+        ODM0LyIsICJ0YXNrX2lkIjogIjZkYmMxMjYyLTRkNjAtNGQyNi05NmVjLTQw
+        ZGUxMjAwMjgzNCIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3Jh
+        XzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIw
+        MTYtMDItMDRUMjE6NDM6MjVaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
+        dGFydF90aW1lIjogIjIwMTYtMDItMDRUMjE6NDM6MjVaIiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAv
+        YXBpL3YyL3Rhc2tzLzc0OGM5ZjkzLThhZDctNDljZi1hMTY1LThjODU5N2E0
+        NDFhZS8iLCAidGFza19pZCI6ICI3NDhjOWY5My04YWQ3LTQ5Y2YtYTE2NS04
+        Yzg1OTdhNDQxYWUifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwi
+        OiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwg
+        InN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVk
+        X3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNv
+        bSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVy
+        X2lkIjogeyIkb2lkIjogIjU2YjNjNWZkYzc4MjFiMzMwMzRiYWRjYyJ9LCAi
+        ZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRy
+        YWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDRUMjE6NDM6
+        MjVaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQi
+        OiAiMjAxNi0wMi0wNFQyMTo0MzoyNVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6
+        ICJ5dW1faW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1t
+        YXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29t
+        cHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0s
+        ICJhZGRlZF9jb3VudCI6IDAsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0
+        ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZiM2M1ZmRjNzgyMWIzNDQ0ZmNjMWYx
+        IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAi
+        aXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3Rv
+        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
+        bV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiM2M1
+        ZmQ4YWRhNDBkYjA0ZWUwODIzIn0sICJpZCI6ICI1NmIzYzVmZDhhZGE0MGRi
+        MDRlZTA4MjMifSwgeyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjog
+        InB1bHAuc2VydmVyLm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVm
+        IjogIi9wdWxwL2FwaS92Mi90YXNrcy84Njg5NjlmOC0wODQ2LTRiOWMtYWQ3
+        NS0wY2IzMTU0NWRkYjcvIiwgInRhc2tfaWQiOiAiODY4OTY5ZjgtMDg0Ni00
+        YjljLWFkNzUtMGNiMzE1NDVkZGI3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
+        dG9yeTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMi0wNFQyMTo0MzozMFoiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNFQyMTo0MzoyOVoi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJl
+        ZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZGE4MjU0NWMtMzQ0Yy00Yjk1LTk3
+        ZGUtNzhmYjFjMWUzZDZhLyIsICJ0YXNrX2lkIjogImRhODI1NDVjLTM0NGMt
+        NGI5NS05N2RlLTc4ZmIxYzFlM2Q2YSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6
+        IHsieXVtX2ltcG9ydGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAi
+        ZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwi
+        OiAwLCAic2l6ZV9sZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJp
+        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX19LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2
+        LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3Mi
+        LCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZiM2M2MDFjNzgyMWIzMzAz
+        NGJhZGQxIn0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
+        cmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0w
+        Mi0wNFQyMTo0MzoyOVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwg
+        ImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA0VDIxOjQzOjMwWiIsICJpbXBvcnRl
+        cl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjog
+        bnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3Ry
+        aWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQi
+        OiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmIzYzYwMmM3ODIx
+        YjM0NDRmY2MxZjYiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90
+        b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxz
+        IjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3Rh
+        bCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1NmIzYzYwMThhZGE0MGRiMDRlZTA4MzUifSwgImlkIjogIjU2YjNj
+        NjAxOGFkYTQwZGIwNGVlMDgzNSJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0
+        YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5
+        bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzMwZmUxNGU1LTEw
+        YzYtNGQ3Ni1hYWU1LTM3NTQ0Mjg4ODhlNC8iLCAidGFza19pZCI6ICIzMGZl
+        MTRlNS0xMGM2LTRkNzYtYWFlNS0zNzU0NDI4ODg4ZTQiLCAidGFncyI6IFsi
+        cHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5j
+        Il0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA0VDIxOjQzOjM0WiIsICJf
+        bnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0
+        VDIxOjQzOjMzWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNr
+        cyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9lOGM3MmYxNy1l
+        YTVkLTRhZmMtYmI0NS0xMzU4YjEzNTVlZjEvIiwgInRhc2tfaWQiOiAiZThj
+        NzJmMTctZWE1ZC00YWZjLWJiNDUtMTM1OGIxMzU1ZWYxIn1dLCAicHJvZ3Jl
+        c3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQiOiB7Iml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1f
+        ZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAi
+        c2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6
+        IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
+        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmIzYzYw
+        NWM3ODIxYjMzMDM0YmFkZDYifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
+        ZCI6ICIyMDE2LTAyLTA0VDIxOjQzOjMzWiIsICJfbnMiOiAicmVwb19zeW5j
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMDRUMjE6NDM6MzRa
+        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAicmVt
+        b3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2
+        YjNjNjA2Yzc4MjFiMzQ0NGZjYzFmYiIsICJkZXRhaWxzIjogeyJjb250ZW50
+        IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNf
+        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0Ijog
+        MCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAs
+        ICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0
+        YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU2YjNjNjA1OGFkYTQwZGIwNGVlMDg0NyJ9LCAi
+        aWQiOiAiNTZiM2M2MDU4YWRhNDBkYjA0ZWUwODQ3In0sIHsiZXhjZXB0aW9u
+        IjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5y
+        ZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3Mv
+        YmIyMDA5ZGYtNzA5OS00N2JlLWE5NTMtODNhZDY4N2U0YzEwLyIsICJ0YXNr
+        X2lkIjogImJiMjAwOWRmLTcwOTktNDdiZS1hOTUzLTgzYWQ2ODdlNGMxMCIs
+        ICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6
+        YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMDRUMjE6
+        NDM6MzhaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
+        IjIwMTYtMDItMDRUMjE6NDM6MzhaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
+        cGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tz
+        L2FhYTM0ZjVmLTA0NmUtNDUyOC04YzYxLWRkYjliYmMxMzg2NS8iLCAidGFz
+        a19pZCI6ICJhYWEzNGY1Zi0wNDZlLTQ1MjgtOGM2MS1kZGI5YmJjMTM4NjUi
+        fV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29u
+        dGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
+        IjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9k
+        b25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJp
+        dGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVm
+        dCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0
+        YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZp
+        bmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQi
+        OiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lk
+        IjogIjU2YjNjNjBhYzc4MjFiMzMwNWNlNTBhNiJ9LCAiZXhjZXB0aW9uIjog
+        bnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDRUMjE6NDM6MzhaIiwgIl9ucyI6
+        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0w
+        NFQyMTo0MzozOFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250
+        ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3Vu
+        dCI6IDAsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAw
+        LCAiaWQiOiAiNTZiM2M2MGFjNzgyMWIzNDQ0ZmNjMjAwIiwgImRldGFpbHMi
+        OiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6
+        IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJz
+        aXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJw
+        bV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0s
+        ICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0
+        ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJv
+        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiM2M2MGE4YWRhNDBkYjA0
+        ZWUwODU5In0sICJpZCI6ICI1NmIzYzYwYThhZGE0MGRiMDRlZTA4NTkifSwg
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zOWYzNmE3Yi04NjIxLTRhNWItOGJjMy0wOTliOTlkOWEx
+        NjUvIiwgInRhc2tfaWQiOiAiMzlmMzZhN2ItODYyMS00YTViLThiYzMtMDk5
+        Yjk5ZDlhMTY1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNFQyMTo0Mzo0M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNFQyMTo0Mzo0MloiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMGE5ZjU1OGEtYzIwZS00YzdkLWJhMWMtMjViNjMxNTg4
+        ZWVjLyIsICJ0YXNrX2lkIjogIjBhOWY1NThhLWMyMGUtNGM3ZC1iYTFjLTI1
+        YjYzMTU4OGVlYyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        c3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRf
+        cmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29t
+        IiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJf
+        aWQiOiB7IiRvaWQiOiAiNTZiM2M2MGVjNzgyMWIzMzAzNGJhZGRiIn0sICJl
+        eGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJh
+        Y2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMTo0Mzo0
+        MloiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6
+        ICIyMDE2LTAyLTA0VDIxOjQzOjQzWiIsICJpbXBvcnRlcl90eXBlX2lkIjog
+        Inl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1h
+        cnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb21w
+        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwg
+        ImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRl
+        ZF9jb3VudCI6IDAsICJpZCI6ICI1NmIzYzYwZmM3ODIxYjM0NDRmY2MyMDUi
+        LCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJp
+        dGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90
+        YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBt
+        X2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNf
+        dG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzYzYw
+        ZThhZGE0MGRiMDRlZTA4NmIifSwgImlkIjogIjU2YjNjNjBlOGFkYTQwZGIw
+        NGVlMDg2YiJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAi
+        cHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2UxZmZjMDE4LWJjMzAtNDdjMi05YWI5
+        LWQ1M2YyYzBmNzkxNC8iLCAidGFza19pZCI6ICJlMWZmYzAxOC1iYzMwLTQ3
+        YzItOWFiOS1kNTNmMmMwZjc5MTQiLCAidGFncyI6IFsicHVscDpyZXBvc2l0
+        b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hf
+        dGltZSI6ICIyMDE2LTAyLTA0VDIxOjQzOjQ3WiIsICJfbnMiOiAidGFza19z
+        dGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0VDIxOjQzOjQ3WiIs
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVm
+        IjogIi9wdWxwL2FwaS92Mi90YXNrcy9lZmM1MmEwMS1kODZjLTQ4MjMtYjM0
+        NC1iMDU3ODY0ZWYzNmUvIiwgInRhc2tfaWQiOiAiZWZjNTJhMDEtZDg2Yy00
+        ODIzLWIzNDQtYjA1Nzg2NGVmMzZlIn1dLCAicHJvZ3Jlc3NfcmVwb3J0Ijog
+        eyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQiOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJk
+        cnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAic2l6ZV90b3RhbCI6
+        IDAsICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0
+        ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmIzYzYxMmM3ODIxYjMzMDQy
+        ZDlkODUifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9y
+        YV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAy
+        LTA0VDIxOjQzOjQ3WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAi
+        Y29tcGxldGVkIjogIjIwMTYtMDItMDRUMjE6NDM6NDdaIiwgImltcG9ydGVy
+        X3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBu
+        dWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
+        YnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAicmVtb3ZlZF9jb3VudCI6
+        IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YjNjNjEzYzc4MjFi
+        MzQ0NGZjYzIwYSIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3Rv
+        dGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMi
+        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
+        IjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
+        IjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
+        IjogIjU2YjNjNjEyOGFkYTQwZGIwNGVlMDg3ZCJ9LCAiaWQiOiAiNTZiM2M2
+        MTI4YWRhNDBkYjA0ZWUwODdkIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRh
+        c2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3lu
+        YyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMGNlZDY4NTktMjM4
+        ZS00ZTMxLWI1NWUtMzc2M2MzMmVlMjNmLyIsICJ0YXNrX2lkIjogIjBjZWQ2
+        ODU5LTIzOGUtNGUzMS1iNTVlLTM3NjNjMzJlZTIzZiIsICJ0YWdzIjogWyJw
+        dWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMi
+        XSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMDRUMjE6NDM6NTJaIiwgIl9u
+        cyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMDRU
+        MjE6NDM6NTFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        IjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2Q0MjM5MjUwLTJl
+        ZmUtNDgyYy05YjQyLTMzMjlhZTkyMThhNi8iLCAidGFza19pZCI6ICJkNDIz
+        OTI1MC0yZWZlLTQ4MmMtOWI0Mi0zMzI5YWU5MjE4YTYifV0sICJwcm9ncmVz
+        c19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRl
+        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJz
+        aXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0Ijog
+        MH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJy
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVs
+        bG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6
+        ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjNjNjE3
+        Yzc4MjFiMzMwNDJkOWQ4YSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9f
+        aWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFydGVk
+        IjogIjIwMTYtMDItMDRUMjE6NDM6NTFaIiwgIl9ucyI6ICJyZXBvX3N5bmNf
+        cmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNFQyMTo0Mzo1Mloi
+        LCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJyb3Jf
+        bWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJl
+        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
+        M2M2MThjNzgyMWIzNDQ0ZmNjMjBmIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
+        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
+        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
+        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
+        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
+        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJk
+        aXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAw
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNTZiM2M2MTc4YWRhNDBkYjA0ZWUwODhmIn0sICJp
+        ZCI6ICI1NmIzYzYxNzhhZGE0MGRiMDRlZTA4OGYifSwgeyJleGNlcHRpb24i
+        OiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVyLm1hbmFnZXJzLnJl
+        cG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8w
+        Njg5OThmOC1lZTk0LTRjZTQtYTJjOC00ZmZjOGQyNDk3N2QvIiwgInRhc2tf
+        aWQiOiAiMDY4OTk4ZjgtZWU5NC00Y2U0LWEyYzgtNGZmYzhkMjQ5NzdkIiwg
+        InRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFfMTciLCAicHVscDph
+        Y3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0wNFQyMTo0
+        Mzo1OVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAi
+        MjAxNi0wMi0wNFQyMTo0Mzo1OVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNw
+        YXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3Mv
+        ZjhlNDYwNTktOTRmZC00MmMzLWEyY2EtYWRiMGUxMGQ1ZGJlLyIsICJ0YXNr
+        X2lkIjogImY4ZTQ2MDU5LTk0ZmQtNDJjMy1hMmNhLWFkYjBlMTBkNWRiZSJ9
+        XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVyIjogeyJjb250
+        ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJycG1fdG90YWwi
+        OiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2Rv
+        bmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0IjogMCwgIml0
+        ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0
+        IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
+        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
+        IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQi
+        OiAiNTZiM2M2MWVjNzgyMWIzMzA0MmQ5ZDkwIn0sICJleGNlcHRpb24iOiBu
+        dWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVs
+        bCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMTo0Mzo1OVoiLCAiX25zIjog
+        InJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA0
+        VDIxOjQzOjU5WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRl
+        ciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRl
+        bnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
+        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50
+        IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAs
+        ICJpZCI6ICI1NmIzYzYxZmM3ODIxYjM0NDRmY2MyMTgiLCAiZGV0YWlscyI6
+        IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0Ijog
+        MCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNp
+        emVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBt
+        X2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwg
+        ImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRl
+        bXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9y
+        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzYzYxZThhZGE0MGRiMDRl
+        ZTA4YjMifSwgImlkIjogIjU2YjNjNjFlOGFkYTQwZGIwNGVlMDhiMyJ9LCB7
+        ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIu
+        bWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
+        L3YyL3Rhc2tzLzgxYzMxNjMwLTkwMTQtNDdmNy1hNDYxLTU1NWMyYjg5ZTFk
+        Yy8iLCAidGFza19pZCI6ICI4MWMzMTYzMC05MDE0LTQ3ZjctYTQ2MS01NTVj
+        MmI4OWUxZGMiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8x
+        NyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2
+        LTAyLTA0VDIxOjQ0OjU3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3Rh
+        cnRfdGltZSI6ICIyMDE2LTAyLTA0VDIxOjQ0OjU3WiIsICJ0cmFjZWJhY2si
+        OiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84M2UxMGNiYS05NzVjLTQ5ZDAtYWIxZC0xMzY0NjhlM2Ew
+        OTgvIiwgInRhc2tfaWQiOiAiODNlMTBjYmEtOTc1Yy00OWQwLWFiMWQtMTM2
+        NDY4ZTNhMDk4In1dLCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0
+        ZXIiOiB7ImNvbnRlbnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7
+        InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjog
+        MCwgImRycG1fZG9uZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xl
+        ZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJz
+        dGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
+        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9p
+        ZCI6IHsiJG9pZCI6ICI1NmIzYzY1OGM3ODIxYjMzMDVjZTUwYjIifSwgImV4
+        Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFj
+        ZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA0VDIxOjQ0OjU3
+        WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjog
+        IjIwMTYtMDItMDRUMjE6NDQ6NTdaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFy
+        eSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAi
+        YWRkZWRfY291bnQiOiAwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVk
+        X2NvdW50IjogMCwgImlkIjogIjU2YjNjNjU5Yzc4MjFiMzQ0NGZjYzIxZCIs
+        ICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0
+        ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklO
+        SVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3Rh
+        bCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1f
+        ZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
+        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjNjNjU5
+        OGFkYTQwZGIwNGVlMDhjNSJ9LCAiaWQiOiAiNTZiM2M2NTk4YWRhNDBkYjA0
+        ZWUwOGM1In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJw
+        dWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6
+        ICIvcHVscC9hcGkvdjIvdGFza3MvMGIxMjkyM2UtM2ZmYi00MDcxLTgxYjgt
+        MzEwYWVhNWZkZGEzLyIsICJ0YXNrX2lkIjogIjBiMTI5MjNlLTNmZmItNDA3
+        MS04MWI4LTMxMGFlYTVmZGRhMyIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRv
+        cnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90
+        aW1lIjogIjIwMTYtMDItMDRUMjE6NDU6MDFaIiwgIl9ucyI6ICJ0YXNrX3N0
+        YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMDRUMjE6NDU6MDFaIiwg
+        InRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzNlMTllMGY3LTczMjUtNDgyNi1iYjYy
+        LWIzN2UzMmMwODBkMy8iLCAidGFza19pZCI6ICIzZTE5ZTBmNy03MzI1LTQ4
+        MjYtYmI2Mi1iMzdlMzJjMDgwZDMifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
+        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjog
+        MCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRl
+        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5l
+        eGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwg
+        ImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjNjNjVjYzc4MjFiMzMwMzRi
+        YWRlMSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3Jh
+        XzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDIt
+        MDRUMjE6NDU6MDFaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJj
+        b21wbGV0ZWQiOiAiMjAxNi0wMi0wNFQyMTo0NTowMVoiLCAiaW1wb3J0ZXJf
+        dHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51
+        bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJyZW1vdmVkX2NvdW50Ijog
+        MCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZiM2M2NWRjNzgyMWIz
+        NDQ0ZmNjMjIyIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90
+        YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAi
+        Y29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNTZiM2M2NWQ4YWRhNDBkYjA0ZWUwOGQ3In0sICJpZCI6ICI1NmIzYzY1
+        ZDhhZGE0MGRiMDRlZTA4ZDcifSwgeyJleGNlcHRpb24iOiBudWxsLCAidGFz
+        a190eXBlIjogInB1bHAuc2VydmVyLm1hbmFnZXJzLnJlcG8uc3luYy5zeW5j
+        IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy85Y2Q2NzIyZC1hMWY2
+        LTRlZTctYWNkNC02ZGJlOWYzOGM3ZDEvIiwgInRhc2tfaWQiOiAiOWNkNjcy
+        MmQtYTFmNi00ZWU3LWFjZDQtNmRiZTlmMzhjN2QxIiwgInRhZ3MiOiBbInB1
+        bHA6cmVwb3NpdG9yeTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246c3luYyJd
+        LCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0wNFQyMTo0NTowNloiLCAiX25z
+        IjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNFQy
+        MTo0NTowNVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3Mi
+        OiBbeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZGQ3ZThhZjEtNmJh
+        OS00NzEwLWE4MjQtZmU0ZjE2NDM0Y2Y1LyIsICJ0YXNrX2lkIjogImRkN2U4
+        YWYxLTZiYTktNDcxMC1hODI0LWZlNGYxNjQzNGNmNSJ9XSwgInByb2dyZXNz
+        X3JlcG9ydCI6IHsieXVtX2ltcG9ydGVyIjogeyJjb250ZW50IjogeyJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2Rv
+        bmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgInNp
+        emVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAw
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29y
+        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
+        by0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0Ijog
+        InN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZiM2M2NjFj
+        NzgyMWIzMzAzNGJhZGU2In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19p
+        ZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQi
+        OiAiMjAxNi0wMi0wNFQyMTo0NTowNVoiLCAiX25zIjogInJlcG9fc3luY19y
+        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA0VDIxOjQ1OjA2WiIs
+        ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9t
+        ZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92
+        ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmIz
+        YzY2MmM3ODIxYjM0NDRmY2MyMjciLCAiZGV0YWlscyI6IHsiY29udGVudCI6
+        IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAs
+        ICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAi
+        ZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFp
+        bHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRp
+        c3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklO
+        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9
+        LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1NmIzYzY2MThhZGE0MGRiMDRlZTA4ZTkifSwgImlk
+        IjogIjU2YjNjNjYxOGFkYTQwZGIwNGVlMDhlOSJ9LCB7ImV4Y2VwdGlvbiI6
+        IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVw
+        by5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzU2
+        OTZiODA4LTE1ODgtNGYwNy1iOTkyLWU0OWY0Nzk3ZjQ2Ni8iLCAidGFza19p
+        ZCI6ICI1Njk2YjgwOC0xNTg4LTRmMDctYjk5Mi1lNDlmNDc5N2Y0NjYiLCAi
+        dGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFj
+        dGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA0VDIxOjQ1
+        OjExWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIy
+        MDE2LTAyLTA0VDIxOjQ1OjEwWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bh
+        d25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81
+        NjM0ZDZhZS0yYWFkLTQ1ZDMtOTgxZC05Yjg2YjIwN2U3ZjcvIiwgInRhc2tf
+        aWQiOiAiNTYzNGQ2YWUtMmFhZC00NWQzLTk4MWQtOWI4NmIyMDdlN2Y3In1d
+        LCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRl
+        bnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
+        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
+        ZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRl
+        bXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5p
+        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
+        eyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6
+        ICI1NmIzYzY2NWM3ODIxYjMzMDM0YmFkZWIifSwgImV4Y2VwdGlvbiI6IG51
+        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
+        LCAic3RhcnRlZCI6ICIyMDE2LTAyLTA0VDIxOjQ1OjEwWiIsICJfbnMiOiAi
+        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMDRU
+        MjE6NDU6MTFaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVu
+        dCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0
+        YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQi
+        OiAwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwg
+        ImlkIjogIjU2YjNjNjY3Yzc4MjFiMzQ0NGZjYzIyYyIsICJkZXRhaWxzIjog
+        eyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAw
+        LCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6
+        ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1f
+        ZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVt
+        c19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3Ii
+        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjNjNjY2OGFkYTQwZGIwNGVl
+        MDhmYiJ9LCAiaWQiOiAiNTZiM2M2NjY4YWRhNDBkYjA0ZWUwOGZiIn0sIHsi
+        ZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5t
+        YW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkv
+        djIvdGFza3MvNzViMzBlNWEtYmU0NS00NTdiLWFhMGMtZmJkM2U2NTE4N2Ri
+        LyIsICJ0YXNrX2lkIjogIjc1YjMwZTVhLWJlNDUtNDU3Yi1hYTBjLWZiZDNl
+        NjUxODdkYiIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3
+        IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYt
+        MDItMDRUMjE6NDU6MTVaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFy
+        dF90aW1lIjogIjIwMTYtMDItMDRUMjE6NDU6MTVaIiwgInRyYWNlYmFjayI6
+        IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBp
+        L3YyL3Rhc2tzL2IzYjA5ZDMyLWI4M2MtNDgzYi1hMTRmLWVkMWRhODgxOWU0
+        NS8iLCAidGFza19pZCI6ICJiM2IwOWQzMi1iODNjLTQ4M2ItYTE0Zi1lZDFk
+        YTg4MTllNDUifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRl
+        ciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsi
+        cnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAw
+        LCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVm
+        dCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0
+        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIs
+        ICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lk
+        IjogeyIkb2lkIjogIjU2YjNjNjZhYzc4MjFiMzMwNDJkOWRhMSJ9LCAiZXhj
+        ZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDRUMjE6NDU6MTVa
+        IiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAi
+        MjAxNi0wMi0wNFQyMTo0NToxNVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5
+        dW1faW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5
+        IjogeyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJh
+        ZGRlZF9jb3VudCI6IDAsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRf
+        Y291bnQiOiAwLCAiaWQiOiAiNTZiM2M2NmJjNzgyMWIzNDQ0ZmNjMjMxIiwg
+        ImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRl
+        bXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
+        IjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9k
+        b25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiM2M2NmE4
+        YWRhNDBkYjA0ZWUwOTBkIn0sICJpZCI6ICI1NmIzYzY2YThhZGE0MGRiMDRl
+        ZTA5MGQifSwgeyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1
+        bHAuc2VydmVyLm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjog
+        Ii9wdWxwL2FwaS92Mi90YXNrcy84YTdjNzcxYy1hYzRkLTQ0ZTktYTQ3Yy0y
+        Mzc2Zjc4OTRkOGEvIiwgInRhc2tfaWQiOiAiOGE3Yzc3MWMtYWM0ZC00NGU5
+        LWE0N2MtMjM3NmY3ODk0ZDhhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0wMi0wNFQyMTo0NToxOVoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNFQyMTo0NToxOVoiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6
+        ICIvcHVscC9hcGkvdjIvdGFza3MvOWUyYWYyNjgtMzFhOS00Y2NjLTkzYmYt
+        NTE5MWUwMGMwZWI3LyIsICJ0YXNrX2lkIjogIjllMmFmMjY4LTMxYTktNGNj
+        Yy05M2JmLTUxOTFlMDBjMGViNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsi
+        eXVtX2ltcG9ydGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJw
+        bV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAw
+        LCAic2l6ZV9sZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVt
+        c190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifX19LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4
+        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
+        aW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZiM2M2NmZjNzgyMWIzMzA0MmQ5
+        ZGE2In0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFf
+        MTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0w
+        NFQyMTo0NToxOVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE2LTAyLTA0VDIxOjQ1OjE5WiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAw
+        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmIzYzY2ZmM3ODIxYjM0
+        NDRmY2MyMzYiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3Rh
+        bCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0
+        YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJj
+        b21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1NmIzYzY2ZjhhZGE0MGRiMDRlZTA5MWYifSwgImlkIjogIjU2YjNjNjZm
+        OGFkYTQwZGIwNGVlMDkxZiJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNr
+        X3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMi
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2I5YzQwM2Y0LTUzYTQt
+        NGExNC1hOGNkLTk3ZWRlZjA2MDRkNy8iLCAidGFza19pZCI6ICJiOWM0MDNm
+        NC01M2E0LTRhMTQtYThjZC05N2VkZWYwNjA0ZDciLCAidGFncyI6IFsicHVs
+        cDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0s
+        ICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA0VDIxOjQ1OjM4WiIsICJfbnMi
+        OiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA0VDIx
+        OjQ1OjM3WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6
+        IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81MDVmZmUxMy01Mzdl
+        LTQxMjMtYTBjNC1lZjI3NzE4NGMzNzEvIiwgInRhc2tfaWQiOiAiNTA1ZmZl
+        MTMtNTM3ZS00MTIzLWEwYzQtZWYyNzcxODRjMzcxIn1dLCAicHJvZ3Jlc3Nf
+        cmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQiOiB7Iml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9u
+        ZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAic2l6
+        ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9
+        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRp
+        b24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxv
+        LTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAi
+        c3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmIzYzY4MWM3
+        ODIxYjMzMDM0YmFkZmEifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lk
+        IjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6
+        ICIyMDE2LTAyLTA0VDIxOjQ1OjM3WiIsICJfbnMiOiAicmVwb19zeW5jX3Jl
+        c3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMDRUMjE6NDU6MzhaIiwg
+        ImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21l
+        c3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJy
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAicmVtb3Zl
+        ZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YjNj
+        NjgyYzc4MjFiMzQ0NGZjYzI0MCIsICJkZXRhaWxzIjogeyJjb250ZW50Ijog
+        eyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwg
+        ImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJk
+        cnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWls
+        cyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlz
+        dHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjU2YjNjNjgxOGFkYTQwZGIwNGVlMDkzYiJ9LCAiaWQi
+        OiAiNTZiM2M2ODE4YWRhNDBkYjA0ZWUwOTNiIn0sIHsiZXhjZXB0aW9uIjog
+        bnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBv
+        LnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvODRl
+        MGY3MjItMzFlNC00NmI4LTk0NGUtNWY1ZjdmNGUyOWFkLyIsICJ0YXNrX2lk
+        IjogIjg0ZTBmNzIyLTMxZTQtNDZiOC05NDRlLTVmNWY3ZjRlMjlhZCIsICJ0
+        YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0
+        aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMDRUMjE6NDU6
+        NDFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTYtMDItMDRUMjE6NDU6NDFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzkz
+        YjM5YzdhLTU5YWQtNDRhMS04ZWI0LTE0OGUzZGFiNDVlOC8iLCAidGFza19p
+        ZCI6ICI5M2IzOWM3YS01OWFkLTQ0YTEtOGViNC0xNDhlM2RhYjQ1ZTgifV0s
+        ICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVu
+        dCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjog
+        MCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25l
+        IjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVt
+        c19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6
+        IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlz
+        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0xQGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7
+        InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjog
+        IjU2YjNjNjg1Yzc4MjFiMzMwNWNlNTBjNiJ9LCAiZXhjZXB0aW9uIjogbnVs
+        bCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGws
+        ICJzdGFydGVkIjogIjIwMTYtMDItMDRUMjE6NDU6NDFaIiwgIl9ucyI6ICJy
+        ZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNFQy
+        MTo0NTo0MVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIi
+        LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
+        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6
+        IDAsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAi
+        aWQiOiAiNTZiM2M2ODVjNzgyMWIzNDQ0ZmNjMjQ1IiwgImRldGFpbHMiOiB7
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0
+        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1z
+        X2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiM2M2ODU4YWRhNDBkYjA0ZWUw
+        OTRkIn0sICJpZCI6ICI1NmIzYzY4NThhZGE0MGRiMDRlZTA5NGQifSwgeyJl
+        eGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVyLm1h
+        bmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92
+        Mi90YXNrcy84ZDFkNjU4Ny0wOWM2LTQ4ODUtOTNkYS1lODgxZTBmZjUyZTUv
+        IiwgInRhc2tfaWQiOiAiOGQxZDY1ODctMDljNi00ODg1LTkzZGEtZTg4MWUw
+        ZmY1MmU1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFfMTci
+        LCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0w
+        Mi0wNFQyMTo0NTo0NloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0
+        X3RpbWUiOiAiMjAxNi0wMi0wNFQyMTo0NTo0NVoiLCAidHJhY2ViYWNrIjog
+        bnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9hcGkv
+        djIvdGFza3MvMWEwOGVmODMtZjQ0NS00ZDcyLThiNjgtNmZmZjVhMmVhOTZm
+        LyIsICJ0YXNrX2lkIjogIjFhMDhlZjgzLWY0NDUtNGQ3Mi04YjY4LTZmZmY1
+        YTJlYTk2ZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
+        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAic3Rh
+        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwg
+        InJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQi
+        OiB7IiRvaWQiOiAiNTZiM2M2ODhjNzgyMWIzMzA0MmQ5ZGIyIn0sICJleGNl
+        cHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2Vi
+        YWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNFQyMTo0NTo0NVoi
+        LCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIy
+        MDE2LTAyLTA0VDIxOjQ1OjQ2WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1
+        bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnki
+        OiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb21wcyI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFk
+        ZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1NmIzYzY4YWM3ODIxYjM0NDRmY2MyNGEiLCAi
+        ZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVt
+        c19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwi
+        OiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2Rv
+        bmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19
+        fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzYzY4OThh
+        ZGE0MGRiMDRlZTA5NWYifSwgImlkIjogIjU2YjNjNjg5OGFkYTQwZGIwNGVl
+        MDk1ZiJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVs
+        cC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAi
+        L3B1bHAvYXBpL3YyL3Rhc2tzLzMyNmVlYjM1LTQxMGUtNDNhNi05ZTFlLWZm
+        NGY2YTI5ZTZhNi8iLCAidGFza19pZCI6ICIzMjZlZWIzNS00MTBlLTQzYTYt
+        OWUxZS1mZjRmNmEyOWU2YTYiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5
+        OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGlt
+        ZSI6ICIyMDE2LTAyLTA1VDE0OjA0OjUwWiIsICJfbnMiOiAidGFza19zdGF0
+        dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA0OjQ5WiIsICJ0
+        cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjog
+        Ii9wdWxwL2FwaS92Mi90YXNrcy81YjVjNjM5Ny1hNmMzLTQzNmMtYmM1Mi1m
+        MmZhNTMzYjgzNTMvIiwgInRhc2tfaWQiOiAiNWI1YzYzOTctYTZjMy00MzZj
+        LWJjNTItZjJmYTUzM2I4MzUzIn1dLCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5
+        dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBt
+        X3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAs
+        ICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhh
+        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJp
+        bXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmI0YWMwMWM3ODIxYjMzMDVjZTUw
+        ZWQifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8x
+        NyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1
+        VDE0OjA0OjQ5WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29t
+        cGxldGVkIjogIjIwMTYtMDItMDVUMTQ6MDQ6NTBaIiwgImltcG9ydGVyX3R5
+        cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxs
+        LCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAicmVtb3ZlZF9jb3VudCI6IDAs
+        ICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YjRhYzAyYzc4MjFiMzQ0
+        NGZjYzI0ZiIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFs
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7
+        InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjog
+        MCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNv
+        bXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjog
+        eyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjog
+        IjU2YjRhYzAxOGFkYTQwZGIwNGVlMDk5ZiJ9LCAiaWQiOiAiNTZiNGFjMDE4
+        YWRhNDBkYjA0ZWUwOTlmIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tf
+        dHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIs
+        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNTZiYmRiZWEtOTVjNy00
+        YjJmLThjZWQtMDU3ZjExZWU4OWE2LyIsICJ0YXNrX2lkIjogIjU2YmJkYmVh
+        LTk1YzctNGIyZi04Y2VkLTA1N2YxMWVlODlhNiIsICJ0YWdzIjogWyJwdWxw
+        OnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwg
+        ImZpbmlzaF90aW1lIjogIjIwMTYtMDItMDVUMTQ6MDU6MThaIiwgIl9ucyI6
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMDVUMTQ6
+        MDU6MTdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        W3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzFlNTM4MTk0LWZkZTkt
+        NDQxMC1iY2U4LWY2ODcxOGYxMmMzMy8iLCAidGFza19pZCI6ICIxZTUzODE5
+        NC1mZGU5LTQ0MTAtYmNlOC1mNjg3MThmMTJjMzMifV0sICJwcm9ncmVzc19y
+        ZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNf
+        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25l
+        IjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXpl
+        X3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        Mi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJz
+        dWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRhYzFkYzc4
+        MjFiMzMwNDJkOWRkZSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQi
+        OiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjog
+        IjIwMTYtMDItMDVUMTQ6MDU6MTdaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVz
+        dWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNToxOFoiLCAi
+        aW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJyb3JfbWVz
+        c2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJyZW1vdmVk
+        X2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZiNGFj
+        MWVjNzgyMWIzNDQ0ZmNjMjU1IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7
+        InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3Rh
+        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAi
+        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
+        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxz
+        IjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
+        cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQi
+        OiB7IiRvaWQiOiAiNTZiNGFjMWQ4YWRhNDBkYjA0ZWUwOWJiIn0sICJpZCI6
+        ICI1NmI0YWMxZDhhZGE0MGRiMDRlZTA5YmIifSwgeyJleGNlcHRpb24iOiBu
+        dWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVyLm1hbmFnZXJzLnJlcG8u
+        c3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81ODcz
+        MTJiNi1iMjMwLTRmYzktOTY3ZS1mMzFhMWMyNGVkMDIvIiwgInRhc2tfaWQi
+        OiAiNTg3MzEyYjYtYjIzMC00ZmM5LTk2N2UtZjMxYTFjMjRlZDAyIiwgInRh
+        Z3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFfMTciLCAicHVscDphY3Rp
+        b246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNToy
+        M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNToyMloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXdu
+        ZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNDQz
+        YmY2YjEtMDhkMi00NjhkLTg1ZGQtYTgxNGQxYjBiMzIxLyIsICJ0YXNrX2lk
+        IjogIjQ0M2JmNmIxLTA4ZDItNDY4ZC04NWRkLWE4MTRkMWIwYjMyMSJ9XSwg
+        InByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVyIjogeyJjb250ZW50
+        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAw
+        LCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUi
+        OiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0IjogMCwgIml0ZW1z
+        X2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAic3RhdGUiOiAiZmluaXNo
+        ZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        cmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAi
+        NTZiNGFjMjJjNzgyMWIzMzAzNGJhZTE1In0sICJleGNlcHRpb24iOiBudWxs
+        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InN0YXJ0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNToyMloiLCAiX25zIjogInJl
+        cG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA1VDE0
+        OjA1OjIzWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50Ijog
+        MCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJp
+        ZCI6ICI1NmI0YWMyM2M3ODIxYjM0NDRmY2MyNWEiLCAiZGV0YWlscyI6IHsi
+        Y29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwg
+        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVf
+        bGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2Rv
+        bmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVy
+        cm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNf
+        bGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9yIjog
+        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWMyMjhhZGE0MGRiMDRlZTA5
+        Y2UifSwgImlkIjogIjU2YjRhYzIyOGFkYTQwZGIwNGVlMDljZSJ9LCB7ImV4
+        Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFu
+        YWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L3Rhc2tzLzc5YTFkYjI5LTY1MjAtNDE1MC05ODJiLTg1ZjIyNWYyZWQ4OC8i
+        LCAidGFza19pZCI6ICI3OWExZGIyOS02NTIwLTQxNTAtOTgyYi04NWYyMjVm
+        MmVkODgiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIs
+        ICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAy
+        LTA1VDE0OjA1OjI5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRf
+        dGltZSI6ICIyMDE2LTAyLTA1VDE0OjA1OjI4WiIsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92
+        Mi90YXNrcy9jYmE2YjVhNC05NGE4LTRkNWMtYmY4OC0xYzUxOWMwNTQyNjEv
+        IiwgInRhc2tfaWQiOiAiY2JhNmI1YTQtOTRhOC00ZDVjLWJmODgtMWM1MTlj
+        MDU0MjYxIn1dLCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIi
+        OiB7ImNvbnRlbnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJw
+        bV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwg
+        ImRycG1fZG9uZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQi
+        OiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0
+        ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0
+        ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6
+        IHsiJG9pZCI6ICI1NmI0YWMyOGM3ODIxYjMzMDM0YmFlMWMifSwgImV4Y2Vw
+        dGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE0OjA1OjI4WiIs
+        ICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIw
+        MTYtMDItMDVUMTQ6MDU6MjlaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVt
+        X2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6
+        IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2Nv
+        dW50IjogMCwgImlkIjogIjU2YjRhYzI5Yzc4MjFiMzQ0NGZjYzI1ZiIsICJk
+        ZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1z
+        X2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6
+        IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9u
+        ZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
+        bCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhYzI4OGFk
+        YTQwZGIwNGVlMDllMSJ9LCAiaWQiOiAiNTZiNGFjMjg4YWRhNDBkYjA0ZWUw
+        OWUxIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxw
+        LnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIv
+        cHVscC9hcGkvdjIvdGFza3MvMzRmZTdjMzktNjNiZC00ODliLWE2YzctNTdi
+        ZDA3Y2IwMDU1LyIsICJ0YXNrX2lkIjogIjM0ZmU3YzM5LTYzYmQtNDg5Yi1h
+        NmM3LTU3YmQwN2NiMDA1NSIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6
+        RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1l
+        IjogIjIwMTYtMDItMDVUMTQ6MDU6MzRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1
+        cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMDVUMTQ6MDU6MzNaIiwgInRy
+        YWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAi
+        L3B1bHAvYXBpL3YyL3Rhc2tzLzQxNzQ1YzNhLTMzNmItNDRhYS04OWRjLTcx
+        YWMyNTc3YTQ4Mi8iLCAidGFza19pZCI6ICI0MTc0NWMzYS0zMzZiLTQ0YWEt
+        ODlkYy03MWFjMjU3N2E0ODIifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1
+        bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1f
+        dG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwg
+        InNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNf
+        dG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5leGFt
+        cGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImlt
+        cG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRhYzJkYzc4MjFiMzMwNDJkOWRl
+        ZCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDVU
+        MTQ6MDU6MzNaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21w
+        bGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNTozNFoiLCAiaW1wb3J0ZXJfdHlw
+        ZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGws
+        ICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRp
+        b24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJyZW1vdmVkX2NvdW50IjogMCwg
+        InVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZiNGFjMmVjNzgyMWIzNDQ0
+        ZmNjMjY0IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwi
+        OiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsi
+        cnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAw
+        LCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29t
+        cHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
+        NTZiNGFjMmQ4YWRhNDBkYjA0ZWUwOWY0In0sICJpZCI6ICI1NmI0YWMyZDhh
+        ZGE0MGRiMDRlZTA5ZjQifSwgeyJleGNlcHRpb24iOiBudWxsLCAidGFza190
+        eXBlIjogInB1bHAuc2VydmVyLm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwg
+        Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9mMDRhNzBmYy01YjFhLTRh
+        NzAtYjQyMC0wNzJiMjZlM2EyZjkvIiwgInRhc2tfaWQiOiAiZjA0YTcwZmMt
+        NWIxYS00YTcwLWI0MjAtMDcyYjI2ZTNhMmY5IiwgInRhZ3MiOiBbInB1bHA6
+        cmVwb3NpdG9yeTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246c3luYyJdLCAi
+        ZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNTozOVoiLCAiX25zIjog
+        InRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDow
+        NTozOVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBb
+        eyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvN2U5OTEyYTctM2I1OC00
+        YzVkLTkxZTUtZDhhZmM2MmE5NWRmLyIsICJ0YXNrX2lkIjogIjdlOTkxMmE3
+        LTNiNTgtNGM1ZC05MWU1LWQ4YWZjNjJhOTVkZiJ9XSwgInByb2dyZXNzX3Jl
+        cG9ydCI6IHsieXVtX2ltcG9ydGVyIjogeyJjb250ZW50IjogeyJpdGVtc190
+        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUi
+        OiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVf
+        dG90YWwiOiAwLCAic2l6ZV9sZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
+        IjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifX19LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2Vy
+        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1
+        Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjMzJjNzgy
+        MWIzMzA1Y2U1MTAyIn0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
+        ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAi
+        MjAxNi0wMi0wNVQxNDowNTozOVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1
+        bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA1VDE0OjA1OjM5WiIsICJp
+        bXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNz
+        YWdlIjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRf
+        Y291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmI0YWMz
+        M2M3ODIxYjM0NDRmY2MyNjkiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsi
+        c2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJk
+        ZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJw
+        bV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMi
+        OiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3Ry
+        aWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAi
+        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6
+        IHsiJG9pZCI6ICI1NmI0YWMzMzhhZGE0MGRiMDRlZTBhMDcifSwgImlkIjog
+        IjU2YjRhYzMzOGFkYTQwZGIwNGVlMGEwNyJ9LCB7ImV4Y2VwdGlvbiI6IG51
+        bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5z
+        eW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzEyNGE4
+        ODg2LWQ5NTQtNDE3My1hZTdhLTJhOTZhZWU2Y2NhOC8iLCAidGFza19pZCI6
+        ICIxMjRhODg4Ni1kOTU0LTQxNzMtYWU3YS0yYTk2YWVlNmNjYTgiLCAidGFn
+        cyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlv
+        bjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA1OjQ1
+        WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTAyLTA1VDE0OjA1OjQ0WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81ZjFi
+        MWFiZC0zZDhlLTQ5YTAtODY0My05ODI0MzU5NTQ3OGIvIiwgInRhc2tfaWQi
+        OiAiNWYxYjFhYmQtM2Q4ZS00OWEwLTg2NDMtOTgyNDM1OTU0NzhiIn1dLCAi
+        cHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQi
+        OiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAs
+        ICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6
+        IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRlbXNf
+        bGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJk
+        aXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAw
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJy
+        ZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1
+        NmI0YWMzOGM3ODIxYjMzMDQyZDlkZjQifSwgImV4Y2VwdGlvbiI6IG51bGws
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAi
+        c3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE0OjA1OjQ0WiIsICJfbnMiOiAicmVw
+        b19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMDVUMTQ6
+        MDU6NDVaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwg
+        ImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAw
+        LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlk
+        IjogIjU2YjRhYzM5Yzc4MjFiMzQ0NGZjYzI2ZSIsICJkZXRhaWxzIjogeyJj
+        b250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAi
+        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9s
+        ZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9u
+        ZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJy
+        b3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhYzM4OGFkYTQwZGIwNGVlMGEx
+        YSJ9LCAiaWQiOiAiNTZiNGFjMzg4YWRhNDBkYjA0ZWUwYTFhIn0sIHsiZXhj
+        ZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5h
+        Z2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIv
+        dGFza3MvZDkyYzA4MmItMDIxYS00OGY3LWJmYzEtNjlhOGU2NTkzNGIzLyIs
+        ICJ0YXNrX2lkIjogImQ5MmMwODJiLTAyMWEtNDhmNy1iZmMxLTY5YThlNjU5
+        MzRiMyIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3Iiwg
+        InB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDIt
+        MDVUMTQ6MDU6NTFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTYtMDItMDVUMTQ6MDU6NTFaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L3Rhc2tzL2VlMjAzM2QxLWU3YWMtNDI2NC05ZDZkLWMyY2E4MDY5OWNkNC8i
+        LCAidGFza19pZCI6ICJlZTIwMzNkMS1lN2FjLTQyNjQtOWQ2ZC1jMmNhODA2
+        OTljZDQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6
+        IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklO
+        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBt
+        X3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAi
+        ZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6
+        IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRl
+        bXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRl
+        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
+        cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJy
+        ZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjog
+        eyIkb2lkIjogIjU2YjRhYzNlYzc4MjFiMzMwNDJkOWRmYiJ9LCAiZXhjZXB0
+        aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDVUMTQ6MDU6NTFaIiwg
+        Il9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAx
+        Ni0wMi0wNVQxNDowNTo1MVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
+        aW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5Ijog
+        eyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRl
+        ZF9jb3VudCI6IDAsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291
+        bnQiOiAwLCAiaWQiOiAiNTZiNGFjM2ZjNzgyMWIzNDQ0ZmNjMjczIiwgImRl
+        dGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNf
+        bGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjog
+        MCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25l
+        IjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjM2U4YWRh
+        NDBkYjA0ZWUwYTJkIn0sICJpZCI6ICI1NmI0YWMzZThhZGE0MGRiMDRlZTBh
+        MmQifSwgeyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAu
+        c2VydmVyLm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8xNGYyZThjZC0zMGE2LTQzYzMtODgzMy05NmY5
+        ZTJmYTQwOTkvIiwgInRhc2tfaWQiOiAiMTRmMmU4Y2QtMzBhNi00M2MzLTg4
+        MzMtOTZmOWUyZmE0MDk5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUi
+        OiAiMjAxNi0wMi0wNVQxNDowNjoxM1oiLCAiX25zIjogInRhc2tfc3RhdHVz
+        IiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNjoxMloiLCAidHJh
+        Y2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIv
+        cHVscC9hcGkvdjIvdGFza3MvNzVhNTU2ZTctZjVmYi00Y2Y5LTgwYWQtNWE0
+        YzkyN2Q4NzM0LyIsICJ0YXNrX2lkIjogIjc1YTU1NmU3LWY1ZmItNGNmOS04
+        MGFkLTVhNGM5MjdkODczNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVt
+        X2ltcG9ydGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDgsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogeyJycG1fdG90YWwiOiA4LCAicnBtX2RvbmUiOiA4LCAiZHJwbV90
+        b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAxNzg3
+        MiwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRl
+        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5l
+        eGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwg
+        ImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRhYzU0Yzc4MjFiMzMwMzRi
+        YWUzZSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3Jh
+        XzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDIt
+        MDVUMTQ6MDY6MTJaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJj
+        b21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNjoxM1oiLCAiaW1wb3J0ZXJf
+        dHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51
+        bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJyZW1vdmVkX2NvdW50Ijog
+        MCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZiNGFjNTVjNzgyMWIz
+        NDQ0ZmNjMjgwIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90
+        YWwiOiAxNzg3MiwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiA4
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
+        bHMiOiB7InJwbV90b3RhbCI6IDgsICJycG1fZG9uZSI6IDgsICJkcnBtX3Rv
+        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
+        aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjU2YjRhYzU0OGFkYTQwZGIwNGVlMGE0OSJ9LCAiaWQiOiAiNTZi
+        NGFjNTQ4YWRhNDBkYjA0ZWUwYTQ5In0sIHsiZXhjZXB0aW9uIjogbnVsbCwg
+        InRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMu
+        c3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvYmYwNjFiYTIt
+        ZTE1OS00ODJhLTkwMTctNTEwNmE2ZGZmMzg3LyIsICJ0YXNrX2lkIjogImJm
+        MDYxYmEyLWUxNTktNDgyYS05MDE3LTUxMDZhNmRmZjM4NyIsICJ0YWdzIjog
+        WyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5
+        bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMDVUMTQ6MDY6MjFaIiwg
+        Il9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDIt
+        MDVUMTQ6MDY6MjFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rh
+        c2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzVhMDc0NGY3
+        LTk3MTItNDBkZi1iNjJmLWVlMGNmZWM4ZjNjNy8iLCAidGFza19pZCI6ICI1
+        YTA3NDRmNy05NzEyLTQwZGYtYjYyZi1lZTBjZmVjOGYzYzcifV0sICJwcm9n
+        cmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsi
+        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJw
+        bV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0s
+        ICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0
+        IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3Ry
+        aWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAi
+        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzVkYzc4MjFiMzMwNWNlNTEyNyJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDY6MjFaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNjoy
+        MVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjNWRjNzgyMWIzNDQ0ZmNjMjg2IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNWQ4YWRhNDBkYjA0ZWUwYTVlIn0s
+        ICJpZCI6ICI1NmI0YWM1ZDhhZGE0MGRiMDRlZTBhNWUifSwgeyJleGNlcHRp
+        b24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVyLm1hbmFnZXJz
+        LnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNr
+        cy82MzA0MzNhOS0zODYxLTQ5ZjgtOGUwMS0zNjQ0MzY1MTJiMzQvIiwgInRh
+        c2tfaWQiOiAiNjMwNDMzYTktMzg2MS00OWY4LThlMDEtMzY0NDM2NTEyYjM0
+        IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFfMTciLCAicHVs
+        cDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0wNVQx
+        NDowNjoyNVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxNi0wMi0wNVQxNDowNjoyNVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFz
+        a3MvODIzY2ZlMTQtYmNjYS00OTRlLWI1NzYtMDAxY2JmMjBiMDI2LyIsICJ0
+        YXNrX2lkIjogIjgyM2NmZTE0LWJjY2EtNDk0ZS1iNTc2LTAwMWNiZjIwYjAy
+        NiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVyIjogeyJj
+        b250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJycG1fdG90
+        YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBt
+        X2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0IjogMCwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRv
+        aWQiOiAiNTZiNGFjNjBjNzgyMWIzMzA1Y2U1MTJjIn0sICJleGNlcHRpb24i
+        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
+        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNjoyNVoiLCAiX25z
+        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAy
+        LTA1VDE0OjA2OjI1WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
+        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7ImNv
+        bnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2Nv
+        dW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6
+        IDAsICJpZCI6ICI1NmI0YWM2MWM3ODIxYjM0NDRmY2MyOGIiLCAiZGV0YWls
+        cyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0
+        IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        InNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAi
+        cnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAw
+        fSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM2MDhhZGE0MGRi
+        MDRlZTBhNzAifSwgImlkIjogIjU2YjRhYzYwOGFkYTQwZGIwNGVlMGE3MCJ9
+        LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2
+        ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAv
+        YXBpL3YyL3Rhc2tzL2RkZjQ2NzdlLTYxMTYtNGVjMS1iZDZiLTNhZTNjMWE0
+        YjhmMy8iLCAidGFza19pZCI6ICJkZGY0Njc3ZS02MTE2LTRlYzEtYmQ2Yi0z
+        YWUzYzFhNGI4ZjMiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9y
+        YV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA2OjI5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA2OjI5WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxw
+        L2FwaS92Mi90YXNrcy9mYWU4NTEzMC1iZTQ5LTRhYmEtOTliOC1hYThkZWJj
+        OTU5Y2IvIiwgInRhc2tfaWQiOiAiZmFlODUxMzAtYmU0OS00YWJhLTk5Yjgt
+        YWE4ZGViYzk1OWNiIn1dLCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1w
+        b3J0ZXIiOiB7ImNvbnRlbnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
+        IjogMCwgImRycG1fZG9uZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXpl
+        X2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
+        ZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRl
+        cl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM2NGM3ODIxYjMzMDQyZDllMTgifSwg
+        ImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0
+        cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE0OjA2
+        OjI5WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMDVUMTQ6MDY6MjlaIiwgImltcG9ydGVyX3R5cGVfaWQi
+        OiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3Vt
+        bWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNv
+        bXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19
+        LCAiYWRkZWRfY291bnQiOiAwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRh
+        dGVkX2NvdW50IjogMCwgImlkIjogIjU2YjRhYzY1Yzc4MjFiMzQ0NGZjYzI5
+        MCIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwg
+        Iml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90
+        b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRy
+        cG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVt
+        c190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRh
+        YzY0OGFkYTQwZGIwNGVlMGE4MiJ9LCAiaWQiOiAiNTZiNGFjNjQ4YWRhNDBk
+        YjA0ZWUwYTgyIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6
+        ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJl
+        ZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNTYwMWJmY2MtYTEwMi00ZmNlLTlh
+        NmMtYTNjNzQ2Njg4ZTQ3LyIsICJ0YXNrX2lkIjogIjU2MDFiZmNjLWExMDIt
+        NGZjZS05YTZjLWEzYzc0NjY4OGU0NyIsICJ0YWdzIjogWyJwdWxwOnJlcG9z
+        aXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTYtMDItMDVUMTQ6MDY6MzNaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMDVUMTQ6MDY6MzNa
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hy
+        ZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2M2NGEwMzdkLTdiZmMtNDI1Yi1h
+        MGRlLTkyYmM5ZDhiNGUyOS8iLCAidGFza19pZCI6ICJjNjRhMDM3ZC03YmZj
+        LTQyNWItYTBkZS05MmJjOWQ4YjRlMjkifV0sICJwcm9ncmVzc19yZXBvcnQi
+        OiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
+        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFs
+        IjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21w
+        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
+        aXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRl
+        di5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
+        IiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRhYzY4Yzc4MjFiMzMw
+        NWNlNTEzMSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVk
+        b3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMTYt
+        MDItMDVUMTQ6MDY6MzNaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIs
+        ICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNjozM1oiLCAiaW1wb3J0
+        ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6
+        IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0
+        cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJyZW1vdmVkX2NvdW50
+        IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZiNGFjNjljNzgy
+        MWIzNDQ0ZmNjMjk1IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVf
+        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
+        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRp
+        b24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRv
+        aWQiOiAiNTZiNGFjNjk4YWRhNDBkYjA0ZWUwYTk0In0sICJpZCI6ICI1NmI0
+        YWM2OThhZGE0MGRiMDRlZTBhOTQifSwgeyJleGNlcHRpb24iOiBudWxsLCAi
+        dGFza190eXBlIjogInB1bHAuc2VydmVyLm1hbmFnZXJzLnJlcG8uc3luYy5z
+        eW5jIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84Nzg4OWNjZi1l
+        N2VmLTRlZjAtOTZhZC0zNDVjZWNjN2RmMzYvIiwgInRhc2tfaWQiOiAiODc4
+        ODljY2YtZTdlZi00ZWYwLTk2YWQtMzQ1Y2VjYzdkZjM2IiwgInRhZ3MiOiBb
+        InB1bHA6cmVwb3NpdG9yeTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246c3lu
+        YyJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNjozN1oiLCAi
+        X25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0w
+        NVQxNDowNjozN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFz
+        a3MiOiBbeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNzE3OGVjMTct
+        ODIwOS00OWIzLWE0M2QtNjY3ZTBjNzk5MmMxLyIsICJ0YXNrX2lkIjogIjcx
+        NzhlYzE3LTgyMDktNDliMy1hNDNkLTY2N2UwYzc5OTJjMSJ9XSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVyIjogeyJjb250ZW50IjogeyJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBt
+        X2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwg
+        InNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0IjogMCwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
+        YnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJl
+        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifX19LCAic3RhdGUiOiAiZmluaXNoZWQiLCAi
+        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0
+        ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0
+        IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZiNGFj
+        NmNjNzgyMWIzMzAzNGJhZTQ0In0sICJleGNlcHRpb24iOiBudWxsLCAicmVw
+        b19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0
+        ZWQiOiAiMjAxNi0wMi0wNVQxNDowNjozN1oiLCAiX25zIjogInJlcG9fc3lu
+        Y19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA1VDE0OjA2OjM3
+        WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJv
+        cl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJl
+        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
+        NmI0YWM2ZGM3ODIxYjM0NDRmY2MyOWEiLCAiZGV0YWlscyI6IHsiY29udGVu
+        dCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6
+        IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAw
+        LCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2Rl
+        dGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6
+        IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmI0YWM2YzhhZGE0MGRiMDRlZTBhYTYifSwg
+        ImlkIjogIjU2YjRhYzZjOGFkYTQwZGIwNGVlMGFhNiJ9LCB7ImV4Y2VwdGlv
+        biI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMu
+        cmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tz
+        LzliMmZiNDQxLTFhZmItNDc0OS1hMmUxLTZiNjZmOTQyN2ZiNC8iLCAidGFz
+        a19pZCI6ICI5YjJmYjQ0MS0xYWZiLTQ3NDktYTJlMS02YjY2Zjk0MjdmYjQi
+        LCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxw
+        OmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA1VDE0
+        OjA2OjQxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6
+        ICIyMDE2LTAyLTA1VDE0OjA2OjQxWiIsICJ0cmFjZWJhY2siOiBudWxsLCAi
+        c3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNr
+        cy9hNTQ0ZTgwOC0yMzQ1LTQ4YTEtYWU2Ny1hOWRiZjY0ODRkMWUvIiwgInRh
+        c2tfaWQiOiAiYTU0NGU4MDgtMjM0NS00OGExLWFlNjctYTlkYmY2NDg0ZDFl
+        In1dLCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNv
+        bnRlbnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3Rh
+        bCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1f
+        ZG9uZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xl
+        ZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
+        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJm
+        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0
+        IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9p
+        ZCI6ICI1NmI0YWM3MGM3ODIxYjMzMDQyZDllMWUifSwgImV4Y2VwdGlvbiI6
+        IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE0OjA2OjQxWiIsICJfbnMi
+        OiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDIt
+        MDVUMTQ6MDY6NDFaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9y
+        dGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29u
+        dGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        bWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291
+        bnQiOiAwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50Ijog
+        MCwgImlkIjogIjU2YjRhYzcxYzc4MjFiMzQ0NGZjYzI5ZiIsICJkZXRhaWxz
+        IjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQi
+        OiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        c2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJy
+        cG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
+        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhYzcwOGFkYTQwZGIw
+        NGVlMGFiOCJ9LCAiaWQiOiAiNTZiNGFjNzA4YWRhNDBkYjA0ZWUwYWI4In0s
+        IHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZl
+        ci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMzFhZjIwNDItNjJkMS00OWFkLWI4NDUtNTM3ZmJlMTcw
+        MDYxLyIsICJ0YXNrX2lkIjogIjMxYWYyMDQyLTYyZDEtNDlhZC1iODQ1LTUz
+        N2ZiZTE3MDA2MSIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3Jh
+        XzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIw
+        MTYtMDItMDVUMTQ6MDY6NDZaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
+        dGFydF90aW1lIjogIjIwMTYtMDItMDVUMTQ6MDY6NDVaIiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAv
+        YXBpL3YyL3Rhc2tzL2Y1YTgwZmJhLTBlZDgtNDNlMy1iMjIzLTY3ZjFiNzg1
+        Zjk1MC8iLCAidGFza19pZCI6ICJmNWE4MGZiYS0wZWQ4LTQzZTMtYjIyMy02
+        N2YxYjc4NWY5NTAifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwi
+        OiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwg
+        InN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVk
+        X3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNv
+        bSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVy
+        X2lkIjogeyIkb2lkIjogIjU2YjRhYzc1Yzc4MjFiMzMwMzRiYWU0YSJ9LCAi
+        ZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRy
+        YWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDVUMTQ6MDY6
+        NDVaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQi
+        OiAiMjAxNi0wMi0wNVQxNDowNjo0NVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6
+        ICJ5dW1faW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1t
+        YXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29t
+        cHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0s
+        ICJhZGRlZF9jb3VudCI6IDAsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0
+        ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZiNGFjNzVjNzgyMWIzNDQ0ZmNjMmE0
+        IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAi
+        aXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3Rv
+        dGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJw
+        bV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFj
+        NzU4YWRhNDBkYjA0ZWUwYWNhIn0sICJpZCI6ICI1NmI0YWM3NThhZGE0MGRi
+        MDRlZTBhY2EifSwgeyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjog
+        InB1bHAuc2VydmVyLm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVm
+        IjogIi9wdWxwL2FwaS92Mi90YXNrcy9iZmM1NTk0YS1mNjI2LTQ4MDgtYjhk
+        ZC1lMmI3MmUzZTU0ZWEvIiwgInRhc2tfaWQiOiAiYmZjNTU5NGEtZjYyNi00
+        ODA4LWI4ZGQtZTJiNzJlM2U1NGVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
+        dG9yeTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNo
+        X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNjo1MFoiLCAiX25zIjogInRhc2tf
+        c3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNjo1MFoi
+        LCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJl
+        ZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMTA1YzliYTQtOTY3ZC00NjQ4LTgw
+        MTMtNTNlZDQ3YjBiNDE4LyIsICJ0YXNrX2lkIjogIjEwNWM5YmE0LTk2N2Qt
+        NDY0OC04MDEzLTUzZWQ0N2IwYjQxOCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6
+        IHsieXVtX2ltcG9ydGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6
+        IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAi
+        ZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwi
+        OiAwLCAic2l6ZV9sZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJp
+        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX19LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2
+        LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3Mi
+        LCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNzljNzgyMWIzMzA1
+        Y2U1MTNhIn0sICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRv
+        cmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0w
+        Mi0wNVQxNDowNjo1MFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwg
+        ImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA1VDE0OjA2OjUwWiIsICJpbXBvcnRl
+        cl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjog
+        bnVsbCwgInN1bW1hcnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3Ry
+        aWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQi
+        OiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NmI0YWM3YWM3ODIx
+        YjM0NDRmY2MyYTkiLCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90
+        b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxz
+        IjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3Rh
+        bCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0s
+        ICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1NmI0YWM3OThhZGE0MGRiMDRlZTBhZGMifSwgImlkIjogIjU2YjRh
+        Yzc5OGFkYTQwZGIwNGVlMGFkYyJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0
+        YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5
+        bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzJjNjc5OWMwLTYy
+        YTctNDEwNi1hZDkxLWVjMzg3YTNmNDUxZS8iLCAidGFza19pZCI6ICIyYzY3
+        OTljMC02MmE3LTQxMDYtYWQ5MS1lYzM4N2EzZjQ1MWUiLCAidGFncyI6IFsi
+        cHVscDpyZXBvc2l0b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5j
+        Il0sICJmaW5pc2hfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA2OjU1WiIsICJf
+        bnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1
+        VDE0OjA2OjU0WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNr
+        cyI6IFt7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8xYzIyNmNlZC1h
+        NTlkLTQwODktYjlmYy0zNDEwNGQ5YWFiODcvIiwgInRhc2tfaWQiOiAiMWMy
+        MjZjZWQtYTU5ZC00MDg5LWI5ZmMtMzQxMDRkOWFhYjg3In1dLCAicHJvZ3Jl
+        c3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQiOiB7Iml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1f
+        ZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAi
+        c2l6ZV90b3RhbCI6IDAsICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6
+        IDB9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
+        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM3
+        ZWM3ODIxYjMzMDM0YmFlNTEifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
+        ZCI6ICIyMDE2LTAyLTA1VDE0OjA2OjU0WiIsICJfbnMiOiAicmVwb19zeW5j
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMDVUMTQ6MDY6NTVa
+        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAicmVt
+        b3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2
+        YjRhYzdmYzc4MjFiMzQ0NGZjYzJhZSIsICJkZXRhaWxzIjogeyJjb250ZW50
+        IjogeyJzaXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNf
+        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0Ijog
+        MCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAs
+        ICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0
+        YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU2YjRhYzdlOGFkYTQwZGIwNGVlMGFlZSJ9LCAi
+        aWQiOiAiNTZiNGFjN2U4YWRhNDBkYjA0ZWUwYWVlIn0sIHsiZXhjZXB0aW9u
+        IjogbnVsbCwgInRhc2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5y
+        ZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3Mv
+        MjM4OTU5YjEtMzU2OS00NGIwLTlhOWItNzgwYzA5ODQyZDdhLyIsICJ0YXNr
+        X2lkIjogIjIzODk1OWIxLTM1NjktNDRiMC05YTliLTc4MGMwOTg0MmQ3YSIs
+        ICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6
+        YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMDVUMTQ6
+        MDY6NTlaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjog
+        IjIwMTYtMDItMDVUMTQ6MDY6NThaIiwgInRyYWNlYmFjayI6IG51bGwsICJz
+        cGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tz
+        L2M1NmVkYThmLTk2OWItNDJlNy1hOGM4LTk4OGNhNjYwYTRjOC8iLCAidGFz
+        a19pZCI6ICJjNTZlZGE4Zi05NjliLTQyZTctYThjOC05ODhjYTY2MGE0Yzgi
+        fV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29u
+        dGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
+        IjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9k
+        b25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJp
+        dGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVm
+        dCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0
+        YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZp
+        bmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQi
+        OiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lk
+        IjogIjU2YjRhYzgyYzc4MjFiMzMwNWNlNTEzZiJ9LCAiZXhjZXB0aW9uIjog
+        bnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzdGFydGVkIjogIjIwMTYtMDItMDVUMTQ6MDY6NThaIiwgIl9ucyI6
+        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0w
+        NVQxNDowNjo1OVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250
+        ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3Vu
+        dCI6IDAsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAw
+        LCAiaWQiOiAiNTZiNGFjODNjNzgyMWIzNDQ0ZmNjMmIzIiwgImRldGFpbHMi
+        OiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6
+        IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJz
+        aXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJw
+        bV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0s
+        ICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0
+        ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJv
+        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjODI4YWRhNDBkYjA0
+        ZWUwYjAwIn0sICJpZCI6ICI1NmI0YWM4MjhhZGE0MGRiMDRlZTBiMDAifSwg
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81OWQ2ZGM2ZC1iY2Y2LTQ4OTktOWIzYi02NDNiZTJkMDkx
+        ODkvIiwgInRhc2tfaWQiOiAiNTlkNmRjNmQtYmNmNi00ODk5LTliM2ItNjQz
+        YmUyZDA5MTg5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNzowM1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNzowM1oiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMjI2ZTVlMDctYTgwMi00ZmYzLWE4NjktMWM4MWVmY2M0
+        MmZmLyIsICJ0YXNrX2lkIjogIjIyNmU1ZTA3LWE4MDItNGZmMy1hODY5LTFj
+        ODFlZmNjNDJmZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        c3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRf
+        cmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29t
+        IiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJf
+        aWQiOiB7IiRvaWQiOiAiNTZiNGFjODZjNzgyMWIzMzAzNGJhZTU2In0sICJl
+        eGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJh
+        Y2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNzow
+        M1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6
+        ICIyMDE2LTAyLTA1VDE0OjA3OjAzWiIsICJpbXBvcnRlcl90eXBlX2lkIjog
+        Inl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1h
+        cnkiOiB7ImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb21w
+        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwg
+        ImFkZGVkX2NvdW50IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRl
+        ZF9jb3VudCI6IDAsICJpZCI6ICI1NmI0YWM4N2M3ODIxYjM0NDRmY2MyYjgi
+        LCAiZGV0YWlscyI6IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJp
+        dGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90
+        YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBt
+        X2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNf
+        dG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM4
+        NjhhZGE0MGRiMDRlZTBiMTIifSwgImlkIjogIjU2YjRhYzg2OGFkYTQwZGIw
+        NGVlMGIxMiJ9LCB7ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAi
+        cHVscC5zZXJ2ZXIubWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL3Rhc2tzL2M5NTRhMThiLWMwMDEtNGE0Zi04MTA2
+        LTliZWU2OTZmZTlkYS8iLCAidGFza19pZCI6ICJjOTU0YTE4Yi1jMDAxLTRh
+        NGYtODEwNi05YmVlNjk2ZmU5ZGEiLCAidGFncyI6IFsicHVscDpyZXBvc2l0
+        b3J5OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hf
+        dGltZSI6ICIyMDE2LTAyLTA1VDE0OjA3OjA4WiIsICJfbnMiOiAidGFza19z
+        dGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA3OjA3WiIs
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVm
+        IjogIi9wdWxwL2FwaS92Mi90YXNrcy8zMzczNTNmZi05NjA3LTQ3NWMtYTgw
+        My1mYzlhY2VlODU5YTcvIiwgInRhc2tfaWQiOiAiMzM3MzUzZmYtOTYwNy00
+        NzVjLWE4MDMtZmM5YWNlZTg1OWE3In1dLCAicHJvZ3Jlc3NfcmVwb3J0Ijog
+        eyJ5dW1faW1wb3J0ZXIiOiB7ImNvbnRlbnQiOiB7Iml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJk
+        cnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAic2l6ZV90b3RhbCI6
+        IDAsICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0
+        ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fX0sICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM4YmM3ODIxYjMzMDM0
+        YmFlNWIifSwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9y
+        YV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAy
+        LTA1VDE0OjA3OjA3WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAi
+        Y29tcGxldGVkIjogIjIwMTYtMDItMDVUMTQ6MDc6MDhaIiwgImltcG9ydGVy
+        X3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBu
+        dWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
+        YnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAwLCAicmVtb3ZlZF9jb3VudCI6
+        IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjU2YjRhYzhjYzc4MjFi
+        MzQ0NGZjYzJiZCIsICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3Rv
+        dGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMi
+        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
+        IjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
+        IjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
+        IjogIjU2YjRhYzhiOGFkYTQwZGIwNGVlMGIyNCJ9LCAiaWQiOiAiNTZiNGFj
+        OGI4YWRhNDBkYjA0ZWUwYjI0In0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRh
+        c2tfdHlwZSI6ICJwdWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3lu
+        YyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvY2QzY2Y0NGItOWIz
+        NS00MmE0LTkyMTYtMmUxNzc4NWRlY2RiLyIsICJ0YXNrX2lkIjogImNkM2Nm
+        NDRiLTliMzUtNDJhNC05MjE2LTJlMTc3ODVkZWNkYiIsICJ0YWdzIjogWyJw
+        dWxwOnJlcG9zaXRvcnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMi
+        XSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMDVUMTQ6MDc6MTJaIiwgIl9u
+        cyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMDVU
+        MTQ6MDc6MTJaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        IjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzk1MmY0MTJjLThh
+        OTYtNDIwMi04NGEzLWQzOGNiZTYxNTlhZS8iLCAidGFza19pZCI6ICI5NTJm
+        NDEyYy04YTk2LTQyMDItODRhMy1kMzhjYmU2MTU5YWUifV0sICJwcm9ncmVz
+        c19yZXBvcnQiOiB7Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRl
+        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJz
+        aXplX3RvdGFsIjogMCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0Ijog
+        MH0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJy
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVs
+        bG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6
+        ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRhYzhm
+        Yzc4MjFiMzMwNDJkOWUyNiJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9f
+        aWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFydGVk
+        IjogIjIwMTYtMDItMDVUMTQ6MDc6MTJaIiwgIl9ucyI6ICJyZXBvX3N5bmNf
+        cmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNzoxMloi
+        LCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJyb3Jf
+        bWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJl
+        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZi
+        NGFjOTBjNzgyMWIzNDQ0ZmNjMmMyIiwgImRldGFpbHMiOiB7ImNvbnRlbnQi
+        OiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190
+        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAw
+        LCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwg
+        ImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRh
+        aWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJk
+        aXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAw
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNTZiNGFjOGY4YWRhNDBkYjA0ZWUwYjM2In0sICJp
+        ZCI6ICI1NmI0YWM4ZjhhZGE0MGRiMDRlZTBiMzYifSwgeyJleGNlcHRpb24i
+        OiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVyLm1hbmFnZXJzLnJl
+        cG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81
+        MDVkZDQ1Zi0wOGViLTQwODItOGEyYi1jNjk5ZjBhZDcwNjcvIiwgInRhc2tf
+        aWQiOiAiNTA1ZGQ0NWYtMDhlYi00MDgyLThhMmItYzY5OWYwYWQ3MDY3Iiwg
+        InRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFfMTciLCAicHVscDph
+        Y3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0wNVQxNDow
+        NzoxN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAi
+        MjAxNi0wMi0wNVQxNDowNzoxNloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNw
+        YXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3Mv
+        N2JiZWYzMzgtZWUwYy00NTUwLWE4NjEtNjczNzk1YmEzZGQ2LyIsICJ0YXNr
+        X2lkIjogIjdiYmVmMzM4LWVlMGMtNDU1MC1hODYxLTY3Mzc5NWJhM2RkNiJ9
+        XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVyIjogeyJjb250
+        ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJycG1fdG90YWwi
+        OiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2Rv
+        bmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0IjogMCwgIml0
+        ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0
+        IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
+        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAic3RhdGUiOiAiZmlu
+        aXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
+        IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiB7IiRvaWQi
+        OiAiNTZiNGFjOTRjNzgyMWIzMzAzNGJhZTYwIn0sICJleGNlcHRpb24iOiBu
+        dWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVs
+        bCwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNzoxNloiLCAiX25zIjog
+        InJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA1
+        VDE0OjA3OjE3WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRl
+        ciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7ImNvbnRl
+        bnQiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
+        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50
+        IjogMCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAs
+        ICJpZCI6ICI1NmI0YWM5NWM3ODIxYjM0NDRmY2MyYzciLCAiZGV0YWlscyI6
+        IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0Ijog
+        MCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNp
+        emVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBt
+        X2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwg
+        ImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRl
+        bXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9y
+        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM5NDhhZGE0MGRiMDRl
+        ZTBiNDgifSwgImlkIjogIjU2YjRhYzk0OGFkYTQwZGIwNGVlMGI0OCJ9LCB7
+        ImV4Y2VwdGlvbiI6IG51bGwsICJ0YXNrX3R5cGUiOiAicHVscC5zZXJ2ZXIu
+        bWFuYWdlcnMucmVwby5zeW5jLnN5bmMiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
+        L3YyL3Rhc2tzL2I3NjZlYjI0LTE2M2MtNDIxNy04YmQ2LTQ1ZjkwYTgzMDk5
+        OS8iLCAidGFza19pZCI6ICJiNzY2ZWIyNC0xNjNjLTQyMTctOGJkNi00NWY5
+        MGE4MzA5OTkiLCAidGFncyI6IFsicHVscDpyZXBvc2l0b3J5OkZlZG9yYV8x
+        NyIsICJwdWxwOmFjdGlvbjpzeW5jIl0sICJmaW5pc2hfdGltZSI6ICIyMDE2
+        LTAyLTA1VDE0OjA3OjIxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3Rh
+        cnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA3OjIxWiIsICJ0cmFjZWJhY2si
+        OiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFt7Il9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85OWE5ODViOC0zY2Y1LTQ0YTEtYTczZS0xZjAwMGU3YTE4
+        YTIvIiwgInRhc2tfaWQiOiAiOTlhOTg1YjgtM2NmNS00NGExLWE3M2UtMWYw
+        MDBlN2ExOGEyIn1dLCAicHJvZ3Jlc3NfcmVwb3J0IjogeyJ5dW1faW1wb3J0
+        ZXIiOiB7ImNvbnRlbnQiOiB7Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiB7
+        InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjog
+        MCwgImRycG1fZG9uZSI6IDB9LCAic2l6ZV90b3RhbCI6IDAsICJzaXplX2xl
+        ZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJz
+        dGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
+        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9p
+        ZCI6IHsiJG9pZCI6ICI1NmI0YWM5OGM3ODIxYjMzMDM0YmFlNjUifSwgImV4
+        Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFj
+        ZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE0OjA3OjIx
+        WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjog
+        IjIwMTYtMDItMDVUMTQ6MDc6MjFaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAi
+        eXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFy
+        eSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBz
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAi
+        YWRkZWRfY291bnQiOiAwLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVk
+        X2NvdW50IjogMCwgImlkIjogIjU2YjRhYzk5Yzc4MjFiMzQ0NGZjYzJjYyIs
+        ICJkZXRhaWxzIjogeyJjb250ZW50IjogeyJzaXplX3RvdGFsIjogMCwgIml0
+        ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklO
+        SVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3Rh
+        bCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFsIjogMCwgImRycG1f
+        ZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
+        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhYzk4
+        OGFkYTQwZGIwNGVlMGI1YSJ9LCAiaWQiOiAiNTZiNGFjOTg4YWRhNDBkYjA0
+        ZWUwYjVhIn0sIHsiZXhjZXB0aW9uIjogbnVsbCwgInRhc2tfdHlwZSI6ICJw
+        dWxwLnNlcnZlci5tYW5hZ2Vycy5yZXBvLnN5bmMuc3luYyIsICJfaHJlZiI6
+        ICIvcHVscC9hcGkvdjIvdGFza3MvODFkN2MzOGMtZTkxYy00N2VlLWEzMTUt
+        N2MzZTRhNWI5Y2QyLyIsICJ0YXNrX2lkIjogIjgxZDdjMzhjLWU5MWMtNDdl
+        ZS1hMzE1LTdjM2U0YTViOWNkMiIsICJ0YWdzIjogWyJwdWxwOnJlcG9zaXRv
+        cnk6RmVkb3JhXzE3IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90
+        aW1lIjogIjIwMTYtMDItMDVUMTQ6MDc6MjZaIiwgIl9ucyI6ICJ0YXNrX3N0
+        YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMDVUMTQ6MDc6MjVaIiwg
+        InRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzJlMzE0ZjRkLTg1MGMtNGIyYy1iMzFm
+        LTE1NGQ0ZTZjMWE5Yy8iLCAidGFza19pZCI6ICIyZTMxNGY0ZC04NTBjLTRi
+        MmMtYjMxZi0xNTRkNGU2YzFhOWMifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        Inl1bV9pbXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
+        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjog
+        MCwgInNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRl
+        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn19fSwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5l
+        eGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwg
+        ImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRhYzlkYzc4MjFiMzMwNWNl
+        NTE0OCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3Jh
+        XzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFydGVkIjogIjIwMTYtMDIt
+        MDVUMTQ6MDc6MjVaIiwgIl9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJj
+        b21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNzoyNloiLCAiaW1wb3J0ZXJf
+        dHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51
+        bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJyZW1vdmVkX2NvdW50Ijog
+        MCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTZiNGFjOWVjNzgyMWIz
+        NDQ0ZmNjMmQxIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90
+        YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAi
+        Y29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24i
+        OiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNTZiNGFjOWQ4YWRhNDBkYjA0ZWUwYjZjIn0sICJpZCI6ICI1NmI0YWM5
+        ZDhhZGE0MGRiMDRlZTBiNmMifV0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:27 GMT
+- request:
+    method: delete
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="GiYO7qUowMDWSHD3ljZOisPBobJEUe4RWnMR2RPkM",
+        oauth_signature="pCKT%2BGAPguLY%2FDb1Wcl9ooHEDD0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681247", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:27 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2ZkZGNjZDk1LWYzOGMtNDQzYy1hNmZjLWJiNjI0NDI3YzFjNi8iLCAi
+        dGFza19pZCI6ICJmZGRjY2Q5NS1mMzhjLTQ0M2MtYTZmYy1iYjYyNDQyN2Mx
+        YzYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:27 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/fddccd95-f38c-443c-a6fc-bb624427c1c6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="kJ99K1zGX9bpugFCcJlG2xAkyKaXkEWBdayeiX1Ac",
+        oauth_signature="ynK7LTSZyO9ZcJ8Cep4pDrqIZhg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681247", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:27 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mZGRjY2Q5NS1mMzhjLTQ0M2MtYTZmYy1iYjYyNDQyN2Mx
+        YzYvIiwgInRhc2tfaWQiOiAiZmRkY2NkOTUtZjM4Yy00NDNjLWE2ZmMtYmI2
+        MjQ0MjdjMWM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM5
+        ZjhhZGE0MGRiMDRlZTBiN2QifSwgImlkIjogIjU2YjRhYzlmOGFkYTQwZGIw
+        NGVlMGI3ZCJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:27 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/fddccd95-f38c-443c-a6fc-bb624427c1c6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="ycnizsaKuhaCLIFvJ0sSA4hUUZ1kAUGP4AChwz4PeE",
+        oauth_signature="K6soLeDA3OxbkKbwCrtfjatT5%2B8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681248", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:28 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mZGRjY2Q5NS1mMzhjLTQ0M2MtYTZmYy1iYjYyNDQyN2Mx
+        YzYvIiwgInRhc2tfaWQiOiAiZmRkY2NkOTUtZjM4Yy00NDNjLWE2ZmMtYmI2
+        MjQ0MjdjMWM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA3OjI3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA3OjI3WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjOWY4YWRhNDBkYjA0ZWUwYjdkIn0sICJpZCI6ICI1NmI0YWM5ZjhhZGE0
+        MGRiMDRlZTBiN2QifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:28 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/pulp/repository/create.yml
+++ b/test/fixtures/vcr_cassettes/pulp/repository/create.yml
@@ -75,53 +75,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:47 GMT
 - request:
-    method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="Bt5tRSN1uCoAqkx3idKPHqx1oFVnhkmgZH4MdhmqM",
-        oauth_signature="%2Bm%2FlVghGbS0ods46GGG6dUnUQN8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628887", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:47 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzUyYzE0OTEyLTQ0MTYtNDNiYi04MGI5LTQ1MDkyMzBhNTMyOC8iLCAi
-        dGFza19pZCI6ICI1MmMxNDkxMi00NDE2LTQzYmItODBiOS00NTA5MjMwYTUz
-        MjgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:47 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/52c14912-4416-43bb-80b9-4509230a5328/
     body:
@@ -233,4 +186,235 @@ http_interactions:
         N2RiZjRkOTZjIn0=
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:48 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
+        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
+        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
+        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
+        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
+        LXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1
+        dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9j
+        b25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoLyIsImh0dHAiOmZh
+        bHNlLCJodHRwcyI6dHJ1ZSwicHJvdGVjdGVkIjp0cnVlfSwiYXV0b19wdWJs
+        aXNoIjp0cnVlLCJkaXN0cmlidXRvcl9pZCI6IkZlZG9yYV8xNyJ9LHsiZGlz
+        dHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9jbG9uZV9kaXN0cmlidXRvciIsImRp
+        c3RyaWJ1dG9yX2NvbmZpZyI6eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9p
+        ZCI6IkZlZG9yYV8xNyJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0cmli
+        dXRvcl9pZCI6IkZlZG9yYV8xN19jbG9uZSJ9LHsiZGlzdHJpYnV0b3JfdHlw
+        ZV9pZCI6ImV4cG9ydF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZp
+        ZyI6eyJodHRwIjpmYWxzZSwiaHR0cHMiOmZhbHNlLCJyZWxhdGl2ZV91cmwi
+        Om51bGx9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRvcl9pZCI6
+        ImV4cG9ydF9kaXN0cmlidXRvciJ9XX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="CsvQqitRhO2jmdiYk11NeKwDPDChFEmByAmjYFo", oauth_signature="XUbi1id1BsoIOm1BozVgYzYSxAY%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681156", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '788'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '320'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
+        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
+        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NTZiNGFjNDRjNzgyMWIzMzA1Y2U1MTEwIn0sICJpZCI6ICJGZWRvcmFfMTci
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
+        MTcvIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:56 GMT
+- request:
+    method: delete
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="ySyRDt0InFdSkaVdhCBiQpJCdIcpfY0tZ0UcFbI4ZSo",
+        oauth_signature="AODWJQIvrrFwKE9%2FpLtoPvR4kOE%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681156", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzI2YTI1ZDQzLWVkOGItNGU2MC1iNWExLWExNWE3ZjRkOWY0Ny8iLCAi
+        dGFza19pZCI6ICIyNmEyNWQ0My1lZDhiLTRlNjAtYjVhMS1hMTVhN2Y0ZDlm
+        NDcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:56 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/26a25d43-ed8b-4e60-b5a1-a15a7f4d9f47/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="m8xLPhf8SYDqhG94cLTpFtg2JrfUXuFktWrCxXa0ZHA",
+        oauth_signature="sVUiOGdnrHL%2BV6XepHJSnkTAINM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681156", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yNmEyNWQ0My1lZDhiLTRlNjAtYjVhMS1hMTVhN2Y0ZDlm
+        NDcvIiwgInRhc2tfaWQiOiAiMjZhMjVkNDMtZWQ4Yi00ZTYwLWI1YTEtYTE1
+        YTdmNGQ5ZjQ3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM0
+        NDhhZGE0MGRiMDRlZTBhNDAifSwgImlkIjogIjU2YjRhYzQ0OGFkYTQwZGIw
+        NGVlMGE0MCJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:56 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/26a25d43-ed8b-4e60-b5a1-a15a7f4d9f47/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="cWg2ghBBp7aMqNerH1k6bgd1lebHcRClvb54hDlEGWE",
+        oauth_signature="2wLK20rMHEqlDwlD5kcwZG2xi0o%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681157", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:57 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yNmEyNWQ0My1lZDhiLTRlNjAtYjVhMS1hMTVhN2Y0ZDlm
+        NDcvIiwgInRhc2tfaWQiOiAiMjZhMjVkNDMtZWQ4Yi00ZTYwLWI1YTEtYTE1
+        YTdmNGQ5ZjQ3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA1OjU3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA1OjU3WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjNDQ4YWRhNDBkYjA0ZWUwYTQwIn0sICJpZCI6ICI1NmI0YWM0NDhhZGE0
+        MGRiMDRlZTBhNDAifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:57 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/pulp/repository/operations.yml
+++ b/test/fixtures/vcr_cassettes/pulp/repository/operations.yml
@@ -272,213 +272,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:35:55 GMT
 - request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/2/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbInJwbSJdLCJmaWx0ZXJzIjp7fSwiZmllbGRzIjp7InVuaXQi
-        OlsibmFtZSIsImVwb2NoIiwidmVyc2lvbiIsInJlbGVhc2UiLCJhcmNoIiwi
-        Y2hlY2tzdW10eXBlIiwiY2hlY2tzdW0iXX19fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="JI6lWojcOwo8uQTbtA32ep82ViGME8Ni8DAsgOmw0s", oauth_signature="%2FXIgXtKYBKDvOGHR6CjNZwzdz9s%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628955", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '163'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:35:55 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2ZhMWYyM2JkLWY1NmUtNDM0My1hZmVlLTEyMGQyNzU1ODRiMy8iLCAi
-        dGFza19pZCI6ICJmYTFmMjNiZC1mNTZlLTQzNDMtYWZlZS0xMjBkMjc1NTg0
-        YjMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:35:55 GMT
-- request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/2/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbImVycmF0dW0iXSwiZmlsdGVycyI6e319fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="PJSTUP2W07puHePAKGvaG2VPsYJuygpJa1k28unYSVs", oauth_signature="mx9tUPpLwad2x60mjQQcyNG%2Ful4%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628955", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '79'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:35:55 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzk0NjNlZDcxLTY1MjUtNGU5Yi04MTc2LWQ4OTk0ZTFhMjZkNC8iLCAi
-        dGFza19pZCI6ICI5NDYzZWQ3MS02NTI1LTRlOWItODE3Ni1kODk5NGUxYTI2
-        ZDQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:35:55 GMT
-- request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/2/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbInBhY2thZ2VfZ3JvdXAiXSwiZmlsdGVycyI6e319fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="X5v9hBdeCxxb6RYQOHK8i9iLb0w7rD6jgKBKTreFZg", oauth_signature="u0v4y6AgTfO21FpyFK1kXogbv5E%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628955", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '85'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:35:55 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2NiYmVmZGMzLWQxOGYtNGUyMS04YmQ5LWY2YmUxMGE0N2NmYS8iLCAi
-        dGFza19pZCI6ICJjYmJlZmRjMy1kMThmLTRlMjEtOGJkOS1mNmJlMTBhNDdj
-        ZmEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:35:55 GMT
-- request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/2/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbInl1bV9yZXBvX21ldGFkYXRhX2ZpbGUiXSwiZmlsdGVycyI6
-        e319fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="JBKexpvtJJRpZQI0rQPO0MN4ZfXvxOfAEjTX0ee08I", oauth_signature="7QYsGEf9ja8YtIxH3P1xR0DILgs%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628955", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '94'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:35:55 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2RlMDliODRlLThlNmQtNGQxNS04ZTdjLTIzOGE0OTIzYzJmOC8iLCAi
-        dGFza19pZCI6ICJkZTA5Yjg0ZS04ZTZkLTRkMTUtOGU3Yy0yMzhhNDkyM2My
-        ZjgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:35:55 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/fa1f23bd-f56e-4343-afee-120d275584b3/
     body:
@@ -1033,53 +826,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:35:57 GMT
 - request:
-    method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/2/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="LQjVpdrZQkQXLTfvgms6DPLmCiDdBkHtuyGU2YIFAU",
-        oauth_signature="LbkkK4zRklm8bXAYe%2BuwTDVV5ak%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628958", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:35:58 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2VkNDk0M2NiLTkzODMtNDUzZi05Zjk0LWRmNmMxNGE2N2QxMS8iLCAi
-        dGFza19pZCI6ICJlZDQ5NDNjYi05MzgzLTQ1M2YtOWY5NC1kZjZjMTRhNjdk
-        MTEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:35:58 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/ed4943cb-9383-453f-9f94-df6c14a67d11/
     body:
@@ -1374,56 +1120,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:36:00 GMT
 - request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjR9fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="4Bh113nZu6czrHSzxgrNm5BDi3HeYkwpvVqOsRthDEI", oauth_signature="4SypFto8v9V%2B%2FG7ktLzwllsVJaE%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628960", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '37'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:36:00 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2E5YWRkNzA5LWVlZTctNDA0ZS1hZjZjLWYwY2M2YWFjNDM1NC8iLCAi
-        dGFza19pZCI6ICJhOWFkZDcwOS1lZWU3LTQwNGUtYWY2Yy1mMGNjNmFhYzQz
-        NTQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:36:00 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/a9add709-eee7-404e-af6c-f0cc6aac4354/
     body:
@@ -1626,53 +1322,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:36:01 GMT
 - request:
-    method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="5Q0B1A19JbuPLeXYRH3E3CKLlcVj1wVnB1q3eSbQ5U",
-        oauth_signature="ZygLPQrke72g1%2B0dAJYpMy9jigM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628962", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:36:02 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2E1MGUzOWI5LTZlZWEtNDJiNS05MDBkLTYyNDg0NzEwYzA1OS8iLCAi
-        dGFza19pZCI6ICJhNTBlMzliOS02ZWVhLTQyYjUtOTAwZC02MjQ4NDcxMGMw
-        NTkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:36:02 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/a50e39b9-6eea-42b5-900d-62484710c059/
     body:
@@ -1784,4 +1433,1758 @@ http_interactions:
         N2RiZjRkYjk4In0=
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:36:02 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/656b3e8d-ec62-4231-bec1-b007d4ed0566/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="E3nPPAWnq707b238RwvbkXHqTat7DHNRLcNNcQnhNk",
+        oauth_signature="BTsIk3Kq3GB5b%2FqJySacpf%2BNLms%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681249", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:29 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82NTZiM2U4ZC1lYzYyLTQyMzEtYmVjMS1iMDA3ZDRlZDA1
+        NjYvIiwgInRhc2tfaWQiOiAiNjU2YjNlOGQtZWM2Mi00MjMxLWJlYzEtYjAw
+        N2Q0ZWQwNTY2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjYTE4
+        YWRhNDBkYjA0ZWUwYjdlIn0sICJpZCI6ICI1NmI0YWNhMThhZGE0MGRiMDRl
+        ZTBiN2UifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:29 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/656b3e8d-ec62-4231-bec1-b007d4ed0566/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="K6wFGolxkjcH1sQaPIKEASRrpWOfPvQ3HbOcCx4XU",
+        oauth_signature="F%2BpUV23oAEQC%2F1tIaJA1luGjTzc%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681250", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:30 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '649'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82NTZiM2U4ZC1lYzYyLTQyMzEtYmVjMS1iMDA3ZDRlZDA1
+        NjYvIiwgInRhc2tfaWQiOiAiNjU2YjNlOGQtZWM2Mi00MjMxLWJlYzEtYjAw
+        N2Q0ZWQwNTY2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0
+        YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwg
+        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNTZiNGFjYTE4YWRhNDBkYjA0ZWUwYjdlIn0sICJpZCI6ICI1NmI0YWNh
+        MThhZGE0MGRiMDRlZTBiN2UifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:30 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/656b3e8d-ec62-4231-bec1-b007d4ed0566/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="kKbTRQ5Kgt52lPb0Owp2al4XyjvNZXArxhDqoDwI",
+        oauth_signature="aHLV1oO8ixG51z2iSzUN3TyMZPc%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681251", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:31 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82NTZiM2U4ZC1lYzYyLTQyMzEtYmVjMS1iMDA3ZDRlZDA1
+        NjYvIiwgInRhc2tfaWQiOiAiNjU2YjNlOGQtZWM2Mi00MjMxLWJlYzEtYjAw
+        N2Q0ZWQwNTY2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNzozMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNzozMFoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNzkzOWE5MzQtYTEyNS00YmQyLWEzZTgtOThiMTc3MTM5
+        NTgzLyIsICJ0YXNrX2lkIjogIjc5MzlhOTM0LWExMjUtNGJkMi1hM2U4LTk4
+        YjE3NzEzOTU4MyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        Y2ExYzc4MjFiMzMwNDJkOWUyYiJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDc6MzBaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNzoz
+        MFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjYTJjNzgyMWIzNDQ0ZmNjMmQ2IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjYTE4YWRhNDBkYjA0ZWUwYjdlIn0s
+        ICJpZCI6ICI1NmI0YWNhMThhZGE0MGRiMDRlZTBiN2UifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:31 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjIiLCJkaXNwbGF5X25hbWUiOiJGZWRvcmEgMTcgeDg2XzY0IGRl
+        diIsImltcG9ydGVyX3R5cGVfaWQiOiJ5dW1faW1wb3J0ZXIiLCJpbXBvcnRl
+        cl9jb25maWciOnt9LCJub3RlcyI6eyJfcmVwby10eXBlIjoicnBtLXJlcG8i
+        fSwiZGlzdHJpYnV0b3JzIjpbeyJkaXN0cmlidXRvcl90eXBlX2lkIjoieXVt
+        X2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7InJlbGF0aXZl
+        X3VybCI6InRlc3RfcGF0aC9saWJyYXJ5X2RlZmF1bHRfdmlld19saWJyYXJ5
+        LyIsImh0dHAiOmZhbHNlLCJodHRwcyI6dHJ1ZSwicHJvdGVjdGVkIjp0cnVl
+        LCJjaGVja3N1bV90eXBlIjpudWxsfSwiYXV0b19wdWJsaXNoIjp0cnVlLCJk
+        aXN0cmlidXRvcl9pZCI6IjIifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5
+        dW1fY2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsi
+        ZGVzdGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiIyIn0sImF1dG9fcHVibGlz
+        aCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiMl9jbG9uZSJ9LHsiZGlzdHJp
+        YnV0b3JfdHlwZV9pZCI6ImV4cG9ydF9kaXN0cmlidXRvciIsImRpc3RyaWJ1
+        dG9yX2NvbmZpZyI6eyJodHRwIjpmYWxzZSwiaHR0cHMiOmZhbHNlLCJyZWxh
+        dGl2ZV91cmwiOm51bGx9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0cmli
+        dXRvcl9pZCI6ImV4cG9ydF9kaXN0cmlidXRvciJ9XX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="3NYh1IoLR5zlNHMk8S0SwU6aAgggRCOziI1x2GFnbNQ", oauth_signature="BP1%2FIDxHA2tdEQw5wF16uhuxNcA%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681251", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '707'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:31 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '308'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/2/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCBkZXYiLCAiZGVzY3JpcHRpb24iOiBudWxsLCAibGFzdF91bml0
+        X2FkZGVkIjogbnVsbCwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
+        ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3Vu
+        aXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lkIjogeyIkb2lk
+        IjogIjU2YjRhY2EzYzc4MjFiMzMwNDJkOWUyZiJ9LCAiaWQiOiAiMiIsICJf
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzLzIvIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:31 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/2/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInJwbSJdLCJmaWx0ZXJzIjp7fSwiZmllbGRzIjp7InVuaXQi
+        OlsibmFtZSIsImVwb2NoIiwidmVyc2lvbiIsInJlbGVhc2UiLCJhcmNoIiwi
+        Y2hlY2tzdW10eXBlIiwiY2hlY2tzdW0iXX19fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="gD3wgBRdPs59SurMnqRDUsxJppg2RbjioIuO5exok", oauth_signature="dkx6XBZDYeHEAyzlBNH%2F38tS6Cg%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681251", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '163'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:31 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzM5NjM2ZTE1LTVjNDgtNDQxZi1hNzkxLTgxMDlkZWJmN2RiZS8iLCAi
+        dGFza19pZCI6ICIzOTYzNmUxNS01YzQ4LTQ0MWYtYTc5MS04MTA5ZGViZjdk
+        YmUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:31 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/2/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbImVycmF0dW0iXSwiZmlsdGVycyI6e319fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="Z3YblWVxguRQgGaZbdrky6aSLQghlLX5Y7phs4vwD8", oauth_signature="OaEVuVn68sdd7uu9oaj92mPUO9o%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681251", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '79'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:31 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2JkYzY4NzhiLWY5NTAtNGJiMy1iNWVjLTNlNTEzYTgzYTUxYS8iLCAi
+        dGFza19pZCI6ICJiZGM2ODc4Yi1mOTUwLTRiYjMtYjVlYy0zZTUxM2E4M2E1
+        MWEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:31 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/2/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInBhY2thZ2VfZ3JvdXAiXSwiZmlsdGVycyI6e319fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="uw5mg3SkPbnrVPCDYRhXal2Hy9uQ7xlUWYQhgyzR0", oauth_signature="RBY9UBoVdHnKV5J9Shg%2BoLzYCps%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681251", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '85'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:31 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2Y1ZjNkZWM3LWY4ODEtNDhjZi05NmIzLTFmM2E0ODY2MjVmNC8iLCAi
+        dGFza19pZCI6ICJmNWYzZGVjNy1mODgxLTQ4Y2YtOTZiMy0xZjNhNDg2NjI1
+        ZjQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:32 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/2/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInl1bV9yZXBvX21ldGFkYXRhX2ZpbGUiXSwiZmlsdGVycyI6
+        e319fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="5PMTZBUIBbMh3lhgRNPBWeYqa9HiKSHU50WHpq58nw", oauth_signature="jayUUDZU136VzJtRybKJmkvYF5U%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681252", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '94'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:32 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzAxZGQ1N2NmLTgzMTItNGJlMS1hYmI0LWQwZWY1MjA3NmQwYS8iLCAi
+        dGFza19pZCI6ICIwMWRkNTdjZi04MzEyLTRiZTEtYWJiNC1kMGVmNTIwNzZk
+        MGEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:32 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/39636e15-5c48-441f-a791-8109debf7dbe/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="1hNFLRS1X6JePYyHhwEZv9NoqakWRhkPN0TDF4uIeY",
+        oauth_signature="%2BZsoFvenDtRm3%2BPnX9%2FyDhqQGSU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681252", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:32 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '702'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8zOTYzNmUx
+        NS01YzQ4LTQ0MWYtYTc5MS04MTA5ZGViZjdkYmUvIiwgInRhc2tfaWQiOiAi
+        Mzk2MzZlMTUtNWM0OC00NDFmLWE3OTEtODEwOWRlYmY3ZGJlIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1bHA6cmVwb3NpdG9yeTpGZWRv
+        cmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5pc2hfdGlt
+        ZSI6IG51bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6
+        IG51bGwsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtd
+        LCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9y
+        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20u
+        ZHEiLCAic3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBs
+        ZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6
+        IHsiJG9pZCI6ICI1NmI0YWNhMzhhZGE0MGRiMDRlZTBiOGYifSwgImlkIjog
+        IjU2YjRhY2EzOGFkYTQwZGIwNGVlMGI4ZiJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:32 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/bdc6878b-f950-4bb3-b5ec-3e513a83a51a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="9le2zCtRQnmYM8SWk21fy6MwFscbGPg3mEM0C3Si8",
+        oauth_signature="OLAJ3LgoY2hzIn%2FgBxdoEhn8ADs%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681252", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:32 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '600'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9iZGM2ODc4
+        Yi1mOTUwLTRiYjMtYjVlYy0zZTUxM2E4M2E1MWEvIiwgInRhc2tfaWQiOiAi
+        YmRjNjg3OGItZjk1MC00YmIzLWI1ZWMtM2U1MTNhODNhNTFhIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1bHA6cmVwb3NpdG9yeTpGZWRv
+        cmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5pc2hfdGlt
+        ZSI6IG51bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6
+        IG51bGwsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtd
+        LCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwg
+        InN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        NmI0YWNhMzhhZGE0MGRiMDRlZTBiOTAifSwgImlkIjogIjU2YjRhY2EzOGFk
+        YTQwZGIwNGVlMGI5MCJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:32 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f5f3dec7-f881-48cf-96b3-1f3a486625f4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="bN0LSY2iJ8bVbttUXvxZljsvz5OneHGd7X9Mawmk",
+        oauth_signature="P3CdHkrC6ifxyVF7lLbn312AF%2BQ%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681252", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:32 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '600'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9mNWYzZGVj
+        Ny1mODgxLTQ4Y2YtOTZiMy0xZjNhNDg2NjI1ZjQvIiwgInRhc2tfaWQiOiAi
+        ZjVmM2RlYzctZjg4MS00OGNmLTk2YjMtMWYzYTQ4NjYyNWY0IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1bHA6cmVwb3NpdG9yeTpGZWRv
+        cmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5pc2hfdGlt
+        ZSI6IG51bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6
+        IG51bGwsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtd
+        LCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwg
+        InN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        NmI0YWNhNDhhZGE0MGRiMDRlZTBiOTEifSwgImlkIjogIjU2YjRhY2E0OGFk
+        YTQwZGIwNGVlMGI5MSJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:32 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/01dd57cf-8312-4be1-abb4-d0ef52076d0a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="fxN5LjN1pIJpCF5VGX33lmX7YIAmilb1HJweYYz5HY4",
+        oauth_signature="5UqGu3wtToYrM7WnIqQJeyGVgs8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681252", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:32 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '600'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8wMWRkNTdj
+        Zi04MzEyLTRiZTEtYWJiNC1kMGVmNTIwNzZkMGEvIiwgInRhc2tfaWQiOiAi
+        MDFkZDU3Y2YtODMxMi00YmUxLWFiYjQtZDBlZjUyMDc2ZDBhIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1bHA6cmVwb3NpdG9yeTpGZWRv
+        cmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5pc2hfdGlt
+        ZSI6IG51bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6
+        IG51bGwsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtd
+        LCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwg
+        InN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        NmI0YWNhNDhhZGE0MGRiMDRlZTBiOTIifSwgImlkIjogIjU2YjRhY2E0OGFk
+        YTQwZGIwNGVlMGI5MiJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:32 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/39636e15-5c48-441f-a791-8109debf7dbe/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="a4OygsqtX4TNe12t5N9uCosGEMj4oIRxJNeyTGyFEs0",
+        oauth_signature="53CQ%2B%2Ft26O8uihftH%2F8umNcYapw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681252", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:32 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2570'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8zOTYzNmUx
+        NS01YzQ4LTQ0MWYtYTc5MS04MTA5ZGViZjdkYmUvIiwgInRhc2tfaWQiOiAi
+        Mzk2MzZlMTUtNWM0OC00NDFmLWE3OTEtODEwOWRlYmY3ZGJlIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1bHA6cmVwb3NpdG9yeTpGZWRv
+        cmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5pc2hfdGlt
+        ZSI6ICIyMDE2LTAyLTA1VDE0OjA3OjMyWiIsICJfbnMiOiAidGFza19zdGF0
+        dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA3OjMyWiIsICJ0
+        cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jl
+        c3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3Rh
+        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwg
+        InJlc3VsdCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5Ijog
+        eyJuYW1lIjogImVsZXBoYW50IiwgImNoZWNrc3VtIjogIjNlMWM3MGNkMWI0
+        MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcy
+        YTBhNzAxZjMiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJy
+        ZWxlYXNlIjogIjAuOCIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5
+        cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InVuaXRfa2V5
+        IjogeyJuYW1lIjogImxpb24iLCAiY2hlY2tzdW0iOiAiMTI0MDBkYzk1YzIz
+        YTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2MmVm
+        YTNlNGFlNCIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJl
+        bGVhc2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlw
+        ZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsidW5pdF9rZXki
+        OiB7Im5hbWUiOiAicGVuZ3VpbiIsICJjaGVja3N1bSI6ICIzZmNiMmM5Mjdk
+        ZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZkNmU0
+        ODYzNWJlNjk0IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAi
+        cmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10
+        eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJ1bml0X2tl
+        eSI6IHsibmFtZSI6ICJtb25rZXkiLCAiY2hlY2tzdW0iOiAiMGU4ZmE1MGQw
+        MTI4ZmJhYmM3Y2NjNTYzMmUzZmEyNWQzOWIwMjgwMTY5ZjYxNjZjYjhlMmM4
+        NGRlODUwMWRiMSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwg
+        InJlbGVhc2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3Vt
+        dHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsidW5pdF9r
+        ZXkiOiB7Im5hbWUiOiAid2FscnVzIiwgImNoZWNrc3VtIjogIjZlOGQ2ZGMw
+        NTdlM2UyYzk4MTlmMGRjN2U2YzdiN2Y4NmJmMmU4NTcxYmJhNDE0YWRlYzdm
+        YjYyMWE0NjFkZmQiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIs
+        ICJyZWxlYXNlIjogIjAuOCIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1
+        bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InVuaXRf
+        a2V5IjogeyJuYW1lIjogImdpcmFmZmUiLCAiY2hlY2tzdW0iOiAiZjI1ZDY3
+        ZDFkOWRhMDRmMTJlNTdjYTMyMzI0N2I0Mzg5MWFjNDY1MzNlMzU1YjgyZGU2
+        ZDE5MjIwMDlmOWYxNCIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4z
+        IiwgInJlbGVhc2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNr
+        c3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsidW5p
+        dF9rZXkiOiB7Im5hbWUiOiAiY2hlZXRhaCIsICJjaGVja3N1bSI6ICI0MjJk
+        MGJhYTBjZDlkNzcxM2FlNzk2ZTg4NmEyM2UxN2Y1NzhmOTI0Zjc0ODgwZGVi
+        ZGJiN2Q2NWZiMzY4ZGFlIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIw
+        LjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hl
+        Y2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJ1
+        bml0X2tleSI6IHsibmFtZSI6ICJzcXVpcnJlbCIsICJjaGVja3N1bSI6ICIy
+        NTE3NjhiZGQxNWYxM2Q3ODQ4N2MyNzYzOGFhNmFlY2QwMTU1MWUyNTM3NTYw
+        OTNjZGUxYzBhZTg3OGExN2QyIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
+        ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAi
+        Y2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifV19
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhY2EzOGFk
+        YTQwZGIwNGVlMGI4ZiJ9LCAiaWQiOiAiNTZiNGFjYTM4YWRhNDBkYjA0ZWUw
+        YjhmIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:32 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/bdc6878b-f950-4bb3-b5ec-3e513a83a51a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="LpCSwuoMPK87EJLnukgpfMN59pyOUe1HSQSuaVsv8",
+        oauth_signature="b9pSLOO0ODRyZL5hWlwriWV1%2Fzc%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681253", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:33 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '943'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9iZGM2ODc4
+        Yi1mOTUwLTRiYjMtYjVlYy0zZTUxM2E4M2E1MWEvIiwgInRhc2tfaWQiOiAi
+        YmRjNjg3OGItZjk1MC00YmIzLWI1ZWMtM2U1MTNhODNhNTFhIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1bHA6cmVwb3NpdG9yeTpGZWRv
+        cmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5pc2hfdGlt
+        ZSI6ICIyMDE2LTAyLTA1VDE0OjA3OjMyWiIsICJfbnMiOiAidGFza19zdGF0
+        dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA3OjMyWiIsICJ0
+        cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jl
+        c3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3Rh
+        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwg
+        InJlc3VsdCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5Ijog
+        eyJpZCI6ICJSSEVBLTIwMTA6MDAwMiJ9LCAidHlwZV9pZCI6ICJlcnJhdHVt
+        In0sIHsidW5pdF9rZXkiOiB7ImlkIjogIlJIU0EtMjAxMDowODU4In0sICJ0
+        eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1bml0X2tleSI6IHsiaWQiOiAiUkhF
+        QS0yMDEwOjAwMDEifSwgInR5cGVfaWQiOiAiZXJyYXR1bSJ9XX0sICJlcnJv
+        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjYTM4YWRhNDBkYjA0
+        ZWUwYjkwIn0sICJpZCI6ICI1NmI0YWNhMzhhZGE0MGRiMDRlZTBiOTAifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:33 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f5f3dec7-f881-48cf-96b3-1f3a486625f4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="cCzNMm9DZq2CGu6vTOXGZmemRGjA8ukcW5YndTDjo4",
+        oauth_signature="khG%2FxCcBztqZ63NLvipy4sYVrCM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681253", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:33 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '907'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9mNWYzZGVj
+        Ny1mODgxLTQ4Y2YtOTZiMy0xZjNhNDg2NjI1ZjQvIiwgInRhc2tfaWQiOiAi
+        ZjVmM2RlYzctZjg4MS00OGNmLTk2YjMtMWYzYTQ4NjYyNWY0IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1bHA6cmVwb3NpdG9yeTpGZWRv
+        cmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5pc2hfdGlt
+        ZSI6ICIyMDE2LTAyLTA1VDE0OjA3OjMyWiIsICJfbnMiOiAidGFza19zdGF0
+        dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA3OjMyWiIsICJ0
+        cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jl
+        c3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3Rh
+        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwg
+        InJlc3VsdCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5Ijog
+        eyJyZXBvX2lkIjogIjIiLCAiaWQiOiAiYmlyZCJ9LCAidHlwZV9pZCI6ICJw
+        YWNrYWdlX2dyb3VwIn0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiMiIs
+        ICJpZCI6ICJtYW1tYWwifSwgInR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9
+        XX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjYTQ4
+        YWRhNDBkYjA0ZWUwYjkxIn0sICJpZCI6ICI1NmI0YWNhNDhhZGE0MGRiMDRl
+        ZTBiOTEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:33 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/01dd57cf-8312-4be1-abb4-d0ef52076d0a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="mCzWur7sfZnkO2v2M3VKQ6hmmj3scaq4zYvtzLGZY",
+        oauth_signature="b%2BEoc8%2FsToxJGjz8tOHfIqZQkVU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681254", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:34 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '759'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8wMWRkNTdj
+        Zi04MzEyLTRiZTEtYWJiNC1kMGVmNTIwNzZkMGEvIiwgInRhc2tfaWQiOiAi
+        MDFkZDU3Y2YtODMxMi00YmUxLWFiYjQtZDBlZjUyMDc2ZDBhIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1bHA6cmVwb3NpdG9yeTpGZWRv
+        cmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5pc2hfdGlt
+        ZSI6ICIyMDE2LTAyLTA1VDE0OjA3OjMzWiIsICJfbnMiOiAidGFza19zdGF0
+        dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA3OjMzWiIsICJ0
+        cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jl
+        c3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3Rh
+        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwg
+        InJlc3VsdCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFtdfSwgImVycm9yIjog
+        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWNhNDhhZGE0MGRiMDRlZTBi
+        OTIifSwgImlkIjogIjU2YjRhY2E0OGFkYTQwZGIwNGVlMGI5MiJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:34 GMT
+- request:
+    method: delete
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Ncb8jOjrgW3oyIMshxxvxRMWTznzO70n3gOp7fDdiE",
+        oauth_signature="iqeHP6V4%2F9wQuiztHk92P5Slljs%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681254", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:34 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzk3OGYxYzc0LWE2ZmUtNGE3YS1hOTg4LTY0YWJjYmUwNDJhOS8iLCAi
+        dGFza19pZCI6ICI5NzhmMWM3NC1hNmZlLTRhN2EtYTk4OC02NGFiY2JlMDQy
+        YTkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:35 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/978f1c74-a6fe-4a7a-a988-64abcbe042a9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="aBmyUJobqAlrqAlZ0yeMgGmpshKIB2p6ThHkZ68M",
+        oauth_signature="BBzGP1Jshqsanm1B7pdviezPn3Q%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681255", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:35 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '661'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85NzhmMWM3NC1hNmZlLTRhN2EtYTk4OC02NGFiY2JlMDQy
+        YTkvIiwgInRhc2tfaWQiOiAiOTc4ZjFjNzQtYTZmZS00YTdhLWE5ODgtNjRh
+        YmNiZTA0MmE5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1
+        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiBudWxsLCAiX25z
+        IjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQx
+        NDowNzozNVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3Mi
+        OiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUu
+        Y29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4
+        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNTZiNGFjYTc4YWRhNDBkYjA0ZWUwYmEwIn0sICJp
+        ZCI6ICI1NmI0YWNhNzhhZGE0MGRiMDRlZTBiYTAifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:35 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/978f1c74-a6fe-4a7a-a988-64abcbe042a9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="58MMskS2mtlONe8mwzKW8YFg0Hh7azFFuz4HUEuSWgU",
+        oauth_signature="ImfVhSZ5gVKxWq3hxajA%2FzePUx8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681255", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:35 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '680'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85NzhmMWM3NC1hNmZlLTRhN2EtYTk4OC02NGFiY2JlMDQy
+        YTkvIiwgInRhc2tfaWQiOiAiOTc4ZjFjNzQtYTZmZS00YTdhLWE5ODgtNjRh
+        YmNiZTA0MmE5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeToyIiwgInB1
+        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0w
+        NVQxNDowNzozNVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3Rp
+        bWUiOiAiMjAxNi0wMi0wNVQxNDowNzozNVoiLCAidHJhY2ViYWNrIjogbnVs
+        bCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9
+        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
+        by0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVk
+        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
+        QGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhY2E3OGFk
+        YTQwZGIwNGVlMGJhMCJ9LCAiaWQiOiAiNTZiNGFjYTc4YWRhNDBkYjA0ZWUw
+        YmEwIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:35 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ac350c2e-5c22-4f4c-b005-7fe83d383f9c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="mjUnTLGuFyPHRzXxrht8IHTk3e3Z7clzAHOCj7rQ",
+        oauth_signature="gxB3RbhUOSh0p4GNPMzKGYrFA2w%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681255", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:35 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hYzM1MGMyZS01YzIyLTRmNGMtYjAwNS03ZmU4M2QzODNm
+        OWMvIiwgInRhc2tfaWQiOiAiYWMzNTBjMmUtNWMyMi00ZjRjLWIwMDUtN2Zl
+        ODNkMzgzZjljIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWNh
+        NzhhZGE0MGRiMDRlZTBiYTEifSwgImlkIjogIjU2YjRhY2E3OGFkYTQwZGIw
+        NGVlMGJhMSJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:36 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ac350c2e-5c22-4f4c-b005-7fe83d383f9c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="ShEeG9saFezxN0hhOFPF1xobqM4nhQmXFRJGfIPX4",
+        oauth_signature="yWUg0E5cCWZVgCpdzBGxvZEZNUM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681256", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:36 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hYzM1MGMyZS01YzIyLTRmNGMtYjAwNS03ZmU4M2QzODNm
+        OWMvIiwgInRhc2tfaWQiOiAiYWMzNTBjMmUtNWMyMi00ZjRjLWIwMDUtN2Zl
+        ODNkMzgzZjljIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA3OjM2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA3OjM2WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjYTc4YWRhNDBkYjA0ZWUwYmExIn0sICJpZCI6ICI1NmI0YWNhNzhhZGE0
+        MGRiMDRlZTBiYTEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:36 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
+        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
+        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
+        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
+        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
+        LXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1
+        dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9j
+        b25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoLyIsImh0dHAiOmZh
+        bHNlLCJodHRwcyI6dHJ1ZSwicHJvdGVjdGVkIjp0cnVlLCJjaGVja3N1bV90
+        eXBlIjpudWxsfSwiYXV0b19wdWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9p
+        ZCI6IkZlZG9yYV8xNyJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9j
+        bG9uZV9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJkZXN0
+        aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6IkZlZG9yYV8xNyJ9LCJhdXRvX3B1
+        Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRvcl9pZCI6IkZlZG9yYV8xN19jbG9u
+        ZSJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ImV4cG9ydF9kaXN0cmlidXRv
+        ciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJodHRwIjpmYWxzZSwiaHR0cHMi
+        OmZhbHNlLCJyZWxhdGl2ZV91cmwiOm51bGx9LCJhdXRvX3B1Ymxpc2giOmZh
+        bHNlLCJkaXN0cmlidXRvcl9pZCI6ImV4cG9ydF9kaXN0cmlidXRvciJ9XX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="zPbDaxhUs9OQ0kPYUoyBck6AytK3hBOzdXEjdWbdHsI", oauth_signature="EFhG23pMk4XtXvv2ut0hAScTE84%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681257", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '809'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:37 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '320'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
+        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
+        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NTZiNGFjYTljNzgyMWIzMzA1Y2U1MTRkIn0sICJpZCI6ICJGZWRvcmFfMTci
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
+        MTcvIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:37 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjR9fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="oBaaa9cYjjA540Ub7ei5sKRBTndEP95hNz8SnDbRo", oauth_signature="WIuzlKzx2uU9nsTfnJQKH2qJJu8%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681257", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '37'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:37 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzFiZTg5MGY1LWVkYzItNGRkYS1iNjRhLWZiYjk3NDRkNDdkOS8iLCAi
+        dGFza19pZCI6ICIxYmU4OTBmNS1lZGMyLTRkZGEtYjY0YS1mYmI5NzQ0ZDQ3
+        ZDkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:37 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/1be890f5-edc2-4dda-b64a-fbb9744d47d9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="4W8RHCFCCZYeMwLNNHihfeYPJ3TF86kDjuzit3OXM",
+        oauth_signature="bm%2BvjXnNHTSQ1pcWhVQ1GY%2BOz58%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681257", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:37 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xYmU4OTBmNS1lZGMyLTRkZGEtYjY0YS1mYmI5NzQ0ZDQ3
+        ZDkvIiwgInRhc2tfaWQiOiAiMWJlODkwZjUtZWRjMi00ZGRhLWI2NGEtZmJi
+        OTc0NGQ0N2Q5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjYTk4
+        YWRhNDBkYjA0ZWUwYmEyIn0sICJpZCI6ICI1NmI0YWNhOThhZGE0MGRiMDRl
+        ZTBiYTIifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:37 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/1be890f5-edc2-4dda-b64a-fbb9744d47d9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="px2F6sztRph2SIUupygp9GxAFFi7gKiCNiQk0ON7MY",
+        oauth_signature="Kudm2l5X3Il%2FaLBk%2FqB75uCrGVg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681257", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:37 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '649'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xYmU4OTBmNS1lZGMyLTRkZGEtYjY0YS1mYmI5NzQ0ZDQ3
+        ZDkvIiwgInRhc2tfaWQiOiAiMWJlODkwZjUtZWRjMi00ZGRhLWI2NGEtZmJi
+        OTc0NGQ0N2Q5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0
+        YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwg
+        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNTZiNGFjYTk4YWRhNDBkYjA0ZWUwYmEyIn0sICJpZCI6ICI1NmI0YWNh
+        OThhZGE0MGRiMDRlZTBiYTIifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:37 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/1be890f5-edc2-4dda-b64a-fbb9744d47d9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="11hgMefee3yjEgMcdRSdrkrpVaySeJ76sQxhpuWZw",
+        oauth_signature="Gn%2FuIooJ865Yr1NZpJXFjo0jGmE%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681258", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:38 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xYmU4OTBmNS1lZGMyLTRkZGEtYjY0YS1mYmI5NzQ0ZDQ3
+        ZDkvIiwgInRhc2tfaWQiOiAiMWJlODkwZjUtZWRjMi00ZGRhLWI2NGEtZmJi
+        OTc0NGQ0N2Q5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNzozOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNzozN1oiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNGMzMTQyMTYtOWZmNi00YjI2LTk3ZTktYTI1ZTI4ZDNi
+        NjUzLyIsICJ0YXNrX2lkIjogIjRjMzE0MjE2LTlmZjYtNGIyNi05N2U5LWEy
+        NWUyOGQzYjY1MyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        Y2E5Yzc4MjFiMzMwNWNlNTE0ZSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDc6MzdaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNzoz
+        OFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjYWFjNzgyMWIzNDQ0ZmNjMmRmIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjYTk4YWRhNDBkYjA0ZWUwYmEyIn0s
+        ICJpZCI6ICI1NmI0YWNhOThhZGE0MGRiMDRlZTBiYTIifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:38 GMT
+- request:
+    method: delete
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="qpTwLx5mTcuLP8SPUiAj9gqk4laXMnD97MYyiA52g",
+        oauth_signature="LbLKxgzvbRPxp73b%2F6CB6pmGeao%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681259", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:39 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzljZmM0NzZjLWFlYzgtNDU1Mi05ODI5LWVmZjg4MTA4YzBjMi8iLCAi
+        dGFza19pZCI6ICI5Y2ZjNDc2Yy1hZWM4LTQ1NTItOTgyOS1lZmY4ODEwOGMw
+        YzIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:39 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/9cfc476c-aec8-4552-9829-eff88108c0c2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="cQByYKFVj0JKr2KXPumWskxJbP3Sq5KHKu9b9WjnyfM",
+        oauth_signature="AcZ0ohoEZ2BXhl25DhMn4GEFGEU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681259", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:39 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85Y2ZjNDc2Yy1hZWM4LTQ1NTItOTgyOS1lZmY4ODEwOGMw
+        YzIvIiwgInRhc2tfaWQiOiAiOWNmYzQ3NmMtYWVjOC00NTUyLTk4MjktZWZm
+        ODgxMDhjMGMyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWNh
+        YjhhZGE0MGRiMDRlZTBiYjMifSwgImlkIjogIjU2YjRhY2FiOGFkYTQwZGIw
+        NGVlMGJiMyJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:39 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/9cfc476c-aec8-4552-9829-eff88108c0c2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Ks4DY8aAFruthkd3UXGzmiZCoffRigd6fXRdoKxU",
+        oauth_signature="MIhRiFJzbVSr7ub%2BGCKy63GwzE0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681260", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:07:40 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85Y2ZjNDc2Yy1hZWM4LTQ1NTItOTgyOS1lZmY4ODEwOGMw
+        YzIvIiwgInRhc2tfaWQiOiAiOWNmYzQ3NmMtYWVjOC00NTUyLTk4MjktZWZm
+        ODgxMDhjMGMyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA3OjM5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA3OjM5WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjYWI4YWRhNDBkYjA0ZWUwYmIzIn0sICJpZCI6ICI1NmI0YWNhYjhhZGE0
+        MGRiMDRlZTBiYjMifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:07:40 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/pulp/repository/puppet.yml
+++ b/test/fixtures/vcr_cassettes/pulp/repository/puppet.yml
@@ -1,198 +1,6 @@
 ---
 http_interactions:
 - request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IjQiLCJkaXNwbGF5X25hbWUiOiJQIEZvcmdlIiwiaW1wb3J0ZXJf
-        dHlwZV9pZCI6InB1cHBldF9pbXBvcnRlciIsImltcG9ydGVyX2NvbmZpZyI6
-        eyJmZWVkIjoiaHR0cDovL2RhdmlkZC5mZWRvcmFwZW9wbGUub3JnL3JlcG9z
-        L3JhbmRvbV9wdXBwZXQvIn0sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJwdXBw
-        ZXQtcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVf
-        aWQiOiJwdXBwZXRfaW5zdGFsbF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9y
-        X2NvbmZpZyI6eyJpbnN0YWxsX3BhdGgiOiIvdmFyL2xpYi9wdWxwL3B1Ymxp
-        c2hlZC9wdXBwZXRfa2F0ZWxsb190ZXN0IiwiYXV0b19wdWJsaXNoIjp0cnVl
-        fSwiYXV0b19wdWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9pZCI6IjQifSx7
-        ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJub2Rlc19odHRwX2Rpc3RyaWJ1dG9y
-        IiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7fSwiYXV0b19wdWJsaXNoIjp0cnVl
-        LCJkaXN0cmlidXRvcl9pZCI6IjRfbm9kZXMifSx7ImRpc3RyaWJ1dG9yX3R5
-        cGVfaWQiOiJwdXBwZXRfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25m
-        aWciOnsiYWJzb2x1dGVfcGF0aCI6bnVsbCwic2VydmVfaHR0cCI6ZmFsc2Us
-        InNlcnZlX2h0dHBzIjp0cnVlfSwiYXV0b19wdWJsaXNoIjp0cnVlLCJkaXN0
-        cmlidXRvcl9pZCI6IjRfcHVwcGV0In1dfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="4Dlu80i6HT03f3J4XMfTcJsvmslHEobhgxL1uRiW8", oauth_signature="PXr5DLPVrBilEZvFl7QjUBpb7pU%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628903", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '700'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:35:03 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Location:
-      - '4'
-      Content-Length:
-      - '298'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUCBGb3JnZSIs
-        ICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRkZWQiOiBudWxs
-        LCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicHVwcGV0LXJlcG8ifSwgImxh
-        c3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3VudHMi
-        OiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNTZiM2Uw
-        Mjc4NGEwOWMwNzA2MzQzNDM4In0sICJpZCI6ICI0IiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvNC8ifQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:35:03 GMT
-- request:
-    method: get
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/4/?details=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="wspb54hahfT3cMLdRg6tcSOlZZ7TRCpVaD6knbdk0",
-        oauth_signature="NSN%2FYAK1zcogn1M3BvCbCk0w1Tw%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628903", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:35:03 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '1444'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUCBGb3JnZSIs
-        ICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMiOiBbeyJyZXBv
-        X2lkIjogIjQiLCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgImxhc3Rf
-        cHVibGlzaCI6IG51bGwsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAic2NoZWR1
-        bGVkX3B1Ymxpc2hlcyI6IFtdLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJw
-        dXBwZXRfZGlzdHJpYnV0b3IiLCAiX2lkIjogeyIkb2lkIjogIjU2YjNlMDI3
-        ODRhMDljMDcwNjM0MzQzYyJ9LCAiY29uZmlnIjogeyJzZXJ2ZV9odHRwcyI6
-        IHRydWUsICJzZXJ2ZV9odHRwIjogZmFsc2V9LCAiaWQiOiAiNF9wdXBwZXQi
-        fSwgeyJyZXBvX2lkIjogIjQiLCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3Jz
-        IiwgImxhc3RfcHVibGlzaCI6IG51bGwsICJhdXRvX3B1Ymxpc2giOiB0cnVl
-        LCAic2NoZWR1bGVkX3B1Ymxpc2hlcyI6IFtdLCAiZGlzdHJpYnV0b3JfdHlw
-        ZV9pZCI6ICJub2Rlc19odHRwX2Rpc3RyaWJ1dG9yIiwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmIzZTAyNzg0YTA5YzA3MDYzNDM0M2IifSwgImNvbmZpZyI6IHt9
-        LCAiaWQiOiAiNF9ub2RlcyJ9LCB7InJlcG9faWQiOiAiNCIsICJfbnMiOiAi
-        cmVwb19kaXN0cmlidXRvcnMiLCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImF1
-        dG9fcHVibGlzaCI6IHRydWUsICJzY2hlZHVsZWRfcHVibGlzaGVzIjogW10s
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInB1cHBldF9pbnN0YWxsX2Rpc3Ry
-        aWJ1dG9yIiwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzZTAyNzg0YTA5YzA3MDYz
-        NDM0M2EifSwgImNvbmZpZyI6IHsiaW5zdGFsbF9wYXRoIjogIi92YXIvbGli
-        L3B1bHAvcHVibGlzaGVkL3B1cHBldF9rYXRlbGxvX3Rlc3QiLCAiYXV0b19w
-        dWJsaXNoIjogdHJ1ZX0sICJpZCI6ICI0In1dLCAibGFzdF91bml0X2FkZGVk
-        IjogbnVsbCwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInB1cHBldC1yZXBv
-        In0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3VuaXRf
-        Y291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiaW1wb3J0ZXJzIjogW3si
-        cmVwb19pZCI6ICI0IiwgIl9ucyI6ICJyZXBvX2ltcG9ydGVycyIsICJpbXBv
-        cnRlcl90eXBlX2lkIjogInB1cHBldF9pbXBvcnRlciIsICJsYXN0X3N5bmMi
-        OiBudWxsLCAic2NoZWR1bGVkX3N5bmNzIjogW10sICJfaWQiOiB7IiRvaWQi
-        OiAiNTZiM2UwMjc4NGEwOWMwNzA2MzQzNDM5In0sICJjb25maWciOiB7ImZl
-        ZWQiOiAiaHR0cDovL2RhdmlkZC5mZWRvcmFwZW9wbGUub3JnL3JlcG9zL3Jh
-        bmRvbV9wdXBwZXQvIn0sICJpZCI6ICJwdXBwZXRfaW1wb3J0ZXIifV0sICJf
-        aWQiOiB7IiRvaWQiOiAiNTZiM2UwMjc4NGEwOWMwNzA2MzQzNDM4In0sICJp
-        ZCI6ICI0IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
-        NC8ifQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:35:03 GMT
-- request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/4/actions/publish/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IjQiLCJvdmVycmlkZV9jb25maWciOm51bGx9
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="Xt9q6COTmvpij48510uSJpmsmyQyeIhnIvV23gjSsYE", oauth_signature="zikE13WMH3l2LDnetT4n2uU%2Fc2s%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628903", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '33'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:35:03 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzg0Y2JiNDFkLWU5NWUtNGZkMy04MzRiLTRiMDFmNGE2ODk0MS8iLCAi
-        dGFza19pZCI6ICI4NGNiYjQxZC1lOTVlLTRmZDMtODM0Yi00YjAxZjRhNjg5
-        NDEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:35:03 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/84cbb41d-e95e-4fd3-834b-4b01f4a68941/
     body:
@@ -312,127 +120,6 @@ http_interactions:
   recorded_at: Thu, 04 Feb 2016 23:35:04 GMT
 - request:
     method: get
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/4/?details=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="atUhdMS1BnkZWfxPFQhlxTQfre5aHOxkJoBCw3UtX4",
-        oauth_signature="91NnXbK28J9mvvvc7ZhfgqSZNAU%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628904", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:35:04 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '1462'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUCBGb3JnZSIs
-        ICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMiOiBbeyJyZXBv
-        X2lkIjogIjQiLCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgImxhc3Rf
-        cHVibGlzaCI6IG51bGwsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAic2NoZWR1
-        bGVkX3B1Ymxpc2hlcyI6IFtdLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJw
-        dXBwZXRfZGlzdHJpYnV0b3IiLCAiX2lkIjogeyIkb2lkIjogIjU2YjNlMDI3
-        ODRhMDljMDcwNjM0MzQzYyJ9LCAiY29uZmlnIjogeyJzZXJ2ZV9odHRwcyI6
-        IHRydWUsICJzZXJ2ZV9odHRwIjogZmFsc2V9LCAiaWQiOiAiNF9wdXBwZXQi
-        fSwgeyJyZXBvX2lkIjogIjQiLCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3Jz
-        IiwgImxhc3RfcHVibGlzaCI6IG51bGwsICJhdXRvX3B1Ymxpc2giOiB0cnVl
-        LCAic2NoZWR1bGVkX3B1Ymxpc2hlcyI6IFtdLCAiZGlzdHJpYnV0b3JfdHlw
-        ZV9pZCI6ICJub2Rlc19odHRwX2Rpc3RyaWJ1dG9yIiwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmIzZTAyNzg0YTA5YzA3MDYzNDM0M2IifSwgImNvbmZpZyI6IHt9
-        LCAiaWQiOiAiNF9ub2RlcyJ9LCB7InJlcG9faWQiOiAiNCIsICJfbnMiOiAi
-        cmVwb19kaXN0cmlidXRvcnMiLCAibGFzdF9wdWJsaXNoIjogIjIwMTYtMDIt
-        MDRUMjM6MzU6MDNaIiwgImF1dG9fcHVibGlzaCI6IHRydWUsICJzY2hlZHVs
-        ZWRfcHVibGlzaGVzIjogW10sICJkaXN0cmlidXRvcl90eXBlX2lkIjogInB1
-        cHBldF9pbnN0YWxsX2Rpc3RyaWJ1dG9yIiwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NmIzZTAyNzg0YTA5YzA3MDYzNDM0M2EifSwgImNvbmZpZyI6IHsiaW5zdGFs
-        bF9wYXRoIjogIi92YXIvbGliL3B1bHAvcHVibGlzaGVkL3B1cHBldF9rYXRl
-        bGxvX3Rlc3QiLCAiYXV0b19wdWJsaXNoIjogdHJ1ZX0sICJpZCI6ICI0In1d
-        LCAibGFzdF91bml0X2FkZGVkIjogbnVsbCwgIm5vdGVzIjogeyJfcmVwby10
-        eXBlIjogInB1cHBldC1yZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51
-        bGwsICJjb250ZW50X3VuaXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3Mi
-        LCAiaW1wb3J0ZXJzIjogW3sicmVwb19pZCI6ICI0IiwgIl9ucyI6ICJyZXBv
-        X2ltcG9ydGVycyIsICJpbXBvcnRlcl90eXBlX2lkIjogInB1cHBldF9pbXBv
-        cnRlciIsICJsYXN0X3N5bmMiOiBudWxsLCAic2NoZWR1bGVkX3N5bmNzIjog
-        W10sICJfaWQiOiB7IiRvaWQiOiAiNTZiM2UwMjc4NGEwOWMwNzA2MzQzNDM5
-        In0sICJjb25maWciOiB7ImZlZWQiOiAiaHR0cDovL2RhdmlkZC5mZWRvcmFw
-        ZW9wbGUub3JnL3JlcG9zL3JhbmRvbV9wdXBwZXQvIn0sICJpZCI6ICJwdXBw
-        ZXRfaW1wb3J0ZXIifV0sICJfaWQiOiB7IiRvaWQiOiAiNTZiM2UwMjc4NGEw
-        OWMwNzA2MzQzNDM4In0sICJpZCI6ICI0IiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi9yZXBvc2l0b3JpZXMvNC8ifQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:35:04 GMT
-- request:
-    method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="h5TYLNrhR0pFIIO1MH413kxqw8osz4Zyf3AiApvUKv8",
-        oauth_signature="0cb3V4XrcNdhpIFiFpJ9C%2FF1EWk%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628904", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:35:04 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzIwNjlkZTQ3LTNmMGYtNGE3MS05MzBlLTViYzRmNDA2ZGRmMy8iLCAi
-        dGFza19pZCI6ICIyMDY5ZGU0Ny0zZjBmLTRhNzEtOTMwZS01YmM0ZjQwNmRk
-        ZjMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:35:04 GMT
-- request:
-    method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/2069de47-3f0f-4a71-930e-5bc4f406ddf3/
     body:
       encoding: US-ASCII
@@ -541,4 +228,567 @@ http_interactions:
         YiJ9
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:35:04 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjQiLCJkaXNwbGF5X25hbWUiOiJQIEZvcmdlIiwiaW1wb3J0ZXJf
+        dHlwZV9pZCI6InB1cHBldF9pbXBvcnRlciIsImltcG9ydGVyX2NvbmZpZyI6
+        eyJmZWVkIjoiaHR0cDovL2RhdmlkZC5mZWRvcmFwZW9wbGUub3JnL3JlcG9z
+        L3JhbmRvbV9wdXBwZXQvIn0sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJwdXBw
+        ZXQtcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVf
+        aWQiOiJwdXBwZXRfaW5zdGFsbF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9y
+        X2NvbmZpZyI6eyJpbnN0YWxsX3BhdGgiOiIvdmFyL2xpYi9wdWxwL3B1Ymxp
+        c2hlZC9wdXBwZXRfa2F0ZWxsb190ZXN0IiwiYXV0b19wdWJsaXNoIjp0cnVl
+        fSwiYXV0b19wdWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9pZCI6IjQifSx7
+        ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJub2Rlc19odHRwX2Rpc3RyaWJ1dG9y
+        IiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7fSwiYXV0b19wdWJsaXNoIjp0cnVl
+        LCJkaXN0cmlidXRvcl9pZCI6IjRfbm9kZXMifSx7ImRpc3RyaWJ1dG9yX3R5
+        cGVfaWQiOiJwdXBwZXRfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25m
+        aWciOnsiYWJzb2x1dGVfcGF0aCI6bnVsbCwic2VydmVfaHR0cCI6ZmFsc2Us
+        InNlcnZlX2h0dHBzIjp0cnVlfSwiYXV0b19wdWJsaXNoIjp0cnVlLCJkaXN0
+        cmlidXRvcl9pZCI6IjRfcHVwcGV0In1dfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="A1kh1a8j6NRsOkRdHfmzFyQ5qGlc5HwUJnFkkNxQVCQ", oauth_signature="ZNHD5e9JqFvnCMs2zH5mrxxMFHA%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681178", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '700'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:18 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '298'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/4/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUCBGb3JnZSIs
+        ICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRkZWQiOiBudWxs
+        LCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicHVwcGV0LXJlcG8ifSwgImxh
+        c3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3VudHMi
+        OiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFj
+        NWFjNzgyMWIzMzA0MmQ5ZTBmIn0sICJpZCI6ICI0IiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvNC8ifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:18 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/4/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="WkHPrYPtcjpiNao2GzXJr8DS4ANHfXR9tNPHGoyXY",
+        oauth_signature="w%2BDzsrKVd5u2Xy81EBelceeCTtc%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681178", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:18 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1718'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUCBGb3JnZSIs
+        ICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMiOiBbeyJyZXBv
+        X2lkIjogIjQiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
+        cy80L2Rpc3RyaWJ1dG9ycy80X3B1cHBldC8iLCAiX25zIjogInJlcG9fZGlz
+        dHJpYnV0b3JzIiwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRv
+        cl90eXBlX2lkIjogInB1cHBldF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxp
+        c2giOiB0cnVlLCAic2NyYXRjaHBhZCI6IHt9LCAiX2lkIjogeyIkb2lkIjog
+        IjU2YjRhYzVhYzc4MjFiMzMwNDJkOWUxMyJ9LCAiY29uZmlnIjogeyJzZXJ2
+        ZV9odHRwcyI6IHRydWUsICJzZXJ2ZV9odHRwIjogZmFsc2V9LCAiaWQiOiAi
+        NF9wdXBwZXQifSwgeyJyZXBvX2lkIjogIjQiLCAiX2hyZWYiOiAiL3B1bHAv
+        YXBpL3YyL3JlcG9zaXRvcmllcy80L2Rpc3RyaWJ1dG9ycy80X25vZGVzLyIs
+        ICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAibGFzdF9wdWJsaXNoIjog
+        bnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0cF9kaXN0
+        cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAic2NyYXRjaHBhZCI6
+        IHt9LCAiX2lkIjogeyIkb2lkIjogIjU2YjRhYzVhYzc4MjFiMzMwNDJkOWUx
+        MiJ9LCAiY29uZmlnIjoge30sICJpZCI6ICI0X25vZGVzIn0sIHsicmVwb19p
+        ZCI6ICI0IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
+        NC9kaXN0cmlidXRvcnMvNC8iLCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3Jz
+        IiwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lk
+        IjogInB1cHBldF9pbnN0YWxsX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlz
+        aCI6IHRydWUsICJzY3JhdGNocGFkIjoge30sICJfaWQiOiB7IiRvaWQiOiAi
+        NTZiNGFjNWFjNzgyMWIzMzA0MmQ5ZTExIn0sICJjb25maWciOiB7Imluc3Rh
+        bGxfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL3B1Ymxpc2hlZC9wdXBwZXRfa2F0
+        ZWxsb190ZXN0IiwgImF1dG9fcHVibGlzaCI6IHRydWV9LCAiaWQiOiAiNCJ9
+        XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3RlcyI6IHsiX3JlcG8t
+        dHlwZSI6ICJwdXBwZXQtcmVwbyJ9LCAibGFzdF91bml0X3JlbW92ZWQiOiBu
+        dWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25zIjogInJlcG9z
+        IiwgImltcG9ydGVycyI6IFt7InNjcmF0Y2hwYWQiOiBudWxsLCAiX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy80L2ltcG9ydGVycy9wdXBw
+        ZXRfaW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBvX2ltcG9ydGVycyIsICJpbXBv
+        cnRlcl90eXBlX2lkIjogInB1cHBldF9pbXBvcnRlciIsICJsYXN0X3N5bmMi
+        OiBudWxsLCAicmVwb19pZCI6ICI0IiwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0
+        YWM1YWM3ODIxYjMzMDQyZDllMTAifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJo
+        dHRwOi8vZGF2aWRkLmZlZG9yYXBlb3BsZS5vcmcvcmVwb3MvcmFuZG9tX3B1
+        cHBldC8ifSwgImlkIjogInB1cHBldF9pbXBvcnRlciJ9XSwgImxvY2FsbHlf
+        c3RvcmVkX3VuaXRzIjogMCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM1YWM3
+        ODIxYjMzMDQyZDllMGYifSwgInRvdGFsX3JlcG9zaXRvcnlfdW5pdHMiOiAw
+        LCAiaWQiOiAiNCIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9y
+        aWVzLzQvIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:18 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/4/actions/publish/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjQiLCJvdmVycmlkZV9jb25maWciOm51bGx9
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="UzCaBDFbytUwN4K3v0MfNLnBEBkFnx5Wl25GfTiyBg", oauth_signature="oZE0FF7qgDWls6CQNPvjarwDdXI%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681178", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '33'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:18 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzAyNTI2NWE5LWE0NDAtNDZlZi1hMDBjLTZjNzMyYzgzZTgxYS8iLCAi
+        dGFza19pZCI6ICIwMjUyNjVhOS1hNDQwLTQ2ZWYtYTAwYy02YzczMmM4M2U4
+        MWEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:18 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/025265a9-a440-46ef-a00c-6c732c83e81a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="WPRtaV5w4TTevzYurJdhTA6TlHbugHdhtYTUkOXAvs",
+        oauth_signature="y3f%2FA8blNdhBa3kV%2BV99X9wOU8g%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681178", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:18 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '548'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8wMjUyNjVhOS1hNDQwLTQ2ZWYtYTAwYy02Yzcz
+        MmM4M2U4MWEvIiwgInRhc2tfaWQiOiAiMDI1MjY1YTktYTQ0MC00NmVmLWEw
+        MGMtNmM3MzJjODNlODFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0
+        IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogbnVs
+        bCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogbnVsbCwg
+        InRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9n
+        cmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIk5vbmUuZHEiLCAic3RhdGUi
+        OiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6IG51bGwsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhYzVh
+        OGFkYTQwZGIwNGVlMGE1YyJ9LCAiaWQiOiAiNTZiNGFjNWE4YWRhNDBkYjA0
+        ZWUwYTVjIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:18 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/025265a9-a440-46ef-a00c-6c732c83e81a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="STySoPUQCL5KHNKfbjfPh1SYS4JKGIkvFbSLfWjhI",
+        oauth_signature="3BwG6CJq84V0EbcgZETYmzptLfo%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681179", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:19 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1068'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8wMjUyNjVhOS1hNDQwLTQ2ZWYtYTAwYy02Yzcz
+        MmM4M2U4MWEvIiwgInRhc2tfaWQiOiAiMDI1MjY1YTktYTQ0MC00NmVmLWEw
+        MGMtNmM3MzJjODNlODFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0
+        IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogIjIw
+        MTYtMDItMDVUMTQ6MDY6MThaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
+        dGFydF90aW1lIjogIjIwMTYtMDItMDVUMTQ6MDY6MThaIiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBv
+        cnQiOiB7fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
+        QGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJm
+        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0
+        IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAi
+        cmVwb19pZCI6ICI0IiwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNVQxNDowNjox
+        OFoiLCAiX25zIjogInJlcG9fcHVibGlzaF9yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDE2LTAyLTA1VDE0OjA2OjE4WiIsICJ0cmFjZWJhY2siOiBudWxs
+        LCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJwdXBwZXRfaW5zdGFsbF9kaXN0
+        cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2Nlc3MiLCAiZXJyb3JfbWVzc2Fn
+        ZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICI0IiwgImlkIjogIjU2YjRh
+        YzVhYzc4MjFiMzQ0NGZjYzI4MiIsICJkZXRhaWxzIjogeyJlcnJvcnMiOiBb
+        XSwgInN1Y2Nlc3NfdW5pdF9rZXlzIjogW119fSwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmI0YWM1YThhZGE0MGRiMDRlZTBhNWMifSwg
+        ImlkIjogIjU2YjRhYzVhOGFkYTQwZGIwNGVlMGE1YyJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:19 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/4/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="EF5P3DAvgUx5u7euVOhXOAACwItJ5NAuIighuulHY",
+        oauth_signature="b2vrHVYF8Ib4VAL2LBYLgumzK7Q%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681179", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:19 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1736'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUCBGb3JnZSIs
+        ICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMiOiBbeyJyZXBv
+        X2lkIjogIjQiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
+        cy80L2Rpc3RyaWJ1dG9ycy80X3B1cHBldC8iLCAiX25zIjogInJlcG9fZGlz
+        dHJpYnV0b3JzIiwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRv
+        cl90eXBlX2lkIjogInB1cHBldF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxp
+        c2giOiB0cnVlLCAic2NyYXRjaHBhZCI6IHt9LCAiX2lkIjogeyIkb2lkIjog
+        IjU2YjRhYzVhYzc4MjFiMzMwNDJkOWUxMyJ9LCAiY29uZmlnIjogeyJzZXJ2
+        ZV9odHRwcyI6IHRydWUsICJzZXJ2ZV9odHRwIjogZmFsc2V9LCAiaWQiOiAi
+        NF9wdXBwZXQifSwgeyJyZXBvX2lkIjogIjQiLCAiX2hyZWYiOiAiL3B1bHAv
+        YXBpL3YyL3JlcG9zaXRvcmllcy80L2Rpc3RyaWJ1dG9ycy80X25vZGVzLyIs
+        ICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAibGFzdF9wdWJsaXNoIjog
+        bnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0cF9kaXN0
+        cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAic2NyYXRjaHBhZCI6
+        IHt9LCAiX2lkIjogeyIkb2lkIjogIjU2YjRhYzVhYzc4MjFiMzMwNDJkOWUx
+        MiJ9LCAiY29uZmlnIjoge30sICJpZCI6ICI0X25vZGVzIn0sIHsicmVwb19p
+        ZCI6ICI0IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
+        NC9kaXN0cmlidXRvcnMvNC8iLCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3Jz
+        IiwgImxhc3RfcHVibGlzaCI6ICIyMDE2LTAyLTA1VDE0OjA2OjE4WiIsICJk
+        aXN0cmlidXRvcl90eXBlX2lkIjogInB1cHBldF9pbnN0YWxsX2Rpc3RyaWJ1
+        dG9yIiwgImF1dG9fcHVibGlzaCI6IHRydWUsICJzY3JhdGNocGFkIjoge30s
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNWFjNzgyMWIzMzA0MmQ5ZTExIn0s
+        ICJjb25maWciOiB7Imluc3RhbGxfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL3B1
+        Ymxpc2hlZC9wdXBwZXRfa2F0ZWxsb190ZXN0IiwgImF1dG9fcHVibGlzaCI6
+        IHRydWV9LCAiaWQiOiAiNCJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGws
+        ICJub3RlcyI6IHsiX3JlcG8tdHlwZSI6ICJwdXBwZXQtcmVwbyJ9LCAibGFz
+        dF91bml0X3JlbW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6
+        IHt9LCAiX25zIjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InNjcmF0Y2hw
+        YWQiOiBudWxsLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
+        cy80L2ltcG9ydGVycy9wdXBwZXRfaW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBv
+        X2ltcG9ydGVycyIsICJpbXBvcnRlcl90eXBlX2lkIjogInB1cHBldF9pbXBv
+        cnRlciIsICJsYXN0X3N5bmMiOiBudWxsLCAicmVwb19pZCI6ICI0IiwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1NmI0YWM1YWM3ODIxYjMzMDQyZDllMTAifSwgImNv
+        bmZpZyI6IHsiZmVlZCI6ICJodHRwOi8vZGF2aWRkLmZlZG9yYXBlb3BsZS5v
+        cmcvcmVwb3MvcmFuZG9tX3B1cHBldC8ifSwgImlkIjogInB1cHBldF9pbXBv
+        cnRlciJ9XSwgImxvY2FsbHlfc3RvcmVkX3VuaXRzIjogMCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1NmI0YWM1YWM3ODIxYjMzMDQyZDllMGYifSwgInRvdGFsX3Jl
+        cG9zaXRvcnlfdW5pdHMiOiAwLCAiaWQiOiAiNCIsICJfaHJlZiI6ICIvcHVs
+        cC9hcGkvdjIvcmVwb3NpdG9yaWVzLzQvIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:19 GMT
+- request:
+    method: delete
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="McC74eOl8V6CdH3WzqSNWA90ko6xLYGJNUWhdXSDMTQ",
+        oauth_signature="0j9dfyUPpybH311bPllNe7%2BPgiw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681179", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:19 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2EzMGRhY2E2LTQ3MjUtNDZlNC1hYmIzLTFmMzAzZjY1MGVhZi8iLCAi
+        dGFza19pZCI6ICJhMzBkYWNhNi00NzI1LTQ2ZTQtYWJiMy0xZjMwM2Y2NTBl
+        YWYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:19 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/a30daca6-4725-46e4-abb3-1f303f650eaf/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="nWRGH0wTyUzuPxJEbT3RNu92nfKSuNir3hFWcfbzFY",
+        oauth_signature="w60Mkq5ngYF580nRWthlo0tt2Ck%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681179", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:19 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '541'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hMzBkYWNhNi00NzI1LTQ2ZTQtYWJiMy0xZjMwM2Y2NTBl
+        YWYvIiwgInRhc2tfaWQiOiAiYTMwZGFjYTYtNDcyNS00NmU0LWFiYjMtMWYz
+        MDNmNjUwZWFmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiBudWxsLCAiX25z
+        IjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAidHJhY2Vi
+        YWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3Jl
+        cG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6ICJ3YWl0
+        aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51bGwsICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNWI4YWRhNDBk
+        YjA0ZWUwYTVkIn0sICJpZCI6ICI1NmI0YWM1YjhhZGE0MGRiMDRlZTBhNWQi
+        fQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:19 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/a30daca6-4725-46e4-abb3-1f303f650eaf/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="5ayYYn6gp9OxaBxM9LqzEjXVrsUaYpTgoE2QqlLoBI",
+        oauth_signature="rFWHzqEwjZUp5%2FCKiDl5LIkfpho%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681180", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:20 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '680'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hMzBkYWNhNi00NzI1LTQ2ZTQtYWJiMy0xZjMwM2Y2NTBl
+        YWYvIiwgInRhc2tfaWQiOiAiYTMwZGFjYTYtNDcyNS00NmU0LWFiYjMtMWYz
+        MDNmNjUwZWFmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0w
+        NVQxNDowNjoxOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3Rp
+        bWUiOiAiMjAxNi0wMi0wNVQxNDowNjoxOVoiLCAidHJhY2ViYWNrIjogbnVs
+        bCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9
+        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
+        by0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVk
+        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
+        QGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhYzViOGFk
+        YTQwZGIwNGVlMGE1ZCJ9LCAiaWQiOiAiNTZiNGFjNWI4YWRhNDBkYjA0ZWUw
+        YTVkIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:20 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/pulp/repository/repository.yml
+++ b/test/fixtures/vcr_cassettes/pulp/repository/repository.yml
@@ -111,53 +111,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:49 GMT
 - request:
-    method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/content/orphans/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="RsoU6NtTEDkHbRzlxGgC1ecOjhu0qpbS2dtCHXw7cI",
-        oauth_signature="sZ77LO2YuWutRqi0LgvqlBHkrlA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628890", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:50 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzQ3OTA1OWFkLWVlZmMtNDBkNC1iMzZkLThkY2I2YzliYzZjNi8iLCAi
-        dGFza19pZCI6ICI0NzkwNTlhZC1lZWZjLTQwZDQtYjM2ZC04ZGNiNmM5YmM2
-        YzYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:50 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/48d08d23-9ae0-4538-be8e-ea5efdc1c25a/
     body:
@@ -820,56 +773,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:34:58 GMT
 - request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjR9fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="WpLZlUSIxkPezOoKgJ0HSUxX2L8tmwqTA698ZLGvqx4", oauth_signature="9QRzJn%2FXYGs1eVJZ%2FJuh%2BahSxtE%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628898", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '37'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:34:58 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2RlYjdiYjkwLTg5MDItNDExYS04YTNlLTNjM2Q5ZDk2NmNhZS8iLCAi
-        dGFza19pZCI6ICJkZWI3YmI5MC04OTAyLTQxMWEtOGEzZS0zYzNkOWQ5NjZj
-        YWUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:58 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/deb7bb90-8902-411a-8a3e-3c3d9d966cae/
     body:
@@ -1256,155 +1159,6 @@ http_interactions:
   recorded_at: Thu, 04 Feb 2016 23:35:01 GMT
 - request:
     method: get
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="lttPyD2axKHTdwImlWveamK15vsLC8zuPheEx0FcY",
-        oauth_signature="ZtB7Nfb073VJmNfXmXEmIjDP3w0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628902", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:35:02 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '2'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W10=
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:35:02 GMT
-- request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY2hlZHVsZSI6IjIwMTMtMDgtMDFUMDA6MDA6MDAtMDQ6MDAvUDFEIn0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="NjGz3RTqvCDASKE24CAVdQWR6qvl6unPaE51UtwU8", oauth_signature="pAJa3XuCkoUP%2F2WNisWNli6Z4ts%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628902", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '44'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:35:02 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Location:
-      - "/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56b3e02684a09c0706343430/"
-      Content-Length:
-      - '610'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJuZXh0X3J1biI6ICIyMDE2LTAyLTA0VDIzOjM1OjAyWiIsICJyZW1haW5p
-        bmdfcnVucyI6IG51bGwsICJsYXN0X3VwZGF0ZWQiOiAxNDU0NjI4OTAyLjA0
-        NDk4NSwgImZpcnN0X3J1biI6ICIyMDEzLTA4LTAxVDAwOjAwOjAwLTA0OjAw
-        IiwgInRvdGFsX3J1bl9jb3VudCI6IDAsICJzY2hlZHVsZSI6ICIyMDEzLTA4
-        LTAxVDAwOjAwOjAwLTA0OjAwL1AxRCIsICJrd2FyZ3MiOiB7Im92ZXJyaWRl
-        cyI6IHt9fSwgImFyZ3MiOiBbIkZlZG9yYV8xNyJdLCAiZW5hYmxlZCI6IHRy
-        dWUsICJsYXN0X3J1bl9hdCI6IG51bGwsICJ0YXNrIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuc3luY193aXRoX2F1dG9fcHVibGlzaCIsICJm
-        YWlsdXJlX3RocmVzaG9sZCI6IG51bGwsICJyZXNvdXJjZSI6ICJwdWxwOmlt
-        cG9ydGVyOkZlZG9yYV8xNzp5dW1faW1wb3J0ZXIiLCAiX2lkIjogIjU2YjNl
-        MDI2ODRhMDljMDcwNjM0MzQzMCIsICJjb25zZWN1dGl2ZV9mYWlsdXJlcyI6
-        IDAsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9y
-        YV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyL3NjaGVkdWxlcy9zeW5jLzU2
-        YjNlMDI2ODRhMDljMDcwNjM0MzQzMC8ifQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:35:02 GMT
-- request:
-    method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="3oWuqGmBOz6mRK4Mw82C16APb9tvxFmg4B3D3U2eJc",
-        oauth_signature="Q8a95b4UbdO3ost%2Bl7bmcvtgv7Y%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628902", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:35:02 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzc5MDAyY2IzLTA3N2ItNDE2NC1hNWQ4LTE4MGM4ZDUwMDE0ZC8iLCAi
-        dGFza19pZCI6ICI3OTAwMmNiMy0wNzdiLTQxNjQtYTVkOC0xODBjOGQ1MDAx
-        NGQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:35:02 GMT
-- request:
-    method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/79002cb3-077b-4164-a5d8-180c8d50014d/
     body:
       encoding: US-ASCII
@@ -1513,4 +1267,1571 @@ http_interactions:
         N2RiZjRkOWJkIn0=
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:35:02 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/131dcbe7-bbcc-4a13-82a4-eebdd46faa05/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="PCs6xYk6aarUPcxrYlYqyMjBGeCQ3kalRSusPySQ",
+        oauth_signature="YSaW0IuWvW%2FI1sU7N0SopJg3cFA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681158", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xMzFkY2JlNy1iYmNjLTRhMTMtODJhNC1lZWJkZDQ2ZmFh
+        MDUvIiwgInRhc2tfaWQiOiAiMTMxZGNiZTctYmJjYy00YTEzLTgyYTQtZWVi
+        ZGQ0NmZhYTA1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM0
+        NjhhZGE0MGRiMDRlZTBhNDEifSwgImlkIjogIjU2YjRhYzQ2OGFkYTQwZGIw
+        NGVlMGE0MSJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:58 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/131dcbe7-bbcc-4a13-82a4-eebdd46faa05/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="eNYyo6YP8VuqI6GzqN5YrbXOd2XfIO4P8yZnx65nLE",
+        oauth_signature="jl8bea0PU2cPD9Ggb0XbkDEovhA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681159", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:05:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xMzFkY2JlNy1iYmNjLTRhMTMtODJhNC1lZWJkZDQ2ZmFh
+        MDUvIiwgInRhc2tfaWQiOiAiMTMxZGNiZTctYmJjYy00YTEzLTgyYTQtZWVi
+        ZGQ0NmZhYTA1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA1OjU4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA1OjU4WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjNDY4YWRhNDBkYjA0ZWUwYTQxIn0sICJpZCI6ICI1NmI0YWM0NjhhZGE0
+        MGRiMDRlZTBhNDEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:05:59 GMT
+- request:
+    method: delete
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/content/orphans/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="kefb7jyDiKizafxMvAWw6ONEuxQdBIoub8bjVSlY",
+        oauth_signature="zaLLh4atGDkuNnrQBmkMOVp46dg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681160", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzU4MGU4NDNmLWQwMDMtNDZiNi1iZWM1LTJlMzdlMzRkMzdkZC8iLCAi
+        dGFza19pZCI6ICI1ODBlODQzZi1kMDAzLTQ2YjYtYmVjNS0yZTM3ZTM0ZDM3
+        ZGQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:00 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/0c6f6909-a0a7-4c97-96ec-4e2db2634aa7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="c64Lr1C6sRWqw3qylapr7BZ1JXnz8p2NR46fo8dckg",
+        oauth_signature="HJRZGxeemz70VtPYWUFERIBiQxU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681160", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wYzZmNjkwOS1hMGE3LTRjOTctOTZlYy00ZTJkYjI2MzRh
+        YTcvIiwgInRhc2tfaWQiOiAiMGM2ZjY5MDktYTBhNy00Yzk3LTk2ZWMtNGUy
+        ZGIyNjM0YWE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM0
+        ODhhZGE0MGRiMDRlZTBhNDMifSwgImlkIjogIjU2YjRhYzQ4OGFkYTQwZGIw
+        NGVlMGE0MyJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:00 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/0c6f6909-a0a7-4c97-96ec-4e2db2634aa7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="KtTfPY5FGELEyl40zDB1UPdDqILXu8PZW2Q0ngQKfI",
+        oauth_signature="AlFCQMlp4KeXhRBzWkRvs31kMlk%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681161", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:01 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wYzZmNjkwOS1hMGE3LTRjOTctOTZlYy00ZTJkYjI2MzRh
+        YTcvIiwgInRhc2tfaWQiOiAiMGM2ZjY5MDktYTBhNy00Yzk3LTk2ZWMtNGUy
+        ZGIyNjM0YWE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA2OjAxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA2OjAxWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjNDg4YWRhNDBkYjA0ZWUwYTQzIn0sICJpZCI6ICI1NmI0YWM0ODhhZGE0
+        MGRiMDRlZTBhNDMifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:01 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f7747d21-f2d3-473b-be09-4c15e164b74f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Gu758ssXAAQ4Y8iq60ddkK0NLNi0hf3uyAJAKNvgDPM",
+        oauth_signature="Ds90hENf%2FvCgISTuGKypOQmnE9M%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681162", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:02 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '651'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mNzc0N2QyMS1mMmQzLTQ3M2ItYmUwOS00YzE1ZTE2NGI3
+        NGYvIiwgInRhc2tfaWQiOiAiZjc3NDdkMjEtZjJkMy00NzNiLWJlMDktNGMx
+        NWUxNjRiNzRmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAi
+        c3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
+        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1NmI0YWM0YThhZGE0MGRiMDRlZTBhNDQifSwgImlkIjogIjU2YjRh
+        YzRhOGFkYTQwZGIwNGVlMGE0NCJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:02 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f7747d21-f2d3-473b-be09-4c15e164b74f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="gPubPxr58k592j6Ashno9pqXzeNWdArMc3n0syPudU",
+        oauth_signature="NfSzDP0OrGAGtM1HSUWDN0ISvug%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681163", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:03 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mNzc0N2QyMS1mMmQzLTQ3M2ItYmUwOS00YzE1ZTE2NGI3
+        NGYvIiwgInRhc2tfaWQiOiAiZjc3NDdkMjEtZjJkMy00NzNiLWJlMDktNGMx
+        NWUxNjRiNzRmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA2OjAyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA2OjAyWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjNGE4YWRhNDBkYjA0ZWUwYTQ0In0sICJpZCI6ICI1NmI0YWM0YThhZGE0
+        MGRiMDRlZTBhNDQifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:03 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/e44f7efd-d04f-40c4-94c4-e23f8c6819c3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="wydI1UZ6koFi4iwL3uNkmtIs97xCJbtlbtCEht5WhAg",
+        oauth_signature="8xLcwLwhfUfhMHyGcObnV5IA8vQ%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681164", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:04 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9lNDRmN2VmZC1kMDRmLTQwYzQtOTRjNC1lMjNmOGM2ODE5
+        YzMvIiwgInRhc2tfaWQiOiAiZTQ0ZjdlZmQtZDA0Zi00MGM0LTk0YzQtZTIz
+        ZjhjNjgxOWMzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM0
+        YzhhZGE0MGRiMDRlZTBhNDUifSwgImlkIjogIjU2YjRhYzRjOGFkYTQwZGIw
+        NGVlMGE0NSJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:04 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/e44f7efd-d04f-40c4-94c4-e23f8c6819c3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="HwmhlV1uLcSZqVn7JB7m1RzxNz0Ccjg3RSf4Nyyd8",
+        oauth_signature="JttCRjpvHq6JN0CR25d3zAaKfNQ%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681165", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:05 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9lNDRmN2VmZC1kMDRmLTQwYzQtOTRjNC1lMjNmOGM2ODE5
+        YzMvIiwgInRhc2tfaWQiOiAiZTQ0ZjdlZmQtZDA0Zi00MGM0LTk0YzQtZTIz
+        ZjhjNjgxOWMzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA2OjA0WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA2OjA0WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjNGM4YWRhNDBkYjA0ZWUwYTQ1In0sICJpZCI6ICI1NmI0YWM0YzhhZGE0
+        MGRiMDRlZTBhNDUifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:05 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/c594f88e-65a5-4d56-ac44-346e6b16814f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="fgrGewO2S4F63EA36SYV0tbkgz0N51UQpr6DffQD4do",
+        oauth_signature="%2Bq8cDNweCzTsDJCuoeCOpCozIow%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681166", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:06 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jNTk0Zjg4ZS02NWE1LTRkNTYtYWM0NC0zNDZlNmIxNjgx
+        NGYvIiwgInRhc2tfaWQiOiAiYzU5NGY4OGUtNjVhNS00ZDU2LWFjNDQtMzQ2
+        ZTZiMTY4MTRmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM0
+        ZThhZGE0MGRiMDRlZTBhNDYifSwgImlkIjogIjU2YjRhYzRlOGFkYTQwZGIw
+        NGVlMGE0NiJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:06 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/c594f88e-65a5-4d56-ac44-346e6b16814f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="rbWbvBCK5SqY9KLEEnVba2N0hBVwK9lMjglOWgdo",
+        oauth_signature="kxx025NGMeqDTKbLwgWiANJFojA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681167", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:07 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jNTk0Zjg4ZS02NWE1LTRkNTYtYWM0NC0zNDZlNmIxNjgx
+        NGYvIiwgInRhc2tfaWQiOiAiYzU5NGY4OGUtNjVhNS00ZDU2LWFjNDQtMzQ2
+        ZTZiMTY4MTRmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA2OjA2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA2OjA2WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjNGU4YWRhNDBkYjA0ZWUwYTQ2In0sICJpZCI6ICI1NmI0YWM0ZThhZGE0
+        MGRiMDRlZTBhNDYifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:07 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/0aebece8-8bbe-4076-b5a9-5dd016ec2c5c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Z9jfgv3cvwfkqF62onLCpXpgyN2KwOaIc9WmOy8Re0",
+        oauth_signature="Ohd5UncDAbCSjPPMZehShcEz3y8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681168", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:08 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wYWViZWNlOC04YmJlLTQwNzYtYjVhOS01ZGQwMTZlYzJj
+        NWMvIiwgInRhc2tfaWQiOiAiMGFlYmVjZTgtOGJiZS00MDc2LWI1YTktNWRk
+        MDE2ZWMyYzVjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM1
+        MDhhZGE0MGRiMDRlZTBhNDcifSwgImlkIjogIjU2YjRhYzUwOGFkYTQwZGIw
+        NGVlMGE0NyJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:08 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/0aebece8-8bbe-4076-b5a9-5dd016ec2c5c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="NB7VJWfLQleIQ9OWGv6X2UIMpwZG2VQAFT3X4NVI7m0",
+        oauth_signature="M7zIBD5JUFxIpOofIuk8nDz5l6g%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681169", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:09 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wYWViZWNlOC04YmJlLTQwNzYtYjVhOS01ZGQwMTZlYzJj
+        NWMvIiwgInRhc2tfaWQiOiAiMGFlYmVjZTgtOGJiZS00MDc2LWI1YTktNWRk
+        MDE2ZWMyYzVjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA2OjA4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA2OjA4WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjNTA4YWRhNDBkYjA0ZWUwYTQ3In0sICJpZCI6ICI1NmI0YWM1MDhhZGE0
+        MGRiMDRlZTBhNDcifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:09 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/035a3586-4d67-43b0-8a73-bd59ba446ff1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="WlDaaoHGD1ZGCYHa6pc7KvJG1Ow4CMs9VpQb6rTNc4",
+        oauth_signature="Vyvx%2FAOJvkvW40utQtJ671v8%2B38%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681170", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:10 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wMzVhMzU4Ni00ZDY3LTQzYjAtOGE3My1iZDU5YmE0NDZm
+        ZjEvIiwgInRhc2tfaWQiOiAiMDM1YTM1ODYtNGQ2Ny00M2IwLThhNzMtYmQ1
+        OWJhNDQ2ZmYxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM1
+        MjhhZGE0MGRiMDRlZTBhNDgifSwgImlkIjogIjU2YjRhYzUyOGFkYTQwZGIw
+        NGVlMGE0OCJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:10 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/035a3586-4d67-43b0-8a73-bd59ba446ff1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="GNq7XCGdqXT7xFnJ58bdd9JXNhywmaXSID0poB90w",
+        oauth_signature="Ge2u%2Bn3FwAHrwpzC81sNgT5NqDY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681171", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:11 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wMzVhMzU4Ni00ZDY3LTQzYjAtOGE3My1iZDU5YmE0NDZm
+        ZjEvIiwgInRhc2tfaWQiOiAiMDM1YTM1ODYtNGQ2Ny00M2IwLThhNzMtYmQ1
+        OWJhNDQ2ZmYxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA2OjEwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA2OjEwWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjNTI4YWRhNDBkYjA0ZWUwYTQ4In0sICJpZCI6ICI1NmI0YWM1MjhhZGE0
+        MGRiMDRlZTBhNDgifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:11 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjR9fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="xpWR4KfU7jxSuh2kFwsXn5pGyVzSfmPPg2UCJXMqKg", oauth_signature="dDl174T%2F3c04c8clssnlxWFYszs%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681172", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '37'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:12 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzE0ZjJlOGNkLTMwYTYtNDNjMy04ODMzLTk2ZjllMmZhNDA5OS8iLCAi
+        dGFza19pZCI6ICIxNGYyZThjZC0zMGE2LTQzYzMtODgzMy05NmY5ZTJmYTQw
+        OTkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:12 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/14f2e8cd-30a6-43c3-8833-96f9e2fa4099/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Yi5y0JMVZq6ohrKxLBPd3NKlXE0pTt7L3j53JCFOMc",
+        oauth_signature="hcbGUOX8GPZnoIjNd0pblxGMUZs%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681172", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:12 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '667'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xNGYyZThjZC0zMGE2LTQzYzMtODgzMy05NmY5ZTJmYTQw
+        OTkvIiwgInRhc2tfaWQiOiAiMTRmMmU4Y2QtMzBhNi00M2MzLTg4MzMtOTZm
+        OWUyZmE0MDk5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0wNVQxNDowNjoxMloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4
+        YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25h
+        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgt
+        ZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51
+        bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjNTQ4YWRhNDBkYjA0ZWUwYTQ5
+        In0sICJpZCI6ICI1NmI0YWM1NDhhZGE0MGRiMDRlZTBhNDkifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:12 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/14f2e8cd-30a6-43c3-8833-96f9e2fa4099/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="npz0CWa92MS3ElCj5b3fYycgveqFdWqbnW0YJHqEU",
+        oauth_signature="UkAlSpzMrbOJfZJPpFR0spHRsNs%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681172", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:12 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1093'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xNGYyZThjZC0zMGE2LTQzYzMtODgzMy05NmY5ZTJmYTQw
+        OTkvIiwgInRhc2tfaWQiOiAiMTRmMmU4Y2QtMzBhNi00M2MzLTg4MzMtOTZm
+        OWUyZmE0MDk5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0wNVQxNDowNjoxMloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
+        bCI6IDAsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiSU5fUFJP
+        R1JFU1MifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjNTQ4YWRhNDBkYjA0ZWUwYTQ5In0sICJpZCI6ICI1NmI0YWM1NDhhZGE0
+        MGRiMDRlZTBhNDkifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:12 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/14f2e8cd-30a6-43c3-8833-96f9e2fa4099/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="vKj18zqoGmWVaqsUduC0cJ3sVzpDLQ2dJ4lD96IwI",
+        oauth_signature="5rqWpirWMde%2BXB9%2F8gjXZJsLpiU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681173", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:13 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2202'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xNGYyZThjZC0zMGE2LTQzYzMtODgzMy05NmY5ZTJmYTQw
+        OTkvIiwgInRhc2tfaWQiOiAiMTRmMmU4Y2QtMzBhNi00M2MzLTg4MzMtOTZm
+        OWUyZmE0MDk5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowNjoxM1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowNjoxMloiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNzVhNTU2ZTctZjVmYi00Y2Y5LTgwYWQtNWE0YzkyN2Q4
+        NzM0LyIsICJ0YXNrX2lkIjogIjc1YTU1NmU3LWY1ZmItNGNmOS04MGFkLTVh
+        NGM5MjdkODczNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiA4LCAicnBtX2RvbmUiOiA4LCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAxNzg3MiwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19
+        fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVs
+        bG8tMi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJy
+        ZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6IHsiJG9pZCI6ICI1
+        NmI0YWM1NGM3ODIxYjMzMDM0YmFlM2UifSwgImV4Y2VwdGlvbiI6IG51bGws
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAi
+        c3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE0OjA2OjEyWiIsICJfbnMiOiAicmVw
+        b19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDItMDVUMTQ6
+        MDY6MTNaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwg
+        ImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRh
+        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAw
+        LCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlk
+        IjogIjU2YjRhYzU1Yzc4MjFiMzQ0NGZjYzI4MCIsICJkZXRhaWxzIjogeyJj
+        b250ZW50IjogeyJzaXplX3RvdGFsIjogMTc4NzIsICJpdGVtc19sZWZ0Ijog
+        MCwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNp
+        emVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiA4LCAicnBt
+        X2RvbmUiOiA4LCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwg
+        ImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRl
+        bXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9y
+        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM1NDhhZGE0MGRiMDRl
+        ZTBhNDkifSwgImlkIjogIjU2YjRhYzU0OGFkYTQwZGIwNGVlMGE0OSJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:13 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ac5a2808-ee1c-4404-8999-b37758fad909/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="AYzaeuHnUKs3CfAzsOtYd8XxrV9AyemntNfOx3q1y1s",
+        oauth_signature="K52LQqmR8zHPTw6jmvQ2ulJTA3c%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681174", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:14 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hYzVhMjgwOC1lZTFjLTQ0MDQtODk5OS1iMzc3NThmYWQ5
+        MDkvIiwgInRhc2tfaWQiOiAiYWM1YTI4MDgtZWUxYy00NDA0LTg5OTktYjM3
+        NzU4ZmFkOTA5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM1
+        NjhhZGE0MGRiMDRlZTBhNWEifSwgImlkIjogIjU2YjRhYzU2OGFkYTQwZGIw
+        NGVlMGE1YSJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:14 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ac5a2808-ee1c-4404-8999-b37758fad909/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="So0qywAx46GhMUcLJz4MtiXDDMdZoEOOC9nkkv7uZY4",
+        oauth_signature="GueDdDYvL6zQAb0iE8WnB2mNY2A%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681175", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:15 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hYzVhMjgwOC1lZTFjLTQ0MDQtODk5OS1iMzc3NThmYWQ5
+        MDkvIiwgInRhc2tfaWQiOiAiYWM1YTI4MDgtZWUxYy00NDA0LTg5OTktYjM3
+        NzU4ZmFkOTA5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA2OjE0WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA2OjE0WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjNTY4YWRhNDBkYjA0ZWUwYTVhIn0sICJpZCI6ICI1NmI0YWM1NjhhZGE0
+        MGRiMDRlZTBhNWEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:15 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
+        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
+        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
+        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
+        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
+        LXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1
+        dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9j
+        b25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoLyIsImh0dHAiOmZh
+        bHNlLCJodHRwcyI6dHJ1ZSwicHJvdGVjdGVkIjp0cnVlfSwiYXV0b19wdWJs
+        aXNoIjp0cnVlLCJkaXN0cmlidXRvcl9pZCI6IkZlZG9yYV8xNyJ9LHsiZGlz
+        dHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9jbG9uZV9kaXN0cmlidXRvciIsImRp
+        c3RyaWJ1dG9yX2NvbmZpZyI6eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9p
+        ZCI6IkZlZG9yYV8xNyJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0cmli
+        dXRvcl9pZCI6IkZlZG9yYV8xN19jbG9uZSJ9LHsiZGlzdHJpYnV0b3JfdHlw
+        ZV9pZCI6ImV4cG9ydF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZp
+        ZyI6eyJodHRwIjpmYWxzZSwiaHR0cHMiOmZhbHNlLCJyZWxhdGl2ZV91cmwi
+        Om51bGx9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRvcl9pZCI6
+        ImV4cG9ydF9kaXN0cmlidXRvciJ9XX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="tRDcy4AtgdbkVFjxZZk6AGere3CB7CFwvAhw5Vwn8", oauth_signature="n5OUHXRFJOJ73pTdJFD9Y2g5ASU%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681176", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '788'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:16 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '320'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
+        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
+        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NTZiNGFjNThjNzgyMWIzMzA1Y2U1MTFmIn0sICJpZCI6ICJGZWRvcmFfMTci
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
+        MTcvIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:16 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="qSrMRQh11K7BTYi38nblvEm4j8cSLogPmKwjUFduOWc",
+        oauth_signature="LzbByzZsjU33ckaFT4ixLw1YgeM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681176", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:16 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '2'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        W10=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:16 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY2hlZHVsZSI6IjIwMTMtMDgtMDFUMDA6MDA6MDAtMDQ6MDAvUDFEIn0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="ZXTtnxWvQwdGDuZoTZ9IFFygJqnPO2H9E0G38t7Cmg", oauth_signature="vdS%2ByNH7KUnNm0srA%2BETitmxgO4%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681176", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '44'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:16 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '670'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer/schedules/sync/56b4ac58c7821b3305ce5125/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuZXh0X3J1biI6ICIyMDE2LTAyLTA1VDE0OjA2OjE2WiIsICJyZW1haW5p
+        bmdfcnVucyI6IG51bGwsICJsYXN0X3VwZGF0ZWQiOiAxNDU0NjgxMTc2LjMx
+        ODIxLCAiZmlyc3RfcnVuIjogIjIwMTMtMDgtMDFUMDA6MDA6MDAtMDQ6MDAi
+        LCAidG90YWxfcnVuX2NvdW50IjogMCwgInNjaGVkdWxlIjogIjIwMTMtMDgt
+        MDFUMDA6MDA6MDAtMDQ6MDAvUDFEIiwgImt3YXJncyI6IHsib3ZlcnJpZGVz
+        Ijoge30sICJzY2hlZHVsZWRfY2FsbF9pZCI6ICI1NmI0YWM1OGM3ODIxYjMz
+        MDVjZTUxMjUifSwgImFyZ3MiOiBbIkZlZG9yYV8xNyJdLCAiZW5hYmxlZCI6
+        IHRydWUsICJsYXN0X3J1bl9hdCI6IG51bGwsICJ0YXNrIjogInB1bHAuc2Vy
+        dmVyLmNvbnRyb2xsZXJzLnJlcG9zaXRvcnkucXVldWVfc3luY193aXRoX2F1
+        dG9fcHVibGlzaCIsICJmYWlsdXJlX3RocmVzaG9sZCI6IG51bGwsICJyZXNv
+        dXJjZSI6ICJwdWxwOmltcG9ydGVyOkZlZG9yYV8xNzp5dW1faW1wb3J0ZXIi
+        LCAiX2lkIjogIjU2YjRhYzU4Yzc4MjFiMzMwNWNlNTEyNSIsICJjb25zZWN1
+        dGl2ZV9mYWlsdXJlcyI6IDAsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVw
+        b3NpdG9yaWVzL0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyL3Nj
+        aGVkdWxlcy9zeW5jLzU2YjRhYzU4Yzc4MjFiMzMwNWNlNTEyNS8ifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:16 GMT
+- request:
+    method: delete
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="OhH6212dX79uaHWVZrLqbAkiPIymtr4lSkZpK5uqg",
+        oauth_signature="qKOusEnwwlZetvAOQXzzz7T%2F0eQ%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681176", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:16 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2ExNzU4ZTgxLTg5MmYtNDQ3NC1iZjk5LWY1MDU3ZmVhYzQ2Yy8iLCAi
+        dGFza19pZCI6ICJhMTc1OGU4MS04OTJmLTQ0NzQtYmY5OS1mNTA1N2ZlYWM0
+        NmMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:16 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/a1758e81-892f-4474-bf99-f5057feac46c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="ZXAWEPH52R56jjN2LknieAozhyU9pC2UR3B1ewNeY",
+        oauth_signature="AULZisIqJ73tVaIKxQY6qdW%2Btxo%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681176", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:16 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hMTc1OGU4MS04OTJmLTQ0NzQtYmY5OS1mNTA1N2ZlYWM0
+        NmMvIiwgInRhc2tfaWQiOiAiYTE3NThlODEtODkyZi00NDc0LWJmOTktZjUw
+        NTdmZWFjNDZjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWM1
+        ODhhZGE0MGRiMDRlZTBhNWIifSwgImlkIjogIjU2YjRhYzU4OGFkYTQwZGIw
+        NGVlMGE1YiJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:16 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/a1758e81-892f-4474-bf99-f5057feac46c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="x4yAKBhLC3MH9TwCjr63PxmOtraLza6V1o8A9q6fA",
+        oauth_signature="%2B%2Bd4jecjMOuhRyLLhkMO%2Fix5%2BqA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681177", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:06:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hMTc1OGU4MS04OTJmLTQ0NzQtYmY5OS1mNTA1N2ZlYWM0
+        NmMvIiwgInRhc2tfaWQiOiAiYTE3NThlODEtODkyZi00NDc0LWJmOTktZjUw
+        NTdmZWFjNDZjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA2OjE2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA2OjE2WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjNTg4YWRhNDBkYjA0ZWUwYTViIn0sICJpZCI6ICI1NmI0YWM1ODhhZGE0
+        MGRiMDRlZTBhNWIifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:06:17 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/services/pulp/erratum.yml
+++ b/test/fixtures/vcr_cassettes/services/pulp/erratum.yml
@@ -1326,66 +1326,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:36:37 GMT
 - request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJlcnJhdHVtIl0sImZpZWxkcyI6
-        eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="Wvivc8pxDlEwdLbCOHDVVEq7z6TXYbUTrEbbbI5ozs4", oauth_signature="9lczaWrGhdLBVCUxSuPpgctuN1o%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628997", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '84'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:36:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '651'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIzMWIyNDEzZS0xOTMzLTRiMTktYjU4
-        OS1iZTNmNmY3YWU4Y2UiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
-        In0sICJfaWQiOiB7IiRvaWQiOiAiNTZiM2UwODQ4NGEwOWMwN2RhOTc5ZGQx
-        In0sICJ1bml0X2lkIjogIjMxYjI0MTNlLTE5MzMtNGIxOS1iNTg5LWJlM2Y2
-        ZjdhZThjZSIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
-        YXRhIjogeyJfaWQiOiAiODYxZDlmODctNjcwMi00YjhlLWJlNGQtNWI4ZTZh
-        NDhiOGJjIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
-        IjogeyIkb2lkIjogIjU2YjNlMDg0ODRhMDljMDdkYTk3OWRkMyJ9LCAidW5p
-        dF9pZCI6ICI4NjFkOWY4Ny02NzAyLTRiOGUtYmU0ZC01YjhlNmE0OGI4YmMi
-        LCAidW5pdF90eXBlX2lkIjogImVycmF0dW0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogImNjY2ZkYzFlLWFiMWEtNDBhNS1hMTYzLTNjMjE5ZmEzMWE4ZSIs
-        ICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0ifSwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmIzZTA4NDg0YTA5YzA3ZGE5NzlkZDIifSwgInVuaXRfaWQiOiAi
-        Y2NjZmRjMWUtYWIxYS00MGE1LWExNjMtM2MyMTlmYTMxYThlIiwgInVuaXRf
-        dHlwZV9pZCI6ICJlcnJhdHVtIn1d
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:36:37 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/99338094-d88e-4653-be2d-7d6fbe7215ab/
     body:
@@ -1569,57 +1509,6 @@ http_interactions:
         NTZiM2UwODY4NGEwOWMwNzA2MzQzNjNlIn0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:36:38 GMT
-- request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
-        Ijp0cnVlfX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="Hzjs7lAUxoQZmkHtCAMeqx0ooDg7gN11wasybDl9I", oauth_signature="PvZxOuwcuIlGJMRdnVH2B%2By6QbY%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628998", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '53'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:36:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2I0NmY3YjdmLWM4NzktNDg5Yy1hNDMwLTQ5NzQ4ZjQyYjM2Mi8iLCAi
-        dGFza19pZCI6ICJiNDZmN2I3Zi1jODc5LTQ4OWMtYTQzMC00OTc0OGY0MmIz
-        NjIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:36:38 GMT
 - request:
@@ -2233,66 +2122,6 @@ http_interactions:
   recorded_at: Thu, 04 Feb 2016 23:36:40 GMT
 - request:
     method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJlcnJhdHVtIl0sImZpZWxkcyI6
-        eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="deVD4By5gObeLU9PzWME5qYGtDjHfx3rpSiUi0x0", oauth_signature="ZIrJ0sx1G7W5fPkBifT8lVOklAY%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454629000", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '84'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:36:40 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '651'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIzMWIyNDEzZS0xOTMzLTRiMTktYjU4
-        OS1iZTNmNmY3YWU4Y2UiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
-        In0sICJfaWQiOiB7IiRvaWQiOiAiNTZiM2UwODc4NGEwOWMwN2RhOTc5ZGVm
-        In0sICJ1bml0X2lkIjogIjMxYjI0MTNlLTE5MzMtNGIxOS1iNTg5LWJlM2Y2
-        ZjdhZThjZSIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
-        YXRhIjogeyJfaWQiOiAiODYxZDlmODctNjcwMi00YjhlLWJlNGQtNWI4ZTZh
-        NDhiOGJjIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
-        IjogeyIkb2lkIjogIjU2YjNlMDg3ODRhMDljMDdkYTk3OWRmMSJ9LCAidW5p
-        dF9pZCI6ICI4NjFkOWY4Ny02NzAyLTRiOGUtYmU0ZC01YjhlNmE0OGI4YmMi
-        LCAidW5pdF90eXBlX2lkIjogImVycmF0dW0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogImNjY2ZkYzFlLWFiMWEtNDBhNS1hMTYzLTNjMjE5ZmEzMWE4ZSIs
-        ICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0ifSwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmIzZTA4Nzg0YTA5YzA3ZGE5NzlkZjAifSwgInVuaXRfaWQiOiAi
-        Y2NjZmRjMWUtYWIxYS00MGE1LWExNjMtM2MyMTlmYTMxYThlIiwgInVuaXRf
-        dHlwZV9pZCI6ICJlcnJhdHVtIn1d
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:36:40 GMT
-- request:
-    method: post
     uri: https://katello-devbox.example.com/pulp/api/v2/content/units/erratum/search/
     body:
       encoding: UTF-8
@@ -2560,53 +2389,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:36:40 GMT
 - request:
-    method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="3HtF5lmqPOGrOEghRjyiVvbQtMkyYOeIWTKMyh0",
-        oauth_signature="nYerwNyVZbaNIsL6Arjn3DqEM%2FI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454629000", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:36:40 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzZlMDExMDlmLWU3N2YtNDIxYy05YTI0LTE1NjQzMmExMzlhNC8iLCAi
-        dGFza19pZCI6ICI2ZTAxMTA5Zi1lNzdmLTQyMWMtOWEyNC0xNTY0MzJhMTM5
-        YTQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:36:40 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/6e01109f-e77f-421c-9a24-156432a139a4/
     body:
@@ -2716,4 +2498,2576 @@ http_interactions:
         N2RiZjRkYmUwIn0=
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:36:40 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/696d0594-53cb-4c66-a524-dd1497823f34/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="MFiZA8CYGajydcdKl6fZQTHBEzj56DWY58r2MPQUM",
+        oauth_signature="tLfZlYYAEWM9%2BhTVhQhU4znv3DI%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681318", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:38 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82OTZkMDU5NC01M2NiLTRjNjYtYTUyNC1kZDE0OTc4MjNm
+        MzQvIiwgInRhc2tfaWQiOiAiNjk2ZDA1OTQtNTNjYi00YzY2LWE1MjQtZGQx
+        NDk3ODIzZjM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjZTY4
+        YWRhNDBkYjA0ZWUwYmI0In0sICJpZCI6ICI1NmI0YWNlNjhhZGE0MGRiMDRl
+        ZTBiYjQifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:38 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/696d0594-53cb-4c66-a524-dd1497823f34/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="jeuFQYy08NfLi0PtHr4DKjweKSftqsPfx8fcVhCkNs",
+        oauth_signature="mnk2qtG4YwijSiGl4RXLhjPQ%2Bpg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681318", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:39 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1087'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82OTZkMDU5NC01M2NiLTRjNjYtYTUyNC1kZDE0OTc4MjNm
+        MzQvIiwgInRhc2tfaWQiOiAiNjk2ZDA1OTQtNTNjYi00YzY2LWE1MjQtZGQx
+        NDk3ODIzZjM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0wNVQxNDowODozOFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
+        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0
+        ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5p
+        bmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjZTY4
+        YWRhNDBkYjA0ZWUwYmI0In0sICJpZCI6ICI1NmI0YWNlNjhhZGE0MGRiMDRl
+        ZTBiYjQifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:39 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/696d0594-53cb-4c66-a524-dd1497823f34/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="uD6PXAQ7PIfLhmCPOPf7kh09v1cbdRUWVoKh6zgs",
+        oauth_signature="Rh36I8YXHKk3iiw9e0%2FUfBf7xl4%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681319", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:39 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82OTZkMDU5NC01M2NiLTRjNjYtYTUyNC1kZDE0OTc4MjNm
+        MzQvIiwgInRhc2tfaWQiOiAiNjk2ZDA1OTQtNTNjYi00YzY2LWE1MjQtZGQx
+        NDk3ODIzZjM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowODozOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowODozOFoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMDljNDU1MzMtZWYyOC00NjA5LTkwMDktNGZmNjYwZmRm
+        ZGQ5LyIsICJ0YXNrX2lkIjogIjA5YzQ1NTMzLWVmMjgtNDYwOS05MDA5LTRm
+        ZjY2MGZkZmRkOSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        Y2U2Yzc4MjFiMzMwMzRiYWU2YyJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDg6MzhaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowODoz
+        OVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjZTdjNzgyMWIzNDQ0ZmNjMmU0IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjZTY4YWRhNDBkYjA0ZWUwYmI0In0s
+        ICJpZCI6ICI1NmI0YWNlNjhhZGE0MGRiMDRlZTBiYjQifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:39 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/09c45533-ef28-4609-9009-4ff660fdfdd9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="LAjXvzfSkWrZfsUdZsk2DEsMch7KFRinVJvrEgfRhA",
+        oauth_signature="5zw4JlJSY9udA8DykzCZZbIDgi0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681319", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:39 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '3523'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8wOWM0NTUzMy1lZjI4LTQ2MDktOTAwOS00ZmY2
+        NjBmZGZkZDkvIiwgInRhc2tfaWQiOiAiMDljNDU1MzMtZWYyOC00NjA5LTkw
+        MDktNGZmNjYwZmRmZGQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxNi0wMi0wNVQxNDowODozOVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlZWRm
+        NjdkNS01ODY5LTRkNmEtYjdmMS03ZGFjOTRlMzIzYWQiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWJiMWQxNjUtMDg1
+        Yy00NzhiLTliZjAtYTI0NDc0MWI5NWZmIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDUsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiZDMwODlhNWUtYmJhMi00OGJiLTk3MzktNWZhMTA1MThmZDE5Iiwg
+        Im51bV9wcm9jZXNzZWQiOiA1fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
+        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRhMWNlMDc5LTc5YTEt
+        NGVkYi05NWM0LTVkMzQxNjk3ZDdlMiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICJmYTgzM2Q3Mi1jZTJhLTRjMjYtOWUzMC1jNGE1NDY3Zjk0NmEi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5
+        cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWM2NGYwNTQtMTk0
+        OC00MjU4LWJjMTktY2IzOTAyOGNiYzE3IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiNjExZjQzYzctZTQ5OS00NjU0LTk1YTctMDFlYzJi
+        NzI4NTMxIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAi
+        c3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiM2YzMDg0ZTMtZmJiZS00N2M1LThhNjktYThkMjBjOWQyMWFj
+        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
+        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        ImJkZGJkZjE0LTk2OTItNDNiOC1iN2VlLTBjYzdiOWI4NmZmZSIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjog
+        InB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE1ZTNk
+        NTQ2LTQwZmItNDgwMy04NWNiLTU2ZDhjMzYwMzllYiIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
+        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZGIyYTY1
+        Y2QtYTE1Mi00ODNmLTg4YTYtNTdlMzQ4ZjE3Y2YyIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjZTc4YWRhNDBkYjA0ZWUwYmM0In0sICJpZCI6ICI1NmI0YWNlNzhhZGE0
+        MGRiMDRlZTBiYzQifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:39 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/696d0594-53cb-4c66-a524-dd1497823f34/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="YQqu8qIWRa81gS8xqVzwgZFhqfQVcxDpr0YyJfQllY",
+        oauth_signature="oVVKKq%2BUxzC73Aut6SUCEolyfTI%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681320", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:40 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82OTZkMDU5NC01M2NiLTRjNjYtYTUyNC1kZDE0OTc4MjNm
+        MzQvIiwgInRhc2tfaWQiOiAiNjk2ZDA1OTQtNTNjYi00YzY2LWE1MjQtZGQx
+        NDk3ODIzZjM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowODozOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowODozOFoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMDljNDU1MzMtZWYyOC00NjA5LTkwMDktNGZmNjYwZmRm
+        ZGQ5LyIsICJ0YXNrX2lkIjogIjA5YzQ1NTMzLWVmMjgtNDYwOS05MDA5LTRm
+        ZjY2MGZkZmRkOSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        Y2U2Yzc4MjFiMzMwMzRiYWU2YyJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDg6MzhaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowODoz
+        OVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjZTdjNzgyMWIzNDQ0ZmNjMmU0IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjZTY4YWRhNDBkYjA0ZWUwYmI0In0s
+        ICJpZCI6ICI1NmI0YWNlNjhhZGE0MGRiMDRlZTBiYjQifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:40 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/09c45533-ef28-4609-9009-4ff660fdfdd9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="FuxLMRSbS66UmrrZ7mQO3zf5i9278OPwe34zJt9WM6U",
+        oauth_signature="u7YE%2Be7LVcxw5EAreeFjV0jJ8ZY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681320", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:40 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '6929'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8wOWM0NTUzMy1lZjI4LTQ2MDktOTAwOS00ZmY2
+        NjBmZGZkZDkvIiwgInRhc2tfaWQiOiAiMDljNDU1MzMtZWYyOC00NjA5LTkw
+        MDktNGZmNjYwZmRmZGQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0wMi0wNVQxNDowODozOVoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowODozOVoiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICJlZWRmNjdkNS01ODY5LTRkNmEtYjdmMS03ZGFjOTRl
+        MzIzYWQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiYWJiMWQxNjUtMDg1Yy00NzhiLTliZjAtYTI0NDc0MWI5NWZmIiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
+        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZDMwODlhNWUtYmJhMi00OGJiLTk3Mzkt
+        NWZhMTA1MThmZDE5IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
+        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGEx
+        Y2UwNzktNzlhMS00ZWRiLTk1YzQtNWQzNDE2OTdkN2UyIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogImZhODMzZDcyLWNlMmEtNGMyNi05ZTMwLWM0YTU0
+        NjdmOTQ2YSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
+        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhYzY0ZjA1
+        NC0xOTQ4LTQyNTgtYmMxOS1jYjM5MDI4Y2JjMTciLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI2MTFmNDNjNy1lNDk5LTQ2NTQtOTVhNy0wMWVj
+        MmI3Mjg1MzEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
+        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICIzZjMwODRlMy1mYmJlLTQ3YzUtOGE2OS1hOGQyMGM5ZDIxYWMi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
+        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiZGRi
+        ZGYxNC05NjkyLTQzYjgtYjdlZS0wY2M3YjliODZmZmUiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
+        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNWUzZDU0Ni00MGZi
+        LTQ4MDMtODVjYi01NmQ4YzM2MDM5ZWIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
+        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImRiMmE2NWNkLWExNTItNDgz
+        Zi04OGE2LTU3ZTM0OGYxN2NmMiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
+        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE0OjA4OjM5
+        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMDVUMTQ6MDg6MzlaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
+        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
+        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
+        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
+        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
+        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
+        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
+        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
+        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGFjZTdjNzgyMWIz
+        NDQ0ZmNjMmU1IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
+        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
+        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImVlZGY2N2Q1LTU4NjktNGQ2YS1iN2YxLTdkYWM5NGUzMjNh
+        ZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
+        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICJhYmIxZDE2NS0wODVjLTQ3OGItOWJmMC1hMjQ0NzQxYjk1ZmYiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
+        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJkMzA4OWE1ZS1iYmEyLTQ4YmItOTczOS01ZmEx
+        MDUxOGZkMTkiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
+        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0YTFjZTA3
+        OS03OWExLTRlZGItOTVjNC01ZDM0MTY5N2Q3ZTIiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiZmE4MzNkNzItY2UyYS00YzI2LTllMzAtYzRhNTQ2N2Y5
+        NDZhIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFjNjRmMDU0LTE5
+        NDgtNDI1OC1iYzE5LWNiMzkwMjhjYmMxNyIsICJudW1fcHJvY2Vzc2VkIjog
+        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjYxMWY0M2M3LWU0OTktNDY1NC05NWE3LTAxZWMyYjcy
+        ODUzMSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
+        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjNmMzA4NGUzLWZiYmUtNDdjNS04YTY5LWE4ZDIwYzlkMjFhYyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
+        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJkZGJkZjE0
+        LTk2OTItNDNiOC1iN2VlLTBjYzdiOWI4NmZmZSIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
+        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE1ZTNkNTQ2LTQwZmItNDgw
+        My04NWNiLTU2ZDhjMzYwMzllYiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
+        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZGIyYTY1Y2QtYTE1Mi00ODNmLTg4
+        YTYtNTdlMzQ4ZjE3Y2YyIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhY2U3OGFkYTQwZGIw
+        NGVlMGJjNCJ9LCAiaWQiOiAiNTZiNGFjZTc4YWRhNDBkYjA0ZWUwYmM0In0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:40 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/756333a9-73f4-495d-9518-c1337d52822e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="FQU3ql3qSIqc6cLb0GzQxKFFAu6hRvMb7G8eSO7Q8k",
+        oauth_signature="XtgrrtbZ3lgoVBmPpxirGvQUePg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681320", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:40 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83NTYzMzNhOS03M2Y0LTQ5NWQtOTUxOC1jMTMzN2Q1Mjgy
+        MmUvIiwgInRhc2tfaWQiOiAiNzU2MzMzYTktNzNmNC00OTVkLTk1MTgtYzEz
+        MzdkNTI4MjJlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWNl
+        ODhhZGE0MGRiMDRlZTBiYzUifSwgImlkIjogIjU2YjRhY2U4OGFkYTQwZGIw
+        NGVlMGJjNSJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:40 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/756333a9-73f4-495d-9518-c1337d52822e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="uMeupZ3NntaKmrA459XL4F4JL6PzgWTOgtgbI73M",
+        oauth_signature="K7snZIVbThQrskX0wGBLjmvfE7E%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681321", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:41 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83NTYzMzNhOS03M2Y0LTQ5NWQtOTUxOC1jMTMzN2Q1Mjgy
+        MmUvIiwgInRhc2tfaWQiOiAiNzU2MzMzYTktNzNmNC00OTVkLTk1MTgtYzEz
+        MzdkNTI4MjJlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA4OjQxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA4OjQxWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjZTg4YWRhNDBkYjA0ZWUwYmM1In0sICJpZCI6ICI1NmI0YWNlODhhZGE0
+        MGRiMDRlZTBiYzUifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:41 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/6dedac27-5879-43ab-b533-b5dc8b585bfe/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="nHdVfVGYGSDyJfvi8odTDF7riExt6nZwXFuvXopOAQY",
+        oauth_signature="DKivWaMZBatrAtvdIPQloV615Jg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681322", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:43 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82ZGVkYWMyNy01ODc5LTQzYWItYjUzMy1iNWRjOGI1ODVi
+        ZmUvIiwgInRhc2tfaWQiOiAiNmRlZGFjMjctNTg3OS00M2FiLWI1MzMtYjVk
+        YzhiNTg1YmZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjZWE4
+        YWRhNDBkYjA0ZWUwYmM2In0sICJpZCI6ICI1NmI0YWNlYThhZGE0MGRiMDRl
+        ZTBiYzYifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:43 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/6dedac27-5879-43ab-b533-b5dc8b585bfe/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="zUv9947mUXw8whzzmzBKUwHL1m0BBt6ycpVv7lUSg",
+        oauth_signature="SG2WgqFKKrxhpoynGFtzLIMCtvo%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681323", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:43 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1081'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82ZGVkYWMyNy01ODc5LTQzYWItYjUzMy1iNWRjOGI1ODVi
+        ZmUvIiwgInRhc2tfaWQiOiAiNmRlZGFjMjctNTg3OS00M2FiLWI1MzMtYjVk
+        YzhiNTg1YmZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0wNVQxNDowODo0M1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJJ
+        Tl9QUk9HUkVTUyJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAi
+        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0
+        ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjZWE4YWRhNDBk
+        YjA0ZWUwYmM2In0sICJpZCI6ICI1NmI0YWNlYThhZGE0MGRiMDRlZTBiYzYi
+        fQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:43 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/6dedac27-5879-43ab-b533-b5dc8b585bfe/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="UjJvOMT4R0UOpx4v0jK0yqGbQh6mqgb4TkhYnk8",
+        oauth_signature="BHB%2BsN6Iz3m3vcAB9yx4TvnHjtc%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681324", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:44 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82ZGVkYWMyNy01ODc5LTQzYWItYjUzMy1iNWRjOGI1ODVi
+        ZmUvIiwgInRhc2tfaWQiOiAiNmRlZGFjMjctNTg3OS00M2FiLWI1MzMtYjVk
+        YzhiNTg1YmZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowODo0M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowODo0M1oiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMzgzMGQxMGQtZTBiNy00ZGYwLWEzZGYtNGVlMjY4ZGQw
+        ZTdjLyIsICJ0YXNrX2lkIjogIjM4MzBkMTBkLWUwYjctNGRmMC1hM2RmLTRl
+        ZTI2OGRkMGU3YyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        Y2VhYzc4MjFiMzMwMzRiYWU3MyJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDg6NDNaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowODo0
+        M1oiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjZWJjNzgyMWIzNDQ0ZmNjMmU5IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjZWE4YWRhNDBkYjA0ZWUwYmM2In0s
+        ICJpZCI6ICI1NmI0YWNlYThhZGE0MGRiMDRlZTBiYzYifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:44 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/3830d10d-e0b7-4df0-a3df-4ee268dd0e7c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="cwZSUHbJ8Xv55UixicGJ85pdCoKZx3t334ABdRmF4vc",
+        oauth_signature="Z5pUPcHa%2B2dOFs2gMjmvX6HJjYg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681324", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:44 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '6929'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8zODMwZDEwZC1lMGI3LTRkZjAtYTNkZi00ZWUy
+        NjhkZDBlN2MvIiwgInRhc2tfaWQiOiAiMzgzMGQxMGQtZTBiNy00ZGYwLWEz
+        ZGYtNGVlMjY4ZGQwZTdjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0wMi0wNVQxNDowODo0NFoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowODo0M1oiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICIxNDlkNWRhZC1lN2Q5LTRlMGItODc0Yy0yNWMyMWFl
+        OTA2YTAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiZjYzNmI0YmEtYTIwOS00ZTlkLThmOGYtNzM5M2FhZjcxYjBmIiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
+        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiOGFiY2RkZjItMmRiNC00ZTYzLWI1NzMt
+        NzFmMjA3OTU1ZDcwIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
+        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGM2
+        MDBlZDItMTNkMi00MTFiLWI1YWYtNTlkOWI3NWM5YmQ4IiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogImMzMmZkZjVkLWM3ZDMtNGYzNy1hMWQ2LTY4NDIx
+        OTAyMDE5ZSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
+        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3OTFmNTEx
+        OC04MWY2LTQ3N2YtYmM1OS1lZjczZjZkYzkwMWIiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJiZTFmMTMxNi1jY2E0LTRjNzgtOWQ3Yi0xYmJh
+        N2ZkOWFhMDgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
+        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI0OTdkMTcxNi03NjAyLTRiMjktODdiZi1mOGI1YjBiMzMzZDci
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
+        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzMTY4
+        NTRmMi05YTliLTQxZWMtOTI5Mi1kMTQxOTQ3MTY4OGQiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
+        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0ZjQ5OTRkOC00OTkw
+        LTRiYjctYTkzYy01NGFjYjNiZjFhNzQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
+        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjk4OWQxZmJhLTBiYWItNDVh
+        OC05ZDIzLTYwZWE2ZjQ3MTk4NSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
+        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE0OjA4OjQz
+        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMDVUMTQ6MDg6NDRaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
+        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
+        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
+        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
+        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
+        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
+        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
+        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
+        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGFjZWNjNzgyMWIz
+        NDQ0ZmNjMmVhIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
+        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
+        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogIjE0OWQ1ZGFkLWU3ZDktNGUwYi04NzRjLTI1YzIxYWU5MDZh
+        MCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
+        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICJmNjM2YjRiYS1hMjA5LTRlOWQtOGY4Zi03MzkzYWFmNzFiMGYiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
+        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI4YWJjZGRmMi0yZGI0LTRlNjMtYjU3My03MWYy
+        MDc5NTVkNzAiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
+        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYzYwMGVk
+        Mi0xM2QyLTQxMWItYjVhZi01OWQ5Yjc1YzliZDgiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiYzMyZmRmNWQtYzdkMy00ZjM3LWExZDYtNjg0MjE5MDIw
+        MTllIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc5MWY1MTE4LTgx
+        ZjYtNDc3Zi1iYzU5LWVmNzNmNmRjOTAxYiIsICJudW1fcHJvY2Vzc2VkIjog
+        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImJlMWYxMzE2LWNjYTQtNGM3OC05ZDdiLTFiYmE3ZmQ5
+        YWEwOCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
+        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjQ5N2QxNzE2LTc2MDItNGIyOS04N2JmLWY4YjViMGIzMzNkNyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
+        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjMxNjg1NGYy
+        LTlhOWItNDFlYy05MjkyLWQxNDE5NDcxNjg4ZCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
+        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRmNDk5NGQ4LTQ5OTAtNGJi
+        Ny1hOTNjLTU0YWNiM2JmMWE3NCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
+        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTg5ZDFmYmEtMGJhYi00NWE4LTlk
+        MjMtNjBlYTZmNDcxOTg1IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhY2ViOGFkYTQwZGIw
+        NGVlMGJkNiJ9LCAiaWQiOiAiNTZiNGFjZWI4YWRhNDBkYjA0ZWUwYmQ2In0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:44 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJlcnJhdHVtIl0sImZpZWxkcyI6
+        eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="hu7InzS4SCMKMwauygEUnEOZFcrBSluTIahNSoDw2U", oauth_signature="AuoRP4cWSCKDtfMFzVAU6IZNr8Q%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681324", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '84'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:44 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '651'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIyNzE1ZGE2Zi0yNTI4LTQ3YmUtODIw
+        MS05ODE0ZWJlMjJmMTgiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
+        In0sICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjZWI4YWRhNDBkYjA0ZWUwYmQw
+        In0sICJ1bml0X2lkIjogIjI3MTVkYTZmLTI1MjgtNDdiZS04MjAxLTk4MTRl
+        YmUyMmYxOCIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
+        YXRhIjogeyJfaWQiOiAiNDhjMDlkZGYtNmE5OS00MmU0LTgxZGEtNjYxOTBk
+        Y2IzMGFhIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
+        IjogeyIkb2lkIjogIjU2YjRhY2ViOGFkYTQwZGIwNGVlMGJkMiJ9LCAidW5p
+        dF9pZCI6ICI0OGMwOWRkZi02YTk5LTQyZTQtODFkYS02NjE5MGRjYjMwYWEi
+        LCAidW5pdF90eXBlX2lkIjogImVycmF0dW0ifSwgeyJtZXRhZGF0YSI6IHsi
+        X2lkIjogImU2NmYwNjE1LWJhYzAtNDRjNC1hYzA3LTIzM2NlMDRjODVkYSIs
+        ICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0ifSwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1NmI0YWNlYjhhZGE0MGRiMDRlZTBiZDEifSwgInVuaXRfaWQiOiAi
+        ZTY2ZjA2MTUtYmFjMC00NGM0LWFjMDctMjMzY2UwNGM4NWRhIiwgInVuaXRf
+        dHlwZV9pZCI6ICJlcnJhdHVtIn1d
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:44 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/6bd35d96-aad0-4cc4-bc4c-5fd3b395776e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="GNiZ4eZa0qGoIYaDdG3siLrcOrwAmhPq83dfz5SJ8NM",
+        oauth_signature="gKPDmt9bLEKrBaS9TrnygyTDqk8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681324", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:44 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82YmQzNWQ5Ni1hYWQwLTRjYzQtYmM0Yy01ZmQzYjM5NTc3
+        NmUvIiwgInRhc2tfaWQiOiAiNmJkMzVkOTYtYWFkMC00Y2M0LWJjNGMtNWZk
+        M2IzOTU3NzZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWNl
+        YzhhZGE0MGRiMDRlZTBiZDcifSwgImlkIjogIjU2YjRhY2VjOGFkYTQwZGIw
+        NGVlMGJkNyJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:44 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/6bd35d96-aad0-4cc4-bc4c-5fd3b395776e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="OToM3Hmmc0D46qG0BU8DmkwC8FiAcDGwcgRKFlK5YbM",
+        oauth_signature="N8RiUJtAy%2BOO7ydWzktNmcHvNjU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681325", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:45 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82YmQzNWQ5Ni1hYWQwLTRjYzQtYmM0Yy01ZmQzYjM5NTc3
+        NmUvIiwgInRhc2tfaWQiOiAiNmJkMzVkOTYtYWFkMC00Y2M0LWJjNGMtNWZk
+        M2IzOTU3NzZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA4OjQ1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA4OjQ1WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjZWM4YWRhNDBkYjA0ZWUwYmQ3In0sICJpZCI6ICI1NmI0YWNlYzhhZGE0
+        MGRiMDRlZTBiZDcifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:45 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
+        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
+        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
+        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
+        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
+        LXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1
+        dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9j
+        b25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIiwiaHR0cCI6ZmFs
+        c2UsImh0dHBzIjp0cnVlLCJwcm90ZWN0ZWQiOnRydWV9LCJhdXRvX3B1Ymxp
+        c2giOnRydWUsImRpc3RyaWJ1dG9yX2lkIjoiRmVkb3JhXzE3In0seyJkaXN0
+        cmlidXRvcl90eXBlX2lkIjoieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwiZGlz
+        dHJpYnV0b3JfY29uZmlnIjp7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lk
+        IjoiRmVkb3JhXzE3In0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1
+        dG9yX2lkIjoiRmVkb3JhXzE3X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBl
+        X2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmln
+        Ijp7Imh0dHAiOmZhbHNlLCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6
+        bnVsbH0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoi
+        ZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="HNlSWZa9cjVWRx6wh7CGYBCcUzJgOqe41fMA4QdhgA", oauth_signature="eeKJhRnSxKS0RmX2UO2PYP12Fh8%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681326", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '787'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:46 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '320'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
+        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
+        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NTZiNGFjZWVjNzgyMWIzMzAzNGJhZTc3In0sICJpZCI6ICJGZWRvcmFfMTci
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
+        MTcvIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:46 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
+        Ijp0cnVlfX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="uNndeCH5yfZXLLo3BqDJpWV6zydxGJJ5SrrxU54SlU", oauth_signature="ItpuSxFpUA8W%2B2IvrTFEwTe5AiE%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681326", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '53'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:46 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzYyM2Y2ODk2LWQ1ZjQtNDdiMy1hYjBjLTFhNTRhNTUxZWNlYy8iLCAi
+        dGFza19pZCI6ICI2MjNmNjg5Ni1kNWY0LTQ3YjMtYWIwYy0xYTU0YTU1MWVj
+        ZWMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:46 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/623f6896-d5f4-47b3-ab0c-1a54a551ecec/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="bsqTY1AXHkk5o4g7M8ttxhuB81irRCa9vyKhdcaM",
+        oauth_signature="eqQL7WfPN7%2F1cZLD5HtGFFY9Bwo%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681326", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:46 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82MjNmNjg5Ni1kNWY0LTQ3YjMtYWIwYy0xYTU0YTU1MWVj
+        ZWMvIiwgInRhc2tfaWQiOiAiNjIzZjY4OTYtZDVmNC00N2IzLWFiMGMtMWE1
+        NGE1NTFlY2VjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjZWU4
+        YWRhNDBkYjA0ZWUwYmQ4In0sICJpZCI6ICI1NmI0YWNlZThhZGE0MGRiMDRl
+        ZTBiZDgifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:46 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/623f6896-d5f4-47b3-ab0c-1a54a551ecec/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="qPf8AVLPzhk1UQCZObWjyJjSdUiVq0goFT6olCcg98",
+        oauth_signature="SAsyJfP48cZvcIDcdckmhYBlggU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681327", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1084'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82MjNmNjg5Ni1kNWY0LTQ3YjMtYWIwYy0xYTU0YTU1MWVj
+        ZWMvIiwgInRhc2tfaWQiOiAiNjIzZjY4OTYtZDVmNC00N2IzLWFiMGMtMWE1
+        NGE1NTFlY2VjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0wNVQxNDowODo0N1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIklOX1BS
+        T0dSRVNTIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
+        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
+        by0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmci
+        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
+        a2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGws
+        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjZWU4YWRh
+        NDBkYjA0ZWUwYmQ4In0sICJpZCI6ICI1NmI0YWNlZThhZGE0MGRiMDRlZTBi
+        ZDgifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:47 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/623f6896-d5f4-47b3-ab0c-1a54a551ecec/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="69CBsTlPiueVukxYF7zzDBirYEgfazJpakARXZDGtVk",
+        oauth_signature="rq4AAnIjkwavw7VGe374b8jev0I%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681328", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:48 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82MjNmNjg5Ni1kNWY0LTQ3YjMtYWIwYy0xYTU0YTU1MWVj
+        ZWMvIiwgInRhc2tfaWQiOiAiNjIzZjY4OTYtZDVmNC00N2IzLWFiMGMtMWE1
+        NGE1NTFlY2VjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowODo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowODo0N1oiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvM2JiNTI4MzEtMWE3My00MWFhLWI2ZjEtZDVhNjZhNjEz
+        OTFkLyIsICJ0YXNrX2lkIjogIjNiYjUyODMxLTFhNzMtNDFhYS1iNmYxLWQ1
+        YTY2YTYxMzkxZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        Y2VlYzc4MjFiMzMwMzRiYWU3OCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDg6NDdaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowODo0
+        N1oiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjZWZjNzgyMWIzNDQ0ZmNjMmVlIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjZWU4YWRhNDBkYjA0ZWUwYmQ4In0s
+        ICJpZCI6ICI1NmI0YWNlZThhZGE0MGRiMDRlZTBiZDgifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:48 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/3bb52831-1a73-41aa-b6f1-d5a66a61391d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="QgJnYXcod69HH6mJ75POqFutBl2R8Jj1qG2yvBRC90",
+        oauth_signature="dnilm7rGWC%2BYPoA2flDK9%2Fn%2Ba2Y%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681328", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:48 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '3497'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8zYmI1MjgzMS0xYTczLTQxYWEtYjZmMS1kNWE2
+        NmE2MTM5MWQvIiwgInRhc2tfaWQiOiAiM2JiNTI4MzEtMWE3My00MWFhLWI2
+        ZjEtZDVhNjZhNjEzOTFkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxNi0wMi0wNVQxNDowODo0N1oiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2ZmRj
+        OTA0Zi0zNzUwLTQ0MGYtOWMxYi1iODY5MTZhYjBkNzQiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGY0OWZkZDUtM2Uw
+        NC00Yzg4LWJkZmEtNDQyMWU3NDE4OWZlIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiMzQ3NjA4ZDEtYjJlNi00YmJlLTgzMGEtYzkzYjBmNDQ2NDI1IiwgIm51
+        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
+        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
+        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjNkMzY0NzUtNjc5Zi00M2QwLWFl
+        NGYtM2Y1ODA3NDk0NGYxIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
+        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjhm
+        OGQ5YTM0LTJiYjctNDQxZS1iNTRiLTM4ODk5ZWJhZjI0ZCIsICJudW1fcHJv
+        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24i
+        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
+        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJjOTRjYjhmMi01NjQzLTRlZjgtYjkyOS03
+        Y2VmMTg0ZmM3YjQiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNj
+        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEu
+        IiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0
+        MTBkZTZlYi0xNjg2LTQwNzgtYTQ3Ny0wYWFlNDNiZTk1YmUiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9u
+        IjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xv
+        c2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4NWU5NTM3Ni0w
+        NTNhLTQwYmQtYmRmYi0zYjMxMmE2ZWI0N2QiLCAibnVtX3Byb2Nlc3NlZCI6
+        IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVy
+        YXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBz
+        cWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiODM1NjQ3OC0xODFjLTRmMGQtODM0
+        MC02NTBiMTIwYzg5MzciLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
+        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMg
+        dG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICI0OGQxNzdmZi0yMjE2LTQ4ZGQtODAyNy03ZWIzNDk0
+        YjI3ODciLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJz
+        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjljODMwY2U4LTU3YmItNDI1YS1hNGJkLTY5ZmY5NmU2
+        YmYxNiIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2Vy
+        dmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5leGFtcGxl
+        LmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5l
+        eGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU2YjRhY2VmOGFkYTQwZGIwNGVlMGJlOCJ9LCAi
+        aWQiOiAiNTZiNGFjZWY4YWRhNDBkYjA0ZWUwYmU4In0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:48 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/623f6896-d5f4-47b3-ab0c-1a54a551ecec/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="VFFeio9hhmKeHeFUJ2QsFFFbt1j3Ga6oquTZOSo",
+        oauth_signature="TUCxHKFjhRoVsBHq6r9okAOedj4%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681328", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:48 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82MjNmNjg5Ni1kNWY0LTQ3YjMtYWIwYy0xYTU0YTU1MWVj
+        ZWMvIiwgInRhc2tfaWQiOiAiNjIzZjY4OTYtZDVmNC00N2IzLWFiMGMtMWE1
+        NGE1NTFlY2VjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowODo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowODo0N1oiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvM2JiNTI4MzEtMWE3My00MWFhLWI2ZjEtZDVhNjZhNjEz
+        OTFkLyIsICJ0YXNrX2lkIjogIjNiYjUyODMxLTFhNzMtNDFhYS1iNmYxLWQ1
+        YTY2YTYxMzkxZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        Y2VlYzc4MjFiMzMwMzRiYWU3OCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDg6NDdaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowODo0
+        N1oiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjZWZjNzgyMWIzNDQ0ZmNjMmVlIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjZWU4YWRhNDBkYjA0ZWUwYmQ4In0s
+        ICJpZCI6ICI1NmI0YWNlZThhZGE0MGRiMDRlZTBiZDgifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:48 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/3bb52831-1a73-41aa-b6f1-d5a66a61391d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="INTue2GBrATQXj0HfizrXIdhrJ2nfldq8jcAKs8sA",
+        oauth_signature="jMNMF9zMDeKxwDmM8jwp7OulFnI%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681328", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:48 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '6929'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8zYmI1MjgzMS0xYTczLTQxYWEtYjZmMS1kNWE2
+        NmE2MTM5MWQvIiwgInRhc2tfaWQiOiAiM2JiNTI4MzEtMWE3My00MWFhLWI2
+        ZjEtZDVhNjZhNjEzOTFkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0wMi0wNVQxNDowODo0OFoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowODo0N1oiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICI2ZmRjOTA0Zi0zNzUwLTQ0MGYtOWMxYi1iODY5MTZh
+        YjBkNzQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiNGY0OWZkZDUtM2UwNC00Yzg4LWJkZmEtNDQyMWU3NDE4OWZlIiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
+        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMzQ3NjA4ZDEtYjJlNi00YmJlLTgzMGEt
+        YzkzYjBmNDQ2NDI1IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
+        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjNk
+        MzY0NzUtNjc5Zi00M2QwLWFlNGYtM2Y1ODA3NDk0NGYxIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjhmOGQ5YTM0LTJiYjctNDQxZS1iNTRiLTM4ODk5
+        ZWJhZjI0ZCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
+        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjOTRjYjhm
+        Mi01NjQzLTRlZjgtYjkyOS03Y2VmMTg0ZmM3YjQiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI0MTBkZTZlYi0xNjg2LTQwNzgtYTQ3Ny0wYWFl
+        NDNiZTk1YmUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
+        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI4NWU5NTM3Ni0wNTNhLTQwYmQtYmRmYi0zYjMxMmE2ZWI0N2Qi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
+        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiODM1
+        NjQ3OC0xODFjLTRmMGQtODM0MC02NTBiMTIwYzg5MzciLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
+        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0OGQxNzdmZi0yMjE2
+        LTQ4ZGQtODAyNy03ZWIzNDk0YjI3ODciLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
+        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjljODMwY2U4LTU3YmItNDI1
+        YS1hNGJkLTY5ZmY5NmU2YmYxNiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
+        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE0OjA4OjQ3
+        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMDVUMTQ6MDg6NDhaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
+        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
+        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
+        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
+        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
+        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
+        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
+        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
+        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGFjZjBjNzgyMWIz
+        NDQ0ZmNjMmVmIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
+        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
+        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogIjZmZGM5MDRmLTM3NTAtNDQwZi05YzFiLWI4NjkxNmFiMGQ3
+        NCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
+        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICI0ZjQ5ZmRkNS0zZTA0LTRjODgtYmRmYS00NDIxZTc0MTg5ZmUiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
+        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICIzNDc2MDhkMS1iMmU2LTRiYmUtODMwYS1jOTNi
+        MGY0NDY0MjUiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
+        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2M2QzNjQ3
+        NS02NzlmLTQzZDAtYWU0Zi0zZjU4MDc0OTQ0ZjEiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiOGY4ZDlhMzQtMmJiNy00NDFlLWI1NGItMzg4OTllYmFm
+        MjRkIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM5NGNiOGYyLTU2
+        NDMtNGVmOC1iOTI5LTdjZWYxODRmYzdiNCIsICJudW1fcHJvY2Vzc2VkIjog
+        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjQxMGRlNmViLTE2ODYtNDA3OC1hNDc3LTBhYWU0M2Jl
+        OTViZSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
+        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjg1ZTk1Mzc2LTA1M2EtNDBiZC1iZGZiLTNiMzEyYTZlYjQ3ZCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
+        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI4MzU2NDc4
+        LTE4MWMtNGYwZC04MzQwLTY1MGIxMjBjODkzNyIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
+        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQ4ZDE3N2ZmLTIyMTYtNDhk
+        ZC04MDI3LTdlYjM0OTRiMjc4NyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
+        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOWM4MzBjZTgtNTdiYi00MjVhLWE0
+        YmQtNjlmZjk2ZTZiZjE2IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhY2VmOGFkYTQwZGIw
+        NGVlMGJlOCJ9LCAiaWQiOiAiNTZiNGFjZWY4YWRhNDBkYjA0ZWUwYmU4In0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:48 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJlcnJhdHVtIl0sImZpZWxkcyI6
+        eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="ECeldQGL87KnnhzJ4Nwb9BgU2aTa6klDB29Vngf8Ldw", oauth_signature="sOnHi34JWtCmq2iBTJfrc346BQc%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681328", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '84'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:48 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '651'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIyNzE1ZGE2Zi0yNTI4LTQ3YmUtODIw
+        MS05ODE0ZWJlMjJmMTgiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
+        In0sICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjZWY4YWRhNDBkYjA0ZWUwYmUy
+        In0sICJ1bml0X2lkIjogIjI3MTVkYTZmLTI1MjgtNDdiZS04MjAxLTk4MTRl
+        YmUyMmYxOCIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
+        YXRhIjogeyJfaWQiOiAiNDhjMDlkZGYtNmE5OS00MmU0LTgxZGEtNjYxOTBk
+        Y2IzMGFhIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
+        IjogeyIkb2lkIjogIjU2YjRhY2VmOGFkYTQwZGIwNGVlMGJlNCJ9LCAidW5p
+        dF9pZCI6ICI0OGMwOWRkZi02YTk5LTQyZTQtODFkYS02NjE5MGRjYjMwYWEi
+        LCAidW5pdF90eXBlX2lkIjogImVycmF0dW0ifSwgeyJtZXRhZGF0YSI6IHsi
+        X2lkIjogImU2NmYwNjE1LWJhYzAtNDRjNC1hYzA3LTIzM2NlMDRjODVkYSIs
+        ICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0ifSwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1NmI0YWNlZjhhZGE0MGRiMDRlZTBiZTMifSwgInVuaXRfaWQiOiAi
+        ZTY2ZjA2MTUtYmFjMC00NGM0LWFjMDctMjMzY2UwNGM4NWRhIiwgInVuaXRf
+        dHlwZV9pZCI6ICJlcnJhdHVtIn1d
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:48 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/content/units/erratum/search/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMjcxNWRh
+        NmYtMjUyOC00N2JlLTgyMDEtOTgxNGViZTIyZjE4IiwiNDhjMDlkZGYtNmE5
+        OS00MmU0LTgxZGEtNjYxOTBkY2IzMGFhIiwiZTY2ZjA2MTUtYmFjMC00NGM0
+        LWFjMDctMjMzY2UwNGM4NWRhIl19fX0sImluY2x1ZGVfcmVwb3MiOnRydWV9
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="qbntWoH7t9ZyZkksXYRhBSmCa4cSk2IfQMzvY75N1Y", oauth_signature="7Q5YRVHOg1I0F3SKBG4LUaUHBbQ%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681328", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '180'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:48 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4700'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJf
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9lcnJhdHVtLzI3
+        MTVkYTZmLTI1MjgtNDdiZS04MjAxLTk4MTRlYmUyMmYxOC8iLCAiaXNzdWVk
+        IjogIjIwMTAtMDEtMDEgMDE6MDE6MDEiLCAicmVmZXJlbmNlcyI6IFtdLCAi
+        cHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lkIjog
+        ImVycmF0dW0iLCAiaWQiOiAiUkhFQS0yMDEwOjAwMDEiLCAiZnJvbSI6ICJs
+        emFwK3B1YkByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRsZSI6
+        ICJFbXB0eSBlcnJhdGEiLCAiY2hpbGRyZW4iOiB7fSwgInZlcnNpb24iOiAi
+        MSIsICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3Vy
+        aXR5IiwgInBrZ2xpc3QiOiBbXSwgInN0YXR1cyI6ICJzdGFibGUiLCAidXBk
+        YXRlZCI6ICIiLCAiZGVzY3JpcHRpb24iOiAiRW1wdHkgZXJyYXRhIiwgIl9s
+        YXN0X3VwZGF0ZWQiOiAiMjAxNi0wMi0wNVQxNDowODo0N1oiLCAicHVzaGNv
+        dW50IjogIiIsICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1t
+        YXJ5IjogIiIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjI3MTVkYTZmLTI1
+        MjgtNDdiZS04MjAxLTk4MTRlYmUyMmYxOCJ9LCB7InJlcG9zaXRvcnlfbWVt
+        YmVyc2hpcHMiOiBbIkZlZG9yYV8xNyJdLCAiX2hyZWYiOiAiL3B1bHAvYXBp
+        L3YyL2NvbnRlbnQvdW5pdHMvZXJyYXR1bS80OGMwOWRkZi02YTk5LTQyZTQt
+        ODFkYS02NjE5MGRjYjMwYWEvIiwgImlzc3VlZCI6ICIyMDEwLTAxLTAxIDAx
+        OjAxOjAxIiwgInJlZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0
+        YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjog
+        IlJIRUEtMjAxMDowMDAyIiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0LmNv
+        bSIsICJzZXZlcml0eSI6ICIiLCAidGl0bGUiOiAiT25lIHBhY2thZ2UgZXJy
+        YXRhIiwgImNoaWxkcmVuIjoge30sICJ2ZXJzaW9uIjogIjEiLCAicmVib290
+        X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2ds
+        aXN0IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRv
+        cmFwcm9qZWN0Lm9yZyIsICJuYW1lIjogImVsZXBoYW50IiwgInN1bSI6IG51
+        bGwsICJmaWxlbmFtZSI6ICJlbGVwaGFudC0wLjMtMC44Lm5vYXJjaC5ycG0i
+        LCAiZXBvY2giOiBudWxsLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6
+        ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogIjEiLCAic2hv
+        cnQiOiAiIn1dLCAic3RhdHVzIjogInN0YWJsZSIsICJ1cGRhdGVkIjogIiIs
+        ICJkZXNjcmlwdGlvbiI6ICJPbmUgcGFja2FnZSBlcnJhdGEiLCAiX2xhc3Rf
+        dXBkYXRlZCI6ICIyMDE2LTAyLTA1VDE0OjA4OjQ3WiIsICJwdXNoY291bnQi
+        OiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnki
+        OiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiNDhjMDlkZGYtNmE5OS00
+        MmU0LTgxZGEtNjYxOTBkY2IzMGFhIn0sIHsicmVwb3NpdG9yeV9tZW1iZXJz
+        aGlwcyI6IFsiRmVkb3JhXzE3Il0sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIv
+        Y29udGVudC91bml0cy9lcnJhdHVtL2U2NmYwNjE1LWJhYzAtNDRjNC1hYzA3
+        LTIzM2NlMDRjODVkYS8iLCAiaXNzdWVkIjogIjIwMTAtMTEtMTAgMDA6MDA6
+        MDAiLCAicmVmZXJlbmNlcyI6IFt7ImhyZWYiOiAiaHR0cHM6Ly9yaG4ucmVk
+        aGF0LmNvbS9lcnJhdGEvUkhTQS0yMDEwLTA4NTguaHRtbCIsICJ0eXBlIjog
+        InNlbGYiLCAiaWQiOiBudWxsLCAidGl0bGUiOiBudWxsfSwgeyJocmVmIjog
+        Imh0dHBzOi8vYnVnemlsbGEucmVkaGF0LmNvbS9idWd6aWxsYS9zaG93X2J1
+        Zy5jZ2k/aWQ9NjI3ODgyIiwgInR5cGUiOiAiYnVnemlsbGEiLCAiaWQiOiAi
+        NjI3ODgyIiwgInRpdGxlIjogbnVsbH0sIHsiaHJlZiI6ICJodHRwczovL3d3
+        dy5yZWRoYXQuY29tL3NlY3VyaXR5L2RhdGEvY3ZlL0NWRS0yMDEwLTA0MDUu
+        aHRtbCIsICJ0eXBlIjogImN2ZSIsICJpZCI6ICJDVkUtMjAxMC0wNDA1Iiwg
+        InRpdGxlIjogbnVsbH0sIHsiaHJlZiI6ICJodHRwOi8vd3d3LnJlZGhhdC5j
+        b20vc2VjdXJpdHkvdXBkYXRlcy9jbGFzc2lmaWNhdGlvbi8jaW1wb3J0YW50
+        IiwgInR5cGUiOiAib3RoZXIiLCAiaWQiOiBudWxsLCAidGl0bGUiOiBudWxs
+        fV0sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVf
+        aWQiOiAiZXJyYXR1bSIsICJpZCI6ICJSSFNBLTIwMTA6MDg1OCIsICJmcm9t
+        IjogInNlY3VyaXR5QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiSW1wb3J0
+        YW50IiwgInRpdGxlIjogIkltcG9ydGFudDogYnppcDIgc2VjdXJpdHkgdXBk
+        YXRlIiwgImNoaWxkcmVuIjoge30sICJ2ZXJzaW9uIjogIjMiLCAicmVib290
+        X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2ds
+        aXN0IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiYnppcDItMS4wLjUtNy5l
+        bDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDItZGV2ZWwiLCAic3VtIjog
+        WyJzaGEyNTYiLCAiZWE2N2M2NjRkYTFmZjk2YTZkYzk0ZDMzMDA5YjczZDhm
+        YWIzMWI1OTgyNDE4M2ZiNDVlOWJhMmViZjgyZDU4MyJdLCAiZmlsZW5hbWUi
+        OiAiYnppcDItZGV2ZWwtMS4wLjUtNy5lbDZfMC5pNjg2LnJwbSIsICJlcG9j
+        aCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVs
+        Nl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03
+        LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJzIiwgInN1bSI6
+        IFsic2hhMjU2IiwgImM5ZjA2NGE2ODYyNTczZmI5ZjJhNmFmZjdjMzYyMWYx
+        OTQwYjQ5MmRmMmVkZmMyZWJiZGMwYjgzMDVmNTExNDciXSwgImZpbGVuYW1l
+        IjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC5pNjg2LnJwbSIsICJlcG9j
+        aCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVs
+        Nl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03
+        LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMiIsICJzdW0iOiBbInNo
+        YTI1NiIsICJiOGEzZjcyYmMyYjBkODliYTczNzA5OWFjOThiZjhkMmFmNGJl
+        YTAyZDMxODg0YzAyZGI5N2Y3ZjY2YzNkNWMyIl0sICJmaWxlbmFtZSI6ICJi
+        emlwMi0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0iLCAiZXBvY2giOiAiMCIs
+        ICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJh
+        cmNoIjogIng4Nl82NCJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8w
+        LnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1kZXZlbCIsICJzdW0iOiBbInNo
+        YTI1NiIsICI3ZjYzMTI0ZTQ2NTViN2M5MmQyM2VjNGMzODIyNmY1ZDM3NDY1
+        Njg4NTNkZmY3NTBmYzg1ZTA1OGU3NGI1Y2Y2Il0sICJmaWxlbmFtZSI6ICJi
+        emlwMi1kZXZlbC0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0iLCAiZXBvY2gi
+        OiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZf
+        MCIsICJhcmNoIjogIng4Nl82NCJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03
+        LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJzIiwgInN1bSI6
+        IFsic2hhMjU2IiwgIjgwMmY0Mzk5ZGJkZDAxNDc2ZTI1NGMzYjMyYzQwYWZm
+        NTljZjVkMjNhNDVmYTQ4OGM2OTE3Y2U4OTA0ZDZiNGQiXSwgImZpbGVuYW1l
+        IjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVw
+        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcu
+        ZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQifV0sICJuYW1lIjogIlJlZCBIYXQg
+        RW50ZXJwcmlzZSBMaW51eCBTZXJ2ZXIgKHYuIDYgZm9yIDY0LWJpdCB4ODZf
+        NjQpIiwgInNob3J0IjogInJoZWwteDg2XzY0LXNlcnZlci02In1dLCAic3Rh
+        dHVzIjogImZpbmFsIiwgInVwZGF0ZWQiOiAiMjAxMC0xMS0xMCAwMDowMDow
+        MCIsICJkZXNjcmlwdGlvbiI6ICJiemlwMiBpcyBhIGZyZWVseSBhdmFpbGFi
+        bGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNvbXByZXNzb3IuIEl0IHByb3ZpZGVz
+        IGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11c3QgYmUgcmVzdGFydGVkIGZvciB0
+        aGUgdXBkYXRlIHRvIHRha2UgZWZmZWN0LiIsICJfbGFzdF91cGRhdGVkIjog
+        IjIwMTYtMDItMDVUMTQ6MDg6NDdaIiwgInB1c2hjb3VudCI6ICIiLCAicmln
+        aHRzIjogIkNvcHlyaWdodCAyMDEwIFJlZCBIYXQgSW5jIiwgInNvbHV0aW9u
+        IjogIkJlZm9yZSBhcHBseWluZyB0aGlzIHVwZGF0ZSwgbWFrZSBzdXJlIGFs
+        bCBwcmV2aW91c2x5LXJlbGVhc2VkIGVycmF0YVxucmVsZXZhbnQgdG8geW91
+        ciBzeXN0ZW0gaGF2ZSBiZWVuIGFwcGxpZWQuXG5cblRoaXMgdXBkYXRlIGlz
+        IGF2YWlsYWJsZSB2aWEgdGhlIFJlZCBIYXQgTmV0d29yay4gRGV0YWlscyBv
+        biBob3cgdG9cbnVzZSB0aGUgUmVkIEhhdCBOZXR3b3JrIHRvIGFwcGx5IHRo
+        aXMgdXBkYXRlIGFyZSBhdmFpbGFibGUgYXRcbmh0dHA6Ly9rYmFzZS5yZWRo
+        YXQuY29tL2ZhcS9kb2NzL0RPQy0xMTI1OSIsICJzdW1tYXJ5IjogIlVwZGF0
+        ZWQgYnppcDIgcGFja2FnZXMgdGhhdCBmaXggb25lIHNlY3VyaXR5IGlzc3Vl
+        IiwgInJlbGVhc2UiOiAiIiwgIl9pZCI6ICJlNjZmMDYxNS1iYWMwLTQ0YzQt
+        YWMwNy0yMzNjZTA0Yzg1ZGEifV0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:48 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/content/units/erratum/search/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiZTY2ZjA2
+        MTUtYmFjMC00NGM0LWFjMDctMjMzY2UwNGM4NWRhIl19fX0sImluY2x1ZGVf
+        cmVwb3MiOnRydWV9
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="Mx9pBhPVmtbKL2UhxyRi3UHre38NavoFSSmMvQ7hrno", oauth_signature="X6szOi3beoncTgJEYCWbN5JMn6w%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681328", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '102'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:49 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '3146'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJf
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9lcnJhdHVtL2U2
+        NmYwNjE1LWJhYzAtNDRjNC1hYzA3LTIzM2NlMDRjODVkYS8iLCAiaXNzdWVk
+        IjogIjIwMTAtMTEtMTAgMDA6MDA6MDAiLCAicmVmZXJlbmNlcyI6IFt7Imhy
+        ZWYiOiAiaHR0cHM6Ly9yaG4ucmVkaGF0LmNvbS9lcnJhdGEvUkhTQS0yMDEw
+        LTA4NTguaHRtbCIsICJ0eXBlIjogInNlbGYiLCAiaWQiOiBudWxsLCAidGl0
+        bGUiOiBudWxsfSwgeyJocmVmIjogImh0dHBzOi8vYnVnemlsbGEucmVkaGF0
+        LmNvbS9idWd6aWxsYS9zaG93X2J1Zy5jZ2k/aWQ9NjI3ODgyIiwgInR5cGUi
+        OiAiYnVnemlsbGEiLCAiaWQiOiAiNjI3ODgyIiwgInRpdGxlIjogbnVsbH0s
+        IHsiaHJlZiI6ICJodHRwczovL3d3dy5yZWRoYXQuY29tL3NlY3VyaXR5L2Rh
+        dGEvY3ZlL0NWRS0yMDEwLTA0MDUuaHRtbCIsICJ0eXBlIjogImN2ZSIsICJp
+        ZCI6ICJDVkUtMjAxMC0wNDA1IiwgInRpdGxlIjogbnVsbH0sIHsiaHJlZiI6
+        ICJodHRwOi8vd3d3LnJlZGhhdC5jb20vc2VjdXJpdHkvdXBkYXRlcy9jbGFz
+        c2lmaWNhdGlvbi8jaW1wb3J0YW50IiwgInR5cGUiOiAib3RoZXIiLCAiaWQi
+        OiBudWxsLCAidGl0bGUiOiBudWxsfV0sICJwdWxwX3VzZXJfbWV0YWRhdGEi
+        OiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6ICJS
+        SFNBLTIwMTA6MDg1OCIsICJmcm9tIjogInNlY3VyaXR5QHJlZGhhdC5jb20i
+        LCAic2V2ZXJpdHkiOiAiSW1wb3J0YW50IiwgInRpdGxlIjogIkltcG9ydGFu
+        dDogYnppcDIgc2VjdXJpdHkgdXBkYXRlIiwgImNoaWxkcmVuIjoge30sICJ2
+        ZXJzaW9uIjogIjMiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlw
+        ZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFja2FnZXMiOiBbeyJz
+        cmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAi
+        YnppcDItZGV2ZWwiLCAic3VtIjogWyJzaGEyNTYiLCAiZWE2N2M2NjRkYTFm
+        Zjk2YTZkYzk0ZDMzMDA5YjczZDhmYWIzMWI1OTgyNDE4M2ZiNDVlOWJhMmVi
+        ZjgyZDU4MyJdLCAiZmlsZW5hbWUiOiAiYnppcDItZGV2ZWwtMS4wLjUtNy5l
+        bDZfMC5pNjg2LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4w
+        LjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7
+        InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6
+        ICJiemlwMi1saWJzIiwgInN1bSI6IFsic2hhMjU2IiwgImM5ZjA2NGE2ODYy
+        NTczZmI5ZjJhNmFmZjdjMzYyMWYxOTQwYjQ5MmRmMmVkZmMyZWJiZGMwYjgz
+        MDVmNTExNDciXSwgImZpbGVuYW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5l
+        bDZfMC5pNjg2LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4w
+        LjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7
+        InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6
+        ICJiemlwMiIsICJzdW0iOiBbInNoYTI1NiIsICJiOGEzZjcyYmMyYjBkODli
+        YTczNzA5OWFjOThiZjhkMmFmNGJlYTAyZDMxODg0YzAyZGI5N2Y3ZjY2YzNk
+        NWMyIl0sICJmaWxlbmFtZSI6ICJiemlwMi0xLjAuNS03LmVsNl8wLng4Nl82
+        NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJl
+        bGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9LCB7InNyYyI6
+        ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlw
+        Mi1kZXZlbCIsICJzdW0iOiBbInNoYTI1NiIsICI3ZjYzMTI0ZTQ2NTViN2M5
+        MmQyM2VjNGMzODIyNmY1ZDM3NDY1Njg4NTNkZmY3NTBmYzg1ZTA1OGU3NGI1
+        Y2Y2Il0sICJmaWxlbmFtZSI6ICJiemlwMi1kZXZlbC0xLjAuNS03LmVsNl8w
+        Lng4Nl82NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41
+        IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9LCB7
+        InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6
+        ICJiemlwMi1saWJzIiwgInN1bSI6IFsic2hhMjU2IiwgIjgwMmY0Mzk5ZGJk
+        ZDAxNDc2ZTI1NGMzYjMyYzQwYWZmNTljZjVkMjNhNDVmYTQ4OGM2OTE3Y2U4
+        OTA0ZDZiNGQiXSwgImZpbGVuYW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5l
+        bDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIx
+        LjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQi
+        fV0sICJuYW1lIjogIlJlZCBIYXQgRW50ZXJwcmlzZSBMaW51eCBTZXJ2ZXIg
+        KHYuIDYgZm9yIDY0LWJpdCB4ODZfNjQpIiwgInNob3J0IjogInJoZWwteDg2
+        XzY0LXNlcnZlci02In1dLCAic3RhdHVzIjogImZpbmFsIiwgInVwZGF0ZWQi
+        OiAiMjAxMC0xMS0xMCAwMDowMDowMCIsICJkZXNjcmlwdGlvbiI6ICJiemlw
+        MiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNv
+        bXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11
+        c3QgYmUgcmVzdGFydGVkIGZvciB0aGUgdXBkYXRlIHRvIHRha2UgZWZmZWN0
+        LiIsICJfbGFzdF91cGRhdGVkIjogIjIwMTYtMDItMDVUMTQ6MDg6NDdaIiwg
+        InB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjogIkNvcHlyaWdodCAyMDEwIFJl
+        ZCBIYXQgSW5jIiwgInNvbHV0aW9uIjogIkJlZm9yZSBhcHBseWluZyB0aGlz
+        IHVwZGF0ZSwgbWFrZSBzdXJlIGFsbCBwcmV2aW91c2x5LXJlbGVhc2VkIGVy
+        cmF0YVxucmVsZXZhbnQgdG8geW91ciBzeXN0ZW0gaGF2ZSBiZWVuIGFwcGxp
+        ZWQuXG5cblRoaXMgdXBkYXRlIGlzIGF2YWlsYWJsZSB2aWEgdGhlIFJlZCBI
+        YXQgTmV0d29yay4gRGV0YWlscyBvbiBob3cgdG9cbnVzZSB0aGUgUmVkIEhh
+        dCBOZXR3b3JrIHRvIGFwcGx5IHRoaXMgdXBkYXRlIGFyZSBhdmFpbGFibGUg
+        YXRcbmh0dHA6Ly9rYmFzZS5yZWRoYXQuY29tL2ZhcS9kb2NzL0RPQy0xMTI1
+        OSIsICJzdW1tYXJ5IjogIlVwZGF0ZWQgYnppcDIgcGFja2FnZXMgdGhhdCBm
+        aXggb25lIHNlY3VyaXR5IGlzc3VlIiwgInJlbGVhc2UiOiAiIiwgIl9pZCI6
+        ICJlNjZmMDYxNS1iYWMwLTQ0YzQtYWMwNy0yMzNjZTA0Yzg1ZGEifV0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:49 GMT
+- request:
+    method: delete
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="oTJSYvcvdwV3Rl0sktRitCbiLgck3CGYaGi6z3BdY",
+        oauth_signature="dUaIVJjUi69yFwKqWURXtZ9kxqI%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681329", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:49 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzI3ZTFkYTgxLWNlMjctNGZjZi05MmZmLWRiMzEyOGE3M2I1NC8iLCAi
+        dGFza19pZCI6ICIyN2UxZGE4MS1jZTI3LTRmY2YtOTJmZi1kYjMxMjhhNzNi
+        NTQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:49 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/27e1da81-ce27-4fcf-92ff-db3128a73b54/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="pr0Rj6wGuCz4sbM1ssGbVVFKrqgizJqXtx6inNALE",
+        oauth_signature="8ZwO36XO1ZjQ2axVs43k4Pygn3Y%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681329", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:49 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yN2UxZGE4MS1jZTI3LTRmY2YtOTJmZi1kYjMxMjhhNzNi
+        NTQvIiwgInRhc2tfaWQiOiAiMjdlMWRhODEtY2UyNy00ZmNmLTkyZmYtZGIz
+        MTI4YTczYjU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWNm
+        MThhZGE0MGRiMDRlZTBiZTkifSwgImlkIjogIjU2YjRhY2YxOGFkYTQwZGIw
+        NGVlMGJlOSJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:49 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/27e1da81-ce27-4fcf-92ff-db3128a73b54/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="GoNGUqAmb9bh6TCG4L6B2K4LqiuPJG2OrVhIfgp3Ziw",
+        oauth_signature="y7xizn1B1PW9nwEspsgsE8RlnRU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681329", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:49 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yN2UxZGE4MS1jZTI3LTRmY2YtOTJmZi1kYjMxMjhhNzNi
+        NTQvIiwgInRhc2tfaWQiOiAiMjdlMWRhODEtY2UyNy00ZmNmLTkyZmYtZGIz
+        MTI4YTczYjU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA4OjQ5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA4OjQ5WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjZjE4YWRhNDBkYjA0ZWUwYmU5In0sICJpZCI6ICI1NmI0YWNmMThhZGE0
+        MGRiMDRlZTBiZTkifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:49 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/services/pulp/package_group.yml
+++ b/test/fixtures/vcr_cassettes/services/pulp/package_group.yml
@@ -1511,57 +1511,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:36:47 GMT
 - request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
-        Ijp0cnVlfX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="v7adrIF3rtRpvIIpydGr62IUY3tAJ5UjNFrTYDOI", oauth_signature="sS6qR7kOR1bQ6TwuOMMQZkmDiAg%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454629007", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '53'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:36:47 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2UxZTE0ZTlkLTJjYWQtNGFlMy1iZTRhLWUwZWU3MjEwNTEyZi8iLCAi
-        dGFza19pZCI6ICJlMWUxNGU5ZC0yY2FkLTRhZTMtYmU0YS1lMGVlNzIxMDUx
-        MmYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:36:47 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/e1e14e9d-2cad-4ae3-be4a-e0ee7210512f/
     body:
@@ -2166,174 +2115,6 @@ http_interactions:
   recorded_at: Thu, 04 Feb 2016 23:36:48 GMT
 - request:
     method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwYWNrYWdlX2dyb3VwIl19fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="hpoKc0o4LWCtq09eiTIyzNH3AY8Bsc95LZYI76q43o", oauth_signature="m6fUeo%2F%2FAM40hshZmQ9qx9NkmR8%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454629008", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '43'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:36:48 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '1792'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W3sidXBkYXRlZCI6ICIyMDE2LTAyLTA0VDIzOjM2OjQ4WiIsICJyZXBvX2lk
-        IjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTYtMDItMDRUMjM6MzY6
-        NDhaIiwgIl9ucyI6ICJyZXBvX2NvbnRlbnRfdW5pdHMiLCAidW5pdF9pZCI6
-        ICIwNGEwM2UzNS00MTJhLTQ3NDMtYTA5NS1kZTFkOGU5Mzk5YmMiLCAibWV0
-        YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiBudWxsLCAibWFuZGF0b3J5X3Bh
-        Y2thZ2VfbmFtZXMiOiBbInBlbmd1aW4iXSwgInJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImRlc2NyaXB0aW9uIjogbnVsbCwgInVzZXJfdmlzaWJsZSI6IHRy
-        dWUsICJkZWZhdWx0IjogdHJ1ZSwgIl9ucyI6ICJ1bml0c19wYWNrYWdlX2dy
-        b3VwIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNDU0NjI5MDA4LCAiZGlzcGxheV9v
-        cmRlciI6IDEwMjQsICJvcHRpb25hbF9wYWNrYWdlX25hbWVzIjogW10sICJ0
-        cmFuc2xhdGVkX25hbWUiOiB7fSwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24i
-        OiB7fSwgImNvbmRpdGlvbmFsX3BhY2thZ2VfbmFtZXMiOiBbXSwgImRlZmF1
-        bHRfcGFja2FnZV9uYW1lcyI6IFtdLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJw
-        YWNrYWdlX2dyb3VwIiwgImxhbmdvbmx5IjogbnVsbCwgIl9pZCI6ICIwNGEw
-        M2UzNS00MTJhLTQ3NDMtYTA5NS1kZTFkOGU5Mzk5YmMiLCAiaWQiOiAiYmly
-        ZCIsICJuYW1lIjogImJpcmQifSwgInVuaXRfdHlwZV9pZCI6ICJwYWNrYWdl
-        X2dyb3VwIiwgIm93bmVyX3R5cGUiOiAiaW1wb3J0ZXIiLCAiX2lkIjogeyIk
-        b2lkIjogIjU2YjNlMDkwODRhMDljMDdkYTk3OWU0YyJ9LCAiaWQiOiAiNTZi
-        M2UwOTA4NGEwOWMwN2RhOTc5ZTRjIiwgIm93bmVyX2lkIjogInl1bV9pbXBv
-        cnRlciJ9LCB7InVwZGF0ZWQiOiAiMjAxNi0wMi0wNFQyMzozNjo0OFoiLCAi
-        cmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE2LTAyLTA0
-        VDIzOjM2OjQ4WiIsICJfbnMiOiAicmVwb19jb250ZW50X3VuaXRzIiwgInVu
-        aXRfaWQiOiAiMjlmZDQ0YzMtMDc1NS00NGEzLWI5YmYtMmFmM2ZiYTJmZWJl
-        IiwgIm1ldGFkYXRhIjogeyJfc3RvcmFnZV9wYXRoIjogbnVsbCwgIm1hbmRh
-        dG9yeV9wYWNrYWdlX25hbWVzIjogWyJlbGVwaGFudCxnaXJhZmZlLGNoZWV0
-        YWgsbGlvbixtb25rZXkscGVuZ3VpbixzcXVpcnJlbCx3YWxydXMiLCAicGVu
-        Z3VpbiJdLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiZGVzY3JpcHRpb24i
-        OiBudWxsLCAidXNlcl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVl
-        LCAiX25zIjogInVuaXRzX3BhY2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRl
-        ZCI6IDE0NTQ2MjkwMDgsICJkaXNwbGF5X29yZGVyIjogMTAyNCwgIm9wdGlv
-        bmFsX3BhY2thZ2VfbmFtZXMiOiBbXSwgInRyYW5zbGF0ZWRfbmFtZSI6IHt9
-        LCAidHJhbnNsYXRlZF9kZXNjcmlwdGlvbiI6IHt9LCAiY29uZGl0aW9uYWxf
-        cGFja2FnZV9uYW1lcyI6IFtdLCAiZGVmYXVsdF9wYWNrYWdlX25hbWVzIjog
-        W10sICJfY29udGVudF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAibGFu
-        Z29ubHkiOiBudWxsLCAiX2lkIjogIjI5ZmQ0NGMzLTA3NTUtNDRhMy1iOWJm
-        LTJhZjNmYmEyZmViZSIsICJpZCI6ICJtYW1tYWwiLCAibmFtZSI6ICJtYW1t
-        YWwifSwgInVuaXRfdHlwZV9pZCI6ICJwYWNrYWdlX2dyb3VwIiwgIm93bmVy
-        X3R5cGUiOiAiaW1wb3J0ZXIiLCAiX2lkIjogeyIkb2lkIjogIjU2YjNlMDkw
-        ODRhMDljMDdkYTk3OWU0ZCJ9LCAiaWQiOiAiNTZiM2UwOTA4NGEwOWMwN2Rh
-        OTc5ZTRkIiwgIm93bmVyX2lkIjogInl1bV9pbXBvcnRlciJ9XQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:36:48 GMT
-- request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwYWNrYWdlX2dyb3VwIl19fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="z6ipUsR4xzBIAwDaEVqbo9SH59s75DIUSrFbgpXfU", oauth_signature="n%2BABfFCkMLvnquvDAu4dWWwEw2A%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454629008", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '43'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:36:48 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '1792'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W3sidXBkYXRlZCI6ICIyMDE2LTAyLTA0VDIzOjM2OjQ4WiIsICJyZXBvX2lk
-        IjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTYtMDItMDRUMjM6MzY6
-        NDhaIiwgIl9ucyI6ICJyZXBvX2NvbnRlbnRfdW5pdHMiLCAidW5pdF9pZCI6
-        ICIwNGEwM2UzNS00MTJhLTQ3NDMtYTA5NS1kZTFkOGU5Mzk5YmMiLCAibWV0
-        YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiBudWxsLCAibWFuZGF0b3J5X3Bh
-        Y2thZ2VfbmFtZXMiOiBbInBlbmd1aW4iXSwgInJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImRlc2NyaXB0aW9uIjogbnVsbCwgInVzZXJfdmlzaWJsZSI6IHRy
-        dWUsICJkZWZhdWx0IjogdHJ1ZSwgIl9ucyI6ICJ1bml0c19wYWNrYWdlX2dy
-        b3VwIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNDU0NjI5MDA4LCAiZGlzcGxheV9v
-        cmRlciI6IDEwMjQsICJvcHRpb25hbF9wYWNrYWdlX25hbWVzIjogW10sICJ0
-        cmFuc2xhdGVkX25hbWUiOiB7fSwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24i
-        OiB7fSwgImNvbmRpdGlvbmFsX3BhY2thZ2VfbmFtZXMiOiBbXSwgImRlZmF1
-        bHRfcGFja2FnZV9uYW1lcyI6IFtdLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJw
-        YWNrYWdlX2dyb3VwIiwgImxhbmdvbmx5IjogbnVsbCwgIl9pZCI6ICIwNGEw
-        M2UzNS00MTJhLTQ3NDMtYTA5NS1kZTFkOGU5Mzk5YmMiLCAiaWQiOiAiYmly
-        ZCIsICJuYW1lIjogImJpcmQifSwgInVuaXRfdHlwZV9pZCI6ICJwYWNrYWdl
-        X2dyb3VwIiwgIm93bmVyX3R5cGUiOiAiaW1wb3J0ZXIiLCAiX2lkIjogeyIk
-        b2lkIjogIjU2YjNlMDkwODRhMDljMDdkYTk3OWU0YyJ9LCAiaWQiOiAiNTZi
-        M2UwOTA4NGEwOWMwN2RhOTc5ZTRjIiwgIm93bmVyX2lkIjogInl1bV9pbXBv
-        cnRlciJ9LCB7InVwZGF0ZWQiOiAiMjAxNi0wMi0wNFQyMzozNjo0OFoiLCAi
-        cmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE2LTAyLTA0
-        VDIzOjM2OjQ4WiIsICJfbnMiOiAicmVwb19jb250ZW50X3VuaXRzIiwgInVu
-        aXRfaWQiOiAiMjlmZDQ0YzMtMDc1NS00NGEzLWI5YmYtMmFmM2ZiYTJmZWJl
-        IiwgIm1ldGFkYXRhIjogeyJfc3RvcmFnZV9wYXRoIjogbnVsbCwgIm1hbmRh
-        dG9yeV9wYWNrYWdlX25hbWVzIjogWyJlbGVwaGFudCxnaXJhZmZlLGNoZWV0
-        YWgsbGlvbixtb25rZXkscGVuZ3VpbixzcXVpcnJlbCx3YWxydXMiLCAicGVu
-        Z3VpbiJdLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiZGVzY3JpcHRpb24i
-        OiBudWxsLCAidXNlcl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVl
-        LCAiX25zIjogInVuaXRzX3BhY2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRl
-        ZCI6IDE0NTQ2MjkwMDgsICJkaXNwbGF5X29yZGVyIjogMTAyNCwgIm9wdGlv
-        bmFsX3BhY2thZ2VfbmFtZXMiOiBbXSwgInRyYW5zbGF0ZWRfbmFtZSI6IHt9
-        LCAidHJhbnNsYXRlZF9kZXNjcmlwdGlvbiI6IHt9LCAiY29uZGl0aW9uYWxf
-        cGFja2FnZV9uYW1lcyI6IFtdLCAiZGVmYXVsdF9wYWNrYWdlX25hbWVzIjog
-        W10sICJfY29udGVudF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAibGFu
-        Z29ubHkiOiBudWxsLCAiX2lkIjogIjI5ZmQ0NGMzLTA3NTUtNDRhMy1iOWJm
-        LTJhZjNmYmEyZmViZSIsICJpZCI6ICJtYW1tYWwiLCAibmFtZSI6ICJtYW1t
-        YWwifSwgInVuaXRfdHlwZV9pZCI6ICJwYWNrYWdlX2dyb3VwIiwgIm93bmVy
-        X3R5cGUiOiAiaW1wb3J0ZXIiLCAiX2lkIjogeyIkb2lkIjogIjU2YjNlMDkw
-        ODRhMDljMDdkYTk3OWU0ZCJ9LCAiaWQiOiAiNTZiM2UwOTA4NGEwOWMwN2Rh
-        OTc5ZTRkIiwgIm93bmVyX2lkIjogInl1bV9pbXBvcnRlciJ9XQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:36:48 GMT
-- request:
-    method: post
     uri: https://katello-devbox.example.com/pulp/api/v2/content/units/package_group/search/
     body:
       encoding: UTF-8
@@ -2393,53 +2174,6 @@ http_interactions:
         cyI6IFtdfV0=
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:36:48 GMT
-- request:
-    method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="9dyTwt8zs7MzzNYUgidFssshe6xAomshum3VPli2g",
-        oauth_signature="fMNA2M6DhaMmauyopAUzY4ZnrVU%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454629009", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:36:49 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzViZWVjZDA1LWRlMDQtNGMyYy05ZTI0LWFkZjJmZmFlYjc5Mi8iLCAi
-        dGFza19pZCI6ICI1YmVlY2QwNS1kZTA0LTRjMmMtOWUyNC1hZGYyZmZhZWI3
-        OTIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:36:49 GMT
 - request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/5beecd05-de04-4c2c-9e24-adf2ffaeb792/
@@ -2550,4 +2284,2154 @@ http_interactions:
         N2RiZjRkYzI4In0=
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:36:49 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/840b60f7-b8b2-4eaf-9b8b-95e35ad337a3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="9puccshwl6blJoBF1qKFC2ILrmMeEhFa9BmBx4oMRk",
+        oauth_signature="jBDtoIw5%2B2ZeSB8IM54jNWnLbDs%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681331", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:51 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1093'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84NDBiNjBmNy1iOGIyLTRlYWYtOWI4Yi05NWUzNWFkMzM3
+        YTMvIiwgInRhc2tfaWQiOiAiODQwYjYwZjctYjhiMi00ZWFmLTliOGItOTVl
+        MzVhZDMzN2EzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0wNVQxNDowODo1MVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
+        bCI6IDAsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiSU5fUFJP
+        R1JFU1MifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjZjM4YWRhNDBkYjA0ZWUwYmVhIn0sICJpZCI6ICI1NmI0YWNmMzhhZGE0
+        MGRiMDRlZTBiZWEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:51 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/840b60f7-b8b2-4eaf-9b8b-95e35ad337a3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="zly419YjCGSjJGl9qIdLonBBvzbFj30jfxHc8ElraA",
+        oauth_signature="fRCsLEd12%2FM51XNxgJpsTzhRJRI%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681332", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:52 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84NDBiNjBmNy1iOGIyLTRlYWYtOWI4Yi05NWUzNWFkMzM3
+        YTMvIiwgInRhc2tfaWQiOiAiODQwYjYwZjctYjhiMi00ZWFmLTliOGItOTVl
+        MzVhZDMzN2EzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowODo1MloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowODo1MVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNjQ1MTIzYjktYjNjMy00NDJhLThhNDAtZjVkY2E0N2Rm
+        N2QyLyIsICJ0YXNrX2lkIjogIjY0NTEyM2I5LWIzYzMtNDQyYS04YTQwLWY1
+        ZGNhNDdkZjdkMiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        Y2YzYzc4MjFiMzMwNWNlNTE1NCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDg6NTFaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowODo1
+        MloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjZjRjNzgyMWIzNDQ0ZmNjMmYzIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjZjM4YWRhNDBkYjA0ZWUwYmVhIn0s
+        ICJpZCI6ICI1NmI0YWNmMzhhZGE0MGRiMDRlZTBiZWEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:52 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/645123b9-b3c3-442a-8a40-f5dca47df7d2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="pA0OukvYUYCMSf29WI5bxxa0OMOksSgs05AObSGhU",
+        oauth_signature="AXBdVGQdGVvyBcldMvv5FTinrDY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681332", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:52 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '658'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy82NDUxMjNiOS1iM2MzLTQ0MmEtOGE0MC1mNWRj
+        YTQ3ZGY3ZDIvIiwgInRhc2tfaWQiOiAiNjQ1MTIzYjktYjNjMy00NDJhLThh
+        NDAtZjVkY2E0N2RmN2QyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiBudWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBb
+        XSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRf
+        cmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVz
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1w
+        bGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQi
+        OiB7IiRvaWQiOiAiNTZiNGFjZjQ4YWRhNDBkYjA0ZWUwYmZhIn0sICJpZCI6
+        ICI1NmI0YWNmNDhhZGE0MGRiMDRlZTBiZmEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:52 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/840b60f7-b8b2-4eaf-9b8b-95e35ad337a3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="5m7QZI55gdYZV3Jq90hBuvGHOAXY6704Fef4DjEjdM4",
+        oauth_signature="wCCG1cD9GzuTxGMUaDXd79Px4GM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681332", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:52 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84NDBiNjBmNy1iOGIyLTRlYWYtOWI4Yi05NWUzNWFkMzM3
+        YTMvIiwgInRhc2tfaWQiOiAiODQwYjYwZjctYjhiMi00ZWFmLTliOGItOTVl
+        MzVhZDMzN2EzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowODo1MloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowODo1MVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNjQ1MTIzYjktYjNjMy00NDJhLThhNDAtZjVkY2E0N2Rm
+        N2QyLyIsICJ0YXNrX2lkIjogIjY0NTEyM2I5LWIzYzMtNDQyYS04YTQwLWY1
+        ZGNhNDdkZjdkMiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        Y2YzYzc4MjFiMzMwNWNlNTE1NCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDg6NTFaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowODo1
+        MloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjZjRjNzgyMWIzNDQ0ZmNjMmYzIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjZjM4YWRhNDBkYjA0ZWUwYmVhIn0s
+        ICJpZCI6ICI1NmI0YWNmMzhhZGE0MGRiMDRlZTBiZWEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:52 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/645123b9-b3c3-442a-8a40-f5dca47df7d2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="CxvAqBUF3fSVbT5nLQum3MtvxJkDzYJR1lgo4Dfk4I",
+        oauth_signature="wAJJIWmBCWSjT51b4i%2FzFc9pNes%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681332", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:52 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '6929'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy82NDUxMjNiOS1iM2MzLTQ0MmEtOGE0MC1mNWRj
+        YTQ3ZGY3ZDIvIiwgInRhc2tfaWQiOiAiNjQ1MTIzYjktYjNjMy00NDJhLThh
+        NDAtZjVkY2E0N2RmN2QyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0wMi0wNVQxNDowODo1MloiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowODo1MloiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICI1YTI1MjdhMy0wYWEzLTQ5MDAtOWFjYy03MzA5OWJk
+        YjI0ZmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiZjdhZDhiMzgtMDBkYy00OTUzLTk0ODUtOTkyNzdkMTIyMGRjIiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
+        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMWEyM2Y1YmQtZjllMS00OGJhLWI3YzAt
+        ZmY0YTdkYTQzNjI5IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
+        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODc5
+        MDNhMjgtMTI4Zi00ZmRlLThlMmQtNTYyMzkwOTk5YTFhIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjA1NDVhYzg5LWUxMGQtNDIwZi04MTRjLTIzYjhl
+        NmQ2ZjUzMiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
+        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzNTdiMGIy
+        ZC05ODgzLTQxZjMtODkxNS1lNjg1NzNiYWI2MDciLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJiOTNjYWU0ZS02MTg1LTQ0OGYtYmI2MS1lODg2
+        MmVkM2QyODIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
+        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICJmZmI2NDYwNC1lNTAzLTQ1YTUtYmQ5Yi0yZTliYTA2OGIxZTci
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
+        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2MTFm
+        MTNhNC1lNjM2LTQ1OTktYWI4Zi1hZjE0YzViYjRjMTkiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
+        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlNWVmNjg2ZC1hMzg3
+        LTQ3OTQtOGYxYy03YjdiMDA1ZmMyNzciLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
+        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI3ZjJiYzhiLWIyYzYtNDNj
+        Ni1iOGExLTZlNjAzZTA1MmEzZiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
+        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE0OjA4OjUy
+        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMDVUMTQ6MDg6NTJaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
+        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
+        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
+        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
+        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
+        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
+        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
+        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
+        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGFjZjRjNzgyMWIz
+        NDQ0ZmNjMmY0IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
+        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
+        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogIjVhMjUyN2EzLTBhYTMtNDkwMC05YWNjLTczMDk5YmRiMjRm
+        ZSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
+        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICJmN2FkOGIzOC0wMGRjLTQ5NTMtOTQ4NS05OTI3N2QxMjIwZGMiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
+        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICIxYTIzZjViZC1mOWUxLTQ4YmEtYjdjMC1mZjRh
+        N2RhNDM2MjkiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
+        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4NzkwM2Ey
+        OC0xMjhmLTRmZGUtOGUyZC01NjIzOTA5OTlhMWEiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiMDU0NWFjODktZTEwZC00MjBmLTgxNGMtMjNiOGU2ZDZm
+        NTMyIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM1N2IwYjJkLTk4
+        ODMtNDFmMy04OTE1LWU2ODU3M2JhYjYwNyIsICJudW1fcHJvY2Vzc2VkIjog
+        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImI5M2NhZTRlLTYxODUtNDQ4Zi1iYjYxLWU4ODYyZWQz
+        ZDI4MiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
+        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImZmYjY0NjA0LWU1MDMtNDVhNS1iZDliLTJlOWJhMDY4YjFlNyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
+        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjYxMWYxM2E0
+        LWU2MzYtNDU5OS1hYjhmLWFmMTRjNWJiNGMxOSIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
+        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImU1ZWY2ODZkLWEzODctNDc5
+        NC04ZjFjLTdiN2IwMDVmYzI3NyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
+        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjdmMmJjOGItYjJjNi00M2M2LWI4
+        YTEtNmU2MDNlMDUyYTNmIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhY2Y0OGFkYTQwZGIw
+        NGVlMGJmYSJ9LCAiaWQiOiAiNTZiNGFjZjQ4YWRhNDBkYjA0ZWUwYmZhIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:52 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/c159ad5a-7700-45b7-ad02-6bc5366ffdbe/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="DznH65uEdfXBHh4QTgkdwFbc1zAyTjZT6aIaCV30sM",
+        oauth_signature="j1JKs3VXyWeNFnTnEO3zzOPM41w%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681333", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:53 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jMTU5YWQ1YS03NzAwLTQ1YjctYWQwMi02YmM1MzY2ZmZk
+        YmUvIiwgInRhc2tfaWQiOiAiYzE1OWFkNWEtNzcwMC00NWI3LWFkMDItNmJj
+        NTM2NmZmZGJlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWNm
+        NThhZGE0MGRiMDRlZTBiZmIifSwgImlkIjogIjU2YjRhY2Y1OGFkYTQwZGIw
+        NGVlMGJmYiJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:53 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/c159ad5a-7700-45b7-ad02-6bc5366ffdbe/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="cWSXTiEK6Pi2ccf4XISIoZFhJLeZ4eRcieVsbYdlI",
+        oauth_signature="ZTIg3vS4jpAIjCp%2FZaQ8TwC0PHU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681333", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:53 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jMTU5YWQ1YS03NzAwLTQ1YjctYWQwMi02YmM1MzY2ZmZk
+        YmUvIiwgInRhc2tfaWQiOiAiYzE1OWFkNWEtNzcwMC00NWI3LWFkMDItNmJj
+        NTM2NmZmZGJlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA4OjUzWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA4OjUzWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjZjU4YWRhNDBkYjA0ZWUwYmZiIn0sICJpZCI6ICI1NmI0YWNmNThhZGE0
+        MGRiMDRlZTBiZmIifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:53 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/caa59bb3-d090-4a1b-9a5a-c702977dde90/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="z4vdVnHW4xYddTzQGtx0vbPE9dLQ5aT6n5ghE9esQM",
+        oauth_signature="GHxCMZQOGgI8RDhiEloFkLO4NjY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681335", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:55 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jYWE1OWJiMy1kMDkwLTRhMWItOWE1YS1jNzAyOTc3ZGRl
+        OTAvIiwgInRhc2tfaWQiOiAiY2FhNTliYjMtZDA5MC00YTFiLTlhNWEtYzcw
+        Mjk3N2RkZTkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjZjc4
+        YWRhNDBkYjA0ZWUwYmZjIn0sICJpZCI6ICI1NmI0YWNmNzhhZGE0MGRiMDRl
+        ZTBiZmMifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:55 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/caa59bb3-d090-4a1b-9a5a-c702977dde90/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="MQdWnIK6Jq1v38SZDuijav8CsF11snrE2SF88isTE",
+        oauth_signature="o9G3OSJiQy9epthBkrjm%2FXgSpN0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681336", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1078'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jYWE1OWJiMy1kMDkwLTRhMWItOWE1YS1jNzAyOTc3ZGRl
+        OTAvIiwgInRhc2tfaWQiOiAiY2FhNTliYjMtZDA5MC00YTFiLTlhNWEtYzcw
+        Mjk3N2RkZTkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0wNVQxNDowODo1NVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
+        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVl
+        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgt
+        ZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29y
+        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
+        by0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJv
+        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjZjc4YWRhNDBkYjA0
+        ZWUwYmZjIn0sICJpZCI6ICI1NmI0YWNmNzhhZGE0MGRiMDRlZTBiZmMifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:56 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/caa59bb3-d090-4a1b-9a5a-c702977dde90/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="MSSPy6hEbqiZ8xdTKpIszrBkLSEMabX8Yul1i9xLsE",
+        oauth_signature="ll%2FTlVEpPl8wgZMw2ALCZhEldt0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681336", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jYWE1OWJiMy1kMDkwLTRhMWItOWE1YS1jNzAyOTc3ZGRl
+        OTAvIiwgInRhc2tfaWQiOiAiY2FhNTliYjMtZDA5MC00YTFiLTlhNWEtYzcw
+        Mjk3N2RkZTkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowODo1NloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowODo1NVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvZTVhYzdhMmYtMDM5OC00OWEyLTg0ZjctMTBiMTRiZDlj
+        ZmU2LyIsICJ0YXNrX2lkIjogImU1YWM3YTJmLTAzOTgtNDlhMi04NGY3LTEw
+        YjE0YmQ5Y2ZlNiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        Y2Y3Yzc4MjFiMzMwNDJkOWU0OCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDg6NTVaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowODo1
+        NloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjZjhjNzgyMWIzNDQ0ZmNjMmY4IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjZjc4YWRhNDBkYjA0ZWUwYmZjIn0s
+        ICJpZCI6ICI1NmI0YWNmNzhhZGE0MGRiMDRlZTBiZmMifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:56 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/e5ac7a2f-0398-49a2-84f7-10b14bd9cfe6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="5X6wPi86m69KMDwqK2Fan8rLSYRzsRNabXOov5ftKwo",
+        oauth_signature="zX%2BkzLQCD7vJ5sQuQ8Rw3xwGxBE%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681336", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '6929'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9lNWFjN2EyZi0wMzk4LTQ5YTItODRmNy0xMGIx
+        NGJkOWNmZTYvIiwgInRhc2tfaWQiOiAiZTVhYzdhMmYtMDM5OC00OWEyLTg0
+        ZjctMTBiMTRiZDljZmU2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0wMi0wNVQxNDowODo1NloiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowODo1NloiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICJjZGExYzdjMy0xYTQ0LTQ3NzEtOTFiYy1kMmU1YmI3
+        MzQ4YzkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiNWIyNTcxNWQtZDFmYi00ZjgxLTg5YzQtZjA4Y2FmNGVkM2U3Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
+        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZGI0N2ZjZmUtY2YzNS00OGQzLWExMGEt
+        MzY5OTlhNGFlNDZlIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
+        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjMw
+        OTA1MDQtZWUwYi00ZjA0LTlhMGEtOWViZGMxZThiOWVjIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjliZWY3ZWJkLTRiYTQtNDhmYS1hZmEzLTMwM2Iz
+        MmQyZWYwZSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
+        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkNGQ3OTBl
+        YS00MjYyLTRmNzAtYWFlMS0zNmE5NzZlZWMxNWUiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJiMDM2YWU3OS04ZWExLTQ5ZjAtYmIwMS1kOTk5
+        OWYxNzEwMTUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
+        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICJlZjg0NGUyOC1mNmM3LTQyZGMtYmNlNy01MTMyNTdlMGQ4NGUi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
+        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzMzE0
+        ZWI3ZC1jZjM4LTQ1OGQtOTg5NS0wNDliMjdjYWMwNzYiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
+        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiYmVhNDdhNy05ZDhm
+        LTRiOGUtODlhOS00NGNhNWYxYjJiYTIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
+        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI0MDc4NTAxLWIyOTAtNDI1
+        NC1hNjY0LWU2NzUyNWM0ZjQ1ZSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
+        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE0OjA4OjU2
+        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMDVUMTQ6MDg6NTZaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
+        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
+        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
+        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
+        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
+        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
+        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
+        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
+        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGFjZjhjNzgyMWIz
+        NDQ0ZmNjMmY5IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
+        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
+        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImNkYTFjN2MzLTFhNDQtNDc3MS05MWJjLWQyZTViYjczNDhj
+        OSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
+        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICI1YjI1NzE1ZC1kMWZiLTRmODEtODljNC1mMDhjYWY0ZWQzZTciLCAibnVt
+        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
+        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJkYjQ3ZmNmZS1jZjM1LTQ4ZDMtYTEwYS0zNjk5
+        OWE0YWU0NmUiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
+        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMzA5MDUw
+        NC1lZTBiLTRmMDQtOWEwYS05ZWJkYzFlOGI5ZWMiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiOWJlZjdlYmQtNGJhNC00OGZhLWFmYTMtMzAzYjMyZDJl
+        ZjBlIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ0ZDc5MGVhLTQy
+        NjItNGY3MC1hYWUxLTM2YTk3NmVlYzE1ZSIsICJudW1fcHJvY2Vzc2VkIjog
+        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImIwMzZhZTc5LThlYTEtNDlmMC1iYjAxLWQ5OTk5ZjE3
+        MTAxNSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
+        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImVmODQ0ZTI4LWY2YzctNDJkYy1iY2U3LTUxMzI1N2UwZDg0ZSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
+        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjMzMTRlYjdk
+        LWNmMzgtNDU4ZC05ODk1LTA0OWIyN2NhYzA3NiIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
+        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJiZWE0N2E3LTlkOGYtNGI4
+        ZS04OWE5LTQ0Y2E1ZjFiMmJhMiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
+        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjQwNzg1MDEtYjI5MC00MjU0LWE2
+        NjQtZTY3NTI1YzRmNDVlIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhY2Y4OGFkYTQwZGIw
+        NGVlMGMwYyJ9LCAiaWQiOiAiNTZiNGFjZjg4YWRhNDBkYjA0ZWUwYzBjIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:56 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f4ac9d0c-e916-411b-aaf4-d6ac1e979640/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Ljkt1J1fNT1XwivASFJl19YOJah0Iav0V7hJmrGbo",
+        oauth_signature="O4wmqN4ndR7OK0f1fGediN3Ir0w%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681337", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:57 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mNGFjOWQwYy1lOTE2LTQxMWItYWFmNC1kNmFjMWU5Nzk2
+        NDAvIiwgInRhc2tfaWQiOiAiZjRhYzlkMGMtZTkxNi00MTFiLWFhZjQtZDZh
+        YzFlOTc5NjQwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWNm
+        OThhZGE0MGRiMDRlZTBjMGQifSwgImlkIjogIjU2YjRhY2Y5OGFkYTQwZGIw
+        NGVlMGMwZCJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:57 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/f4ac9d0c-e916-411b-aaf4-d6ac1e979640/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Pr5cp4uJufTlsPVDbU4USvZr87dRa5ksmuvql7FEzas",
+        oauth_signature="kh4wej6dCc2LKL92MBUjHLTYEE4%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681337", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:57 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9mNGFjOWQwYy1lOTE2LTQxMWItYWFmNC1kNmFjMWU5Nzk2
+        NDAvIiwgInRhc2tfaWQiOiAiZjRhYzlkMGMtZTkxNi00MTFiLWFhZjQtZDZh
+        YzFlOTc5NjQwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA4OjU3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA4OjU3WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjZjk4YWRhNDBkYjA0ZWUwYzBkIn0sICJpZCI6ICI1NmI0YWNmOThhZGE0
+        MGRiMDRlZTBjMGQifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:57 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
+        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
+        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
+        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
+        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
+        LXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1
+        dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9j
+        b25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIiwiaHR0cCI6ZmFs
+        c2UsImh0dHBzIjp0cnVlLCJwcm90ZWN0ZWQiOnRydWV9LCJhdXRvX3B1Ymxp
+        c2giOnRydWUsImRpc3RyaWJ1dG9yX2lkIjoiRmVkb3JhXzE3In0seyJkaXN0
+        cmlidXRvcl90eXBlX2lkIjoieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwiZGlz
+        dHJpYnV0b3JfY29uZmlnIjp7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lk
+        IjoiRmVkb3JhXzE3In0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1
+        dG9yX2lkIjoiRmVkb3JhXzE3X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBl
+        X2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmln
+        Ijp7Imh0dHAiOmZhbHNlLCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6
+        bnVsbH0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoi
+        ZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="ma7VoQa1l6tX0BMS4edjf0wteuU7FUERGRHUNgoT1aU", oauth_signature="M0ZGoPTT1amSGPvBdp8VmBdbiUg%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681338", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '787'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '320'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
+        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
+        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NTZiNGFjZmJjNzgyMWIzMzA1Y2U1MTU5In0sICJpZCI6ICJGZWRvcmFfMTci
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
+        MTcvIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:59 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
+        Ijp0cnVlfX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="wvGl5ZrefaUAU6sA7o4xZK6qxRSplW2xGxfjmLelGw", oauth_signature="roBaJfDUNyCubGc89jan1%2F06774%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681339", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '53'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzU0YjJkNWM1LTdkMDAtNGNkYi04YjdhLWVkMzQ1ZWMxMTgwNC8iLCAi
+        dGFza19pZCI6ICI1NGIyZDVjNS03ZDAwLTRjZGItOGI3YS1lZDM0NWVjMTE4
+        MDQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:59 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/54b2d5c5-7d00-4cdb-8b7a-ed345ec11804/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="hl1qXllvW3w1gN2v8hIGFXkz8TNnOeuBITRztwuRAKo",
+        oauth_signature="ECKXTR8ZwXFkhpqF0pFAtZZ44To%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681339", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '649'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NGIyZDVjNS03ZDAwLTRjZGItOGI3YS1lZDM0NWVjMTE4
+        MDQvIiwgInRhc2tfaWQiOiAiNTRiMmQ1YzUtN2QwMC00Y2RiLThiN2EtZWQz
+        NDVlYzExODA0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0
+        YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwg
+        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNTZiNGFjZmI4YWRhNDBkYjA0ZWUwYzBlIn0sICJpZCI6ICI1NmI0YWNm
+        YjhhZGE0MGRiMDRlZTBjMGUifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:08:59 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/54b2d5c5-7d00-4cdb-8b7a-ed345ec11804/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="ajzfReqQRaCIxzmCg79yPqk4WsIUC7nCPF0SXi2a8",
+        oauth_signature="U4jnumxdTOLL%2F61LZddOQLZnJSk%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681339", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:08:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NGIyZDVjNS03ZDAwLTRjZGItOGI3YS1lZDM0NWVjMTE4
+        MDQvIiwgInRhc2tfaWQiOiAiNTRiMmQ1YzUtN2QwMC00Y2RiLThiN2EtZWQz
+        NDVlYzExODA0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowODo1OVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowODo1OVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvN2ZlZTQ5NDgtZDljZC00MzA0LTkzMjktNTBkN2E2OTky
+        MzgxLyIsICJ0YXNrX2lkIjogIjdmZWU0OTQ4LWQ5Y2QtNDMwNC05MzI5LTUw
+        ZDdhNjk5MjM4MSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        Y2ZiYzc4MjFiMzMwNWNlNTE1YSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDg6NTlaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowODo1
+        OVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjZmJjNzgyMWIzNDQ0ZmNjMmZkIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjZmI4YWRhNDBkYjA0ZWUwYzBlIn0s
+        ICJpZCI6ICI1NmI0YWNmYjhhZGE0MGRiMDRlZTBjMGUifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:00 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/7fee4948-d9cd-4304-9329-50d7a6992381/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="naEkV41nuCcUUMWUcWU9IJU4rcpqeeRUHoqdWm3YM",
+        oauth_signature="FJWMYsGyqSixP59QCcL4XFm3uGQ%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681340", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '658'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy83ZmVlNDk0OC1kOWNkLTQzMDQtOTMyOS01MGQ3
+        YTY5OTIzODEvIiwgInRhc2tfaWQiOiAiN2ZlZTQ5NDgtZDljZC00MzA0LTkz
+        MjktNTBkN2E2OTkyMzgxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiBudWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBb
+        XSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRf
+        cmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVz
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1w
+        bGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQi
+        OiB7IiRvaWQiOiAiNTZiNGFjZmI4YWRhNDBkYjA0ZWUwYzFlIn0sICJpZCI6
+        ICI1NmI0YWNmYjhhZGE0MGRiMDRlZTBjMWUifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:00 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/54b2d5c5-7d00-4cdb-8b7a-ed345ec11804/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="hhB6s77C2aG4lTT3YRCRp03YIueB94dspsT9TgQ",
+        oauth_signature="zW1GgWskZvk0jWE335pYdAJIXzU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681340", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NGIyZDVjNS03ZDAwLTRjZGItOGI3YS1lZDM0NWVjMTE4
+        MDQvIiwgInRhc2tfaWQiOiAiNTRiMmQ1YzUtN2QwMC00Y2RiLThiN2EtZWQz
+        NDVlYzExODA0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowODo1OVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowODo1OVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvN2ZlZTQ5NDgtZDljZC00MzA0LTkzMjktNTBkN2E2OTky
+        MzgxLyIsICJ0YXNrX2lkIjogIjdmZWU0OTQ4LWQ5Y2QtNDMwNC05MzI5LTUw
+        ZDdhNjk5MjM4MSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        Y2ZiYzc4MjFiMzMwNWNlNTE1YSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDg6NTlaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowODo1
+        OVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFjZmJjNzgyMWIzNDQ0ZmNjMmZkIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjZmI4YWRhNDBkYjA0ZWUwYzBlIn0s
+        ICJpZCI6ICI1NmI0YWNmYjhhZGE0MGRiMDRlZTBjMGUifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:00 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/7fee4948-d9cd-4304-9329-50d7a6992381/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Gk8nLRVA3jd2Rv8E3AjSYkCvsXEyVgI0M7TfhrYo",
+        oauth_signature="eCGzvM%2BbUpT9TS0nKOojCivdCfU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681340", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '6929'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy83ZmVlNDk0OC1kOWNkLTQzMDQtOTMyOS01MGQ3
+        YTY5OTIzODEvIiwgInRhc2tfaWQiOiAiN2ZlZTQ5NDgtZDljZC00MzA0LTkz
+        MjktNTBkN2E2OTkyMzgxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0wMi0wNVQxNDowOTowMFoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowOTowMFoiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICJmMjNjMDcwNS1iNDJkLTQ5NzItODFjOS1hMzE3MzM1
+        Yzk3NzgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiMWY0OTc0N2ItNDAxNi00ZWZlLWI3N2YtNGI4NGZiM2FhMzU3Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
+        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNDY4MTRmMzEtZmE4MC00ZTY1LTgyYWYt
+        MWVjNWY2ZmYxZmI3IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
+        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmU2
+        ZDk2MGUtMmEzMS00MWNmLTgyOWUtZGRhZmQ1ODE5ZDU1IiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogImM2MjRlNTNiLWJmYzQtNDY2ZS1iMzZlLTk4NTZh
+        ZGUzOGIxNSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
+        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0NWRmNmZk
+        Zi05NzU3LTQ3YTgtYjM1ZS1lODc0NzhjODNmM2YiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI4ZDc0YzUzZS1jMTJkLTQ3YWEtOWU4NS0zYWU5
+        NDc1NTZhZjEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
+        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICIzNzJjZjU2Ni0zZjNjLTRkYzUtYjg4NS03NTJhOTJhZDg0ZDQi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
+        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmMmRj
+        M2VhZC1hMDNhLTQ4ODUtODkxZC03NzVlN2I2NjJmZWEiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
+        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyN2JjYzQ4OC03NjBi
+        LTQ3N2YtOWQwOS0yNmYwMGE5NzIxOGIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
+        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZmNjJjOGQ3LTJjYWYtNDdm
+        Ny04ZjhhLTRhNDFlOTBmODFjZSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
+        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE0OjA5OjAw
+        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMDVUMTQ6MDk6MDBaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
+        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
+        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
+        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
+        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
+        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
+        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
+        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
+        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGFjZmNjNzgyMWIz
+        NDQ0ZmNjMmZlIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
+        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
+        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImYyM2MwNzA1LWI0MmQtNDk3Mi04MWM5LWEzMTczMzVjOTc3
+        OCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
+        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICIxZjQ5NzQ3Yi00MDE2LTRlZmUtYjc3Zi00Yjg0ZmIzYWEzNTciLCAibnVt
+        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
+        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI0NjgxNGYzMS1mYTgwLTRlNjUtODJhZi0xZWM1
+        ZjZmZjFmYjciLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
+        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyZTZkOTYw
+        ZS0yYTMxLTQxY2YtODI5ZS1kZGFmZDU4MTlkNTUiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiYzYyNGU1M2ItYmZjNC00NjZlLWIzNmUtOTg1NmFkZTM4
+        YjE1IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQ1ZGY2ZmRmLTk3
+        NTctNDdhOC1iMzVlLWU4NzQ3OGM4M2YzZiIsICJudW1fcHJvY2Vzc2VkIjog
+        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjhkNzRjNTNlLWMxMmQtNDdhYS05ZTg1LTNhZTk0NzU1
+        NmFmMSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
+        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjM3MmNmNTY2LTNmM2MtNGRjNS1iODg1LTc1MmE5MmFkODRkNCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
+        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImYyZGMzZWFk
+        LWEwM2EtNDg4NS04OTFkLTc3NWU3YjY2MmZlYSIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
+        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI3YmNjNDg4LTc2MGItNDc3
+        Zi05ZDA5LTI2ZjAwYTk3MjE4YiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
+        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmY2MmM4ZDctMmNhZi00N2Y3LThm
+        OGEtNGE0MWU5MGY4MWNlIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhY2ZiOGFkYTQwZGIw
+        NGVlMGMxZSJ9LCAiaWQiOiAiNTZiNGFjZmI4YWRhNDBkYjA0ZWUwYzFlIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:00 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwYWNrYWdlX2dyb3VwIl19fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="MFYkONqLXyQf8ldXfv4H6GnIUoahwGOXTKlv1Esdr8", oauth_signature="gJRZYLeiG2An9ETEhV5t2n2FjWE%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681340", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '43'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1486'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Im1hbmRhdG9yeV9wYWNrYWdlX25hbWVzIjogWyJw
+        ZW5ndWluIl0sICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogImJp
+        cmQiLCAidXNlcl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVlLCAi
+        X25zIjogInVuaXRzX3BhY2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRlZCI6
+        IDE0NTQ2ODExNzMsICJvcHRpb25hbF9wYWNrYWdlX25hbWVzIjogW10sICJ0
+        cmFuc2xhdGVkX25hbWUiOiB7fSwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24i
+        OiB7fSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNr
+        YWdlX25hbWVzIjogW10sICJfY29udGVudF90eXBlX2lkIjogInBhY2thZ2Vf
+        Z3JvdXAiLCAiaWQiOiAiYmlyZCIsICJfaWQiOiAiMjU5MjRiYzctYzE0Ny00
+        YjkzLTg3OWYtOGE4ZjgyZDFlMjFlIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0
+        LCAiY29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQi
+        OiAiMjAxNi0wMi0wNVQxNDowODo1OVoiLCAicmVwb19pZCI6ICJGZWRvcmFf
+        MTciLCAiY3JlYXRlZCI6ICIyMDE2LTAyLTA1VDE0OjA4OjU5WiIsICJ1bml0
+        X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0X2lkIjogIjI1OTI0
+        YmM3LWMxNDctNGI5My04NzlmLThhOGY4MmQxZTIxZSIsICJfaWQiOiB7IiRv
+        aWQiOiAiNTZiNGFjZmI4YWRhNDBkYjA0ZWUwYzFiIn19LCB7Im1ldGFkYXRh
+        IjogeyJtYW5kYXRvcnlfcGFja2FnZV9uYW1lcyI6IFsiZWxlcGhhbnQsZ2ly
+        YWZmZSxjaGVldGFoLGxpb24sbW9ua2V5LHBlbmd1aW4sc3F1aXJyZWwsd2Fs
+        cnVzIiwgInBlbmd1aW4iXSwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5h
+        bWUiOiAibWFtbWFsIiwgInVzZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0
+        IjogdHJ1ZSwgIl9ucyI6ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0
+        X3VwZGF0ZWQiOiAxNDU0NjgxMTczLCAib3B0aW9uYWxfcGFja2FnZV9uYW1l
+        cyI6IFtdLCAidHJhbnNsYXRlZF9uYW1lIjoge30sICJ0cmFuc2xhdGVkX2Rl
+        c2NyaXB0aW9uIjoge30sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImRl
+        ZmF1bHRfcGFja2FnZV9uYW1lcyI6IFtdLCAiX2NvbnRlbnRfdHlwZV9pZCI6
+        ICJwYWNrYWdlX2dyb3VwIiwgImlkIjogIm1hbW1hbCIsICJfaWQiOiAiZmYy
+        YmQxY2MtZjg3ZS00OTY1LTg2NjYtYmIzNDI0ZTQ3NDdkIiwgImRpc3BsYXlf
+        b3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtd
+        fSwgInVwZGF0ZWQiOiAiMjAxNi0wMi0wNVQxNDowODo1OVoiLCAicmVwb19p
+        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE2LTAyLTA1VDE0OjA4
+        OjU5WiIsICJ1bml0X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0
+        X2lkIjogImZmMmJkMWNjLWY4N2UtNDk2NS04NjY2LWJiMzQyNGU0NzQ3ZCIs
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjZmI4YWRhNDBkYjA0ZWUwYzFjIn19
+        XQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:00 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwYWNrYWdlX2dyb3VwIl19fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="8vvIH1GmY4oCz3HmLADbHNVmDP1RqmNAg9bQS03EI8I", oauth_signature="fs3YgzPLCht1UVHJ9WUdoJXsIlY%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681340", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '43'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1486'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Im1hbmRhdG9yeV9wYWNrYWdlX25hbWVzIjogWyJw
+        ZW5ndWluIl0sICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogImJp
+        cmQiLCAidXNlcl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVlLCAi
+        X25zIjogInVuaXRzX3BhY2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRlZCI6
+        IDE0NTQ2ODExNzMsICJvcHRpb25hbF9wYWNrYWdlX25hbWVzIjogW10sICJ0
+        cmFuc2xhdGVkX25hbWUiOiB7fSwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24i
+        OiB7fSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNr
+        YWdlX25hbWVzIjogW10sICJfY29udGVudF90eXBlX2lkIjogInBhY2thZ2Vf
+        Z3JvdXAiLCAiaWQiOiAiYmlyZCIsICJfaWQiOiAiMjU5MjRiYzctYzE0Ny00
+        YjkzLTg3OWYtOGE4ZjgyZDFlMjFlIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0
+        LCAiY29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQi
+        OiAiMjAxNi0wMi0wNVQxNDowODo1OVoiLCAicmVwb19pZCI6ICJGZWRvcmFf
+        MTciLCAiY3JlYXRlZCI6ICIyMDE2LTAyLTA1VDE0OjA4OjU5WiIsICJ1bml0
+        X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0X2lkIjogIjI1OTI0
+        YmM3LWMxNDctNGI5My04NzlmLThhOGY4MmQxZTIxZSIsICJfaWQiOiB7IiRv
+        aWQiOiAiNTZiNGFjZmI4YWRhNDBkYjA0ZWUwYzFiIn19LCB7Im1ldGFkYXRh
+        IjogeyJtYW5kYXRvcnlfcGFja2FnZV9uYW1lcyI6IFsiZWxlcGhhbnQsZ2ly
+        YWZmZSxjaGVldGFoLGxpb24sbW9ua2V5LHBlbmd1aW4sc3F1aXJyZWwsd2Fs
+        cnVzIiwgInBlbmd1aW4iXSwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5h
+        bWUiOiAibWFtbWFsIiwgInVzZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0
+        IjogdHJ1ZSwgIl9ucyI6ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0
+        X3VwZGF0ZWQiOiAxNDU0NjgxMTczLCAib3B0aW9uYWxfcGFja2FnZV9uYW1l
+        cyI6IFtdLCAidHJhbnNsYXRlZF9uYW1lIjoge30sICJ0cmFuc2xhdGVkX2Rl
+        c2NyaXB0aW9uIjoge30sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImRl
+        ZmF1bHRfcGFja2FnZV9uYW1lcyI6IFtdLCAiX2NvbnRlbnRfdHlwZV9pZCI6
+        ICJwYWNrYWdlX2dyb3VwIiwgImlkIjogIm1hbW1hbCIsICJfaWQiOiAiZmYy
+        YmQxY2MtZjg3ZS00OTY1LTg2NjYtYmIzNDI0ZTQ3NDdkIiwgImRpc3BsYXlf
+        b3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtd
+        fSwgInVwZGF0ZWQiOiAiMjAxNi0wMi0wNVQxNDowODo1OVoiLCAicmVwb19p
+        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE2LTAyLTA1VDE0OjA4
+        OjU5WiIsICJ1bml0X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0
+        X2lkIjogImZmMmJkMWNjLWY4N2UtNDk2NS04NjY2LWJiMzQyNGU0NzQ3ZCIs
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFjZmI4YWRhNDBkYjA0ZWUwYzFjIn19
+        XQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:00 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/content/units/package_group/search/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMjU5MjRi
+        YzctYzE0Ny00YjkzLTg3OWYtOGE4ZjgyZDFlMjFlIl19fX0sImluY2x1ZGVf
+        cmVwb3MiOnRydWV9
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="A5e0POCfJzNX18EnqfxRHW68B5b2y9haYdhsAZtLBU", oauth_signature="1rS9elNsy%2F%2Bx0I%2FyT%2FvCWEEeYVg%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681340", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '102'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '602'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJt
+        YW5kYXRvcnlfcGFja2FnZV9uYW1lcyI6IFsicGVuZ3VpbiJdLCAicmVwb19p
+        ZCI6ICJGZWRvcmFfMTciLCAibmFtZSI6ICJiaXJkIiwgInVzZXJfdmlzaWJs
+        ZSI6IHRydWUsICJkZWZhdWx0IjogdHJ1ZSwgIl9sYXN0X3VwZGF0ZWQiOiAi
+        MjAxNi0wMi0wNVQxNDowNjoxM1oiLCAiY2hpbGRyZW4iOiB7fSwgIm9wdGlv
+        bmFsX3BhY2thZ2VfbmFtZXMiOiBbXSwgInRyYW5zbGF0ZWRfbmFtZSI6IHt9
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcGFja2Fn
+        ZV9ncm91cC8yNTkyNGJjNy1jMTQ3LTRiOTMtODc5Zi04YThmODJkMWUyMWUv
+        IiwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24iOiB7fSwgInB1bHBfdXNlcl9t
+        ZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNrYWdlX25hbWVzIjogW10sICJf
+        Y29udGVudF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAiaWQiOiAiYmly
+        ZCIsICJfaWQiOiAiMjU5MjRiYzctYzE0Ny00YjkzLTg3OWYtOGE4ZjgyZDFl
+        MjFlIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxfcGFj
+        a2FnZV9uYW1lcyI6IFtdfV0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:01 GMT
+- request:
+    method: delete
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="TxPC185t3QCMsM5YX9ulKG1qpJbbbT6mQGvOzvYxk",
+        oauth_signature="t2QqqeCS%2BIFGS3DeH6d4xRfePRo%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681341", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:01 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzM3Zjg5YmZjLTE5MjktNGY3Ny1hZDRjLTM5Y2UxZGFjZTIzOC8iLCAi
+        dGFza19pZCI6ICIzN2Y4OWJmYy0xOTI5LTRmNzctYWQ0Yy0zOWNlMWRhY2Uy
+        MzgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:01 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/37f89bfc-1929-4f77-ad4c-39ce1dace238/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="o11SBRwgk8HCfAIxz3SnWWV7Ut1UduFUV4mZlyQ",
+        oauth_signature="S0%2FXuzxib3p6oijV6CjGfGA9gpc%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681341", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:01 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '651'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zN2Y4OWJmYy0xOTI5LTRmNzctYWQ0Yy0zOWNlMWRhY2Uy
+        MzgvIiwgInRhc2tfaWQiOiAiMzdmODliZmMtMTkyOS00Zjc3LWFkNGMtMzlj
+        ZTFkYWNlMjM4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAi
+        c3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
+        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1NmI0YWNmZDhhZGE0MGRiMDRlZTBjMWYifSwgImlkIjogIjU2YjRh
+        Y2ZkOGFkYTQwZGIwNGVlMGMxZiJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:01 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/37f89bfc-1929-4f77-ad4c-39ce1dace238/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="HNN3sggOBJn1dTjEGzQ4RwmGCkBAkmjG98T8EDR76Mg",
+        oauth_signature="WURmz%2FYqmVskcgKAOOIZSIjfdMo%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681341", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:01 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zN2Y4OWJmYy0xOTI5LTRmNzctYWQ0Yy0zOWNlMWRhY2Uy
+        MzgvIiwgInRhc2tfaWQiOiAiMzdmODliZmMtMTkyOS00Zjc3LWFkNGMtMzlj
+        ZTFkYWNlMjM4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA5OjAxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA5OjAxWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFjZmQ4YWRhNDBkYjA0ZWUwYzFmIn0sICJpZCI6ICI1NmI0YWNmZDhhZGE0
+        MGRiMDRlZTBjMWYifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:01 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/services/pulp/puppet_module.yml
+++ b/test/fixtures/vcr_cassettes/services/pulp/puppet_module.yml
@@ -1,198 +1,6 @@
 ---
 http_interactions:
 - request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IjQiLCJkaXNwbGF5X25hbWUiOiJQIEZvcmdlIiwiaW1wb3J0ZXJf
-        dHlwZV9pZCI6InB1cHBldF9pbXBvcnRlciIsImltcG9ydGVyX2NvbmZpZyI6
-        eyJmZWVkIjoiaHR0cDovL2RhdmlkZC5mZWRvcmFwZW9wbGUub3JnL3JlcG9z
-        L3JhbmRvbV9wdXBwZXQvIn0sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJwdXBw
-        ZXQtcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVf
-        aWQiOiJwdXBwZXRfaW5zdGFsbF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9y
-        X2NvbmZpZyI6eyJpbnN0YWxsX3BhdGgiOiIvdmFyL2xpYi9wdWxwL3B1Ymxp
-        c2hlZC9wdXBwZXRfa2F0ZWxsb190ZXN0IiwiYXV0b19wdWJsaXNoIjp0cnVl
-        fSwiYXV0b19wdWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9pZCI6IjQifSx7
-        ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJub2Rlc19odHRwX2Rpc3RyaWJ1dG9y
-        IiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7fSwiYXV0b19wdWJsaXNoIjp0cnVl
-        LCJkaXN0cmlidXRvcl9pZCI6IjRfbm9kZXMifSx7ImRpc3RyaWJ1dG9yX3R5
-        cGVfaWQiOiJwdXBwZXRfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25m
-        aWciOnsiYWJzb2x1dGVfcGF0aCI6bnVsbCwic2VydmVfaHR0cCI6ZmFsc2Us
-        InNlcnZlX2h0dHBzIjp0cnVlfSwiYXV0b19wdWJsaXNoIjp0cnVlLCJkaXN0
-        cmlidXRvcl9pZCI6IjRfcHVwcGV0In1dfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="IqAC1lGseCqY2Hw7WM8ukUb84BcNEFHCHW31iNxBjg", oauth_signature="Mvy7XZFLIrr3huuc6RlcmFUATfs%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454629010", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '700'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:36:50 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Location:
-      - '4'
-      Content-Length:
-      - '298'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUCBGb3JnZSIs
-        ICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRkZWQiOiBudWxs
-        LCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicHVwcGV0LXJlcG8ifSwgImxh
-        c3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3VudHMi
-        OiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNTZiM2Uw
-        OTI4NGEwOWMwNzA2MzQzNmM0In0sICJpZCI6ICI0IiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvNC8ifQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:36:50 GMT
-- request:
-    method: get
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/4/?details=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="evDxMgOM7IptMUjxyS9WFTE53AHwVRO0KpgMJYsStY4",
-        oauth_signature="OTJOVUPjhoUEl20eXBxUYuameAQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454629010", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:36:50 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '1444'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUCBGb3JnZSIs
-        ICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMiOiBbeyJyZXBv
-        X2lkIjogIjQiLCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgImxhc3Rf
-        cHVibGlzaCI6IG51bGwsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAic2NoZWR1
-        bGVkX3B1Ymxpc2hlcyI6IFtdLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJw
-        dXBwZXRfZGlzdHJpYnV0b3IiLCAiX2lkIjogeyIkb2lkIjogIjU2YjNlMDky
-        ODRhMDljMDcwNjM0MzZjOCJ9LCAiY29uZmlnIjogeyJzZXJ2ZV9odHRwcyI6
-        IHRydWUsICJzZXJ2ZV9odHRwIjogZmFsc2V9LCAiaWQiOiAiNF9wdXBwZXQi
-        fSwgeyJyZXBvX2lkIjogIjQiLCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3Jz
-        IiwgImxhc3RfcHVibGlzaCI6IG51bGwsICJhdXRvX3B1Ymxpc2giOiB0cnVl
-        LCAic2NoZWR1bGVkX3B1Ymxpc2hlcyI6IFtdLCAiZGlzdHJpYnV0b3JfdHlw
-        ZV9pZCI6ICJub2Rlc19odHRwX2Rpc3RyaWJ1dG9yIiwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NmIzZTA5Mjg0YTA5YzA3MDYzNDM2YzcifSwgImNvbmZpZyI6IHt9
-        LCAiaWQiOiAiNF9ub2RlcyJ9LCB7InJlcG9faWQiOiAiNCIsICJfbnMiOiAi
-        cmVwb19kaXN0cmlidXRvcnMiLCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImF1
-        dG9fcHVibGlzaCI6IHRydWUsICJzY2hlZHVsZWRfcHVibGlzaGVzIjogW10s
-        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInB1cHBldF9pbnN0YWxsX2Rpc3Ry
-        aWJ1dG9yIiwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzZTA5Mjg0YTA5YzA3MDYz
-        NDM2YzYifSwgImNvbmZpZyI6IHsiaW5zdGFsbF9wYXRoIjogIi92YXIvbGli
-        L3B1bHAvcHVibGlzaGVkL3B1cHBldF9rYXRlbGxvX3Rlc3QiLCAiYXV0b19w
-        dWJsaXNoIjogdHJ1ZX0sICJpZCI6ICI0In1dLCAibGFzdF91bml0X2FkZGVk
-        IjogbnVsbCwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInB1cHBldC1yZXBv
-        In0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3VuaXRf
-        Y291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiaW1wb3J0ZXJzIjogW3si
-        cmVwb19pZCI6ICI0IiwgIl9ucyI6ICJyZXBvX2ltcG9ydGVycyIsICJpbXBv
-        cnRlcl90eXBlX2lkIjogInB1cHBldF9pbXBvcnRlciIsICJsYXN0X3N5bmMi
-        OiBudWxsLCAic2NoZWR1bGVkX3N5bmNzIjogW10sICJfaWQiOiB7IiRvaWQi
-        OiAiNTZiM2UwOTI4NGEwOWMwNzA2MzQzNmM1In0sICJjb25maWciOiB7ImZl
-        ZWQiOiAiaHR0cDovL2RhdmlkZC5mZWRvcmFwZW9wbGUub3JnL3JlcG9zL3Jh
-        bmRvbV9wdXBwZXQvIn0sICJpZCI6ICJwdXBwZXRfaW1wb3J0ZXIifV0sICJf
-        aWQiOiB7IiRvaWQiOiAiNTZiM2UwOTI4NGEwOWMwNzA2MzQzNmM0In0sICJp
-        ZCI6ICI0IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
-        NC8ifQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:36:50 GMT
-- request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/4/actions/publish/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IjQiLCJvdmVycmlkZV9jb25maWciOm51bGx9
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="wtgkWHHogUx84ASbxvVusT93gu2PeBfcaEtMeFShIM", oauth_signature="cK1h8Vzm9mtNjXzDcImXZGkaa%2B0%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454629010", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '33'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:36:50 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzliMjZiMGIyLTJmMjYtNDJiYy04YzgxLTBjYTllNTBmMjNhZC8iLCAi
-        dGFza19pZCI6ICI5YjI2YjBiMi0yZjI2LTQyYmMtOGM4MS0wY2E5ZTUwZjIz
-        YWQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:36:50 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/9b26b0b2-2f26-42bc-8c81-0ca9e50f23ad/
     body:
@@ -310,57 +118,6 @@ http_interactions:
         ZTVjIiwgInJlc3VsdCI6ICJzdWNjZXNzIn0sICJlcnJvciI6IG51bGwsICJf
         aWQiOiB7IiRvaWQiOiAiNTZiM2UwOTI4NjgwYjVjYTVjODQyNGM2In0sICJp
         ZCI6ICI1NmIzZTA5Mjg0YTA5YzA3ZGJmNGRjMmYifQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:36:51 GMT
-- request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/4/actions/sync/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
-        Ijp0cnVlfX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="GwgcZoyNfdOubDMePSlgu2vHlFE42XINLT3gnFkoJ4", oauth_signature="70i8cv7WSArUZtfJ8rUSW3zhkpU%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454629011", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '53'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:36:51 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2RhNzY3MWNkLWMwMjUtNDVlMi05MGQxLTNjNDNhMTgxMTMwYS8iLCAi
-        dGFza19pZCI6ICJkYTc2NzFjZC1jMDI1LTQ1ZTItOTBkMS0zYzQzYTE4MTEz
-        MGEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:36:51 GMT
 - request:
@@ -1768,72 +1525,6 @@ http_interactions:
   recorded_at: Thu, 04 Feb 2016 23:37:17 GMT
 - request:
     method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/4/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwdXBwZXRfbW9kdWxlIl0sImZp
-        ZWxkcyI6eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="AvPZ7UQSi17ow9DUqV0Iv3URC4NDEP4FMKSywrV4520", oauth_signature="lBQLqp5%2FCTV3Yfc5oK81ukwF5hM%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454629037", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '90'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:37:17 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '916'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICI4MGYzMDEwNi1hYTg1LTQxZWMtYWM2
-        NS0zNDY4MjBmZjU3NWIiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwdXBwZXRf
-        bW9kdWxlIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiM2UwOTc4NGEwOWMwN2Rh
-        OTc5ZTVmIn0sICJ1bml0X2lkIjogIjgwZjMwMTA2LWFhODUtNDFlYy1hYzY1
-        LTM0NjgyMGZmNTc1YiIsICJ1bml0X3R5cGVfaWQiOiAicHVwcGV0X21vZHVs
-        ZSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiYWY1ODg2OWItYmUwYS00OWRh
-        LWFlNDktNjdhZWMwOTg1OTExIiwgIl9jb250ZW50X3R5cGVfaWQiOiAicHVw
-        cGV0X21vZHVsZSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2YjNlMGFiODRhMDlj
-        MDdkYTk3OWU2MSJ9LCAidW5pdF9pZCI6ICJhZjU4ODY5Yi1iZTBhLTQ5ZGEt
-        YWU0OS02N2FlYzA5ODU5MTEiLCAidW5pdF90eXBlX2lkIjogInB1cHBldF9t
-        b2R1bGUifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjogImJlZmQ5MGYwLTkyMjEt
-        NGFkMC05YWU4LWMzYjA4YzAyYTc5ZSIsICJfY29udGVudF90eXBlX2lkIjog
-        InB1cHBldF9tb2R1bGUifSwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzZTA5ODg0
-        YTA5YzA3ZGE5NzllNjAifSwgInVuaXRfaWQiOiAiYmVmZDkwZjAtOTIyMS00
-        YWQwLTlhZTgtYzNiMDhjMDJhNzllIiwgInVuaXRfdHlwZV9pZCI6ICJwdXBw
-        ZXRfbW9kdWxlIn0sIHsibWV0YWRhdGEiOiB7Il9pZCI6ICI1ZGFkZDU3NC04
-        NzRjLTRiYTctODNmNy1mNzYyODcyOGY0MjUiLCAiX2NvbnRlbnRfdHlwZV9p
-        ZCI6ICJwdXBwZXRfbW9kdWxlIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiM2Uw
-        OTY4NGEwOWMwN2RhOTc5ZTVlIn0sICJ1bml0X2lkIjogIjVkYWRkNTc0LTg3
-        NGMtNGJhNy04M2Y3LWY3NjI4NzI4ZjQyNSIsICJ1bml0X3R5cGVfaWQiOiAi
-        cHVwcGV0X21vZHVsZSJ9XQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:37:17 GMT
-- request:
-    method: post
     uri: https://katello-devbox.example.com/pulp/api/v2/content/units/puppet_module/search/
     body:
       encoding: UTF-8
@@ -2085,72 +1776,6 @@ http_interactions:
   recorded_at: Thu, 04 Feb 2016 23:37:17 GMT
 - request:
     method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/4/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwdXBwZXRfbW9kdWxlIl0sImZp
-        ZWxkcyI6eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="l7NA9ud6ClwbnNKaxZavFVgbY8GjpNHrxqobG1efcw", oauth_signature="MgU8axVky%2BVGDP8avAL8Ro0QwxM%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454629037", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '90'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:37:17 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '916'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICI4MGYzMDEwNi1hYTg1LTQxZWMtYWM2
-        NS0zNDY4MjBmZjU3NWIiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwdXBwZXRf
-        bW9kdWxlIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiM2UwOTc4NGEwOWMwN2Rh
-        OTc5ZTVmIn0sICJ1bml0X2lkIjogIjgwZjMwMTA2LWFhODUtNDFlYy1hYzY1
-        LTM0NjgyMGZmNTc1YiIsICJ1bml0X3R5cGVfaWQiOiAicHVwcGV0X21vZHVs
-        ZSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiYWY1ODg2OWItYmUwYS00OWRh
-        LWFlNDktNjdhZWMwOTg1OTExIiwgIl9jb250ZW50X3R5cGVfaWQiOiAicHVw
-        cGV0X21vZHVsZSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2YjNlMGFiODRhMDlj
-        MDdkYTk3OWU2MSJ9LCAidW5pdF9pZCI6ICJhZjU4ODY5Yi1iZTBhLTQ5ZGEt
-        YWU0OS02N2FlYzA5ODU5MTEiLCAidW5pdF90eXBlX2lkIjogInB1cHBldF9t
-        b2R1bGUifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjogImJlZmQ5MGYwLTkyMjEt
-        NGFkMC05YWU4LWMzYjA4YzAyYTc5ZSIsICJfY29udGVudF90eXBlX2lkIjog
-        InB1cHBldF9tb2R1bGUifSwgIl9pZCI6IHsiJG9pZCI6ICI1NmIzZTA5ODg0
-        YTA5YzA3ZGE5NzllNjAifSwgInVuaXRfaWQiOiAiYmVmZDkwZjAtOTIyMS00
-        YWQwLTlhZTgtYzNiMDhjMDJhNzllIiwgInVuaXRfdHlwZV9pZCI6ICJwdXBw
-        ZXRfbW9kdWxlIn0sIHsibWV0YWRhdGEiOiB7Il9pZCI6ICI1ZGFkZDU3NC04
-        NzRjLTRiYTctODNmNy1mNzYyODcyOGY0MjUiLCAiX2NvbnRlbnRfdHlwZV9p
-        ZCI6ICJwdXBwZXRfbW9kdWxlIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiM2Uw
-        OTY4NGEwOWMwN2RhOTc5ZTVlIn0sICJ1bml0X2lkIjogIjVkYWRkNTc0LTg3
-        NGMtNGJhNy04M2Y3LWY3NjI4NzI4ZjQyNSIsICJ1bml0X3R5cGVfaWQiOiAi
-        cHVwcGV0X21vZHVsZSJ9XQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:37:17 GMT
-- request:
-    method: post
     uri: https://katello-devbox.example.com/pulp/api/v2/content/units/puppet_module/search/
     body:
       encoding: UTF-8
@@ -2227,53 +1852,6 @@ http_interactions:
         bV90eXBlIjogInNoYTI1NiIsICJfaWQiOiAiNWRhZGQ1NzQtODc0Yy00YmE3
         LTgzZjctZjc2Mjg3MjhmNDI1IiwgImNoaWxkcmVuIjoge30sICJ0eXBlcyI6
         IFtdLCAibmFtZSI6ICJzYW1iYSJ9XQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:37:17 GMT
-- request:
-    method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="Zq97Okxw5IeG69rnMOW5ZECDoJ0XR4cJzllFz9JP2c",
-        oauth_signature="lNbjIdxIFNdKsDT%2BKqxpUb%2BWW14%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454629037", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:37:17 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzU1N2I5MzczLWNhMjQtNGMxOS05NjNkLThkZjNjMDBiZjI0NS8iLCAi
-        dGFza19pZCI6ICI1NTdiOTM3My1jYTI0LTRjMTktOTYzZC04ZGYzYzAwYmYy
-        NDUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:37:17 GMT
 - request:
@@ -2386,4 +1964,2250 @@ http_interactions:
         OSJ9
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:37:18 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjQiLCJkaXNwbGF5X25hbWUiOiJQIEZvcmdlIiwiaW1wb3J0ZXJf
+        dHlwZV9pZCI6InB1cHBldF9pbXBvcnRlciIsImltcG9ydGVyX2NvbmZpZyI6
+        eyJmZWVkIjoiaHR0cDovL2RhdmlkZC5mZWRvcmFwZW9wbGUub3JnL3JlcG9z
+        L3JhbmRvbV9wdXBwZXQvIn0sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJwdXBw
+        ZXQtcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVf
+        aWQiOiJwdXBwZXRfaW5zdGFsbF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9y
+        X2NvbmZpZyI6eyJpbnN0YWxsX3BhdGgiOiIvdmFyL2xpYi9wdWxwL3B1Ymxp
+        c2hlZC9wdXBwZXRfa2F0ZWxsb190ZXN0IiwiYXV0b19wdWJsaXNoIjp0cnVl
+        fSwiYXV0b19wdWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9pZCI6IjQifSx7
+        ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJub2Rlc19odHRwX2Rpc3RyaWJ1dG9y
+        IiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7fSwiYXV0b19wdWJsaXNoIjp0cnVl
+        LCJkaXN0cmlidXRvcl9pZCI6IjRfbm9kZXMifSx7ImRpc3RyaWJ1dG9yX3R5
+        cGVfaWQiOiJwdXBwZXRfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25m
+        aWciOnsiYWJzb2x1dGVfcGF0aCI6bnVsbCwic2VydmVfaHR0cCI6ZmFsc2Us
+        InNlcnZlX2h0dHBzIjp0cnVlfSwiYXV0b19wdWJsaXNoIjp0cnVlLCJkaXN0
+        cmlidXRvcl9pZCI6IjRfcHVwcGV0In1dfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="j74qvU3ANKnQhF81lbBvZmFCopxpN1GWWgZ2XIRDBYA", oauth_signature="d87Z54J%2BzgUMT3vYPXaRFEVkBXo%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681342", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '700'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:02 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '298'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/4/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUCBGb3JnZSIs
+        ICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRkZWQiOiBudWxs
+        LCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicHVwcGV0LXJlcG8ifSwgImxh
+        c3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3VudHMi
+        OiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFj
+        ZmVjNzgyMWIzMzAzNGJhZTdjIn0sICJpZCI6ICI0IiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvNC8ifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:03 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/4/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="2opOTyY1gwnkfpyduDQH8V3Bsr8GaxlwRPeD3pVXtRM",
+        oauth_signature="pxniriq0wsjSblNUZgY%2Bdjg1Lb4%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681343", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:03 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1718'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUCBGb3JnZSIs
+        ICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMiOiBbeyJyZXBv
+        X2lkIjogIjQiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
+        cy80L2Rpc3RyaWJ1dG9ycy80X3B1cHBldC8iLCAiX25zIjogInJlcG9fZGlz
+        dHJpYnV0b3JzIiwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRv
+        cl90eXBlX2lkIjogInB1cHBldF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxp
+        c2giOiB0cnVlLCAic2NyYXRjaHBhZCI6IHt9LCAiX2lkIjogeyIkb2lkIjog
+        IjU2YjRhY2ZmYzc4MjFiMzMwMzRiYWU4MCJ9LCAiY29uZmlnIjogeyJzZXJ2
+        ZV9odHRwcyI6IHRydWUsICJzZXJ2ZV9odHRwIjogZmFsc2V9LCAiaWQiOiAi
+        NF9wdXBwZXQifSwgeyJyZXBvX2lkIjogIjQiLCAiX2hyZWYiOiAiL3B1bHAv
+        YXBpL3YyL3JlcG9zaXRvcmllcy80L2Rpc3RyaWJ1dG9ycy80X25vZGVzLyIs
+        ICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAibGFzdF9wdWJsaXNoIjog
+        bnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAibm9kZXNfaHR0cF9kaXN0
+        cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAic2NyYXRjaHBhZCI6
+        IHt9LCAiX2lkIjogeyIkb2lkIjogIjU2YjRhY2ZmYzc4MjFiMzMwMzRiYWU3
+        ZiJ9LCAiY29uZmlnIjoge30sICJpZCI6ICI0X25vZGVzIn0sIHsicmVwb19p
+        ZCI6ICI0IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
+        NC9kaXN0cmlidXRvcnMvNC8iLCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3Jz
+        IiwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lk
+        IjogInB1cHBldF9pbnN0YWxsX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlz
+        aCI6IHRydWUsICJzY3JhdGNocGFkIjoge30sICJfaWQiOiB7IiRvaWQiOiAi
+        NTZiNGFjZmZjNzgyMWIzMzAzNGJhZTdlIn0sICJjb25maWciOiB7Imluc3Rh
+        bGxfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL3B1Ymxpc2hlZC9wdXBwZXRfa2F0
+        ZWxsb190ZXN0IiwgImF1dG9fcHVibGlzaCI6IHRydWV9LCAiaWQiOiAiNCJ9
+        XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3RlcyI6IHsiX3JlcG8t
+        dHlwZSI6ICJwdXBwZXQtcmVwbyJ9LCAibGFzdF91bml0X3JlbW92ZWQiOiBu
+        dWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25zIjogInJlcG9z
+        IiwgImltcG9ydGVycyI6IFt7InNjcmF0Y2hwYWQiOiBudWxsLCAiX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy80L2ltcG9ydGVycy9wdXBw
+        ZXRfaW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBvX2ltcG9ydGVycyIsICJpbXBv
+        cnRlcl90eXBlX2lkIjogInB1cHBldF9pbXBvcnRlciIsICJsYXN0X3N5bmMi
+        OiBudWxsLCAicmVwb19pZCI6ICI0IiwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0
+        YWNmZWM3ODIxYjMzMDM0YmFlN2QifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJo
+        dHRwOi8vZGF2aWRkLmZlZG9yYXBlb3BsZS5vcmcvcmVwb3MvcmFuZG9tX3B1
+        cHBldC8ifSwgImlkIjogInB1cHBldF9pbXBvcnRlciJ9XSwgImxvY2FsbHlf
+        c3RvcmVkX3VuaXRzIjogMCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWNmZWM3
+        ODIxYjMzMDM0YmFlN2MifSwgInRvdGFsX3JlcG9zaXRvcnlfdW5pdHMiOiAw
+        LCAiaWQiOiAiNCIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9y
+        aWVzLzQvIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:03 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/4/actions/publish/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjQiLCJvdmVycmlkZV9jb25maWciOm51bGx9
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="EBPwIFEjrq2CxDlnyDl3mDC0tLCRmhDburtBTe8svU", oauth_signature="Rt6VvmU6OjdPBPCc93HcKIrVbKY%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681343", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '33'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:03 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2ExOTZkNTFiLWIzMzgtNGUyMS1hY2U0LWMyM2Y1MDk3NWE3OC8iLCAi
+        dGFza19pZCI6ICJhMTk2ZDUxYi1iMzM4LTRlMjEtYWNlNC1jMjNmNTA5NzVh
+        NzgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:03 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/a196d51b-b338-4e21-ace4-c23f50975a78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="MdMM6Q8GRcFpgaNqsDGfKsZr95OenLuUaWSjqi6Yo",
+        oauth_signature="OmfZ77abgNAITB8qOSbpq%2FnFG6M%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681343", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:03 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '548'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9hMTk2ZDUxYi1iMzM4LTRlMjEtYWNlNC1jMjNm
+        NTA5NzVhNzgvIiwgInRhc2tfaWQiOiAiYTE5NmQ1MWItYjMzOC00ZTIxLWFj
+        ZTQtYzIzZjUwOTc1YTc4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0
+        IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogbnVs
+        bCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogbnVsbCwg
+        InRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9n
+        cmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIk5vbmUuZHEiLCAic3RhdGUi
+        OiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6IG51bGwsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhY2Zm
+        OGFkYTQwZGIwNGVlMGMyMCJ9LCAiaWQiOiAiNTZiNGFjZmY4YWRhNDBkYjA0
+        ZWUwYzIwIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:03 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/a196d51b-b338-4e21-ace4-c23f50975a78/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="U5rxpisP6xwrDSk4V9h6z989LpTj3LMi0pny2mVdIJw",
+        oauth_signature="O8gJmd2lqi3UU5PqO80qfV5pIMI%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681343", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:03 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1068'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9hMTk2ZDUxYi1iMzM4LTRlMjEtYWNlNC1jMjNm
+        NTA5NzVhNzgvIiwgInRhc2tfaWQiOiAiYTE5NmQ1MWItYjMzOC00ZTIxLWFj
+        ZTQtYzIzZjUwOTc1YTc4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0
+        IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogIjIw
+        MTYtMDItMDVUMTQ6MDk6MDNaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
+        dGFydF90aW1lIjogIjIwMTYtMDItMDVUMTQ6MDk6MDNaIiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBv
+        cnQiOiB7fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
+        QGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJm
+        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0
+        IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAi
+        cmVwb19pZCI6ICI0IiwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNVQxNDowOTow
+        M1oiLCAiX25zIjogInJlcG9fcHVibGlzaF9yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDE2LTAyLTA1VDE0OjA5OjAzWiIsICJ0cmFjZWJhY2siOiBudWxs
+        LCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJwdXBwZXRfaW5zdGFsbF9kaXN0
+        cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2Nlc3MiLCAiZXJyb3JfbWVzc2Fn
+        ZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICI0IiwgImlkIjogIjU2YjRh
+        Y2ZmYzc4MjFiMzQ0NGZjYzJmZiIsICJkZXRhaWxzIjogeyJlcnJvcnMiOiBb
+        XSwgInN1Y2Nlc3NfdW5pdF9rZXlzIjogW119fSwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmI0YWNmZjhhZGE0MGRiMDRlZTBjMjAifSwg
+        ImlkIjogIjU2YjRhY2ZmOGFkYTQwZGIwNGVlMGMyMCJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:03 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/4/actions/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
+        Ijp0cnVlfX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="1kGIY0YhYu0kffhgxB0nx7zmaOAclVJHqpPFQtIOM", oauth_signature="2OLJeA8so7eMtgcWJn%2F0iDRNk1M%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681344", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '53'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:04 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2FmMzQ1NTI0LTNmZjMtNDgyYi04YTIwLTdlZWQ5MDNmZWYyYy8iLCAi
+        dGFza19pZCI6ICJhZjM0NTUyNC0zZmYzLTQ4MmItOGEyMC03ZWVkOTAzZmVm
+        MmMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:04 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/af345524-3ff3-482b-8a20-7eed903fef2c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="1fv6t6ren2MNThgLHNaGOf29ufyPig2XwaZoV95iMxw",
+        oauth_signature="y8GY8p2jy5gOhuG0Do9Z7X6mU80%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681344", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:04 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '539'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hZjM0NTUyNC0zZmYzLTQ4MmItOGEyMC03ZWVkOTAzZmVm
+        MmMvIiwgInRhc2tfaWQiOiAiYWYzNDU1MjQtM2ZmMy00ODJiLThhMjAtN2Vl
+        ZDkwM2ZlZjJjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogbnVsbCwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBv
+        cnQiOiB7fSwgInF1ZXVlIjogIk5vbmUuZHEiLCAic3RhdGUiOiAid2FpdGlu
+        ZyIsICJ3b3JrZXJfbmFtZSI6IG51bGwsICJyZXN1bHQiOiBudWxsLCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhZDAwOGFkYTQwZGIw
+        NGVlMGMyMSJ9LCAiaWQiOiAiNTZiNGFkMDA4YWRhNDBkYjA0ZWUwYzIxIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:04 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/af345524-3ff3-482b-8a20-7eed903fef2c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="4emOcCFC4FOkqtsHGLfFVPQANjbH10XfGg9M0cyX4",
+        oauth_signature="%2BezRYwY063bAVKS1WwYMAbTY%2BQo%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681344", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:04 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1080'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hZjM0NTUyNC0zZmYzLTQ4MmItOGEyMC03ZWVkOTAzZmVm
+        MmMvIiwgInRhc2tfaWQiOiAiYWYzNDU1MjQtM2ZmMy00ODJiLThhMjAtN2Vl
+        ZDkwM2ZlZjJjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMDVUMTQ6
+        MDk6MDRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        W10sICJwcm9ncmVzc19yZXBvcnQiOiB7InB1cHBldF9pbXBvcnRlciI6IHsi
+        bW9kdWxlcyI6IHsiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJleGVjdXRpb25f
+        dGltZSI6IG51bGwsICJ0b3RhbF9jb3VudCI6IG51bGwsICJ0cmFjZWJhY2si
+        OiBudWxsLCAiaW5kaXZpZHVhbF9lcnJvcnMiOiBbXSwgInN0YXRlIjogIm5v
+        dC1zdGFydGVkIiwgImVycm9yX2NvdW50IjogbnVsbCwgImVycm9yIjogIk5v
+        bmUiLCAiZmluaXNoZWRfY291bnQiOiBudWxsfSwgIm1ldGFkYXRhIjogeyJx
+        dWVyeV9maW5pc2hlZF9jb3VudCI6IDAsICJ0cmFjZWJhY2siOiBudWxsLCAi
+        ZXhlY3V0aW9uX3RpbWUiOiBudWxsLCAicXVlcnlfdG90YWxfY291bnQiOiAx
+        LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdGF0ZSI6ICJydW5uaW5nIiwg
+        ImVycm9yIjogIk5vbmUiLCAiY3VycmVudF9xdWVyeSI6IG51bGx9fX0sICJx
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTIt
+        OC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWQwMDhhZGE0MGRi
+        MDRlZTBjMjEifSwgImlkIjogIjU2YjRhZDAwOGFkYTQwZGIwNGVlMGMyMSJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:04 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/af345524-3ff3-482b-8a20-7eed903fef2c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="I5HIcmDP39LgGbmvQ1zBRhiKGalkqJpU7k4ZK1GWio",
+        oauth_signature="aiFDdrPFnZktJm%2BGbNXfneTwuqE%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681345", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:05 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1141'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hZjM0NTUyNC0zZmYzLTQ4MmItOGEyMC03ZWVkOTAzZmVm
+        MmMvIiwgInRhc2tfaWQiOiAiYWYzNDU1MjQtM2ZmMy00ODJiLThhMjAtN2Vl
+        ZDkwM2ZlZjJjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMDVUMTQ6
+        MDk6MDRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        W10sICJwcm9ncmVzc19yZXBvcnQiOiB7InB1cHBldF9pbXBvcnRlciI6IHsi
+        bW9kdWxlcyI6IHsiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJleGVjdXRpb25f
+        dGltZSI6IG51bGwsICJ0b3RhbF9jb3VudCI6IG51bGwsICJ0cmFjZWJhY2si
+        OiBudWxsLCAiaW5kaXZpZHVhbF9lcnJvcnMiOiBbXSwgInN0YXRlIjogIm5v
+        dC1zdGFydGVkIiwgImVycm9yX2NvdW50IjogbnVsbCwgImVycm9yIjogIk5v
+        bmUiLCAiZmluaXNoZWRfY291bnQiOiBudWxsfSwgIm1ldGFkYXRhIjogeyJx
+        dWVyeV9maW5pc2hlZF9jb3VudCI6IDEsICJ0cmFjZWJhY2siOiBudWxsLCAi
+        ZXhlY3V0aW9uX3RpbWUiOiBudWxsLCAicXVlcnlfdG90YWxfY291bnQiOiAx
+        LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdGF0ZSI6ICJydW5uaW5nIiwg
+        ImVycm9yIjogIk5vbmUiLCAiY3VycmVudF9xdWVyeSI6ICJodHRwOi8vZGF2
+        aWRkLmZlZG9yYXBlb3BsZS5vcmcvcmVwb3MvcmFuZG9tX3B1cHBldC9tb2R1
+        bGVzLmpzb24ifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
+        IjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
+        NTZiNGFkMDA4YWRhNDBkYjA0ZWUwYzIxIn0sICJpZCI6ICI1NmI0YWQwMDhh
+        ZGE0MGRiMDRlZTBjMjEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:05 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/af345524-3ff3-482b-8a20-7eed903fef2c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Ye6TUHmrj2FoUOrIJ14p3HVv7UiFmxqJymr23IVmec",
+        oauth_signature="gLn0ldS3eE62HA6HGqaZHMoR4vs%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681346", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:06 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1141'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hZjM0NTUyNC0zZmYzLTQ4MmItOGEyMC03ZWVkOTAzZmVm
+        MmMvIiwgInRhc2tfaWQiOiAiYWYzNDU1MjQtM2ZmMy00ODJiLThhMjAtN2Vl
+        ZDkwM2ZlZjJjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMDVUMTQ6
+        MDk6MDRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        W10sICJwcm9ncmVzc19yZXBvcnQiOiB7InB1cHBldF9pbXBvcnRlciI6IHsi
+        bW9kdWxlcyI6IHsiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJleGVjdXRpb25f
+        dGltZSI6IG51bGwsICJ0b3RhbF9jb3VudCI6IG51bGwsICJ0cmFjZWJhY2si
+        OiBudWxsLCAiaW5kaXZpZHVhbF9lcnJvcnMiOiBbXSwgInN0YXRlIjogIm5v
+        dC1zdGFydGVkIiwgImVycm9yX2NvdW50IjogbnVsbCwgImVycm9yIjogIk5v
+        bmUiLCAiZmluaXNoZWRfY291bnQiOiBudWxsfSwgIm1ldGFkYXRhIjogeyJx
+        dWVyeV9maW5pc2hlZF9jb3VudCI6IDEsICJ0cmFjZWJhY2siOiBudWxsLCAi
+        ZXhlY3V0aW9uX3RpbWUiOiBudWxsLCAicXVlcnlfdG90YWxfY291bnQiOiAx
+        LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdGF0ZSI6ICJydW5uaW5nIiwg
+        ImVycm9yIjogIk5vbmUiLCAiY3VycmVudF9xdWVyeSI6ICJodHRwOi8vZGF2
+        aWRkLmZlZG9yYXBlb3BsZS5vcmcvcmVwb3MvcmFuZG9tX3B1cHBldC9tb2R1
+        bGVzLmpzb24ifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
+        IjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
+        NTZiNGFkMDA4YWRhNDBkYjA0ZWUwYzIxIn0sICJpZCI6ICI1NmI0YWQwMDhh
+        ZGE0MGRiMDRlZTBjMjEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:06 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/af345524-3ff3-482b-8a20-7eed903fef2c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="FYgmQoLvnbb3zbgkl2MV36RfiT6Yr1kRezLjShrZU",
+        oauth_signature="QTMmGVeFv7TlnOQwooC9sxy7qr8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681346", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:06 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1125'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hZjM0NTUyNC0zZmYzLTQ4MmItOGEyMC03ZWVkOTAzZmVm
+        MmMvIiwgInRhc2tfaWQiOiAiYWYzNDU1MjQtM2ZmMy00ODJiLThhMjAtN2Vl
+        ZDkwM2ZlZjJjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMDVUMTQ6
+        MDk6MDRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        W10sICJwcm9ncmVzc19yZXBvcnQiOiB7InB1cHBldF9pbXBvcnRlciI6IHsi
+        bW9kdWxlcyI6IHsiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJleGVjdXRpb25f
+        dGltZSI6IG51bGwsICJ0b3RhbF9jb3VudCI6IDQsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAiaW5kaXZpZHVhbF9lcnJvcnMiOiBbXSwgInN0YXRlIjogInJ1bm5p
+        bmciLCAiZXJyb3JfY291bnQiOiAwLCAiZXJyb3IiOiAiTm9uZSIsICJmaW5p
+        c2hlZF9jb3VudCI6IDB9LCAibWV0YWRhdGEiOiB7InF1ZXJ5X2ZpbmlzaGVk
+        X2NvdW50IjogMSwgInRyYWNlYmFjayI6IG51bGwsICJleGVjdXRpb25fdGlt
+        ZSI6IDEsICJxdWVyeV90b3RhbF9jb3VudCI6IDEsICJlcnJvcl9tZXNzYWdl
+        IjogbnVsbCwgInN0YXRlIjogInN1Y2Nlc3MiLCAiZXJyb3IiOiAiTm9uZSIs
+        ICJjdXJyZW50X3F1ZXJ5IjogImh0dHA6Ly9kYXZpZGQuZmVkb3JhcGVvcGxl
+        Lm9yZy9yZXBvcy9yYW5kb21fcHVwcGV0L21vZHVsZXMuanNvbiJ9fX0sICJx
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTIt
+        OC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWQwMDhhZGE0MGRi
+        MDRlZTBjMjEifSwgImlkIjogIjU2YjRhZDAwOGFkYTQwZGIwNGVlMGMyMSJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:06 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/af345524-3ff3-482b-8a20-7eed903fef2c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="4LINvinpNJa1pVP6zNMrj1FopWdKkNmZQQiFvADjlg",
+        oauth_signature="zZdMNZCkPEGsoZABYnOnaFQj8b4%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681347", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:07 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1125'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hZjM0NTUyNC0zZmYzLTQ4MmItOGEyMC03ZWVkOTAzZmVm
+        MmMvIiwgInRhc2tfaWQiOiAiYWYzNDU1MjQtM2ZmMy00ODJiLThhMjAtN2Vl
+        ZDkwM2ZlZjJjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMDVUMTQ6
+        MDk6MDRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        W10sICJwcm9ncmVzc19yZXBvcnQiOiB7InB1cHBldF9pbXBvcnRlciI6IHsi
+        bW9kdWxlcyI6IHsiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJleGVjdXRpb25f
+        dGltZSI6IG51bGwsICJ0b3RhbF9jb3VudCI6IDQsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAiaW5kaXZpZHVhbF9lcnJvcnMiOiBbXSwgInN0YXRlIjogInJ1bm5p
+        bmciLCAiZXJyb3JfY291bnQiOiAwLCAiZXJyb3IiOiAiTm9uZSIsICJmaW5p
+        c2hlZF9jb3VudCI6IDB9LCAibWV0YWRhdGEiOiB7InF1ZXJ5X2ZpbmlzaGVk
+        X2NvdW50IjogMSwgInRyYWNlYmFjayI6IG51bGwsICJleGVjdXRpb25fdGlt
+        ZSI6IDEsICJxdWVyeV90b3RhbF9jb3VudCI6IDEsICJlcnJvcl9tZXNzYWdl
+        IjogbnVsbCwgInN0YXRlIjogInN1Y2Nlc3MiLCAiZXJyb3IiOiAiTm9uZSIs
+        ICJjdXJyZW50X3F1ZXJ5IjogImh0dHA6Ly9kYXZpZGQuZmVkb3JhcGVvcGxl
+        Lm9yZy9yZXBvcy9yYW5kb21fcHVwcGV0L21vZHVsZXMuanNvbiJ9fX0sICJx
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTIt
+        OC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWQwMDhhZGE0MGRi
+        MDRlZTBjMjEifSwgImlkIjogIjU2YjRhZDAwOGFkYTQwZGIwNGVlMGMyMSJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:07 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/af345524-3ff3-482b-8a20-7eed903fef2c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="AcwwwcwWm9aBRpUSsjAN5bHx8WTlnhUddun1004n94",
+        oauth_signature="0i4UBy8AH2F1CZRwLAwU1Ws7TEk%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681348", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:08 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1125'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hZjM0NTUyNC0zZmYzLTQ4MmItOGEyMC03ZWVkOTAzZmVm
+        MmMvIiwgInRhc2tfaWQiOiAiYWYzNDU1MjQtM2ZmMy00ODJiLThhMjAtN2Vl
+        ZDkwM2ZlZjJjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMDVUMTQ6
+        MDk6MDRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        W10sICJwcm9ncmVzc19yZXBvcnQiOiB7InB1cHBldF9pbXBvcnRlciI6IHsi
+        bW9kdWxlcyI6IHsiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJleGVjdXRpb25f
+        dGltZSI6IG51bGwsICJ0b3RhbF9jb3VudCI6IDQsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAiaW5kaXZpZHVhbF9lcnJvcnMiOiBbXSwgInN0YXRlIjogInJ1bm5p
+        bmciLCAiZXJyb3JfY291bnQiOiAwLCAiZXJyb3IiOiAiTm9uZSIsICJmaW5p
+        c2hlZF9jb3VudCI6IDF9LCAibWV0YWRhdGEiOiB7InF1ZXJ5X2ZpbmlzaGVk
+        X2NvdW50IjogMSwgInRyYWNlYmFjayI6IG51bGwsICJleGVjdXRpb25fdGlt
+        ZSI6IDEsICJxdWVyeV90b3RhbF9jb3VudCI6IDEsICJlcnJvcl9tZXNzYWdl
+        IjogbnVsbCwgInN0YXRlIjogInN1Y2Nlc3MiLCAiZXJyb3IiOiAiTm9uZSIs
+        ICJjdXJyZW50X3F1ZXJ5IjogImh0dHA6Ly9kYXZpZGQuZmVkb3JhcGVvcGxl
+        Lm9yZy9yZXBvcy9yYW5kb21fcHVwcGV0L21vZHVsZXMuanNvbiJ9fX0sICJx
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTIt
+        OC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWQwMDhhZGE0MGRi
+        MDRlZTBjMjEifSwgImlkIjogIjU2YjRhZDAwOGFkYTQwZGIwNGVlMGMyMSJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:08 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/af345524-3ff3-482b-8a20-7eed903fef2c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Owh7E9MHNQ3L8WAF9bHPyp7CwCSuEcOMR4RmwHvYw",
+        oauth_signature="CSBq07bnGNeQsLfKsmDJ8gBjiC4%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681349", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:09 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1125'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hZjM0NTUyNC0zZmYzLTQ4MmItOGEyMC03ZWVkOTAzZmVm
+        MmMvIiwgInRhc2tfaWQiOiAiYWYzNDU1MjQtM2ZmMy00ODJiLThhMjAtN2Vl
+        ZDkwM2ZlZjJjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMDVUMTQ6
+        MDk6MDRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        W10sICJwcm9ncmVzc19yZXBvcnQiOiB7InB1cHBldF9pbXBvcnRlciI6IHsi
+        bW9kdWxlcyI6IHsiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJleGVjdXRpb25f
+        dGltZSI6IG51bGwsICJ0b3RhbF9jb3VudCI6IDQsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAiaW5kaXZpZHVhbF9lcnJvcnMiOiBbXSwgInN0YXRlIjogInJ1bm5p
+        bmciLCAiZXJyb3JfY291bnQiOiAwLCAiZXJyb3IiOiAiTm9uZSIsICJmaW5p
+        c2hlZF9jb3VudCI6IDJ9LCAibWV0YWRhdGEiOiB7InF1ZXJ5X2ZpbmlzaGVk
+        X2NvdW50IjogMSwgInRyYWNlYmFjayI6IG51bGwsICJleGVjdXRpb25fdGlt
+        ZSI6IDEsICJxdWVyeV90b3RhbF9jb3VudCI6IDEsICJlcnJvcl9tZXNzYWdl
+        IjogbnVsbCwgInN0YXRlIjogInN1Y2Nlc3MiLCAiZXJyb3IiOiAiTm9uZSIs
+        ICJjdXJyZW50X3F1ZXJ5IjogImh0dHA6Ly9kYXZpZGQuZmVkb3JhcGVvcGxl
+        Lm9yZy9yZXBvcy9yYW5kb21fcHVwcGV0L21vZHVsZXMuanNvbiJ9fX0sICJx
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTIt
+        OC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWQwMDhhZGE0MGRi
+        MDRlZTBjMjEifSwgImlkIjogIjU2YjRhZDAwOGFkYTQwZGIwNGVlMGMyMSJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:09 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/af345524-3ff3-482b-8a20-7eed903fef2c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="6NAmRGEgzXCIAh0SQB1fB49z7AY0QYTVMtQXgkzy1so",
+        oauth_signature="CFhgctwFZCHDmYfLYCKkW76Z%2FU8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681350", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:10 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1125'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hZjM0NTUyNC0zZmYzLTQ4MmItOGEyMC03ZWVkOTAzZmVm
+        MmMvIiwgInRhc2tfaWQiOiAiYWYzNDU1MjQtM2ZmMy00ODJiLThhMjAtN2Vl
+        ZDkwM2ZlZjJjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDItMDVUMTQ6
+        MDk6MDRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        W10sICJwcm9ncmVzc19yZXBvcnQiOiB7InB1cHBldF9pbXBvcnRlciI6IHsi
+        bW9kdWxlcyI6IHsiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJleGVjdXRpb25f
+        dGltZSI6IG51bGwsICJ0b3RhbF9jb3VudCI6IDQsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAiaW5kaXZpZHVhbF9lcnJvcnMiOiBbXSwgInN0YXRlIjogInJ1bm5p
+        bmciLCAiZXJyb3JfY291bnQiOiAwLCAiZXJyb3IiOiAiTm9uZSIsICJmaW5p
+        c2hlZF9jb3VudCI6IDN9LCAibWV0YWRhdGEiOiB7InF1ZXJ5X2ZpbmlzaGVk
+        X2NvdW50IjogMSwgInRyYWNlYmFjayI6IG51bGwsICJleGVjdXRpb25fdGlt
+        ZSI6IDEsICJxdWVyeV90b3RhbF9jb3VudCI6IDEsICJlcnJvcl9tZXNzYWdl
+        IjogbnVsbCwgInN0YXRlIjogInN1Y2Nlc3MiLCAiZXJyb3IiOiAiTm9uZSIs
+        ICJjdXJyZW50X3F1ZXJ5IjogImh0dHA6Ly9kYXZpZGQuZmVkb3JhcGVvcGxl
+        Lm9yZy9yZXBvcy9yYW5kb21fcHVwcGV0L21vZHVsZXMuanNvbiJ9fX0sICJx
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTIt
+        OC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRl
+        bGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWQwMDhhZGE0MGRi
+        MDRlZTBjMjEifSwgImlkIjogIjU2YjRhZDAwOGFkYTQwZGIwNGVlMGMyMSJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:10 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/af345524-3ff3-482b-8a20-7eed903fef2c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="0VvnW4HPsYWSOLBojD01XIONnbfM48m9o1CJxRYwYI",
+        oauth_signature="Flm%2Br84A%2Fux71ycZsIIe8jx3gVM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681351", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:11 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1993'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hZjM0NTUyNC0zZmYzLTQ4MmItOGEyMC03ZWVkOTAzZmVm
+        MmMvIiwgInRhc2tfaWQiOiAiYWYzNDU1MjQtM2ZmMy00ODJiLThhMjAtN2Vl
+        ZDkwM2ZlZjJjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMDVU
+        MTQ6MDk6MTBaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
+        IjogIjIwMTYtMDItMDVUMTQ6MDk6MDRaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzc4YjkyMjA2LWJiNjktNDNjMy04ZTkyLTQ5N2FkZDRkZjYzYS8iLCAi
+        dGFza19pZCI6ICI3OGI5MjIwNi1iYjY5LTQzYzMtOGU5Mi00OTdhZGQ0ZGY2
+        M2EifSwgeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMzdiZjE3YmUt
+        MjJmMy00MzMxLWE1MjUtY2U5MmJiY2MwMzg3LyIsICJ0YXNrX2lkIjogIjM3
+        YmYxN2JlLTIyZjMtNDMzMS1hNTI1LWNlOTJiYmNjMDM4NyJ9LCB7Il9ocmVm
+        IjogIi9wdWxwL2FwaS92Mi90YXNrcy9iZTA0ZGRmYy1kN2YxLTRmMTMtOGM4
+        Yy02YTliY2FlZTc5ZTgvIiwgInRhc2tfaWQiOiAiYmUwNGRkZmMtZDdmMS00
+        ZjEzLThjOGMtNmE5YmNhZWU3OWU4In1dLCAicHJvZ3Jlc3NfcmVwb3J0Ijog
+        eyJwdXBwZXRfaW1wb3J0ZXIiOiB7Im1vZHVsZXMiOiB7ImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAiZXhlY3V0aW9uX3RpbWUiOiA0LCAidG90YWxfY291bnQi
+        OiA0LCAidHJhY2ViYWNrIjogbnVsbCwgImluZGl2aWR1YWxfZXJyb3JzIjog
+        W10sICJzdGF0ZSI6ICJzdWNjZXNzIiwgImVycm9yX2NvdW50IjogMCwgImVy
+        cm9yIjogIk5vbmUiLCAiZmluaXNoZWRfY291bnQiOiA0fSwgIm1ldGFkYXRh
+        IjogeyJxdWVyeV9maW5pc2hlZF9jb3VudCI6IDEsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAiZXhlY3V0aW9uX3RpbWUiOiAxLCAicXVlcnlfdG90YWxfY291bnQi
+        OiAxLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdGF0ZSI6ICJzdWNjZXNz
+        IiwgImVycm9yIjogIk5vbmUiLCAiY3VycmVudF9xdWVyeSI6ICJodHRwOi8v
+        ZGF2aWRkLmZlZG9yYXBlb3BsZS5vcmcvcmVwb3MvcmFuZG9tX3B1cHBldC9t
+        b2R1bGVzLmpzb24ifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0
+        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIs
+        ICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lk
+        IjogeyIkb2lkIjogIjU2YjRhY2ZlYzc4MjFiMzMwMzRiYWU3ZCJ9LCAiZXhj
+        ZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiNCIsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE0OjA5OjA0WiIsICJfbnMi
+        OiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDIt
+        MDVUMTQ6MDk6MTBaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAicHVwcGV0X2lt
+        cG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsi
+        dG90YWxfZXhlY3V0aW9uX3RpbWUiOiA1fSwgImFkZGVkX2NvdW50IjogMCwg
+        InJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6
+        ICI1NmI0YWQwNmM3ODIxYjM0NDRmY2MzMDAiLCAiZGV0YWlscyI6IHsiZmlu
+        aXNoZWRfY291bnQiOiA0LCAidG90YWxfY291bnQiOiA0LCAiZXJyb3JfY291
+        bnQiOiAwfX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFkMDA4YWRhNDBkYjA0ZWUwYzIxIn0sICJpZCI6ICI1NmI0YWQwMDhhZGE0
+        MGRiMDRlZTBjMjEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:11 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/78b92206-bb69-43c3-8e92-497add4df63a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="bCzAIU4nAtMEY0j6VQ2aP408z3Si9zBI8KomMFfU",
+        oauth_signature="16cEtU%2B50YGAOcNyZMfkj4KhEZA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681351", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:11 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1426'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy83OGI5MjIwNi1iYjY5LTQzYzMtOGU5Mi00OTdh
+        ZGQ0ZGY2M2EvIiwgInRhc2tfaWQiOiAiNzhiOTIyMDYtYmI2OS00M2MzLThl
+        OTItNDk3YWRkNGRmNjNhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0
+        IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogIjIw
+        MTYtMDItMDVUMTQ6MDk6MTFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
+        dGFydF90aW1lIjogIjIwMTYtMDItMDVUMTQ6MDk6MTBaIiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBv
+        cnQiOiB7IjRfcHVwcGV0IjogeyJtb2R1bGVzIjogeyJlcnJvcl9tZXNzYWdl
+        IjogbnVsbCwgImV4ZWN1dGlvbl90aW1lIjogMCwgInRvdGFsX2NvdW50Ijog
+        NCwgInRyYWNlYmFjayI6IG51bGwsICJpbmRpdmlkdWFsX2Vycm9ycyI6IG51
+        bGwsICJzdGF0ZSI6ICJzdWNjZXNzIiwgImVycm9yX2NvdW50IjogMCwgImVy
+        cm9yIjogIk5vbmUiLCAiZmluaXNoZWRfY291bnQiOiA0fSwgInB1Ymxpc2hp
+        bmciOiB7Imh0dHAiOiAic2tpcHBlZCIsICJodHRwcyI6ICJzdWNjZXNzIn0s
+        ICJtZXRhZGF0YSI6IHsiZXhlY3V0aW9uX3RpbWUiOiAwLCAic3RhdGUiOiAi
+        c3VjY2VzcyIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgImVycm9yIjogIk5v
+        bmUiLCAidHJhY2ViYWNrIjogbnVsbH19fSwgInF1ZXVlIjogInJlc2VydmVk
+        X3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNv
+        bS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhh
+        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJl
+        eGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICI0IiwgInN0YXJ0ZWQiOiAi
+        MjAxNi0wMi0wNVQxNDowOToxMFoiLCAiX25zIjogInJlcG9fcHVibGlzaF9y
+        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA1VDE0OjA5OjExWiIs
+        ICJ0cmFjZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJw
+        dXBwZXRfZGlzdHJpYnV0b3IiLCAic3VtbWFyeSI6IHsidG90YWxfZXhlY3V0
+        aW9uX3RpbWUiOiAwfSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJp
+        YnV0b3JfaWQiOiAiNF9wdXBwZXQiLCAiaWQiOiAiNTZiNGFkMDdjNzgyMWIz
+        NDQ0ZmNjMzAxIiwgImRldGFpbHMiOiB7fX0sICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNTZiNGFkMDY4YWRhNDBkYjA0ZWUwYzI2In0sICJp
+        ZCI6ICI1NmI0YWQwNjhhZGE0MGRiMDRlZTBjMjYifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:11 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/37bf17be-22f3-4331-a525-ce92bbcc0387/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="TwrRXZuheOsFfsKiQ8g9nm8F7mMrz2bYy22LmHcPg",
+        oauth_signature="nXrykdVOZI6vPvhrINDoivBOSKY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681351", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:11 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1050'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8zN2JmMTdiZS0yMmYzLTQzMzEtYTUyNS1jZTky
+        YmJjYzAzODcvIiwgInRhc2tfaWQiOiAiMzdiZjE3YmUtMjJmMy00MzMxLWE1
+        MjUtY2U5MmJiY2MwMzg3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0
+        IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogIjIw
+        MTYtMDItMDVUMTQ6MDk6MTFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
+        dGFydF90aW1lIjogIjIwMTYtMDItMDVUMTQ6MDk6MTFaIiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBv
+        cnQiOiB7fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
+        QGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJm
+        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0
+        IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAi
+        cmVwb19pZCI6ICI0IiwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNVQxNDowOTox
+        MVoiLCAiX25zIjogInJlcG9fcHVibGlzaF9yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDE2LTAyLTA1VDE0OjA5OjExWiIsICJ0cmFjZWJhY2siOiBudWxs
+        LCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJub2Rlc19odHRwX2Rpc3RyaWJ1
+        dG9yIiwgInN1bW1hcnkiOiAic3VjY2VlZGVkIiwgImVycm9yX21lc3NhZ2Ui
+        OiBudWxsLCAiZGlzdHJpYnV0b3JfaWQiOiAiNF9ub2RlcyIsICJpZCI6ICI1
+        NmI0YWQwN2M3ODIxYjM0NDRmY2MzMDIiLCAiZGV0YWlscyI6IHsidW5pdF9j
+        b3VudCI6IDR9fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        NmI0YWQwNjhhZGE0MGRiMDRlZTBjMjcifSwgImlkIjogIjU2YjRhZDA2OGFk
+        YTQwZGIwNGVlMGMyNyJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:11 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/be04ddfc-d7f1-4f13-8c8c-6a9bcaee79e8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="BJMas86Kdcpq4qwAR4hdvmGJU6fC4e1u78ulcMvpU",
+        oauth_signature="EyzepJC7JgBOCvlpjA%2BqrLXC10E%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681351", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:11 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '668'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9iZTA0ZGRmYy1kN2YxLTRmMTMtOGM4Yy02YTli
+        Y2FlZTc5ZTgvIiwgInRhc2tfaWQiOiAiYmUwNGRkZmMtZDdmMS00ZjEzLThj
+        OGMtNmE5YmNhZWU3OWU4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0
+        IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogbnVs
+        bCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYt
+        MDItMDVUMTQ6MDk6MTFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
+        X3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5l
+        eGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9u
+        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04
+        LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhZDA2OGFkYTQwZGIwNGVlMGMy
+        OCJ9LCAiaWQiOiAiNTZiNGFkMDY4YWRhNDBkYjA0ZWUwYzI4In0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:11 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/af345524-3ff3-482b-8a20-7eed903fef2c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="J8spwMucGYumWprLJZvICoT7OqNO5kbzHxdzIyff2tI",
+        oauth_signature="WCeESYQEKouiPc7RqPW%2FB9nIO8Q%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681353", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:13 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1993'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hZjM0NTUyNC0zZmYzLTQ4MmItOGEyMC03ZWVkOTAzZmVm
+        MmMvIiwgInRhc2tfaWQiOiAiYWYzNDU1MjQtM2ZmMy00ODJiLThhMjAtN2Vl
+        ZDkwM2ZlZjJjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDItMDVU
+        MTQ6MDk6MTBaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
+        IjogIjIwMTYtMDItMDVUMTQ6MDk6MDRaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzc4YjkyMjA2LWJiNjktNDNjMy04ZTkyLTQ5N2FkZDRkZjYzYS8iLCAi
+        dGFza19pZCI6ICI3OGI5MjIwNi1iYjY5LTQzYzMtOGU5Mi00OTdhZGQ0ZGY2
+        M2EifSwgeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMzdiZjE3YmUt
+        MjJmMy00MzMxLWE1MjUtY2U5MmJiY2MwMzg3LyIsICJ0YXNrX2lkIjogIjM3
+        YmYxN2JlLTIyZjMtNDMzMS1hNTI1LWNlOTJiYmNjMDM4NyJ9LCB7Il9ocmVm
+        IjogIi9wdWxwL2FwaS92Mi90YXNrcy9iZTA0ZGRmYy1kN2YxLTRmMTMtOGM4
+        Yy02YTliY2FlZTc5ZTgvIiwgInRhc2tfaWQiOiAiYmUwNGRkZmMtZDdmMS00
+        ZjEzLThjOGMtNmE5YmNhZWU3OWU4In1dLCAicHJvZ3Jlc3NfcmVwb3J0Ijog
+        eyJwdXBwZXRfaW1wb3J0ZXIiOiB7Im1vZHVsZXMiOiB7ImVycm9yX21lc3Nh
+        Z2UiOiBudWxsLCAiZXhlY3V0aW9uX3RpbWUiOiA0LCAidG90YWxfY291bnQi
+        OiA0LCAidHJhY2ViYWNrIjogbnVsbCwgImluZGl2aWR1YWxfZXJyb3JzIjog
+        W10sICJzdGF0ZSI6ICJzdWNjZXNzIiwgImVycm9yX2NvdW50IjogMCwgImVy
+        cm9yIjogIk5vbmUiLCAiZmluaXNoZWRfY291bnQiOiA0fSwgIm1ldGFkYXRh
+        IjogeyJxdWVyeV9maW5pc2hlZF9jb3VudCI6IDEsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAiZXhlY3V0aW9uX3RpbWUiOiAxLCAicXVlcnlfdG90YWxfY291bnQi
+        OiAxLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdGF0ZSI6ICJzdWNjZXNz
+        IiwgImVycm9yIjogIk5vbmUiLCAiY3VycmVudF9xdWVyeSI6ICJodHRwOi8v
+        ZGF2aWRkLmZlZG9yYXBlb3BsZS5vcmcvcmVwb3MvcmFuZG9tX3B1cHBldC9t
+        b2R1bGVzLmpzb24ifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0
+        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIs
+        ICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lk
+        IjogeyIkb2lkIjogIjU2YjRhY2ZlYzc4MjFiMzMwMzRiYWU3ZCJ9LCAiZXhj
+        ZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiNCIsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE0OjA5OjA0WiIsICJfbnMi
+        OiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDIt
+        MDVUMTQ6MDk6MTBaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAicHVwcGV0X2lt
+        cG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsi
+        dG90YWxfZXhlY3V0aW9uX3RpbWUiOiA1fSwgImFkZGVkX2NvdW50IjogMCwg
+        InJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6
+        ICI1NmI0YWQwNmM3ODIxYjM0NDRmY2MzMDAiLCAiZGV0YWlscyI6IHsiZmlu
+        aXNoZWRfY291bnQiOiA0LCAidG90YWxfY291bnQiOiA0LCAiZXJyb3JfY291
+        bnQiOiAwfX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFkMDA4YWRhNDBkYjA0ZWUwYzIxIn0sICJpZCI6ICI1NmI0YWQwMDhhZGE0
+        MGRiMDRlZTBjMjEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:13 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/78b92206-bb69-43c3-8e92-497add4df63a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="iKWBfkum7xApSLPl2mQmtO0WhrqMjj5K4XC9AtIk",
+        oauth_signature="1WYoj%2BMa1etftmJ5RBhOp5Y3kJQ%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681353", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:13 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1426'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy83OGI5MjIwNi1iYjY5LTQzYzMtOGU5Mi00OTdh
+        ZGQ0ZGY2M2EvIiwgInRhc2tfaWQiOiAiNzhiOTIyMDYtYmI2OS00M2MzLThl
+        OTItNDk3YWRkNGRmNjNhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0
+        IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogIjIw
+        MTYtMDItMDVUMTQ6MDk6MTFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
+        dGFydF90aW1lIjogIjIwMTYtMDItMDVUMTQ6MDk6MTBaIiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBv
+        cnQiOiB7IjRfcHVwcGV0IjogeyJtb2R1bGVzIjogeyJlcnJvcl9tZXNzYWdl
+        IjogbnVsbCwgImV4ZWN1dGlvbl90aW1lIjogMCwgInRvdGFsX2NvdW50Ijog
+        NCwgInRyYWNlYmFjayI6IG51bGwsICJpbmRpdmlkdWFsX2Vycm9ycyI6IG51
+        bGwsICJzdGF0ZSI6ICJzdWNjZXNzIiwgImVycm9yX2NvdW50IjogMCwgImVy
+        cm9yIjogIk5vbmUiLCAiZmluaXNoZWRfY291bnQiOiA0fSwgInB1Ymxpc2hp
+        bmciOiB7Imh0dHAiOiAic2tpcHBlZCIsICJodHRwcyI6ICJzdWNjZXNzIn0s
+        ICJtZXRhZGF0YSI6IHsiZXhlY3V0aW9uX3RpbWUiOiAwLCAic3RhdGUiOiAi
+        c3VjY2VzcyIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgImVycm9yIjogIk5v
+        bmUiLCAidHJhY2ViYWNrIjogbnVsbH19fSwgInF1ZXVlIjogInJlc2VydmVk
+        X3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNv
+        bS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhh
+        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJl
+        eGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICI0IiwgInN0YXJ0ZWQiOiAi
+        MjAxNi0wMi0wNVQxNDowOToxMFoiLCAiX25zIjogInJlcG9fcHVibGlzaF9y
+        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTAyLTA1VDE0OjA5OjExWiIs
+        ICJ0cmFjZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJw
+        dXBwZXRfZGlzdHJpYnV0b3IiLCAic3VtbWFyeSI6IHsidG90YWxfZXhlY3V0
+        aW9uX3RpbWUiOiAwfSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJp
+        YnV0b3JfaWQiOiAiNF9wdXBwZXQiLCAiaWQiOiAiNTZiNGFkMDdjNzgyMWIz
+        NDQ0ZmNjMzAxIiwgImRldGFpbHMiOiB7fX0sICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNTZiNGFkMDY4YWRhNDBkYjA0ZWUwYzI2In0sICJp
+        ZCI6ICI1NmI0YWQwNjhhZGE0MGRiMDRlZTBjMjYifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:13 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/37bf17be-22f3-4331-a525-ce92bbcc0387/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="RwBetmlk9gLOW8eFGqL5tAKUPZWxk5TB9uy9bA0MpGQ",
+        oauth_signature="0PLuFv5FJ%2FI2VK6AeiRQwCujXDo%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681353", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:13 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1050'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8zN2JmMTdiZS0yMmYzLTQzMzEtYTUyNS1jZTky
+        YmJjYzAzODcvIiwgInRhc2tfaWQiOiAiMzdiZjE3YmUtMjJmMy00MzMxLWE1
+        MjUtY2U5MmJiY2MwMzg3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0
+        IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogIjIw
+        MTYtMDItMDVUMTQ6MDk6MTFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
+        dGFydF90aW1lIjogIjIwMTYtMDItMDVUMTQ6MDk6MTFaIiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBv
+        cnQiOiB7fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
+        QGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJm
+        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0
+        IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAi
+        cmVwb19pZCI6ICI0IiwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNVQxNDowOTox
+        MVoiLCAiX25zIjogInJlcG9fcHVibGlzaF9yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDE2LTAyLTA1VDE0OjA5OjExWiIsICJ0cmFjZWJhY2siOiBudWxs
+        LCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJub2Rlc19odHRwX2Rpc3RyaWJ1
+        dG9yIiwgInN1bW1hcnkiOiAic3VjY2VlZGVkIiwgImVycm9yX21lc3NhZ2Ui
+        OiBudWxsLCAiZGlzdHJpYnV0b3JfaWQiOiAiNF9ub2RlcyIsICJpZCI6ICI1
+        NmI0YWQwN2M3ODIxYjM0NDRmY2MzMDIiLCAiZGV0YWlscyI6IHsidW5pdF9j
+        b3VudCI6IDR9fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        NmI0YWQwNjhhZGE0MGRiMDRlZTBjMjcifSwgImlkIjogIjU2YjRhZDA2OGFk
+        YTQwZGIwNGVlMGMyNyJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:13 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/be04ddfc-d7f1-4f13-8c8c-6a9bcaee79e8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="X72mFHmRwNbfHmgMxjz5pYVodNwDfUuPKCHPw8Y89s",
+        oauth_signature="oGBHlYm4YTQfG%2FfhiRANEvDxGac%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681353", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:13 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1302'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9iZTA0ZGRmYy1kN2YxLTRmMTMtOGM4Yy02YTli
+        Y2FlZTc5ZTgvIiwgInRhc2tfaWQiOiAiYmUwNGRkZmMtZDdmMS00ZjEzLThj
+        OGMtNmE5YmNhZWU3OWU4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0
+        IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogIjIw
+        MTYtMDItMDVUMTQ6MDk6MTJaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
+        dGFydF90aW1lIjogIjIwMTYtMDItMDVUMTQ6MDk6MTFaIiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBv
+        cnQiOiB7fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
+        QGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJm
+        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0
+        IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAi
+        cmVwb19pZCI6ICI0IiwgInN0YXJ0ZWQiOiAiMjAxNi0wMi0wNVQxNDowOTox
+        MVoiLCAiX25zIjogInJlcG9fcHVibGlzaF9yZXN1bHRzIiwgImNvbXBsZXRl
+        ZCI6ICIyMDE2LTAyLTA1VDE0OjA5OjEyWiIsICJ0cmFjZWJhY2siOiBudWxs
+        LCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJwdXBwZXRfaW5zdGFsbF9kaXN0
+        cmlidXRvciIsICJzdW1tYXJ5IjogInN1Y2Nlc3MiLCAiZXJyb3JfbWVzc2Fn
+        ZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICI0IiwgImlkIjogIjU2YjRh
+        ZDA4Yzc4MjFiMzQ0NGZjYzMwMyIsICJkZXRhaWxzIjogeyJlcnJvcnMiOiBb
+        XSwgInN1Y2Nlc3NfdW5pdF9rZXlzIjogW3sidmVyc2lvbiI6ICIwLjIuMCIs
+        ICJuYW1lIjogImh0dHBkIiwgImF1dGhvciI6ICI1dWJaM3IwIn0sIHsidmVy
+        c2lvbiI6ICIxLjAuMiIsICJuYW1lIjogInB1cmVmdHBkIiwgImF1dGhvciI6
+        ICJzYXoifSwgeyJ2ZXJzaW9uIjogIjAuMC4xIiwgIm5hbWUiOiAiY3JvbiIs
+        ICJhdXRob3IiOiAicHVwcGV0In0sIHsidmVyc2lvbiI6ICIwLjIuMCIsICJu
+        YW1lIjogInNhbWJhIiwgImF1dGhvciI6ICJwdXBwZXQifV19fSwgImVycm9y
+        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWQwNjhhZGE0MGRiMDRl
+        ZTBjMjgifSwgImlkIjogIjU2YjRhZDA2OGFkYTQwZGIwNGVlMGMyOCJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:13 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/4/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwdXBwZXRfbW9kdWxlIl0sImZp
+        ZWxkcyI6eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="22CZOKK5SLc0LF77Aj2cbfCEGTzGV3lWExRcejx5eM", oauth_signature="C20OWCJea4O52Nal8SxSe3MuqbY%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681353", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '90'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:13 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '916'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIzMWQwNzk2Ny1jNGFlLTRhYzUtODI4
+        YS03YTkwN2JlNmU5YTEiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwdXBwZXRf
+        bW9kdWxlIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFkMDM4YWRhNDBkYjA0
+        ZWUwYzIyIn0sICJ1bml0X2lkIjogIjMxZDA3OTY3LWM0YWUtNGFjNS04Mjhh
+        LTdhOTA3YmU2ZTlhMSIsICJ1bml0X3R5cGVfaWQiOiAicHVwcGV0X21vZHVs
+        ZSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNWRmMDAyZjYtNWZlZC00Mjdh
+        LTljMTktZjMzMzQzNTY2ZTM2IiwgIl9jb250ZW50X3R5cGVfaWQiOiAicHVw
+        cGV0X21vZHVsZSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2YjRhZDA0OGFkYTQw
+        ZGIwNGVlMGMyMyJ9LCAidW5pdF9pZCI6ICI1ZGYwMDJmNi01ZmVkLTQyN2Et
+        OWMxOS1mMzMzNDM1NjZlMzYiLCAidW5pdF90eXBlX2lkIjogInB1cHBldF9t
+        b2R1bGUifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjogImQ0NGE0YjQ5LWMwZTUt
+        NDA1MC05MjRlLWRjNmRjNDEwZTY4ZiIsICJfY29udGVudF90eXBlX2lkIjog
+        InB1cHBldF9tb2R1bGUifSwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWQwNjhh
+        ZGE0MGRiMDRlZTBjMjUifSwgInVuaXRfaWQiOiAiZDQ0YTRiNDktYzBlNS00
+        MDUwLTkyNGUtZGM2ZGM0MTBlNjhmIiwgInVuaXRfdHlwZV9pZCI6ICJwdXBw
+        ZXRfbW9kdWxlIn0sIHsibWV0YWRhdGEiOiB7Il9pZCI6ICJkYmMyZDY3OS1j
+        NmUwLTQ4NTgtYTQ4OC0wYzZkYmJmYzNlZTEiLCAiX2NvbnRlbnRfdHlwZV9p
+        ZCI6ICJwdXBwZXRfbW9kdWxlIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFk
+        MDU4YWRhNDBkYjA0ZWUwYzI0In0sICJ1bml0X2lkIjogImRiYzJkNjc5LWM2
+        ZTAtNDg1OC1hNDg4LTBjNmRiYmZjM2VlMSIsICJ1bml0X3R5cGVfaWQiOiAi
+        cHVwcGV0X21vZHVsZSJ9XQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:13 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/content/units/puppet_module/search/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMzFkMDc5
+        NjctYzRhZS00YWM1LTgyOGEtN2E5MDdiZTZlOWExIiwiNWRmMDAyZjYtNWZl
+        ZC00MjdhLTljMTktZjMzMzQzNTY2ZTM2IiwiZDQ0YTRiNDktYzBlNS00MDUw
+        LTkyNGUtZGM2ZGM0MTBlNjhmIiwiZGJjMmQ2NzktYzZlMC00ODU4LWE0ODgt
+        MGM2ZGJiZmMzZWUxIl19fX0sImluY2x1ZGVfcmVwb3MiOnRydWV9
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="u4rcGx0jRAK3AXcrrcSOK2tlUySN7SMLKTdBaDpwms", oauth_signature="UHa56qKr6x0Dk30nNc3CQWvJcrw%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681353", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '219'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:13 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '9732'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcHVwcGV0
+        X21vZHVsZS8zMWQwNzk2Ny1jNGFlLTRhYzUtODI4YS03YTkwN2JlNmU5YTEv
+        IiwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9p
+        ZCI6ICJwdXBwZXRfbW9kdWxlIiwgImNoZWNrc3VtcyI6IFtbImZpbGVzL2Rl
+        ZmxhdGUuY29uZiIsICIxZmM2NzhhYTk2N2Y0ZmQzYzgyMzhjOTExMTAxOWEx
+        ZCJdLCBbInNwZWMvc3BlYy5vcHRzIiwgImE2MDBkZWQ5OTVkOTQ4ZTM5M2Zi
+        ZTIzMjBiYThlNTFjIl0sIFsidGVtcGxhdGVzL2h0dHBkLmNvbmYuUkhFTC5l
+        cmIiLCAiNGNiY2MyOTc2NTM1NmFlYjlhMDFiZWVjZTY3MzhmZTgiXSwgWyJm
+        aWxlcy9zcGR5L21vZC1zcGR5LWJldGFfY3VycmVudF9pMzg2LnJwbSIsICI0
+        YWJkZWUzNTM5MmMxYzZkMzI5ZGVmMjAxNzM5MzQwMyJdLCBbInRlbXBsYXRl
+        cy9waHAuaW5pLlJIRUwuZXJiIiwgIjI1Y2JiNzYwZTVmY2Y4MTE2NWZiYzMz
+        Y2U5OGZlNmQ5Il0sIFsibWFuaWZlc3RzL3BhcmFtcy5wcCIsICJkMDJlYjg3
+        YTNlZDY5ZmY2MzhjYTAyOGI2NzAwMTYyMSJdLCBbImZpbGVzL2Vycm9yL2Vy
+        cm9yLmh0bWwiLCAiM2FmODQxMWM4MmEwNzI1YzBiYTZiYTBmYTY4MWJkMDgi
+        XSwgWyJmaWxlcy9zcGR5L21vZC1zcGR5LWJldGFfY3VycmVudF94ODZfNjQu
+        cnBtIiwgIjZkMjVkMDNiZmI4MjQ5ZjdjNmRjZDk5MDY5MDljOTk1Il0sIFsi
+        bWFuaWZlc3RzL3NzbC5wcCIsICI2ZDhhOWNhZjFhMTMxMzJiNmNkMjQ2NGRh
+        NjA2MjgxYiJdLCBbIm1hbmlmZXN0cy9pbml0LnBwIiwgImZjZDhjOGY5NzY3
+        MTBlYWM2NTMyYWRjMmYyOGJmYTQ0Il0sIFsibWFuaWZlc3RzL2Rldi5wcCIs
+        ICIxM2UwNTY0ZDM2NmYyNzY5NGIxMTVmODExMjQwNjQyOSJdLCBbIm1hbmlm
+        ZXN0cy92aG9zdC5wcCIsICI2ZWFjODQyMDFkMjM5NDM2YzM4NmZlMmFkZjRj
+        NDI1MiJdLCBbImZpbGVzL3NwZHkvbW9kLXNwZHktYmV0YV9jdXJyZW50X2kz
+        ODYuZGViIiwgIjdkNzI0NzRlMzk4M2YzOTBkYWY4OWYxMjg5ZTA4NTIxIl0s
+        IFsidGVtcGxhdGVzL3NzbC5jb25mLlJIRUwuZXJiIiwgImYxMTY2MThmYjg1
+        ZmZkZGEzY2VmMWZjZjVhODIxMGM4Il0sIFsibGliL3B1cHBldC9wcm92aWRl
+        ci9hMm1vZC9hMm1vZC5yYiIsICIwYWNmNDJkM2Q2NzBhOTkxNWM1YTNmNDZh
+        ZTczMzVmMSJdLCBbImxpYi9wdXBwZXQvcHJvdmlkZXIvYTJtb2QvbW9kZml4
+        LnJiIiwgImY0NTM2Y2RjYTY4ZDE1YTIzNWNiYjFlMGI2N2U0NDA2Il0sIFsi
+        dGVtcGxhdGVzL2xvY2FsaXplZC1lcnJvci1wYWdlcy5EZWJpYW4uZXJiIiwg
+        IjU3OGRmZDUzNzkxMWE3YjhkZGNkNDg1NjQwNDUyYWMzIl0sIFsic3BlYy9z
+        cGVjX2hlbHBlci5yYiIsICJjYTE5ZWM0ZjQ1MWViYzdmZGIwMzViNTJlYWU2
+        ZTkwOSJdLCBbIm1hbmlmZXN0cy9zcGR5LnBwIiwgImVmNzkyYjQxNDA4MjM2
+        YWVkYTdmNTdhNDI3ZjU3NGViIl0sIFsiZmlsZXMvc3BkeS9tb2Qtc3BkeS1i
+        ZXRhX2N1cnJlbnRfYW1kNjQuZGViIiwgIjgzNGM4NTAzOGFlNTAyNjBkYTNh
+        MDcwY2ZhMGNkYmRmIl0sIFsiTW9kdWxlZmlsZSIsICJlYTMzZTJkN2ZlNGQ5
+        N2VhZmEwNzE3MmM5MmMxMzBkYiJdLCBbIm1hbmlmZXN0cy9waHAucHAiLCAi
+        NTZlYTdmMjk3YWFhY2RkZTAwMWQzNTI5MDUxYjNjMGUiXSwgWyJ0ZW1wbGF0
+        ZXMvdmhvc3QtZGVmYXVsdC5jb25mLmVyYiIsICJlZDY0YTUzYWYwZDdiYWQ3
+        NjIxNzZhOThjOWVhM2U2MiJdLCBbIlJFQURNRSIsICI0YzliNDM2ZTQ4YTQ0
+        N2Q2MzRlYjgyMWMwNmZmZjZmYyJdLCBbInRlbXBsYXRlcy9waHAuaW5pLkRl
+        Ymlhbi5lcmIiLCAiMTgwYTM5Y2EyNjJlMTMyYzZkNDMxOTczOTg2ZDdlMzki
+        XSwgWyJsaWIvcHVwcGV0L3R5cGUvYTJtb2QucmIiLCAiYWRjZjc1NGEwNzYx
+        NTM0NDJlYWMyYmViNDI3MzY1NDciXV0sICJjaGlsZHJlbiI6IHt9LCAiYXV0
+        aG9yIjogIjV1YlozcjAiLCAicHJvamVjdF9wYWdlIjogIiIsICJzb3VyY2Ui
+        OiAiIiwgInZlcnNpb24iOiAiMC4yLjAiLCAicmVwb3NpdG9yeV9tZW1iZXJz
+        aGlwcyI6IFsiNCJdLCAiZGVzY3JpcHRpb24iOiAiVGhpcyBtb2R1bGUgaGFu
+        ZGxlcyBhIHN0YW5kYXJkIGh0dHBkIGluc3RhbGxhdGlvbi5cblxuSXQgaGFz
+        IG9wdGlvbmFsIGNsYXNzZXMgaWYgeW91IHdhbnQgdG8gaW5zdGFsbCBhbmQg
+        Y29uZmlndXJlIG1vZF9zc2wsIHBocCwgbW9kX3NwZHkgb3IgaHR0cGQtZGV2
+        LlxuXG5JdCBoYXMgYmVlbiB0ZXN0ZWQgb24gQ2VudE9TIDYuMiBhbmQgQ2Vu
+        dE9TIDUuOC5cbkl0IGNvdWxkIHdvcmsgYWxzbyBvbiBkZWJpYW4sIGJ1dCB0
+        aGF0IG5lZWRzIHRvIGJlIHRlc3RlZC4iLCAiX2xhc3RfdXBkYXRlZCI6ICIy
+        MDE2LTAyLTA1VDE0OjA5OjA3WiIsICJkb3dubG9hZGVkIjogdHJ1ZSwgImRl
+        cGVuZGVuY2llcyI6IFtdLCAidHlwZXMiOiBbeyJkb2MiOiAiTWFuYWdlIEFw
+        YWNoZSAyIG1vZHVsZXMgb24gRGViaWFuIGFuZCBVYnVudHUiLCAibmFtZSI6
+        ICJhMm1vZCIsICJwYXJhbWV0ZXJzIjogW3siZG9jIjogIlRoZSBuYW1lIG9m
+        IHRoZSBtb2R1bGUgdG8gYmUgbWFuYWdlZCIsICJuYW1lIjogIm5hbWUifV0s
+        ICJwcm92aWRlcnMiOiBbeyJkb2MiOiAiTWFuYWdlIEFwYWNoZSAyIG1vZHVs
+        ZXMgb24gRGViaWFuIGFuZCBVYnVudHUiLCAibmFtZSI6ICJhMm1vZCJ9LCB7
+        ImRvYyI6ICJEdW1teSBwcm92aWRlciBmb3IgQTJtb2QuXG5cbiAgICBGYWtl
+        IG5pbCByZXNvdXJjZXMgd2hlbiB0aGVyZSBpcyBubyBjcm9udGFiIGJpbmFy
+        eSBhdmFpbGFibGUuIEFsbG93c1xuICAgIHB1cHBldGQgdG8gcnVuIG9uIGEg
+        Ym9vdHN0cmFwcGVkIG1hY2hpbmUgYmVmb3JlIGEgQ3JvbiBwYWNrYWdlIGhh
+        cyBiZWVuXG4gICAgaW5zdGFsbGVkLiBXb3JrYXJvdW5kIGZvcjogaHR0cDov
+        L3Byb2plY3RzLnB1cHBldGxhYnMuY29tL2lzc3Vlcy8yMzg0XG4gICAgIiwg
+        Im5hbWUiOiAibW9kZml4In1dfV0sICJfc3RvcmFnZV9wYXRoIjogIi92YXIv
+        bGliL3B1bHAvY29udGVudC91bml0cy9wdXBwZXRfbW9kdWxlLzMxZDAvMzFk
+        MDc5NjctYzRhZS00YWM1LTgyOGEtN2E5MDdiZTZlOWExLzVVYlozcjAtaHR0
+        cGQtMC4yLjAudGFyLmd6IiwgIl9pZCI6ICIzMWQwNzk2Ny1jNGFlLTRhYzUt
+        ODI4YS03YTkwN2JlNmU5YTEiLCAibmFtZSI6ICJodHRwZCIsICJsaWNlbnNl
+        IjogIkdQTCB2MyIsICJjaGVja3N1bSI6ICIwMDQzMGRlYmI5OWU5NDE2YTBm
+        NzNlMTgxMjljNjNlZWU2NzkwMjNiY2RmMGQyNjc3NDJlYmU4ZmYxMGU5Yzk5
+        IiwgInN1bW1hcnkiOiAiVGhpcyBtb2R1bGUgaGFuZGxlcyBhIHN0YW5kYXJk
+        IGh0dHBkIGluc3RhbGxhdGlvbi4iLCAiY2hlY2tzdW1fdHlwZSI6ICJzaGEy
+        NTYiLCAidGFnX2xpc3QiOiBbXX0sIHsiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L2NvbnRlbnQvdW5pdHMvcHVwcGV0X21vZHVsZS81ZGYwMDJmNi01ZmVkLTQy
+        N2EtOWMxOS1mMzMzNDM1NjZlMzYvIiwgInB1bHBfdXNlcl9tZXRhZGF0YSI6
+        IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwdXBwZXRfbW9kdWxlIiwgImNo
+        ZWNrc3VtcyI6IFtbImZpbGVzXFxkZWJpYW5cXE1heENsaWVudHNOdW1iZXIi
+        LCAiMmE1MmE1ZTY1ZmMzYzQzZjQwOTU1MGRmYWQxZjkwNGYiXSwgWyJzcGVj
+        XFx1bml0XFxwdXBwZXRcXHR5cGVcXFJFQURNRS5tYXJrZG93biIsICJkZTI2
+        YTc2NDM4MTNhYmQ2YzJlN2UyODA3MWIxZWY5NCJdLCBbInNwZWNcXHVuaXRc
+        XHB1cHBldFxccHJvdmlkZXJcXFJFQURNRS5tYXJrZG93biIsICJlNTI2Njg5
+        NDRlZTZhZjJmYjVkNWI5ZTc5ODM0MjY0NSJdLCBbImZpbGVzXFxkZWJpYW5c
+        XERvbnRSZXNvbHZlIiwgImViNDU4NWFkOWZlMDQyNjc4MWVkN2M0OTI1MmY4
+        MjI1Il0sIFsidGVzdHNcXGluaXQucHAiLCAiNWQ2ZTg0YmQwNmUyM2M0ZDU2
+        NTc4MmRiNjdlMzMzZWMiXSwgWyJ0ZW1wbGF0ZXNcXGRlZmF1bHRfY29uZmln
+        LmVyYiIsICIyMjI5NDUxODljNWI4ZDRlZmE5ZmUyYzNjYzAxZjQzNSJdLCBb
+        InNwZWNcXFJFQURNRS5tYXJrZG93biIsICIzMmExZmMwMTIxYzI4YWZmNTU0
+        ZWY1ZDQyMmI4YjUxZSJdLCBbImZpbGVzXFxkZWJpYW5cXEFsdExvZyIsICJh
+        M2Q3Zjg5ZGM5MTYwNjIyMzQyMzdhY2Y3NWJkZTk3ZCJdLCBbIlJFQURNRS5t
+        ZCIsICI5Y2JiOTQ1YzZjZTczMDMxYjAwYjFjNTI2OWNiYjYzOCJdLCBbImZp
+        bGVzXFxkZWJpYW5cXENocm9vdEV2ZXJ5b25lIiwgImViNDU4NWFkOWZlMDQy
+        Njc4MWVkN2M0OTI1MmY4MjI1Il0sIFsiZmlsZXNcXGRlYmlhblxcTm9Bbm9u
+        eW1vdXMiLCAiZWI0NTg1YWQ5ZmUwNDI2NzgxZWQ3YzQ5MjUyZjgyMjUiXSwg
+        WyJmaWxlc1xcZGViaWFuXFxWZXJib3NlTG9nIiwgIjdmYTNiNzY3YzQ2MGI1
+        NGEyYmU0ZDQ5MDMwYjM0OWM3Il0sIFsiZmlsZXNcXGRlYmlhblxcUEFNQXV0
+        aGVudGljYXRpb24iLCAiZWI0NTg1YWQ5ZmUwNDI2NzgxZWQ3YzQ5MjUyZjgy
+        MjUiXSwgWyJtYW5pZmVzdHNcXHBhcmFtcy5wcCIsICJlN2IzY2YzYTYxMTVl
+        OTZhNmY3NmQzZmYyYzU0NTYyNSJdLCBbImZpbGVzXFxkZWJpYW5cXFB1cmVE
+        QiIsICI2ZGI1OTY1Njk4NTI3ZTFmMTQwZGZjNzNlZDQwZDQ3YyJdLCBbIm1h
+        bmlmZXN0c1xcY29uZmlnLnBwIiwgImIxMmQ2MzMxMzQ5ZDIxN2JiYmE2ODRh
+        MGM1NjUyNjIwIl0sIFsiZmlsZXNcXGRlYmlhblxcVW5peEF1dGhlbnRpY2F0
+        aW9uIiwgImViNDU4NWFkOWZlMDQyNjc4MWVkN2M0OTI1MmY4MjI1Il0sIFsi
+        bWFuaWZlc3RzXFxpbml0LnBwIiwgIjYxNjc1YTkwNWM0MDY0MWU3MGQ2Zjc0
+        OTg1ZmRhOGM4Il0sIFsiTW9kdWxlZmlsZSIsICJkZWNhYWFiMzJhOTkzMWMz
+        NTY1YTZmYzQ3ZjI2YTc0MCJdLCBbImZpbGVzXFxkZWJpYW5cXE1pblVJRCIs
+        ICI0ZmJhZmQ2OTQ4YjY1MjljYWEyYjc4ZTQ3NjM1OTg3NSJdLCBbIm1hbmlm
+        ZXN0c1xcc2VydmljZS5wcCIsICI3MjJkNjI2NTFlNmM2MWRhNDMzMDMzMmI2
+        MzgyZjVhOSJdLCBbInNwZWNcXHNwZWMub3B0cyIsICJhNjAwZGVkOTk1ZDk0
+        OGUzOTNmYmUyMzIwYmE4ZTUxYyJdLCBbInNwZWNcXHNwZWNfaGVscGVyLnJi
+        IiwgImNhMTllYzRmNDUxZWJjN2ZkYjAzNWI1MmVhZTZlOTA5Il0sIFsibWFu
+        aWZlc3RzXFxpbnN0YWxsLnBwIiwgIjUxY2FhMjVmOTBhNDc5Y2Q1MDE4MjQz
+        NjJiOWJkYmExIl1dLCAiY2hpbGRyZW4iOiB7fSwgImF1dGhvciI6ICJzYXoi
+        LCAicHJvamVjdF9wYWdlIjogImh0dHBzOi8vZ2l0aHViLmNvbS9zYXovcHVw
+        cGV0LXB1cmVmdHBkIiwgInNvdXJjZSI6ICIiLCAidmVyc2lvbiI6ICIxLjAu
+        MiIsICJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyI0Il0sICJkZXNjcmlw
+        dGlvbiI6ICJNYW5hZ2UgUHVyZS1GVFBkIHZpYSBQdXBwZXQiLCAiX2xhc3Rf
+        dXBkYXRlZCI6ICIyMDE2LTAyLTA1VDE0OjA5OjA4WiIsICJkb3dubG9hZGVk
+        IjogdHJ1ZSwgImRlcGVuZGVuY2llcyI6IFtdLCAidHlwZXMiOiBbXSwgIl9z
+        dG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVscC9jb250ZW50L3VuaXRzL3B1
+        cHBldF9tb2R1bGUvNWRmMC81ZGYwMDJmNi01ZmVkLTQyN2EtOWMxOS1mMzMz
+        NDM1NjZlMzYvNVViWjNyMC1wdXJlZnRwZC0xLjAuMi50YXIuZ3oiLCAiX2lk
+        IjogIjVkZjAwMmY2LTVmZWQtNDI3YS05YzE5LWYzMzM0MzU2NmUzNiIsICJu
+        YW1lIjogInB1cmVmdHBkIiwgImxpY2Vuc2UiOiAiQXBhY2hlIExpY2Vuc2Us
+        IFZlcnNpb24gMi4wIiwgImNoZWNrc3VtIjogImVlZjE4ZThiZDUxNjJhMDFk
+        ODA1Yzc2MzM1YjhhOTRjNDgwNjdlYTg0YTBlNmY5NGVkMWJlZWY1NWZhZWU4
+        MDkiLCAic3VtbWFyeSI6ICIiLCAiY2hlY2tzdW1fdHlwZSI6ICJzaGEyNTYi
+        LCAidGFnX2xpc3QiOiBbXX0sIHsiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2Nv
+        bnRlbnQvdW5pdHMvcHVwcGV0X21vZHVsZS9kNDRhNGI0OS1jMGU1LTQwNTAt
+        OTI0ZS1kYzZkYzQxMGU2OGYvIiwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9
+        LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwdXBwZXRfbW9kdWxlIiwgImNoZWNr
+        c3VtcyI6IFtbIm1hbmlmZXN0cy90YXNrLnBwIiwgIjRjYjRhYTQ5ZGY4Yzkw
+        NjE5ZDkwMzk5OTJhNTE2YzA3Il0sIFsic3BlYy9zcGVjLm9wdHMiLCAiYTYw
+        MGRlZDk5NWQ5NDhlMzkzZmJlMjMyMGJhOGU1MWMiXSwgWyJtYW5pZmVzdHMv
+        bW9udGhseS5wcCIsICJiOTkwMGY2ZTJkYjA4NTRmMzRjNjY5MzAyODdkYjcw
+        MCJdLCBbInRlc3RzL2luaXQucHAiLCAiNGJjYjdlMDNhY2VkOGJiNDY4MzUx
+        YTQ1ZThlOWJjNzYiXSwgWyJzcGVjL3NwZWNfaGVscGVyLnJiIiwgImNhMTll
+        YzRmNDUxZWJjN2ZkYjAzNWI1MmVhZTZlOTA5Il0sIFsibWFuaWZlc3RzL3dl
+        ZWtseS5wcCIsICI3ZDM0YTAwZDYyOTU3NWVlMmU0ZjRiZDU4ZWFiMWQ0MCJd
+        LCBbIm1hbmlmZXN0cy9kYWlseS5wcCIsICI5NmZmZDBlNTkyZGUzZjVkZDA1
+        NGRlMzc1NWE4YmNmZiJdLCBbIk1vZHVsZWZpbGUiLCAiMThjOTIwOGU3N2Ez
+        YzQzYjRkZjY1YWU4YmIzYmY4MDQiXSwgWyJtYW5pZmVzdHMvaW5pdC5wcCIs
+        ICI4YzNlMTBiYzNlMjQ2NTkwODQzNmYxYWE3NzFmMDM5YiJdLCBbIm1hbmlm
+        ZXN0cy9ob3VybHkucHAiLCAiN2ExNzYyMWE3MzE3NTBjNDBjODcyZTdhNWI2
+        ZjQ0NDIiXSwgWyJSRUFETUUiLCAiNDkxZTYzYTljZjc1ZjgyNTM2OTUyODk4
+        M2NhYWU4N2EiXSwgWyJtYW5pZmVzdHMvcGFyYW1zLnBwIiwgImQ1OTI0OTE4
+        ZmMwNTlkYWE0N2FhMzU1NTM0YTRiNDM0Il1dLCAiY2hpbGRyZW4iOiB7fSwg
+        ImF1dGhvciI6ICJwdXBwZXQiLCAicHJvamVjdF9wYWdlIjogImh0dHBzOi8v
+        Z2l0aHViLmNvbS81VWItWjNyMC9wdXBwZXQtY3JvbiIsICJzb3VyY2UiOiAi
+        aHR0cHM6Ly9naXRodWIuY29tLzVVYi1aM3IwL3B1cHBldC1jcm9uLmdpdCIs
+        ICJ2ZXJzaW9uIjogIjAuMC4xIiwgInJlcG9zaXRvcnlfbWVtYmVyc2hpcHMi
+        OiBbIjQiXSwgImRlc2NyaXB0aW9uIjogIlRoaXMgcHVwcGV0IG1vZHVsZSBt
+        YW5hZ2VzIHRoZSBzY2hlZHVsaW5nIG9mIHRhc2sgdHJvdWdoIGNyb24uXG5J
+        dCBoYXMgc2hvcnRjdXRzICBjbGFzc2VzIGZvciBob3VybHkgKC9ldGMvY3Jv
+        bi5ob3VybHkpLCBkYWlseSAoL2V0Yy9jcm9uLmRhaWx5KSwgd2Vla2x5ICgv
+        ZXRjL2Nyb24uZGFpbHkpIGFuZCBtb250aGx5ICgvZXRjL2Nyb24ubW9udGhs
+        eSkgc2NoZWR1bGF0aW9uLlxuXG5JdCBoYXMgYmVlbiB0ZXN0ZWQgb25seSAu
+        Li5cblxuVGVzdGVkIG9uIENlbnRPUyA2LjIsIFJIRUwgNi4yLCBDZW50T1Mg
+        NS44LlxuXG5SZXF1aXJlbWVudHM6XG5cbiAqIFtGYWN0ZXJdKGh0dHA6Ly93
+        d3cucHVwcGV0bGFicy5jb20vcHVwcGV0L3JlbGF0ZWQtcHJvamVjdHMvZmFj
+        dGVyLykgMS42LjEgb3IgZ3JlYXRlciAodmVyc2lvbnMgdGhhdCBzdXBwb3J0
+        IHRoZSBvc2ZhbWlseSBmYWN0KVxuICogW3B1cHBldGxhYnMvc3RkbGliXSBm
+        b3IgdGhlIHZhbGlkYXRlX2Fic29sdXRlX3BhdGggc3RhdGVtZW50XG5cblRv
+        ZG86XG4tIFNldCB1cCBhbmQgaW5zdGFsbCBjcm9uIGluIHRoZSAtIHZlcnkg
+        dW5saWtlbHkgLSBjYXNlIHRoYXQgaXQncyBub3QgaW5zdGFsbGVkO1xuLSBN
+        YWtlIGNyb246OnRhc2sgd29yayB3aXRoIHdpbmRvd3MuIiwgIl9sYXN0X3Vw
+        ZGF0ZWQiOiAiMjAxNi0wMi0wNVQxNDowOToxMFoiLCAiZG93bmxvYWRlZCI6
+        IHRydWUsICJkZXBlbmRlbmNpZXMiOiBbeyJuYW1lIjogInB1cHBldGxhYnMv
+        c3RkbGliIiwgInZlcnNpb25fcmVxdWlyZW1lbnQiOiAiPj0zLjAuMCJ9XSwg
+        InR5cGVzIjogW10sICJfc3RvcmFnZV9wYXRoIjogIi92YXIvbGliL3B1bHAv
+        Y29udGVudC91bml0cy9wdXBwZXRfbW9kdWxlL2Q0NGEvZDQ0YTRiNDktYzBl
+        NS00MDUwLTkyNGUtZGM2ZGM0MTBlNjhmLzVVYlozcjAtY3Jvbi0wLjAuMS50
+        YXIuZ3oiLCAiX2lkIjogImQ0NGE0YjQ5LWMwZTUtNDA1MC05MjRlLWRjNmRj
+        NDEwZTY4ZiIsICJuYW1lIjogImNyb24iLCAibGljZW5zZSI6ICJHUEwgdjMi
+        LCAiY2hlY2tzdW0iOiAiMGU5NDg1ZTAwNDI2MzZjMDk1MjIwNWNkNjdhZDY2
+        OTA0ZDBjNGY2YjM3ZWExOTJkMTViNzY0MjZlOTYxMDRhNiIsICJzdW1tYXJ5
+        IjogIlB1cHBldCBtb2R1bGUgdGhhdCBtYW5hZ2VzIHNjaGVkdWxpbmcgb2Yg
+        dGFzayB0cm91Z2ggY3JvbiIsICJjaGVja3N1bV90eXBlIjogInNoYTI1NiIs
+        ICJ0YWdfbGlzdCI6IFtdfSwgeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29u
+        dGVudC91bml0cy9wdXBwZXRfbW9kdWxlL2RiYzJkNjc5LWM2ZTAtNDg1OC1h
+        NDg4LTBjNmRiYmZjM2VlMS8iLCAicHVscF91c2VyX21ldGFkYXRhIjoge30s
+        ICJfY29udGVudF90eXBlX2lkIjogInB1cHBldF9tb2R1bGUiLCAiY2hlY2tz
+        dW1zIjogW1sibWFuaWZlc3RzL3NlcnZpY2UucHAiLCAiMTkyYzgxOTc5MWUy
+        MDQyNzAzODkxZTUxYTYxZDMxNGEiXSwgWyJNb2R1bGVmaWxlIiwgImQzMDll
+        ZTMxNTE3NmVhM2Y5MjM0ODBjMjg2ZTNhNTViIl0sIFsic3BlYy9zcGVjLm9w
+        dHMiLCAiYTYwMGRlZDk5NWQ5NDhlMzkzZmJlMjMyMGJhOGU1MWMiXSwgWyJ0
+        ZXN0cy9pbml0LnBwIiwgIjRkY2MyODY4Y2I5NzQwYzMyZWI2OGYzNDVhN2I3
+        MTk0Il0sIFsic3BlYy9zcGVjX2hlbHBlci5yYiIsICJjYTE5ZWM0ZjQ1MWVi
+        YzdmZGIwMzViNTJlYWU2ZTkwOSJdLCBbIm1hbmlmZXN0cy9jb25mLnBwIiwg
+        ImFkNGIyODVhNjczNmFlYmViYjZmYTU5ZTM4ZGRkZWQxIl0sIFsibWFuaWZl
+        c3RzL3BhcmFtcy5wcCIsICJmNDFkMTFlN2RiYmRlNjdhMmNmNGQyOWNmNjc4
+        M2E1NSJdLCBbIm1hbmlmZXN0cy9pbnN0YWxsLnBwIiwgImM5MjllMTNmNTQ2
+        YmNkYjNmMDJlZmVkZTlkYjFhZjliIl0sIFsibWFuaWZlc3RzL2luaXQucHAi
+        LCAiZjY1OGI1OTRhYzg4ZGE5MDI2YzY3NWJmZTAzMTBkNTciXSwgWyJSRUFE
+        TUUiLCAiNjI3ZmJiNTdlYjhkOTQzMDhmMDFhMTE0MzA0MThmYjYiXV0sICJj
+        aGlsZHJlbiI6IHt9LCAiYXV0aG9yIjogInB1cHBldCIsICJwcm9qZWN0X3Bh
+        Z2UiOiAiaHR0cHM6Ly9naXRodWIuY29tLzVVYi1aM3IwL3B1cHBldC1zYW1i
+        YSIsICJzb3VyY2UiOiAiaHR0cHM6Ly9naXRodWIuY29tLzVVYi1aM3IwL3B1
+        cHBldC1zYW1iYSIsICJ2ZXJzaW9uIjogIjAuMi4wIiwgInJlcG9zaXRvcnlf
+        bWVtYmVyc2hpcHMiOiBbIjQiXSwgImRlc2NyaXB0aW9uIjogIlRoaXMgcHVw
+        cGV0IG1vZHVsZSBtYW5hZ2VzIHNhbWJhIGNvbmZpZ3VyYXRpb24uXG5cbkl0
+        IGhhcyBiZWVuIHRlc3RlZCBvbmx5IGZvciBzYW1iYSBtYW5hZ2luZyBzaGFy
+        ZXMsIHRvdWdoIGl0IGRvZXMgbm90IGNhcmUgYWJvdXQgdGhlIGNvbnRlbnQg
+        b2YgeW91ciBjb25maWcgZmlsZS5cblxuVGVzdGVkIG9uIENlbnRPUyA2LjIs
+        IFJIRUwgNi4yLCBDZW50T1MgNS44LiIsICJfbGFzdF91cGRhdGVkIjogIjIw
+        MTYtMDItMDVUMTQ6MDk6MDlaIiwgImRvd25sb2FkZWQiOiB0cnVlLCAiZGVw
+        ZW5kZW5jaWVzIjogW10sICJ0eXBlcyI6IFtdLCAiX3N0b3JhZ2VfcGF0aCI6
+        ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQvdW5pdHMvcHVwcGV0X21vZHVsZS9k
+        YmMyL2RiYzJkNjc5LWM2ZTAtNDg1OC1hNDg4LTBjNmRiYmZjM2VlMS81VWJa
+        M3IwLXNhbWJhLTAuMi4wLnRhci5neiIsICJfaWQiOiAiZGJjMmQ2NzktYzZl
+        MC00ODU4LWE0ODgtMGM2ZGJiZmMzZWUxIiwgIm5hbWUiOiAic2FtYmEiLCAi
+        bGljZW5zZSI6ICJHUEwgdjMiLCAiY2hlY2tzdW0iOiAiYzc3MmRlY2Y3ODM2
+        ZTQyYTcyMTVjMmFlZTNmOGJkNzQyZTFjNDgwMzk0YTY1MGI2NTk0N2IzYzA4
+        MzI4NGNhYyIsICJzdW1tYXJ5IjogIkEgcHVwcGV0IG1vZHVsZSB0aGF0IG1h
+        bmFnZXMgc2FtYmEiLCAiY2hlY2tzdW1fdHlwZSI6ICJzaGEyNTYiLCAidGFn
+        X2xpc3QiOiBbXX1d
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:13 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/4/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwdXBwZXRfbW9kdWxlIl0sImZp
+        ZWxkcyI6eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="gN3Wgtg3qTEKcjkBhW2683GsGy1KJqboK1vOzEJW8", oauth_signature="ub6%2FZZ7kZ%2BY0l8L4AubkzDXt4h8%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681353", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '90'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:13 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '916'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIzMWQwNzk2Ny1jNGFlLTRhYzUtODI4
+        YS03YTkwN2JlNmU5YTEiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwdXBwZXRf
+        bW9kdWxlIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFkMDM4YWRhNDBkYjA0
+        ZWUwYzIyIn0sICJ1bml0X2lkIjogIjMxZDA3OTY3LWM0YWUtNGFjNS04Mjhh
+        LTdhOTA3YmU2ZTlhMSIsICJ1bml0X3R5cGVfaWQiOiAicHVwcGV0X21vZHVs
+        ZSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNWRmMDAyZjYtNWZlZC00Mjdh
+        LTljMTktZjMzMzQzNTY2ZTM2IiwgIl9jb250ZW50X3R5cGVfaWQiOiAicHVw
+        cGV0X21vZHVsZSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2YjRhZDA0OGFkYTQw
+        ZGIwNGVlMGMyMyJ9LCAidW5pdF9pZCI6ICI1ZGYwMDJmNi01ZmVkLTQyN2Et
+        OWMxOS1mMzMzNDM1NjZlMzYiLCAidW5pdF90eXBlX2lkIjogInB1cHBldF9t
+        b2R1bGUifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjogImQ0NGE0YjQ5LWMwZTUt
+        NDA1MC05MjRlLWRjNmRjNDEwZTY4ZiIsICJfY29udGVudF90eXBlX2lkIjog
+        InB1cHBldF9tb2R1bGUifSwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWQwNjhh
+        ZGE0MGRiMDRlZTBjMjUifSwgInVuaXRfaWQiOiAiZDQ0YTRiNDktYzBlNS00
+        MDUwLTkyNGUtZGM2ZGM0MTBlNjhmIiwgInVuaXRfdHlwZV9pZCI6ICJwdXBw
+        ZXRfbW9kdWxlIn0sIHsibWV0YWRhdGEiOiB7Il9pZCI6ICJkYmMyZDY3OS1j
+        NmUwLTQ4NTgtYTQ4OC0wYzZkYmJmYzNlZTEiLCAiX2NvbnRlbnRfdHlwZV9p
+        ZCI6ICJwdXBwZXRfbW9kdWxlIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFk
+        MDU4YWRhNDBkYjA0ZWUwYzI0In0sICJ1bml0X2lkIjogImRiYzJkNjc5LWM2
+        ZTAtNDg1OC1hNDg4LTBjNmRiYmZjM2VlMSIsICJ1bml0X3R5cGVfaWQiOiAi
+        cHVwcGV0X21vZHVsZSJ9XQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:13 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/content/units/puppet_module/search/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMzFkMDc5
+        NjctYzRhZS00YWM1LTgyOGEtN2E5MDdiZTZlOWExIl19fX0sImluY2x1ZGVf
+        cmVwb3MiOnRydWV9
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="c7qYEiakKUDtqBDUUUAZNuyMwBYdXXsS891T7kUs", oauth_signature="LsvPCVOse4ndYLQr10fxXlCgimo%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681353", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '102'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:13 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '3351'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcHVwcGV0
+        X21vZHVsZS8zMWQwNzk2Ny1jNGFlLTRhYzUtODI4YS03YTkwN2JlNmU5YTEv
+        IiwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9p
+        ZCI6ICJwdXBwZXRfbW9kdWxlIiwgImNoZWNrc3VtcyI6IFtbImZpbGVzL2Rl
+        ZmxhdGUuY29uZiIsICIxZmM2NzhhYTk2N2Y0ZmQzYzgyMzhjOTExMTAxOWEx
+        ZCJdLCBbInNwZWMvc3BlYy5vcHRzIiwgImE2MDBkZWQ5OTVkOTQ4ZTM5M2Zi
+        ZTIzMjBiYThlNTFjIl0sIFsidGVtcGxhdGVzL2h0dHBkLmNvbmYuUkhFTC5l
+        cmIiLCAiNGNiY2MyOTc2NTM1NmFlYjlhMDFiZWVjZTY3MzhmZTgiXSwgWyJm
+        aWxlcy9zcGR5L21vZC1zcGR5LWJldGFfY3VycmVudF9pMzg2LnJwbSIsICI0
+        YWJkZWUzNTM5MmMxYzZkMzI5ZGVmMjAxNzM5MzQwMyJdLCBbInRlbXBsYXRl
+        cy9waHAuaW5pLlJIRUwuZXJiIiwgIjI1Y2JiNzYwZTVmY2Y4MTE2NWZiYzMz
+        Y2U5OGZlNmQ5Il0sIFsibWFuaWZlc3RzL3BhcmFtcy5wcCIsICJkMDJlYjg3
+        YTNlZDY5ZmY2MzhjYTAyOGI2NzAwMTYyMSJdLCBbImZpbGVzL2Vycm9yL2Vy
+        cm9yLmh0bWwiLCAiM2FmODQxMWM4MmEwNzI1YzBiYTZiYTBmYTY4MWJkMDgi
+        XSwgWyJmaWxlcy9zcGR5L21vZC1zcGR5LWJldGFfY3VycmVudF94ODZfNjQu
+        cnBtIiwgIjZkMjVkMDNiZmI4MjQ5ZjdjNmRjZDk5MDY5MDljOTk1Il0sIFsi
+        bWFuaWZlc3RzL3NzbC5wcCIsICI2ZDhhOWNhZjFhMTMxMzJiNmNkMjQ2NGRh
+        NjA2MjgxYiJdLCBbIm1hbmlmZXN0cy9pbml0LnBwIiwgImZjZDhjOGY5NzY3
+        MTBlYWM2NTMyYWRjMmYyOGJmYTQ0Il0sIFsibWFuaWZlc3RzL2Rldi5wcCIs
+        ICIxM2UwNTY0ZDM2NmYyNzY5NGIxMTVmODExMjQwNjQyOSJdLCBbIm1hbmlm
+        ZXN0cy92aG9zdC5wcCIsICI2ZWFjODQyMDFkMjM5NDM2YzM4NmZlMmFkZjRj
+        NDI1MiJdLCBbImZpbGVzL3NwZHkvbW9kLXNwZHktYmV0YV9jdXJyZW50X2kz
+        ODYuZGViIiwgIjdkNzI0NzRlMzk4M2YzOTBkYWY4OWYxMjg5ZTA4NTIxIl0s
+        IFsidGVtcGxhdGVzL3NzbC5jb25mLlJIRUwuZXJiIiwgImYxMTY2MThmYjg1
+        ZmZkZGEzY2VmMWZjZjVhODIxMGM4Il0sIFsibGliL3B1cHBldC9wcm92aWRl
+        ci9hMm1vZC9hMm1vZC5yYiIsICIwYWNmNDJkM2Q2NzBhOTkxNWM1YTNmNDZh
+        ZTczMzVmMSJdLCBbImxpYi9wdXBwZXQvcHJvdmlkZXIvYTJtb2QvbW9kZml4
+        LnJiIiwgImY0NTM2Y2RjYTY4ZDE1YTIzNWNiYjFlMGI2N2U0NDA2Il0sIFsi
+        dGVtcGxhdGVzL2xvY2FsaXplZC1lcnJvci1wYWdlcy5EZWJpYW4uZXJiIiwg
+        IjU3OGRmZDUzNzkxMWE3YjhkZGNkNDg1NjQwNDUyYWMzIl0sIFsic3BlYy9z
+        cGVjX2hlbHBlci5yYiIsICJjYTE5ZWM0ZjQ1MWViYzdmZGIwMzViNTJlYWU2
+        ZTkwOSJdLCBbIm1hbmlmZXN0cy9zcGR5LnBwIiwgImVmNzkyYjQxNDA4MjM2
+        YWVkYTdmNTdhNDI3ZjU3NGViIl0sIFsiZmlsZXMvc3BkeS9tb2Qtc3BkeS1i
+        ZXRhX2N1cnJlbnRfYW1kNjQuZGViIiwgIjgzNGM4NTAzOGFlNTAyNjBkYTNh
+        MDcwY2ZhMGNkYmRmIl0sIFsiTW9kdWxlZmlsZSIsICJlYTMzZTJkN2ZlNGQ5
+        N2VhZmEwNzE3MmM5MmMxMzBkYiJdLCBbIm1hbmlmZXN0cy9waHAucHAiLCAi
+        NTZlYTdmMjk3YWFhY2RkZTAwMWQzNTI5MDUxYjNjMGUiXSwgWyJ0ZW1wbGF0
+        ZXMvdmhvc3QtZGVmYXVsdC5jb25mLmVyYiIsICJlZDY0YTUzYWYwZDdiYWQ3
+        NjIxNzZhOThjOWVhM2U2MiJdLCBbIlJFQURNRSIsICI0YzliNDM2ZTQ4YTQ0
+        N2Q2MzRlYjgyMWMwNmZmZjZmYyJdLCBbInRlbXBsYXRlcy9waHAuaW5pLkRl
+        Ymlhbi5lcmIiLCAiMTgwYTM5Y2EyNjJlMTMyYzZkNDMxOTczOTg2ZDdlMzki
+        XSwgWyJsaWIvcHVwcGV0L3R5cGUvYTJtb2QucmIiLCAiYWRjZjc1NGEwNzYx
+        NTM0NDJlYWMyYmViNDI3MzY1NDciXV0sICJjaGlsZHJlbiI6IHt9LCAiYXV0
+        aG9yIjogIjV1YlozcjAiLCAicHJvamVjdF9wYWdlIjogIiIsICJzb3VyY2Ui
+        OiAiIiwgInZlcnNpb24iOiAiMC4yLjAiLCAicmVwb3NpdG9yeV9tZW1iZXJz
+        aGlwcyI6IFsiNCJdLCAiZGVzY3JpcHRpb24iOiAiVGhpcyBtb2R1bGUgaGFu
+        ZGxlcyBhIHN0YW5kYXJkIGh0dHBkIGluc3RhbGxhdGlvbi5cblxuSXQgaGFz
+        IG9wdGlvbmFsIGNsYXNzZXMgaWYgeW91IHdhbnQgdG8gaW5zdGFsbCBhbmQg
+        Y29uZmlndXJlIG1vZF9zc2wsIHBocCwgbW9kX3NwZHkgb3IgaHR0cGQtZGV2
+        LlxuXG5JdCBoYXMgYmVlbiB0ZXN0ZWQgb24gQ2VudE9TIDYuMiBhbmQgQ2Vu
+        dE9TIDUuOC5cbkl0IGNvdWxkIHdvcmsgYWxzbyBvbiBkZWJpYW4sIGJ1dCB0
+        aGF0IG5lZWRzIHRvIGJlIHRlc3RlZC4iLCAiX2xhc3RfdXBkYXRlZCI6ICIy
+        MDE2LTAyLTA1VDE0OjA5OjA3WiIsICJkb3dubG9hZGVkIjogdHJ1ZSwgImRl
+        cGVuZGVuY2llcyI6IFtdLCAidHlwZXMiOiBbeyJkb2MiOiAiTWFuYWdlIEFw
+        YWNoZSAyIG1vZHVsZXMgb24gRGViaWFuIGFuZCBVYnVudHUiLCAibmFtZSI6
+        ICJhMm1vZCIsICJwYXJhbWV0ZXJzIjogW3siZG9jIjogIlRoZSBuYW1lIG9m
+        IHRoZSBtb2R1bGUgdG8gYmUgbWFuYWdlZCIsICJuYW1lIjogIm5hbWUifV0s
+        ICJwcm92aWRlcnMiOiBbeyJkb2MiOiAiTWFuYWdlIEFwYWNoZSAyIG1vZHVs
+        ZXMgb24gRGViaWFuIGFuZCBVYnVudHUiLCAibmFtZSI6ICJhMm1vZCJ9LCB7
+        ImRvYyI6ICJEdW1teSBwcm92aWRlciBmb3IgQTJtb2QuXG5cbiAgICBGYWtl
+        IG5pbCByZXNvdXJjZXMgd2hlbiB0aGVyZSBpcyBubyBjcm9udGFiIGJpbmFy
+        eSBhdmFpbGFibGUuIEFsbG93c1xuICAgIHB1cHBldGQgdG8gcnVuIG9uIGEg
+        Ym9vdHN0cmFwcGVkIG1hY2hpbmUgYmVmb3JlIGEgQ3JvbiBwYWNrYWdlIGhh
+        cyBiZWVuXG4gICAgaW5zdGFsbGVkLiBXb3JrYXJvdW5kIGZvcjogaHR0cDov
+        L3Byb2plY3RzLnB1cHBldGxhYnMuY29tL2lzc3Vlcy8yMzg0XG4gICAgIiwg
+        Im5hbWUiOiAibW9kZml4In1dfV0sICJfc3RvcmFnZV9wYXRoIjogIi92YXIv
+        bGliL3B1bHAvY29udGVudC91bml0cy9wdXBwZXRfbW9kdWxlLzMxZDAvMzFk
+        MDc5NjctYzRhZS00YWM1LTgyOGEtN2E5MDdiZTZlOWExLzVVYlozcjAtaHR0
+        cGQtMC4yLjAudGFyLmd6IiwgIl9pZCI6ICIzMWQwNzk2Ny1jNGFlLTRhYzUt
+        ODI4YS03YTkwN2JlNmU5YTEiLCAibmFtZSI6ICJodHRwZCIsICJsaWNlbnNl
+        IjogIkdQTCB2MyIsICJjaGVja3N1bSI6ICIwMDQzMGRlYmI5OWU5NDE2YTBm
+        NzNlMTgxMjljNjNlZWU2NzkwMjNiY2RmMGQyNjc3NDJlYmU4ZmYxMGU5Yzk5
+        IiwgInN1bW1hcnkiOiAiVGhpcyBtb2R1bGUgaGFuZGxlcyBhIHN0YW5kYXJk
+        IGh0dHBkIGluc3RhbGxhdGlvbi4iLCAiY2hlY2tzdW1fdHlwZSI6ICJzaGEy
+        NTYiLCAidGFnX2xpc3QiOiBbXX1d
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:13 GMT
+- request:
+    method: delete
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="YqKpLThI4fgtbRxwJpTSTKqTstSYnUBnhowtGEU6Gww",
+        oauth_signature="3DzxdBf9G%2BonaU9Q23pya9f%2B1ik%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681353", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:13 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzc2YTdmNTIwLWM4NDYtNDQ0OC05NDAxLWU0ZDljYzk3MTBmYy8iLCAi
+        dGFza19pZCI6ICI3NmE3ZjUyMC1jODQ2LTQ0NDgtOTQwMS1lNGQ5Y2M5NzEw
+        ZmMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:13 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/76a7f520-c846-4448-9401-e4d9cc9710fc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="9tRb2PDigjIBOFzOYPOV6inEDQM6QC7Z8NETZWTDc",
+        oauth_signature="5NZySdOQAhhS4wRhyuFOhn01tx0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681353", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:13 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '541'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83NmE3ZjUyMC1jODQ2LTQ0NDgtOTQwMS1lNGQ5Y2M5NzEw
+        ZmMvIiwgInRhc2tfaWQiOiAiNzZhN2Y1MjAtYzg0Ni00NDQ4LTk0MDEtZTRk
+        OWNjOTcxMGZjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiBudWxsLCAiX25z
+        IjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAidHJhY2Vi
+        YWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3Jl
+        cG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6ICJ3YWl0
+        aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51bGwsICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFkMDk4YWRhNDBk
+        YjA0ZWUwYzI5In0sICJpZCI6ICI1NmI0YWQwOThhZGE0MGRiMDRlZTBjMjki
+        fQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:13 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/76a7f520-c846-4448-9401-e4d9cc9710fc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="S9839fUu3oW7XRU68E0jWvfZrpbl2gjfWsWrdkru4u4",
+        oauth_signature="qvYURz%2FCnEtF%2BA3fkJloTF2Skfk%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681354", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:14 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '680'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83NmE3ZjUyMC1jODQ2LTQ0NDgtOTQwMS1lNGQ5Y2M5NzEw
+        ZmMvIiwgInRhc2tfaWQiOiAiNzZhN2Y1MjAtYzg0Ni00NDQ4LTk0MDEtZTRk
+        OWNjOTcxMGZjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wMi0w
+        NVQxNDowOToxM1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3Rp
+        bWUiOiAiMjAxNi0wMi0wNVQxNDowOToxM1oiLCAidHJhY2ViYWNrIjogbnVs
+        bCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9
+        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
+        by0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVk
+        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
+        QGthdGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhZDA5OGFk
+        YTQwZGIwNGVlMGMyOSJ9LCAiaWQiOiAiNTZiNGFkMDk4YWRhNDBkYjA0ZWUw
+        YzI5In0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:14 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/services/pulp/rpm.yml
+++ b/test/fixtures/vcr_cassettes/services/pulp/rpm.yml
@@ -1519,57 +1519,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:37:24 GMT
 - request:
-    method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
-        Ijp0cnVlfX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="f3aTwg1cjo7dHrUHTub1vUkHKsorGOhZhMEnQY18bJY", oauth_signature="4CLX3ATm1P%2BUhSkkMH0XsqRNVXo%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454629044", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '53'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:37:24 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2E3YzcxOTlmLWQxMDYtNDdhNS1hOWFlLTgzMGRjODQ4MmI4ZS8iLCAi
-        dGFza19pZCI6ICJhN2M3MTk5Zi1kMTA2LTQ3YTUtYTlhZS04MzBkYzg0ODJi
-        OGUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:37:24 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/a7c7199f-d106-47a5-a9ae-830dc8482b8e/
     body:
@@ -2254,89 +2203,6 @@ http_interactions:
   recorded_at: Thu, 04 Feb 2016 23:37:26 GMT
 - request:
     method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwiZmllbGRzIjp7InVu
-        aXQiOltdLCJhc3NvY2lhdGlvbiI6WyJ1bml0X2lkIl19fX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="WArtQpyx0s8nc35HuB5N2V4tr7UBrcE0rPGJZEYUmY", oauth_signature="MtIqDsfe27jzhk5Nt%2BTmDT2davE%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454629046", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '80'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:37:26 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '1672'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICI5MmJmMDE0ZC0wYTg0LTQwZWEtYWMw
-        Yy1kZGM1ZDUyZDFiNWMiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
-        Il9pZCI6IHsiJG9pZCI6ICI1NmIzZTBiNDg0YTA5YzA3ZGE5NzllYWUifSwg
-        InVuaXRfaWQiOiAiOTJiZjAxNGQtMGE4NC00MGVhLWFjMGMtZGRjNWQ1MmQx
-        YjVjIiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogIjI5NzFlZmNhLTk3ZTctNDBkMC05MTk5LTUxNThhZDgyYzYwMCIs
-        ICJfY29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjog
-        IjU2YjNlMGI0ODRhMDljMDdkYTk3OWVhYSJ9LCAidW5pdF9pZCI6ICIyOTcx
-        ZWZjYS05N2U3LTQwZDAtOTE5OS01MTU4YWQ4MmM2MDAiLCAidW5pdF90eXBl
-        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiYmZmZTdjZTgt
-        ZTc4ZS00MWYwLWE0MjktMjkyODM2NjE0YTJlIiwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiM2UwYjQ4NGEwOWMw
-        N2RhOTc5ZWE5In0sICJ1bml0X2lkIjogImJmZmU3Y2U4LWU3OGUtNDFmMC1h
-        NDI5LTI5MjgzNjYxNGEyZSIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
-        bWV0YWRhdGEiOiB7Il9pZCI6ICJiNWE2M2UyZS0zMzRjLTRlZDgtYjNjZi0w
-        YzE5YmI5N2Y0NTIiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1NmIzZTBiNDg0YTA5YzA3ZGE5NzllYWIifSwgInVu
-        aXRfaWQiOiAiYjVhNjNlMmUtMzM0Yy00ZWQ4LWIzY2YtMGMxOWJiOTdmNDUy
-        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lk
-        IjogImUwMmRjZTRhLTIwMWEtNDA5Ny04YmY0LTQ0ZTZhMzAyYjRiZCIsICJf
-        Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2
-        YjNlMGI0ODRhMDljMDdkYTk3OWVhYyJ9LCAidW5pdF9pZCI6ICJlMDJkY2U0
-        YS0yMDFhLTQwOTctOGJmNC00NGU2YTMwMmI0YmQiLCAidW5pdF90eXBlX2lk
-        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNjkzOTE3YTAtYTRm
-        ZS00OTg5LTk4ZmMtOTlkMmZkY2ZmN2ViIiwgIl9jb250ZW50X3R5cGVfaWQi
-        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiM2UwYjQ4NGEwOWMwN2Rh
-        OTc5ZWFkIn0sICJ1bml0X2lkIjogIjY5MzkxN2EwLWE0ZmUtNDk4OS05OGZj
-        LTk5ZDJmZGNmZjdlYiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
-        YWRhdGEiOiB7Il9pZCI6ICI3NmFlZTViMi03ZTc4LTQ2NzQtOGZhMy05Zjhl
-        ZDE1NDBiZTIiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NmIzZTBiNDg0YTA5YzA3ZGE5NzllYjAifSwgInVuaXRf
-        aWQiOiAiNzZhZWU1YjItN2U3OC00Njc0LThmYTMtOWY4ZWQxNTQwYmUyIiwg
-        InVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjog
-        ImIzNThlMDA3LTA0ZWQtNGE5Yi05Mzc1LWRiMTllYTA3Y2VhMSIsICJfY29u
-        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2YjNl
-        MGI0ODRhMDljMDdkYTk3OWVhZiJ9LCAidW5pdF9pZCI6ICJiMzU4ZTAwNy0w
-        NGVkLTRhOWItOTM3NS1kYjE5ZWEwN2NlYTEiLCAidW5pdF90eXBlX2lkIjog
-        InJwbSJ9XQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:37:26 GMT
-- request:
-    method: post
     uri: https://katello-devbox.example.com/pulp/api/v2/content/units/rpm/search/
     body:
       encoding: UTF-8
@@ -2476,89 +2342,6 @@ http_interactions:
   recorded_at: Thu, 04 Feb 2016 23:37:26 GMT
 - request:
     method: post
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwiZmllbGRzIjp7InVu
-        aXQiOltdLCJhc3NvY2lhdGlvbiI6WyJ1bml0X2lkIl19fX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="woCSqXOwq8OXhUThLxc0F7YZaJt8fMYZpsrkG8", oauth_signature="NN6CJWXrcd3dT7BRvmuFSF6RG3Y%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454629046", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      Content-Length:
-      - '80'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:37:26 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '1672'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICI5MmJmMDE0ZC0wYTg0LTQwZWEtYWMw
-        Yy1kZGM1ZDUyZDFiNWMiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
-        Il9pZCI6IHsiJG9pZCI6ICI1NmIzZTBiNDg0YTA5YzA3ZGE5NzllYWUifSwg
-        InVuaXRfaWQiOiAiOTJiZjAxNGQtMGE4NC00MGVhLWFjMGMtZGRjNWQ1MmQx
-        YjVjIiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogIjI5NzFlZmNhLTk3ZTctNDBkMC05MTk5LTUxNThhZDgyYzYwMCIs
-        ICJfY29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjog
-        IjU2YjNlMGI0ODRhMDljMDdkYTk3OWVhYSJ9LCAidW5pdF9pZCI6ICIyOTcx
-        ZWZjYS05N2U3LTQwZDAtOTE5OS01MTU4YWQ4MmM2MDAiLCAidW5pdF90eXBl
-        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiYmZmZTdjZTgt
-        ZTc4ZS00MWYwLWE0MjktMjkyODM2NjE0YTJlIiwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiM2UwYjQ4NGEwOWMw
-        N2RhOTc5ZWE5In0sICJ1bml0X2lkIjogImJmZmU3Y2U4LWU3OGUtNDFmMC1h
-        NDI5LTI5MjgzNjYxNGEyZSIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
-        bWV0YWRhdGEiOiB7Il9pZCI6ICJiNWE2M2UyZS0zMzRjLTRlZDgtYjNjZi0w
-        YzE5YmI5N2Y0NTIiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1NmIzZTBiNDg0YTA5YzA3ZGE5NzllYWIifSwgInVu
-        aXRfaWQiOiAiYjVhNjNlMmUtMzM0Yy00ZWQ4LWIzY2YtMGMxOWJiOTdmNDUy
-        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lk
-        IjogImUwMmRjZTRhLTIwMWEtNDA5Ny04YmY0LTQ0ZTZhMzAyYjRiZCIsICJf
-        Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2
-        YjNlMGI0ODRhMDljMDdkYTk3OWVhYyJ9LCAidW5pdF9pZCI6ICJlMDJkY2U0
-        YS0yMDFhLTQwOTctOGJmNC00NGU2YTMwMmI0YmQiLCAidW5pdF90eXBlX2lk
-        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNjkzOTE3YTAtYTRm
-        ZS00OTg5LTk4ZmMtOTlkMmZkY2ZmN2ViIiwgIl9jb250ZW50X3R5cGVfaWQi
-        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiM2UwYjQ4NGEwOWMwN2Rh
-        OTc5ZWFkIn0sICJ1bml0X2lkIjogIjY5MzkxN2EwLWE0ZmUtNDk4OS05OGZj
-        LTk5ZDJmZGNmZjdlYiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
-        YWRhdGEiOiB7Il9pZCI6ICI3NmFlZTViMi03ZTc4LTQ2NzQtOGZhMy05Zjhl
-        ZDE1NDBiZTIiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NmIzZTBiNDg0YTA5YzA3ZGE5NzllYjAifSwgInVuaXRf
-        aWQiOiAiNzZhZWU1YjItN2U3OC00Njc0LThmYTMtOWY4ZWQxNTQwYmUyIiwg
-        InVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjog
-        ImIzNThlMDA3LTA0ZWQtNGE5Yi05Mzc1LWRiMTllYTA3Y2VhMSIsICJfY29u
-        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2YjNl
-        MGI0ODRhMDljMDdkYTk3OWVhZiJ9LCAidW5pdF9pZCI6ICJiMzU4ZTAwNy0w
-        NGVkLTRhOWItOTM3NS1kYjE5ZWEwN2NlYTEiLCAidW5pdF90eXBlX2lkIjog
-        InJwbSJ9XQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:37:26 GMT
-- request:
-    method: post
     uri: https://katello-devbox.example.com/pulp/api/v2/content/units/rpm/search/
     body:
       encoding: UTF-8
@@ -2673,53 +2456,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:37:26 GMT
 - request:
-    method: delete
-    uri: https://katello-devbox.example.com/pulp/api/v2/repositories/Fedora_17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="7gOKHNvwpZGHxohB9o81kh9vVC6YU6OH0zzA3uyB0",
-        oauth_signature="HKztkNhJjLccoQpku%2F3psfdLceA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454629046", oauth_version="1.0"
-      Pulp-User:
-      - admin
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 04 Feb 2016 23:37:26 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Encoding:
-      - utf-8
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzY0Mzk4MWM5LTJhMWUtNDY2Yi05MzM2LTFjMmIxNzVkYmNmNi8iLCAi
-        dGFza19pZCI6ICI2NDM5ODFjOS0yYTFlLTQ2NmItOTMzNi0xYzJiMTc1ZGJj
-        ZjYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:37:26 GMT
-- request:
     method: get
     uri: https://katello-devbox.example.com/pulp/api/v2/tasks/643981c9-2a1e-466b-9336-1c2b175dbcf6/
     body:
@@ -2829,4 +2565,2476 @@ http_interactions:
         N2RiZjRkYzk0In0=
     http_version: 
   recorded_at: Thu, 04 Feb 2016 23:37:26 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ad277ae9-f555-4c44-bf64-6eaae27e95f4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="SnMKVUZBFhcRJgGEJ2cTuuiGCJ5MmIZcpKu7tBUQhk",
+        oauth_signature="%2BZKPsdRuhUZp6b%2B1AcFRfR1ta98%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681355", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:16 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hZDI3N2FlOS1mNTU1LTRjNDQtYmY2NC02ZWFhZTI3ZTk1
+        ZjQvIiwgInRhc2tfaWQiOiAiYWQyNzdhZTktZjU1NS00YzQ0LWJmNjQtNmVh
+        YWUyN2U5NWY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFkMGI4
+        YWRhNDBkYjA0ZWUwYzJhIn0sICJpZCI6ICI1NmI0YWQwYjhhZGE0MGRiMDRl
+        ZTBjMmEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:16 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ad277ae9-f555-4c44-bf64-6eaae27e95f4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="cfMvmqJEDTacAwcA2DKAwmIowz6HgZduSbe8mpGsA",
+        oauth_signature="j3d%2B46JCszd3s%2FKVLQqWyCwayB8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681356", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:16 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1084'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hZDI3N2FlOS1mNTU1LTRjNDQtYmY2NC02ZWFhZTI3ZTk1
+        ZjQvIiwgInRhc2tfaWQiOiAiYWQyNzdhZTktZjU1NS00YzQ0LWJmNjQtNmVh
+        YWUyN2U5NWY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0wNVQxNDowOToxNloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIklOX1BS
+        T0dSRVNTIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
+        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
+        by0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmci
+        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
+        a2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGws
+        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFkMGI4YWRh
+        NDBkYjA0ZWUwYzJhIn0sICJpZCI6ICI1NmI0YWQwYjhhZGE0MGRiMDRlZTBj
+        MmEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:16 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ad277ae9-f555-4c44-bf64-6eaae27e95f4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="H47vBBWKxEI5JJ5Dptq7zkq7hMU3MA37IPKrEe0tA",
+        oauth_signature="%2BevVaK7lTFhx6keheCldwdllJUo%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681357", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hZDI3N2FlOS1mNTU1LTRjNDQtYmY2NC02ZWFhZTI3ZTk1
+        ZjQvIiwgInRhc2tfaWQiOiAiYWQyNzdhZTktZjU1NS00YzQ0LWJmNjQtNmVh
+        YWUyN2U5NWY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowOToxNloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowOToxNloiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvYWZkZTRlM2UtNjViNi00MGM3LWI2YzUtOWJkYTFhMThh
+        YmEzLyIsICJ0YXNrX2lkIjogImFmZGU0ZTNlLTY1YjYtNDBjNy1iNmM1LTli
+        ZGExYTE4YWJhMyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        ZDBiYzc4MjFiMzMwMzRiYWU4MiJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDk6MTZaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowOTox
+        NloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFkMGNjNzgyMWIzNDQ0ZmNjMzA3IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFkMGI4YWRhNDBkYjA0ZWUwYzJhIn0s
+        ICJpZCI6ICI1NmI0YWQwYjhhZGE0MGRiMDRlZTBjMmEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:17 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/afde4e3e-65b6-40c7-b6c5-9bda1a18aba3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="DLmXAFeg9QVNgKjjqLFQ0E3xIPPtgy3HiIk4kJ8",
+        oauth_signature="3CUpwDZDr%2FXLjp78A9oVHGpkKRg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681357", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '3523'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9hZmRlNGUzZS02NWI2LTQwYzctYjZjNS05YmRh
+        MWExOGFiYTMvIiwgInRhc2tfaWQiOiAiYWZkZTRlM2UtNjViNi00MGM3LWI2
+        YzUtOWJkYTFhMThhYmEzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxNi0wMi0wNVQxNDowOToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzY2Q3
+        NzUxMy01MWU2LTQ0OGUtOWYzYi1hMTEwYmVhNDU4Y2IiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzQ4OTRhNzctZmJl
+        OS00YTkxLWFmYzgtYmFmYjVmYzJmMjA5IiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiYTQ1ZTRjMzgtZmFjMi00ZTI2LWEyYWMtY2E5MjBmZWNjM2EzIiwg
+        Im51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
+        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjhiMzI5ZWRhLTYyODUt
+        NDczMC1iYzVjLTQ3MzAxY2IzNDgyNiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI4NDdmNmY5My1hMjUyLTQwYzMtOGRhOC1kNDEwNjFhMDZhZDAi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5
+        cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjU3OTk5ZDAtYWE0
+        NC00NWE1LTk1MjYtNGVlZjgzYjg4MzZhIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiNjMyNDEzNDgtMjA5Ni00ZGYxLWJkZDktOTNlOTM4
+        NzcwOGZlIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAi
+        c3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiOTJmODJmMTYtOTg3Ny00MzQ4LTlhNTItNDNiNGM2YTI0ODJl
+        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
+        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjM4NTdmZGU1LWMwODktNGRiOS04YWZmLWNlNTczYmU5YzNhZSIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjog
+        InB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImY3MWVh
+        M2U5LTcyMDQtNDE5OS04N2E4LTlkMGFhMjU1ODJiYiIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
+        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDlmYjMz
+        NWQtNTYyOS00MjkxLWI0MmUtYTY1NmNiNjM2YWMxIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFkMGM4YWRhNDBkYjA0ZWUwYzNhIn0sICJpZCI6ICI1NmI0YWQwYzhhZGE0
+        MGRiMDRlZTBjM2EifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:17 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ad277ae9-f555-4c44-bf64-6eaae27e95f4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="GxxCHJitgrsXmdpTgElZSYRhegIuDwj3SqOOXvKzY",
+        oauth_signature="EqOzOdZro22Ta2%2FNZQT%2BESvTSMU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681358", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:18 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hZDI3N2FlOS1mNTU1LTRjNDQtYmY2NC02ZWFhZTI3ZTk1
+        ZjQvIiwgInRhc2tfaWQiOiAiYWQyNzdhZTktZjU1NS00YzQ0LWJmNjQtNmVh
+        YWUyN2U5NWY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowOToxNloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowOToxNloiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvYWZkZTRlM2UtNjViNi00MGM3LWI2YzUtOWJkYTFhMThh
+        YmEzLyIsICJ0YXNrX2lkIjogImFmZGU0ZTNlLTY1YjYtNDBjNy1iNmM1LTli
+        ZGExYTE4YWJhMyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        ZDBiYzc4MjFiMzMwMzRiYWU4MiJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDk6MTZaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowOTox
+        NloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFkMGNjNzgyMWIzNDQ0ZmNjMzA3IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFkMGI4YWRhNDBkYjA0ZWUwYzJhIn0s
+        ICJpZCI6ICI1NmI0YWQwYjhhZGE0MGRiMDRlZTBjMmEifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:18 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/afde4e3e-65b6-40c7-b6c5-9bda1a18aba3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="g4BR4bPUBkSaxVbSbdm6Dh8XXael0X6IIUXstH8lk",
+        oauth_signature="Gwv6rYzq2%2F5M55Dixn3u3LDhbl8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681358", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:18 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '6929'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9hZmRlNGUzZS02NWI2LTQwYzctYjZjNS05YmRh
+        MWExOGFiYTMvIiwgInRhc2tfaWQiOiAiYWZkZTRlM2UtNjViNi00MGM3LWI2
+        YzUtOWJkYTFhMThhYmEzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0wMi0wNVQxNDowOToxN1oiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowOToxN1oiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICIzY2Q3NzUxMy01MWU2LTQ0OGUtOWYzYi1hMTEwYmVh
+        NDU4Y2IiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiYzQ4OTRhNzctZmJlOS00YTkxLWFmYzgtYmFmYjVmYzJmMjA5Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
+        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiYTQ1ZTRjMzgtZmFjMi00ZTI2LWEyYWMt
+        Y2E5MjBmZWNjM2EzIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
+        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOGIz
+        MjllZGEtNjI4NS00NzMwLWJjNWMtNDczMDFjYjM0ODI2IiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjg0N2Y2ZjkzLWEyNTItNDBjMy04ZGE4LWQ0MTA2
+        MWEwNmFkMCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
+        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyNTc5OTlk
+        MC1hYTQ0LTQ1YTUtOTUyNi00ZWVmODNiODgzNmEiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI2MzI0MTM0OC0yMDk2LTRkZjEtYmRkOS05M2U5
+        Mzg3NzA4ZmUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
+        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI5MmY4MmYxNi05ODc3LTQzNDgtOWE1Mi00M2I0YzZhMjQ4MmUi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
+        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzODU3
+        ZmRlNS1jMDg5LTRkYjktOGFmZi1jZTU3M2JlOWMzYWUiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
+        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmNzFlYTNlOS03MjA0
+        LTQxOTktODdhOC05ZDBhYTI1NTgyYmIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
+        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA5ZmIzMzVkLTU2MjktNDI5
+        MS1iNDJlLWE2NTZjYjYzNmFjMSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
+        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE0OjA5OjE3
+        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMDVUMTQ6MDk6MTdaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
+        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
+        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
+        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
+        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
+        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
+        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
+        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
+        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGFkMGRjNzgyMWIz
+        NDQ0ZmNjMzA4IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
+        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
+        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogIjNjZDc3NTEzLTUxZTYtNDQ4ZS05ZjNiLWExMTBiZWE0NThj
+        YiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
+        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICJjNDg5NGE3Ny1mYmU5LTRhOTEtYWZjOC1iYWZiNWZjMmYyMDkiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
+        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJhNDVlNGMzOC1mYWMyLTRlMjYtYTJhYy1jYTky
+        MGZlY2MzYTMiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
+        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4YjMyOWVk
+        YS02Mjg1LTQ3MzAtYmM1Yy00NzMwMWNiMzQ4MjYiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiODQ3ZjZmOTMtYTI1Mi00MGMzLThkYTgtZDQxMDYxYTA2
+        YWQwIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI1Nzk5OWQwLWFh
+        NDQtNDVhNS05NTI2LTRlZWY4M2I4ODM2YSIsICJudW1fcHJvY2Vzc2VkIjog
+        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjYzMjQxMzQ4LTIwOTYtNGRmMS1iZGQ5LTkzZTkzODc3
+        MDhmZSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
+        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjkyZjgyZjE2LTk4NzctNDM0OC05YTUyLTQzYjRjNmEyNDgyZSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
+        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM4NTdmZGU1
+        LWMwODktNGRiOS04YWZmLWNlNTczYmU5YzNhZSIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
+        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImY3MWVhM2U5LTcyMDQtNDE5
+        OS04N2E4LTlkMGFhMjU1ODJiYiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
+        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDlmYjMzNWQtNTYyOS00MjkxLWI0
+        MmUtYTY1NmNiNjM2YWMxIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhZDBjOGFkYTQwZGIw
+        NGVlMGMzYSJ9LCAiaWQiOiAiNTZiNGFkMGM4YWRhNDBkYjA0ZWUwYzNhIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:18 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/bce560fa-9325-4652-8622-1aaa8e81c755/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="dqsADc8VSDPiJjTVs5jac4KzSaV0KDGuv9eOwbz3vw",
+        oauth_signature="t4Z%2BU1ar1ozeSEgig09iNVGITKM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681358", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:18 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iY2U1NjBmYS05MzI1LTQ2NTItODYyMi0xYWFhOGU4MWM3
+        NTUvIiwgInRhc2tfaWQiOiAiYmNlNTYwZmEtOTMyNS00NjUyLTg2MjItMWFh
+        YThlODFjNzU1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWQw
+        ZThhZGE0MGRiMDRlZTBjM2IifSwgImlkIjogIjU2YjRhZDBlOGFkYTQwZGIw
+        NGVlMGMzYiJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:18 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/bce560fa-9325-4652-8622-1aaa8e81c755/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="lcn9QaKKps3n0fwuZA0hjZ8RnHRRzSn1VlqkRVy4w",
+        oauth_signature="ggMPFXjd%2Fqkil5AUcYOikeXsEO8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681359", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:19 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iY2U1NjBmYS05MzI1LTQ2NTItODYyMi0xYWFhOGU4MWM3
+        NTUvIiwgInRhc2tfaWQiOiAiYmNlNTYwZmEtOTMyNS00NjUyLTg2MjItMWFh
+        YThlODFjNzU1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA5OjE5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA5OjE5WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFkMGU4YWRhNDBkYjA0ZWUwYzNiIn0sICJpZCI6ICI1NmI0YWQwZThhZGE0
+        MGRiMDRlZTBjM2IifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:19 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ce77ee42-a7d6-401b-9e80-ee17338d66d7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="2nFMgQvjlySZuJY87EpewtrvkxNAyjAk9C0mUeUaws",
+        oauth_signature="zQhp%2Fe40vXxAPCBHrGTsGLiYYnM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681360", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:20 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jZTc3ZWU0Mi1hN2Q2LTQwMWItOWU4MC1lZTE3MzM4ZDY2
+        ZDcvIiwgInRhc2tfaWQiOiAiY2U3N2VlNDItYTdkNi00MDFiLTllODAtZWUx
+        NzMzOGQ2NmQ3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFkMTA4
+        YWRhNDBkYjA0ZWUwYzNjIn0sICJpZCI6ICI1NmI0YWQxMDhhZGE0MGRiMDRl
+        ZTBjM2MifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:20 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ce77ee42-a7d6-401b-9e80-ee17338d66d7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="w33TAo8jVIPHV6N6CgCg2tot3MhvdzcgUPsWCkIo",
+        oauth_signature="fhAuipO%2BaIBv4DEIZLsYXTL2l10%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681361", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1078'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jZTc3ZWU0Mi1hN2Q2LTQwMWItOWU4MC1lZTE3MzM4ZDY2
+        ZDcvIiwgInRhc2tfaWQiOiAiY2U3N2VlNDItYTdkNi00MDFiLTllODAtZWUx
+        NzMzOGQ2NmQ3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
+        Mi0wNVQxNDowOToyMFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
+        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVl
+        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgt
+        ZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29y
+        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxs
+        by0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJv
+        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFkMTA4YWRhNDBkYjA0
+        ZWUwYzNjIn0sICJpZCI6ICI1NmI0YWQxMDhhZGE0MGRiMDRlZTBjM2MifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:21 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ce77ee42-a7d6-401b-9e80-ee17338d66d7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="8FEzI3iYBzH7RnmOKHMHRGl7Ex4mJ8rLpe1vTcKggs",
+        oauth_signature="erUOtAVP%2Fe73lD6865kPwlCn8d0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681361", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jZTc3ZWU0Mi1hN2Q2LTQwMWItOWU4MC1lZTE3MzM4ZDY2
+        ZDcvIiwgInRhc2tfaWQiOiAiY2U3N2VlNDItYTdkNi00MDFiLTllODAtZWUx
+        NzMzOGQ2NmQ3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowOToyMVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowOToyMFoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvN2IxYTY3NzItMTc1Yy00NDUxLWE0NjYtZWZlZmY1ZmQz
+        NTY5LyIsICJ0YXNrX2lkIjogIjdiMWE2NzcyLTE3NWMtNDQ1MS1hNDY2LWVm
+        ZWZmNWZkMzU2OSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        ZDEwYzc4MjFiMzMwNWNlNTE2NSJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDk6MjBaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowOToy
+        MVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFkMTFjNzgyMWIzNDQ0ZmNjMzBjIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFkMTA4YWRhNDBkYjA0ZWUwYzNjIn0s
+        ICJpZCI6ICI1NmI0YWQxMDhhZGE0MGRiMDRlZTBjM2MifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:21 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/7b1a6772-175c-4451-a466-efeff5fd3569/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="z7bp04VGtAfBPEtAypcyt0fFsZh0sJ8Y3hi9rAlETI",
+        oauth_signature="UvPftbAQO5XLpTRlBTksI0JQbKg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681361", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '6929'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy83YjFhNjc3Mi0xNzVjLTQ0NTEtYTQ2Ni1lZmVm
+        ZjVmZDM1NjkvIiwgInRhc2tfaWQiOiAiN2IxYTY3NzItMTc1Yy00NDUxLWE0
+        NjYtZWZlZmY1ZmQzNTY5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0wMi0wNVQxNDowOToyMVoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowOToyMVoiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICI1ZTE5Njc5ZS1kMDcwLTRmOWUtYWY4OC1jNmUwYzAz
+        ODg3NmMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiMjhlOWI3ZTUtNWY5My00ZGIxLWIyZWYtZGZhYTVjNTZmZWQ2Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
+        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMTFmYTE3ZjAtNjMyMi00OTViLTg4NjQt
+        M2NlMWIwMTA4Y2ZiIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
+        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjcy
+        YjAzOWMtMzY0OC00MmIxLTgxZmMtMTM1OGRhYTkxNDU5IiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogImMzZjI1MmIxLTY5MWItNDIwNy05ZDczLTY2NjI5
+        NDM5N2RjNyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
+        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkYjc4ZWVj
+        ZC0xODM3LTQxYWEtYWNkZS00MjE4OTJhMzAyM2YiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICIyYTQ2N2U1OC00ZTBjLTQ5NjQtYTM0Mi04M2Y1
+        ZmM2MjJkM2YiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
+        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI5YjIwZDMwMC0xYTY5LTQ2YzMtODI2Yy04NjU5ZjZiOTg3MTAi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
+        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3Yzk0
+        ZTcwYy04NjE2LTRlNTItYmNmMi1hMjhhN2U5Nzk1NWIiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
+        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkNjcyMjFmYy0wM2Rm
+        LTRjNTUtOWFmZi0wNzNkNDUzN2E3YmEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
+        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImMyZmRiZjM4LTc4NTctNDE2
+        My1iZDYyLTkyYzFjYTk0YjAyYSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
+        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE0OjA5OjIx
+        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMDVUMTQ6MDk6MjFaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
+        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
+        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
+        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
+        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
+        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
+        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
+        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
+        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGFkMTFjNzgyMWIz
+        NDQ0ZmNjMzBkIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
+        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
+        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogIjVlMTk2NzllLWQwNzAtNGY5ZS1hZjg4LWM2ZTBjMDM4ODc2
+        YyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
+        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICIyOGU5YjdlNS01ZjkzLTRkYjEtYjJlZi1kZmFhNWM1NmZlZDYiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
+        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICIxMWZhMTdmMC02MzIyLTQ5NWItODg2NC0zY2Ux
+        YjAxMDhjZmIiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
+        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmNzJiMDM5
+        Yy0zNjQ4LTQyYjEtODFmYy0xMzU4ZGFhOTE0NTkiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiYzNmMjUyYjEtNjkxYi00MjA3LTlkNzMtNjY2Mjk0Mzk3
+        ZGM3IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImRiNzhlZWNkLTE4
+        MzctNDFhYS1hY2RlLTQyMTg5MmEzMDIzZiIsICJudW1fcHJvY2Vzc2VkIjog
+        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjJhNDY3ZTU4LTRlMGMtNDk2NC1hMzQyLTgzZjVmYzYy
+        MmQzZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
+        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjliMjBkMzAwLTFhNjktNDZjMy04MjZjLTg2NTlmNmI5ODcxMCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
+        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdjOTRlNzBj
+        LTg2MTYtNGU1Mi1iY2YyLWEyOGE3ZTk3OTU1YiIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
+        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ2NzIyMWZjLTAzZGYtNGM1
+        NS05YWZmLTA3M2Q0NTM3YTdiYSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
+        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzJmZGJmMzgtNzg1Ny00MTYzLWJk
+        NjItOTJjMWNhOTRiMDJhIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhZDExOGFkYTQwZGIw
+        NGVlMGM0YyJ9LCAiaWQiOiAiNTZiNGFkMTE4YWRhNDBkYjA0ZWUwYzRjIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:22 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/c8485ad1-1ad5-4a8f-ab2d-8fd6fc2029a9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="KlfacajwBjN0Wfxj6h1B9ZPcghEhRej8j7XcIGVgo",
+        oauth_signature="lnPl111s5wUOK9QLO0DkZ7GaFek%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681362", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:22 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '651'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jODQ4NWFkMS0xYWQ1LTRhOGYtYWIyZC04ZmQ2ZmMyMDI5
+        YTkvIiwgInRhc2tfaWQiOiAiYzg0ODVhZDEtMWFkNS00YThmLWFiMmQtOGZk
+        NmZjMjAyOWE5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAi
+        c3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
+        ZXNvdXJjZV93b3JrZXItMUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1NmI0YWQxMjhhZGE0MGRiMDRlZTBjNGQifSwgImlkIjogIjU2YjRh
+        ZDEyOGFkYTQwZGIwNGVlMGM0ZCJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:22 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/c8485ad1-1ad5-4a8f-ab2d-8fd6fc2029a9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="zXsDxz5eLxKJV2vqErZ2HfRqkNREre4N5D8VJMU5NA",
+        oauth_signature="R%2BggIEJSQ1tfG6vXeF7dkZQ7rOc%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681363", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:23 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jODQ4NWFkMS0xYWQ1LTRhOGYtYWIyZC04ZmQ2ZmMyMDI5
+        YTkvIiwgInRhc2tfaWQiOiAiYzg0ODVhZDEtMWFkNS00YThmLWFiMmQtOGZk
+        NmZjMjAyOWE5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA5OjIyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA5OjIyWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFkMTI4YWRhNDBkYjA0ZWUwYzRkIn0sICJpZCI6ICI1NmI0YWQxMjhhZGE0
+        MGRiMDRlZTBjNGQifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:23 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
+        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
+        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
+        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
+        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbH0sIm5vdGVzIjp7Il9yZXBv
+        LXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1
+        dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9j
+        b25maWciOnsicmVsYXRpdmVfdXJsIjoidGVzdF9wYXRoIiwiaHR0cCI6ZmFs
+        c2UsImh0dHBzIjp0cnVlLCJwcm90ZWN0ZWQiOnRydWV9LCJhdXRvX3B1Ymxp
+        c2giOnRydWUsImRpc3RyaWJ1dG9yX2lkIjoiRmVkb3JhXzE3In0seyJkaXN0
+        cmlidXRvcl90eXBlX2lkIjoieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwiZGlz
+        dHJpYnV0b3JfY29uZmlnIjp7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lk
+        IjoiRmVkb3JhXzE3In0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1
+        dG9yX2lkIjoiRmVkb3JhXzE3X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBl
+        X2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmln
+        Ijp7Imh0dHAiOmZhbHNlLCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6
+        bnVsbH0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoi
+        ZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="yFiktWmZnuYpPWwLmJgs8yBE3mO2PcvBQddgdMjQo", oauth_signature="OIivZ1BMKMxYIVPx2lMi2cFG8Yc%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681364", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '787'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '320'
+      Location:
+      - https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
+        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
+        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NTZiNGFkMTRjNzgyMWIzMzA0MmQ5ZTU3In0sICJpZCI6ICJGZWRvcmFfMTci
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
+        MTcvIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:24 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
+        Ijp0cnVlfX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="oIPE4h5eHHcugQJmYEaaMsqxaMTr3DqKjgibGuIdss", oauth_signature="%2BcE0t5DGJQfxZnKB7FwtbxYnagY%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681364", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '53'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzQ1N2VkYzQ0LTMzMGItNDU2MS1iOTgyLTMyZDVjOWVhY2Q0Yy8iLCAi
+        dGFza19pZCI6ICI0NTdlZGM0NC0zMzBiLTQ1NjEtYjk4Mi0zMmQ1YzllYWNk
+        NGMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:24 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/457edc44-330b-4561-b982-32d5c9eacd4c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="62hnA7vBH3BceeqNoNDSp4Bfinmwsv0Ir4XhSW2Znk",
+        oauth_signature="2dtqbYtebomC2YefWHmR5VHoAhg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681364", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '547'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy80NTdlZGM0NC0zMzBiLTQ1NjEtYjk4Mi0zMmQ1YzllYWNk
+        NGMvIiwgInRhc2tfaWQiOiAiNDU3ZWRjNDQtMzMwYi00NTYxLWI5ODItMzJk
+        NWM5ZWFjZDRjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFkMTQ4
+        YWRhNDBkYjA0ZWUwYzRlIn0sICJpZCI6ICI1NmI0YWQxNDhhZGE0MGRiMDRl
+        ZTBjNGUifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:24 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/457edc44-330b-4561-b982-32d5c9eacd4c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="dCtJZvWBcENFDdARkqNhAAoVbLEv7RxWO8FuFYJhtQ",
+        oauth_signature="5fSHROU%2BHACtfW4NIcIVx6M7jqg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681365", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:25 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy80NTdlZGM0NC0zMzBiLTQ1NjEtYjk4Mi0zMmQ1YzllYWNk
+        NGMvIiwgInRhc2tfaWQiOiAiNDU3ZWRjNDQtMzMwYi00NTYxLWI5ODItMzJk
+        NWM5ZWFjZDRjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowOToyNVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowOToyNFoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvZWNkY2QwMDYtNmJjMS00NjkyLWFlN2YtYmU5Njc0Nzk0
+        MDdhLyIsICJ0YXNrX2lkIjogImVjZGNkMDA2LTZiYzEtNDY5Mi1hZTdmLWJl
+        OTY3NDc5NDA3YSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        ZDE0Yzc4MjFiMzMwNDJkOWU1OCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDk6MjRaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowOToy
+        NVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFkMTVjNzgyMWIzNDQ0ZmNjMzExIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFkMTQ4YWRhNDBkYjA0ZWUwYzRlIn0s
+        ICJpZCI6ICI1NmI0YWQxNDhhZGE0MGRiMDRlZTBjNGUifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:25 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ecdcd006-6bc1-4692-ae7f-be967479407a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="Jle0vAmO9wCpmE9H8ZwdPcrmTXOYz4UFEA0OmhGyV0",
+        oauth_signature="jn0WCMgIQpnH7WRAfwS4O7tpt1A%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681365", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:25 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '658'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9lY2RjZDAwNi02YmMxLTQ2OTItYWU3Zi1iZTk2
+        NzQ3OTQwN2EvIiwgInRhc2tfaWQiOiAiZWNkY2QwMDYtNmJjMS00NjkyLWFl
+        N2YtYmU5Njc0Nzk0MDdhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiBudWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBb
+        XSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRf
+        cmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVz
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1w
+        bGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQi
+        OiB7IiRvaWQiOiAiNTZiNGFkMTU4YWRhNDBkYjA0ZWUwYzVlIn0sICJpZCI6
+        ICI1NmI0YWQxNThhZGE0MGRiMDRlZTBjNWUifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:25 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/457edc44-330b-4561-b982-32d5c9eacd4c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="8K2KPKNj4GQeKp4zmcGyez2UjZwEKTN5uLKNN78E",
+        oauth_signature="JK0cl9MdI%2FsZdRkQv%2FCP%2BO71qzM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681365", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:25 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2194'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy80NTdlZGM0NC0zMzBiLTQ1NjEtYjk4Mi0zMmQ1YzllYWNk
+        NGMvIiwgInRhc2tfaWQiOiAiNDU3ZWRjNDQtMzMwYi00NTYxLWI5ODItMzJk
+        NWM5ZWFjZDRjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0wMi0wNVQxNDowOToyNVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowOToyNFoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvZWNkY2QwMDYtNmJjMS00NjkyLWFlN2YtYmU5Njc0Nzk0
+        MDdhLyIsICJ0YXNrX2lkIjogImVjZGNkMDA2LTZiYzEtNDY5Mi1hZTdmLWJl
+        OTY3NDc5NDA3YSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6
+        IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAa2F0ZWxsby0y
+        LTgtZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGth
+        dGVsbG8tMi04LWRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3Vs
+        dCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lkIjogeyIkb2lkIjogIjU2YjRh
+        ZDE0Yzc4MjFiMzMwNDJkOWU1OCJ9LCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJzdGFy
+        dGVkIjogIjIwMTYtMDItMDVUMTQ6MDk6MjRaIiwgIl9ucyI6ICJyZXBvX3N5
+        bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wMi0wNVQxNDowOToy
+        NVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXJy
+        b3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50IjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJkaXN0cmlidXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDAsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTZiNGFkMTVjNzgyMWIzNDQ0ZmNjMzExIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
+        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFkMTQ4YWRhNDBkYjA0ZWUwYzRlIn0s
+        ICJpZCI6ICI1NmI0YWQxNDhhZGE0MGRiMDRlZTBjNGUifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:25 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/ecdcd006-6bc1-4692-ae7f-be967479407a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="04gOaIDwS0vVWtIbZT2xrJLzPeG8oeKNpKqEdMKBgEw",
+        oauth_signature="uaTKcuY%2FJ6hNvTaCvht33%2F53JYY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681365", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:25 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '6929'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9lY2RjZDAwNi02YmMxLTQ2OTItYWU3Zi1iZTk2
+        NzQ3OTQwN2EvIiwgInRhc2tfaWQiOiAiZWNkY2QwMDYtNmJjMS00NjkyLWFl
+        N2YtYmU5Njc0Nzk0MDdhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0wMi0wNVQxNDowOToyNVoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wMi0wNVQxNDowOToyNVoiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICIxZTVlNTA0OC1jNDIwLTRkMjMtODZmZi1kMjRkOWZj
+        YTdhMGYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiY2Q2YTc5MjktNTY1Ny00YjU0LWE1NjItMmRjZWZiNzJhOTRmIiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
+        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZmE0OTUyYjAtMzQ5OS00ZDk5LWJkYTAt
+        YzBkODdjNDI1MDliIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
+        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWFm
+        MWUxZmMtZmFlOC00NjUwLTkyYTItZWQwZDZlNjgxMDRmIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogImE5NmIwNmRjLTYyMmEtNDIzNS1iOGU2LTVmOTUw
+        NGQzZjdlMyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
+        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjNGVmY2Uw
+        NC1lODFiLTRlODItYjNlMS1lZGFkNzQ3YjE1OGIiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJjYWYyZWZlMS00YjlkLTRkNGEtYmIzOC0yZTAz
+        MTg2Y2ZmN2MiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
+        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI2NWIwNmQ3Zi0wYzIyLTQ1YzctYTJlMi01ZjdjYjgwNTMxMjMi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
+        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0OWRi
+        ZTkxNy1hN2JkLTRmYjQtYTJlOC05NzkzNDkzZDQ4MTEiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
+        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0MmQ2ZmYzNS1mZmMy
+        LTQzMzMtOTc3Yy00YjI5MWQ4YWRkZGUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
+        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRiYWNjYzc0LTc4MjctNGE4
+        OS1hZjBmLWZiOWZjMjdkMTlmYSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGthdGVsbG8t
+        Mi04LWRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBr
+        YXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
+        ICJGZWRvcmFfMTciLCAic3RhcnRlZCI6ICIyMDE2LTAyLTA1VDE0OjA5OjI1
+        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTYtMDItMDVUMTQ6MDk6MjVaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
+        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0
+        aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJG
+        SU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwg
+        ImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlz
+        dHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5Ijog
+        IkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6
+        ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
+        dXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQiOiAiNTZiNGFkMTVjNzgyMWIz
+        NDQ0ZmNjMzEyIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJk
+        ZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJz
+        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogIjFlNWU1MDQ4LWM0MjAtNGQyMy04NmZmLWQyNGQ5ZmNhN2Ew
+        ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMi
+        LCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICJjZDZhNzkyOS01NjU3LTRiNTQtYTU2Mi0yZGNlZmI3MmE5NGYiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
+        ICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJmYTQ5NTJiMC0zNDk5LTRkOTktYmRhMC1jMGQ4
+        N2M0MjUwOWIiLCAibnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
+        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhYWYxZTFm
+        Yy1mYWU4LTQ2NTAtOTJhMi1lZDBkNmU2ODEwNGYiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiYTk2YjA2ZGMtNjIyYS00MjM1LWI4ZTYtNWY5NTA0ZDNm
+        N2UzIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM0ZWZjZTA0LWU4
+        MWItNGU4Mi1iM2UxLWVkYWQ3NDdiMTU4YiIsICJudW1fcHJvY2Vzc2VkIjog
+        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImNhZjJlZmUxLTRiOWQtNGQ0YS1iYjM4LTJlMDMxODZj
+        ZmY3YyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0
+        ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjY1YjA2ZDdmLTBjMjItNDVjNy1hMmUyLTVmN2NiODA1MzEyMyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBl
+        IjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQ5ZGJlOTE3
+        LWE3YmQtNGZiNC1hMmU4LTk3OTM0OTNkNDgxMSIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
+        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQyZDZmZjM1LWZmYzItNDMz
+        My05NzdjLTRiMjkxZDhhZGRkZSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
+        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGJhY2NjNzQtNzgyNy00YTg5LWFm
+        MGYtZmI5ZmMyN2QxOWZhIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU2YjRhZDE1OGFkYTQwZGIw
+        NGVlMGM1ZSJ9LCAiaWQiOiAiNTZiNGFkMTU4YWRhNDBkYjA0ZWUwYzVlIn0=
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:25 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwiZmllbGRzIjp7InVu
+        aXQiOltdLCJhc3NvY2lhdGlvbiI6WyJ1bml0X2lkIl19fX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="OY5dL0SXR0zfPyT32kCz0pLvg1vB1wKwMOVudFMI8", oauth_signature="fYKsTrxgF2VmmK02gfe39NoTVeg%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681366", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '80'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:26 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1672'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIwYjUzZGRkMC0yZTk1LTRlMTktOTY4
+        OS02YTdiODIwZGVmNTYiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmI0YWQxNDhhZGE0MGRiMDRlZTBjNGYifSwg
+        InVuaXRfaWQiOiAiMGI1M2RkZDAtMmU5NS00ZTE5LTk2ODktNmE3YjgyMGRl
+        ZjU2IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
+        X2lkIjogIjE2OGQ0N2IxLTEzMTgtNDQ5ZC05MmVhLWZlZDIxZjVjNjJkZCIs
+        ICJfY29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjog
+        IjU2YjRhZDE0OGFkYTQwZGIwNGVlMGM1MCJ9LCAidW5pdF9pZCI6ICIxNjhk
+        NDdiMS0xMzE4LTQ0OWQtOTJlYS1mZWQyMWY1YzYyZGQiLCAidW5pdF90eXBl
+        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNjFkYjdiMjEt
+        YzkxMy00OTlhLTgzYzctYTk3OWExMzE4MDQxIiwgIl9jb250ZW50X3R5cGVf
+        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFkMTQ4YWRhNDBk
+        YjA0ZWUwYzUyIn0sICJ1bml0X2lkIjogIjYxZGI3YjIxLWM5MTMtNDk5YS04
+        M2M3LWE5NzlhMTMxODA0MSIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
+        bWV0YWRhdGEiOiB7Il9pZCI6ICI2OGI2N2M5Yy05NzY0LTQ5ZjEtYTZhYy0z
+        NWFiMzcyYWIxMDMiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1NmI0YWQxNDhhZGE0MGRiMDRlZTBjNTEifSwgInVu
+        aXRfaWQiOiAiNjhiNjdjOWMtOTc2NC00OWYxLWE2YWMtMzVhYjM3MmFiMTAz
+        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lk
+        IjogIjdmYTExOGZlLThhZTQtNGJhOC1iZjRmLTZkM2NhOTYwZTZjYSIsICJf
+        Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2
+        YjRhZDE0OGFkYTQwZGIwNGVlMGM1NSJ9LCAidW5pdF9pZCI6ICI3ZmExMThm
+        ZS04YWU0LTRiYTgtYmY0Zi02ZDNjYTk2MGU2Y2EiLCAidW5pdF90eXBlX2lk
+        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiYTg2NGVjZjUtMGZj
+        Ni00ZjIzLWJkODEtNjk2NzA1OThjZGFiIiwgIl9jb250ZW50X3R5cGVfaWQi
+        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFkMTQ4YWRhNDBkYjA0
+        ZWUwYzUzIn0sICJ1bml0X2lkIjogImE4NjRlY2Y1LTBmYzYtNGYyMy1iZDgx
+        LTY5NjcwNTk4Y2RhYiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
+        YWRhdGEiOiB7Il9pZCI6ICJhYzgyYjNmZC1kY2QyLTRiYWYtYjg2NC0wMjUz
+        ZWJkMjNiMjciLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
+        IHsiJG9pZCI6ICI1NmI0YWQxNDhhZGE0MGRiMDRlZTBjNTQifSwgInVuaXRf
+        aWQiOiAiYWM4MmIzZmQtZGNkMi00YmFmLWI4NjQtMDI1M2ViZDIzYjI3Iiwg
+        InVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjog
+        ImQ0YTAwMmM0LWJlYjYtNDliYy04ODAxLTQwNDYxNjhhYzRhYiIsICJfY29u
+        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2YjRh
+        ZDE0OGFkYTQwZGIwNGVlMGM1NiJ9LCAidW5pdF9pZCI6ICJkNGEwMDJjNC1i
+        ZWI2LTQ5YmMtODgwMS00MDQ2MTY4YWM0YWIiLCAidW5pdF90eXBlX2lkIjog
+        InJwbSJ9XQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:26 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/content/units/rpm/search/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMGI1M2Rk
+        ZDAtMmU5NS00ZTE5LTk2ODktNmE3YjgyMGRlZjU2IiwiMTY4ZDQ3YjEtMTMx
+        OC00NDlkLTkyZWEtZmVkMjFmNWM2MmRkIiwiNjFkYjdiMjEtYzkxMy00OTlh
+        LTgzYzctYTk3OWExMzE4MDQxIiwiNjhiNjdjOWMtOTc2NC00OWYxLWE2YWMt
+        MzVhYjM3MmFiMTAzIiwiN2ZhMTE4ZmUtOGFlNC00YmE4LWJmNGYtNmQzY2E5
+        NjBlNmNhIiwiYTg2NGVjZjUtMGZjNi00ZjIzLWJkODEtNjk2NzA1OThjZGFi
+        IiwiYWM4MmIzZmQtZGNkMi00YmFmLWI4NjQtMDI1M2ViZDIzYjI3IiwiZDRh
+        MDAyYzQtYmViNi00OWJjLTg4MDEtNDA0NjE2OGFjNGFiIl19fSwiZmllbGRz
+        IjpbIm5hbWUiLCJ2ZXJzaW9uIiwicmVsZWFzZSIsImFyY2giLCJlcG9jaCIs
+        InN1bW1hcnkiLCJzb3VyY2VycG0iLCJjaGVja3N1bSIsImZpbGVuYW1lIiwi
+        X2lkIl19LCJpbmNsdWRlX3JlcG9zIjp0cnVlfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="addWKim5TPjFqgnADZuLqJ3oqyt2AX6hKvnjJtgEQMo", oauth_signature="D7aeWGDHCGOuR5ipxTBZDaV7t4Q%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681366", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '478'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:26 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '3804'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJz
+        b3VyY2VycG0iOiAibW9ua2V5LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjog
+        Im1vbmtleSIsICJjaGVja3N1bSI6ICIwZThmYTUwZDAxMjhmYmFiYzdjY2M1
+        NjMyZTNmYTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwg
+        InN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIsICJmaWxl
+        bmFtZSI6ICJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjog
+        IjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lk
+        IjogIjBiNTNkZGQwLTJlOTUtNGUxOS05Njg5LTZhN2I4MjBkZWY1NiIsICJh
+        cmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBtLzBiNTNkZGQwLTJlOTUtNGUx
+        OS05Njg5LTZhN2I4MjBkZWY1Ni8ifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNo
+        aXBzIjogWyJGZWRvcmFfMTciXSwgInNvdXJjZXJwbSI6ICJ3YWxydXMtMC4z
+        LTAuOC5zcmMucnBtIiwgIm5hbWUiOiAid2FscnVzIiwgImNoZWNrc3VtIjog
+        IjZlOGQ2ZGMwNTdlM2UyYzk4MTlmMGRjN2U2YzdiN2Y4NmJmMmU4NTcxYmJh
+        NDE0YWRlYzdmYjYyMWE0NjFkZmQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBh
+        Y2thZ2Ugb2Ygd2FscnVzIiwgImZpbGVuYW1lIjogIndhbHJ1cy0wLjMtMC44
+        Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIs
+        ICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiMTY4ZDQ3YjEtMTMxOC00NDlk
+        LTkyZWEtZmVkMjFmNWM2MmRkIiwgImFyY2giOiAibm9hcmNoIiwgImNoaWxk
+        cmVuIjoge30sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0
+        cy9ycG0vMTY4ZDQ3YjEtMTMxOC00NDlkLTkyZWEtZmVkMjFmNWM2MmRkLyJ9
+        LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBbIkZlZG9yYV8xNyJdLCAi
+        c291cmNlcnBtIjogInNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsICJuYW1l
+        IjogInNxdWlycmVsIiwgImNoZWNrc3VtIjogIjI1MTc2OGJkZDE1ZjEzZDc4
+        NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3
+        ZDIiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwi
+        LCAiZmlsZW5hbWUiOiAic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwg
+        ImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIw
+        LjgiLCAiX2lkIjogIjYxZGI3YjIxLWM5MTMtNDk5YS04M2M3LWE5NzlhMTMx
+        ODA0MSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hy
+        ZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBtLzYxZGI3YjIx
+        LWM5MTMtNDk5YS04M2M3LWE5NzlhMTMxODA0MS8ifSwgeyJyZXBvc2l0b3J5
+        X21lbWJlcnNoaXBzIjogWyJGZWRvcmFfMTciXSwgInNvdXJjZXJwbSI6ICJw
+        ZW5ndWluLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogInBlbmd1aW4iLCAi
+        Y2hlY2tzdW0iOiAiM2ZjYjJjOTI3ZGU5ZTEzYmY2ODQ2OTAzMmEyOGIxMzlk
+        M2U1YWQyZTU4NTY0ZmMyMTBmZDZlNDg2MzViZTY5NCIsICJzdW1tYXJ5Ijog
+        IkEgZHVtbXkgcGFja2FnZSBvZiBwZW5ndWluIiwgImZpbGVuYW1lIjogInBl
+        bmd1aW4tMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVy
+        c2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjY4YjY3
+        YzljLTk3NjQtNDlmMS1hNmFjLTM1YWIzNzJhYjEwMyIsICJhcmNoIjogIm5v
+        YXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L2NvbnRlbnQvdW5pdHMvcnBtLzY4YjY3YzljLTk3NjQtNDlmMS1hNmFjLTM1
+        YWIzNzJhYjEwMy8ifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJG
+        ZWRvcmFfMTciXSwgInNvdXJjZXJwbSI6ICJsaW9uLTAuMy0wLjguc3JjLnJw
+        bSIsICJuYW1lIjogImxpb24iLCAiY2hlY2tzdW0iOiAiMTI0MDBkYzk1YzIz
+        YTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0Y2Q2MmVm
+        YTNlNGFlNCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBsaW9u
+        IiwgImZpbGVuYW1lIjogImxpb24tMC4zLTAuOC5ub2FyY2gucnBtIiwgImVw
+        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgi
+        LCAiX2lkIjogIjdmYTExOGZlLThhZTQtNGJhOC1iZjRmLTZkM2NhOTYwZTZj
+        YSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBtLzdmYTExOGZlLThh
+        ZTQtNGJhOC1iZjRmLTZkM2NhOTYwZTZjYS8ifSwgeyJyZXBvc2l0b3J5X21l
+        bWJlcnNoaXBzIjogWyJGZWRvcmFfMTciXSwgInNvdXJjZXJwbSI6ICJjaGVl
+        dGFoLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogImNoZWV0YWgiLCAiY2hl
+        Y2tzdW0iOiAiNDIyZDBiYWEwY2Q5ZDc3MTNhZTc5NmU4ODZhMjNlMTdmNTc4
+        ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2OGRhZSIsICJzdW1tYXJ5IjogIkEg
+        ZHVtbXkgcGFja2FnZSBvZiBjaGVldGFoIiwgImZpbGVuYW1lIjogImNoZWV0
+        YWgtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lv
+        biI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogImE4NjRlY2Y1
+        LTBmYzYtNGYyMy1iZDgxLTY5NjcwNTk4Y2RhYiIsICJhcmNoIjogIm5vYXJj
+        aCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2Nv
+        bnRlbnQvdW5pdHMvcnBtL2E4NjRlY2Y1LTBmYzYtNGYyMy1iZDgxLTY5Njcw
+        NTk4Y2RhYi8ifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJGZWRv
+        cmFfMTciXSwgInNvdXJjZXJwbSI6ICJlbGVwaGFudC0wLjMtMC44LnNyYy5y
+        cG0iLCAibmFtZSI6ICJlbGVwaGFudCIsICJjaGVja3N1bSI6ICIzZTFjNzBj
+        ZDFiNDIxMzI4YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMz
+        MTM3MmEwYTcwMWYzIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9m
+        IGVsZXBoYW50IiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9h
+        cmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJl
+        bGVhc2UiOiAiMC44IiwgIl9pZCI6ICJhYzgyYjNmZC1kY2QyLTRiYWYtYjg2
+        NC0wMjUzZWJkMjNiMjciLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4i
+        OiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3Jw
+        bS9hYzgyYjNmZC1kY2QyLTRiYWYtYjg2NC0wMjUzZWJkMjNiMjcvIn0sIHsi
+        cmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJzb3Vy
+        Y2VycG0iOiAiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJn
+        aXJhZmZlIiwgImNoZWNrc3VtIjogImYyNWQ2N2QxZDlkYTA0ZjEyZTU3Y2Ez
+        MjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQiLCAi
+        c3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsICJmaWxl
+        bmFtZSI6ICJnaXJhZmZlLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6
+        ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgIl9p
+        ZCI6ICJkNGEwMDJjNC1iZWI2LTQ5YmMtODgwMS00MDQ2MTY4YWM0YWIiLCAi
+        YXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS9kNGEwMDJjNC1iZWI2LTQ5
+        YmMtODgwMS00MDQ2MTY4YWM0YWIvIn1d
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:26 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwiZmllbGRzIjp7InVu
+        aXQiOltdLCJhc3NvY2lhdGlvbiI6WyJ1bml0X2lkIl19fX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="uIuOsWvKu5bDPn6a41dERbRDTtfaaouWvJRxC5WfM", oauth_signature="LPlSNBNbBToUnqpj0hP2YejRRb8%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681366", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '80'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:26 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1672'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIwYjUzZGRkMC0yZTk1LTRlMTktOTY4
+        OS02YTdiODIwZGVmNTYiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1NmI0YWQxNDhhZGE0MGRiMDRlZTBjNGYifSwg
+        InVuaXRfaWQiOiAiMGI1M2RkZDAtMmU5NS00ZTE5LTk2ODktNmE3YjgyMGRl
+        ZjU2IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
+        X2lkIjogIjE2OGQ0N2IxLTEzMTgtNDQ5ZC05MmVhLWZlZDIxZjVjNjJkZCIs
+        ICJfY29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjog
+        IjU2YjRhZDE0OGFkYTQwZGIwNGVlMGM1MCJ9LCAidW5pdF9pZCI6ICIxNjhk
+        NDdiMS0xMzE4LTQ0OWQtOTJlYS1mZWQyMWY1YzYyZGQiLCAidW5pdF90eXBl
+        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNjFkYjdiMjEt
+        YzkxMy00OTlhLTgzYzctYTk3OWExMzE4MDQxIiwgIl9jb250ZW50X3R5cGVf
+        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFkMTQ4YWRhNDBk
+        YjA0ZWUwYzUyIn0sICJ1bml0X2lkIjogIjYxZGI3YjIxLWM5MTMtNDk5YS04
+        M2M3LWE5NzlhMTMxODA0MSIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
+        bWV0YWRhdGEiOiB7Il9pZCI6ICI2OGI2N2M5Yy05NzY0LTQ5ZjEtYTZhYy0z
+        NWFiMzcyYWIxMDMiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1NmI0YWQxNDhhZGE0MGRiMDRlZTBjNTEifSwgInVu
+        aXRfaWQiOiAiNjhiNjdjOWMtOTc2NC00OWYxLWE2YWMtMzVhYjM3MmFiMTAz
+        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lk
+        IjogIjdmYTExOGZlLThhZTQtNGJhOC1iZjRmLTZkM2NhOTYwZTZjYSIsICJf
+        Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2
+        YjRhZDE0OGFkYTQwZGIwNGVlMGM1NSJ9LCAidW5pdF9pZCI6ICI3ZmExMThm
+        ZS04YWU0LTRiYTgtYmY0Zi02ZDNjYTk2MGU2Y2EiLCAidW5pdF90eXBlX2lk
+        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiYTg2NGVjZjUtMGZj
+        Ni00ZjIzLWJkODEtNjk2NzA1OThjZGFiIiwgIl9jb250ZW50X3R5cGVfaWQi
+        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTZiNGFkMTQ4YWRhNDBkYjA0
+        ZWUwYzUzIn0sICJ1bml0X2lkIjogImE4NjRlY2Y1LTBmYzYtNGYyMy1iZDgx
+        LTY5NjcwNTk4Y2RhYiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
+        YWRhdGEiOiB7Il9pZCI6ICJhYzgyYjNmZC1kY2QyLTRiYWYtYjg2NC0wMjUz
+        ZWJkMjNiMjciLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
+        IHsiJG9pZCI6ICI1NmI0YWQxNDhhZGE0MGRiMDRlZTBjNTQifSwgInVuaXRf
+        aWQiOiAiYWM4MmIzZmQtZGNkMi00YmFmLWI4NjQtMDI1M2ViZDIzYjI3Iiwg
+        InVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjog
+        ImQ0YTAwMmM0LWJlYjYtNDliYy04ODAxLTQwNDYxNjhhYzRhYiIsICJfY29u
+        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU2YjRh
+        ZDE0OGFkYTQwZGIwNGVlMGM1NiJ9LCAidW5pdF9pZCI6ICJkNGEwMDJjNC1i
+        ZWI2LTQ5YmMtODgwMS00MDQ2MTY4YWM0YWIiLCAidW5pdF90eXBlX2lkIjog
+        InJwbSJ9XQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:26 GMT
+- request:
+    method: post
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/content/units/rpm/search/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMGI1M2Rk
+        ZDAtMmU5NS00ZTE5LTk2ODktNmE3YjgyMGRlZjU2Il19fX0sImluY2x1ZGVf
+        cmVwb3MiOnRydWV9
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="tCSbcnczztCJoh9NeO7SyoRRSZQY0LDX7nh3eDRk2E", oauth_signature="4CBMRhQJef3oh0lnETtiBwS2SkM%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681366", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      Content-Length:
+      - '102'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:26 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2974'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJf
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9ycG0vMGI1M2Rk
+        ZDAtMmU5NS00ZTE5LTk2ODktNmE3YjgyMGRlZjU2LyIsICJidWlsZF90aW1l
+        IjogMTMwODI1NzI2MCwgImJ1aWxkaG9zdCI6ICJkaGNwLTI2LTExOC5icnEu
+        cmVkaGF0LmNvbSIsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250
+        ZW50X3R5cGVfaWQiOiAicnBtIiwgImNoaWxkcmVuIjoge30sICJzaXplIjog
+        MjIzMiwgImxpY2Vuc2UiOiAiR1BMdjIiLCAiZ3JvdXAiOiAiSW50ZXJuZXQv
+        QXBwbGljYXRpb25zIiwgImZpbGVuYW1lIjogIm1vbmtleS0wLjMtMC44Lm5v
+        YXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJ2
+        ZXJzaW9uX3NvcnRfaW5kZXgiOiAiMDEtMC4wMS0zIiwgInByb3ZpZGVzIjog
+        W3sicmVsZWFzZSI6ICIwLjgiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjog
+        IjAuMyIsICJmbGFncyI6ICJFUSIsICJuYW1lIjogIm1vbmtleSJ9XSwgImZp
+        bGVzIjogeyJkaXIiOiBbXSwgImZpbGUiOiBbIi8vbW9ua2V5LnR4dCJdfSwg
+        InJlcG9kYXRhIjogeyJmaWxlbGlzdHMiOiAiPHBhY2thZ2UgYXJjaD1cIm5v
+        YXJjaFwiIG5hbWU9XCJtb25rZXlcIiBwa2dpZD1cIjBlOGZhNTBkMDEyOGZi
+        YWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1
+        MDFkYjFcIj5cbiAgICA8dmVyc2lvbiBlcG9jaD1cIjBcIiByZWw9XCIwLjhc
+        IiB2ZXI9XCIwLjNcIiAvPlxuXG4gICAgPGZpbGU+Ly9tb25rZXkudHh0PC9m
+        aWxlPlxuPC9wYWNrYWdlPlxuXG4iLCAib3RoZXIiOiAiPHBhY2thZ2UgYXJj
+        aD1cIm5vYXJjaFwiIG5hbWU9XCJtb25rZXlcIiBwa2dpZD1cIjBlOGZhNTBk
+        MDEyOGZiYWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJj
+        ODRkZTg1MDFkYjFcIj5cbiAgICA8dmVyc2lvbiBlcG9jaD1cIjBcIiByZWw9
+        XCIwLjhcIiB2ZXI9XCIwLjNcIiAvPlxuXG48L3BhY2thZ2U+XG5cbiIsICJw
+        cmltYXJ5IjogIjxwYWNrYWdlIHR5cGU9XCJycG1cIj5cbiAgPG5hbWU+bW9u
+        a2V5PC9uYW1lPlxuICA8YXJjaD5ub2FyY2g8L2FyY2g+XG4gIDx2ZXJzaW9u
+        IGVwb2NoPVwiMFwiIHJlbD1cIjAuOFwiIHZlcj1cIjAuM1wiIC8+XG4gIDxj
+        aGVja3N1bSBwa2dpZD1cIllFU1wiIHR5cGU9XCJzaGEyNTZcIj4wZThmYTUw
+        ZDAxMjhmYmFiYzdjY2M1NjMyZTNmYTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUy
+        Yzg0ZGU4NTAxZGIxPC9jaGVja3N1bT5cbiAgPHN1bW1hcnk+QSBkdW1teSBw
+        YWNrYWdlIG9mIG1vbmtleTwvc3VtbWFyeT5cbiAgPGRlc2NyaXB0aW9uPkEg
+        ZHVtbXkgcGFja2FnZSBvZiBtb25rZXk8L2Rlc2NyaXB0aW9uPlxuICA8cGFj
+        a2FnZXIgLz5cbiAgPHVybD5odHRwOi8vdHN0cmFjaG90YS5mZWRvcmFwZW9w
+        bGUub3JnPC91cmw+XG4gIDx0aW1lIGJ1aWxkPVwiMTMwODI1NzI2MFwiIGZp
+        bGU9XCIxMzIxODkxMDI5XCIgLz5cbiAgPHNpemUgYXJjaGl2ZT1cIjI5Mlwi
+        IGluc3RhbGxlZD1cIjQyXCIgcGFja2FnZT1cIjIyMzJcIiAvPlxuPGxvY2F0
+        aW9uIGhyZWY9XCJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtXCIvPlxuICA8
+        Zm9ybWF0PlxuICAgIDxycG06bGljZW5zZT5HUEx2MjwvcnBtOmxpY2Vuc2U+
+        XG4gICAgPHJwbTp2ZW5kb3IgLz5cbiAgICA8cnBtOmdyb3VwPkludGVybmV0
+        L0FwcGxpY2F0aW9uczwvcnBtOmdyb3VwPlxuICAgIDxycG06YnVpbGRob3N0
+        PmRoY3AtMjYtMTE4LmJycS5yZWRoYXQuY29tPC9ycG06YnVpbGRob3N0Plxu
+        ICAgIDxycG06c291cmNlcnBtPm1vbmtleS0wLjMtMC44LnNyYy5ycG08L3Jw
+        bTpzb3VyY2VycG0+XG4gICAgPHJwbTpoZWFkZXItcmFuZ2UgZW5kPVwiMjAx
+        NlwiIHN0YXJ0PVwiMjgwXCIgLz5cbiAgICA8cnBtOnByb3ZpZGVzPlxuICAg
+        ICAgPHJwbTplbnRyeSBlcG9jaD1cIjBcIiBmbGFncz1cIkVRXCIgbmFtZT1c
+        Im1vbmtleVwiIHJlbD1cIjAuOFwiIHZlcj1cIjAuM1wiIC8+XG4gICAgPC9y
+        cG06cHJvdmlkZXM+XG4gICAgPHJwbTpyZXF1aXJlcz5cbiAgICAgIDxycG06
+        ZW50cnkgbmFtZT1cIi9iaW4vc2hcIiBwcmU9XCIxXCIgLz5cbiAgICA8L3Jw
+        bTpyZXF1aXJlcz5cbiAgPC9mb3JtYXQ+XG48L3BhY2thZ2U+XG4ifSwgImRl
+        c2NyaXB0aW9uIjogIkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCAiX2xh
+        c3RfdXBkYXRlZCI6ICIyMDE2LTAyLTA1VDE0OjA2OjEyWiIsICJ0aW1lIjog
+        MTMyMTg5MTAyOSwgImRvd25sb2FkZWQiOiB0cnVlLCAiaGVhZGVyX3Jhbmdl
+        IjogeyJzdGFydCI6IDI4MCwgImVuZCI6IDIwMTZ9LCAiYXJjaCI6ICJub2Fy
+        Y2giLCAibmFtZSI6ICJtb25rZXkiLCAiX3N0b3JhZ2VfcGF0aCI6ICIvdmFy
+        L2xpYi9wdWxwL2NvbnRlbnQvdW5pdHMvcnBtLzBiNTMvMGI1M2RkZDAtMmU5
+        NS00ZTE5LTk2ODktNmE3YjgyMGRlZjU2L21vbmtleS0wLjMtMC44Lm5vYXJj
+        aC5ycG0iLCAic291cmNlcnBtIjogIm1vbmtleS0wLjMtMC44LnNyYy5ycG0i
+        LCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiIsICJyZWxlYXNlX3NvcnRfaW5k
+        ZXgiOiAiMDEtMC4wMS04IiwgImNoYW5nZWxvZyI6IFtdLCAidXJsIjogImh0
+        dHA6Ly90c3RyYWNob3RhLmZlZG9yYXBlb3BsZS5vcmciLCAiY2hlY2tzdW0i
+        OiAiMGU4ZmE1MGQwMTI4ZmJhYmM3Y2NjNTYzMmUzZmEyNWQzOWIwMjgwMTY5
+        ZjYxNjZjYjhlMmM4NGRlODUwMWRiMSIsICJzdW1tYXJ5IjogIkEgZHVtbXkg
+        cGFja2FnZSBvZiBtb25rZXkiLCAicmVsYXRpdmVwYXRoIjogIm1vbmtleS0w
+        LjMtMC44Lm5vYXJjaC5ycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjog
+        IjBiNTNkZGQwLTJlOTUtNGUxOS05Njg5LTZhN2I4MjBkZWY1NiIsICJyZXF1
+        aXJlcyI6IFt7InJlbGVhc2UiOiBudWxsLCAiZXBvY2giOiBudWxsLCAidmVy
+        c2lvbiI6IG51bGwsICJmbGFncyI6IG51bGwsICJuYW1lIjogIi9iaW4vc2gi
+        fV19XQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:26 GMT
+- request:
+    method: delete
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/repositories/Fedora_17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="9EUkfcSlJhTvBaqo9FKhczkMrIqbF1KYCpGb4gzy44",
+        oauth_signature="h8fUieVXpKRlp6YXg6itU7jNT2k%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681366", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:26 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzNkMjA2NjU1LWZiOWEtNDE3Yi05MDY5LWQ3Yzc4MjExMzIxZi8iLCAi
+        dGFza19pZCI6ICIzZDIwNjY1NS1mYjlhLTQxN2ItOTA2OS1kN2M3ODIxMTMy
+        MWYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:26 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/3d206655-fb9a-417b-9069-d7c78211321f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="FrQ5bhG3UMfbBmE5z4d08ic2dgcgz3WpCVSoOL2S4",
+        oauth_signature="hzmVnUofXYYEwgkNdPpfqsncXA0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681366", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:26 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zZDIwNjY1NS1mYjlhLTQxN2ItOTA2OS1kN2M3ODIxMTMy
+        MWYvIiwgInRhc2tfaWQiOiAiM2QyMDY2NTUtZmI5YS00MTdiLTkwNjktZDdj
+        NzgyMTEzMjFmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NmI0YWQx
+        NjhhZGE0MGRiMDRlZTBjNWYifSwgImlkIjogIjU2YjRhZDE2OGFkYTQwZGIw
+        NGVlMGM1ZiJ9
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:26 GMT
+- request:
+    method: get
+    uri: https://katello-2-8-dev.example.com/pulp/api/v2/tasks/3d206655-fb9a-417b-9069-d7c78211321f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="oHMiPYQctXFbgihZAfi5Yow7rSWPg2RldZz3BiLo",
+        oauth_signature="lZxYPBcxsT9Nn8PvMcobljSarQI%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681367", oauth_version="1.0"
+      Pulp-User:
+      - admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Feb 2016 14:09:27 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '688'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zZDIwNjY1NS1mYjlhLTQxN2ItOTA2OS1kN2M3ODIxMTMy
+        MWYvIiwgInRhc2tfaWQiOiAiM2QyMDY2NTUtZmI5YS00MTdiLTkwNjktZDdj
+        NzgyMTEzMjFmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTAyLTA1VDE0OjA5OjI2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTAyLTA1VDE0OjA5OjI2WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUBrYXRlbGxvLTItOC1kZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAa2F0ZWxsby0yLTgtZGV2LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTZi
+        NGFkMTY4YWRhNDBkYjA0ZWUwYzVmIn0sICJpZCI6ICI1NmI0YWQxNjhhZGE0
+        MGRiMDRlZTBjNWYifQ==
+    http_version: 
+  recorded_at: Fri, 05 Feb 2016 14:09:27 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/support/candlepin/organization.yml
+++ b/test/fixtures/vcr_cassettes/support/candlepin/organization.yml
@@ -16,15 +16,15 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="gFi3OVoes1cyua73vSFHmOM7mgHgqguX042sgS1H3kA", oauth_signature="nOdvCEnRI7tUWlSkCtx%2FmfXrKhw%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628859", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="x6Glk5BM7Z6MOymJ3jBF3ervIMc29qWHPSUHsrqNdg8", oauth_signature="eqvUOmxuBvydsaTN6NpGRquDlu8%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681110", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
       - application/json
       Cp-User:
-      - admin
+      - foreman_admin
       Content-Length:
       - '142'
       User-Agent:
@@ -37,29 +37,29 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 883b4634-289e-4ed6-9ab4-e644702c6ed3
+      - 4d902032-9be1-439a-820e-a8a0468ec9ff
       X-Version:
-      - 0.9.47-1
+      - 0.9.51.3-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 04 Feb 2016 23:34:19 GMT
+      - Fri, 05 Feb 2016 14:05:10 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiI0MDI4ZjliODUyYWNhOTE2MDE1
-        MmFlYTJlZmQ5MDAzMiIsImtleSI6IkdsdWVDYW5kbGVwaW5Pd25lclRlc3RT
+        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiJmZjgwODA4MTUyYTc4NzE5MDE1
+        MmIxYzAzN2QwMDAzZiIsImtleSI6IkdsdWVDYW5kbGVwaW5Pd25lclRlc3RT
         eXN0ZW1fMSIsImRpc3BsYXlOYW1lIjoiR2x1ZUNhbmRsZXBpbk93bmVyVGVz
         dFN5c3RlbV8xIiwiY29udGVudFByZWZpeCI6Ii9HbHVlQ2FuZGxlcGluT3du
         ZXJUZXN0U3lzdGVtXzEvJGVudiIsImRlZmF1bHRTZXJ2aWNlTGV2ZWwiOm51
         bGwsInVwc3RyZWFtQ29uc3VtZXIiOm51bGwsImxvZ0xldmVsIjpudWxsLCJo
         cmVmIjoiL293bmVycy9HbHVlQ2FuZGxlcGluT3duZXJUZXN0U3lzdGVtXzEi
-        LCJjcmVhdGVkIjoiMjAxNi0wMi0wNFQyMzozNDoxOS44NjUrMDAwMCIsInVw
-        ZGF0ZWQiOiIyMDE2LTAyLTA0VDIzOjM0OjE5Ljg2NSswMDAwIn0=
+        LCJjcmVhdGVkIjoiMjAxNi0wMi0wNVQxNDowNToxMC40ODArMDAwMCIsInVw
+        ZGF0ZWQiOiIyMDE2LTAyLTA1VDE0OjA1OjEwLjQ4MCswMDAwIn0=
     http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:19 GMT
+  recorded_at: Fri, 05 Feb 2016 14:05:10 GMT
 - request:
     method: delete
     uri: https://localhost:8443/candlepin/owners/GlueCandlepinOwnerTestSystem_1
@@ -72,11 +72,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="cOjc5mx4zV8JagrBH8As8xaAACOPtkKPtBJyak8hfjY",
-        oauth_signature="KYg%2FRXxVWNFZU%2FqjSMmFtC%2BTAe0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628860", oauth_version="1.0"
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="ZekFIbe71jLrztLi6LOiAswbtxOiD6jNyuqiog5r20",
+        oauth_signature="n4DNifKRBSIDy71KAg2hktRWG3Q%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681111", oauth_version="1.0"
       Cp-User:
-      - secret_admin
+      - foreman_admin
       User-Agent:
       - Ruby
   response:
@@ -87,16 +87,16 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - f58bf10c-f989-4f22-bd5b-76cc084e8aaa
+      - 9cfec366-aecd-46e0-9b3b-7fa24307ec1b
       X-Version:
-      - 0.9.47-1
+      - 0.9.51.3-1
       Date:
-      - Thu, 04 Feb 2016 23:34:19 GMT
+      - Fri, 05 Feb 2016 14:05:10 GMT
     body:
       encoding: UTF-8
       base64_string: ''
     http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:20 GMT
+  recorded_at: Fri, 05 Feb 2016 14:05:11 GMT
 - request:
     method: post
     uri: https://localhost:8443/candlepin/owners/
@@ -112,15 +112,15 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="katello",
-        oauth_nonce="hNmbMFVz2IOUMw76XPoj4tGKOwJ7F4xGZZb1BPCbk", oauth_signature="m%2Fh%2F%2BAEJXt%2FVDJcdkfaF1Q3DJ18%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454628861", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f",
+        oauth_nonce="38EQ2it3fUH4086gnsdRVm5CWBtZlParaYdbMFWx0I", oauth_signature="Yz80mbx6Q4J1HTzhUBVfGDcDxnY%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1454681112", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
       - application/json
       Cp-User:
-      - admin
+      - foreman_admin
       Content-Length:
       - '94'
       User-Agent:
@@ -133,28 +133,28 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 7cce5f76-cf12-4576-b046-3a0894f83d6c
+      - 7e123055-1ec9-437b-8731-f9db67c25b8f
       X-Version:
-      - 0.9.47-1
+      - 0.9.51.3-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 04 Feb 2016 23:34:21 GMT
+      - Fri, 05 Feb 2016 14:05:12 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiI0MDI4ZjliODUyYWNhOTE2MDE1
-        MmFlYTJmNmJhMDAzYSIsImtleSI6Ik9yZ2FuaXphdGlvbl8yIiwiZGlzcGxh
+        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiJmZjgwODA4MTUyYTc4NzE5MDE1
+        MmIxYzA0MTNkMDA0NyIsImtleSI6Ik9yZ2FuaXphdGlvbl8yIiwiZGlzcGxh
         eU5hbWUiOiJPcmdhbml6YXRpb24gMiIsImNvbnRlbnRQcmVmaXgiOiIvT3Jn
         YW5pemF0aW9uXzIvJGVudiIsImRlZmF1bHRTZXJ2aWNlTGV2ZWwiOm51bGws
         InVwc3RyZWFtQ29uc3VtZXIiOm51bGwsImxvZ0xldmVsIjpudWxsLCJocmVm
         IjoiL293bmVycy9Pcmdhbml6YXRpb25fMiIsImNyZWF0ZWQiOiIyMDE2LTAy
-        LTA0VDIzOjM0OjIxLjYyNiswMDAwIiwidXBkYXRlZCI6IjIwMTYtMDItMDRU
-        MjM6MzQ6MjEuNjI2KzAwMDAifQ==
+        LTA1VDE0OjA1OjEyLjg5MyswMDAwIiwidXBkYXRlZCI6IjIwMTYtMDItMDVU
+        MTQ6MDU6MTIuODkzKzAwMDAifQ==
     http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:21 GMT
+  recorded_at: Fri, 05 Feb 2016 14:05:12 GMT
 - request:
     method: delete
     uri: https://localhost:8443/candlepin/owners/Organization_2
@@ -167,11 +167,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - OAuth oauth_consumer_key="katello", oauth_nonce="ZuCLajf3PPhXQhkADAy0IELWEr3LoG6cWLlKBvv5s",
-        oauth_signature="w8ySnRNM3QBlaXklvCvRMHqOoCg%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1454628861", oauth_version="1.0"
+      - OAuth oauth_consumer_key="WhqJhRh94gkhNXvNxnueN3AEmQzWgK2f", oauth_nonce="cI5mqTkaTQHV1lWwaxusuwt2EBGwZ39sqgXrW2PpCM",
+        oauth_signature="d89OmW5TEO70CTyFWS3xhF9IfLw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1454681113", oauth_version="1.0"
       Cp-User:
-      - secret_admin
+      - foreman_admin
       User-Agent:
       - Ruby
   response:
@@ -182,14 +182,14 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 4e3478a4-5928-4960-b3f3-9268dbc8d77a
+      - fd42fc2c-d8f1-4729-81f1-71da6d9a3f96
       X-Version:
-      - 0.9.47-1
+      - 0.9.51.3-1
       Date:
-      - Thu, 04 Feb 2016 23:34:21 GMT
+      - Fri, 05 Feb 2016 14:05:12 GMT
     body:
       encoding: UTF-8
       base64_string: ''
     http_version: 
-  recorded_at: Thu, 04 Feb 2016 23:34:21 GMT
+  recorded_at: Fri, 05 Feb 2016 14:05:13 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
Lazy sync doesn't support node distributors. We're removing support for pulp
nodes in #5750. As a way to let lazy sync work continue, we'd like to remove
the creation of node distributors in pulp for yum repositories.