### PR TITLE
Fixes #13585 - Adding Ostree functionality

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -1,5 +1,6 @@
 module Katello
   class Api::V2::RepositoriesController < Api::V2::ApiController
+    wrap_parameters :include => (Repository.attribute_names + [:ostree_branches])
     include Katello::Concerns::FilteredAutoCompleteSearch
 
     before_filter :find_organization, :only => [:index, :auto_complete_search]
@@ -27,10 +28,11 @@ module Katello
       param :url, String, :desc => N_("repository source url")
       param :gpg_key_id, :number, :desc => N_("id of the gpg key that will be assigned to the new repository")
       param :unprotected, :bool, :desc => N_("true if this repository can be published via HTTP")
-      param :content_type, String, :required => true, :desc => N_("type of repo (either 'yum', 'puppet' or 'docker')")
+      param :content_type, String, :required => true, :desc => N_("type of repo (either 'yum', 'puppet', 'docker', or 'ostree')")
       param :checksum_type, String, :desc => N_("checksum of the repository, currently 'sha1' & 'sha256' are supported.'")
       param :docker_upstream_name, String, :desc => N_("name of the upstream docker repository")
       param :download_policy, ["immediate", "on_demand", "background"], :desc => N_("download policy for yum repos (either 'immediate', 'on_demand', or 'background')")
+      param :ostree_branches, Array, :desc => N_("list of ostree branch refs associated to an rpm ostree repository")
     end
 
     api :GET, "/repositories", N_("List of enabled repositories")
@@ -129,7 +131,7 @@ module Katello
                                      repo_params[:content_type], unprotected,
                                      gpg_key, repository_params[:checksum_type], repo_params[:download_policy])
       repository.docker_upstream_name = repo_params[:docker_upstream_name] if repo_params[:docker_upstream_name]
-      sync_task(::Actions::Katello::Repository::Create, repository, false, true)
+      sync_task(::Actions::Katello::Repository::Create, repository, false, true, repo_params[:ostree_branches])
       repository = Repository.find(repository.id)
       respond_for_show(:resource => repository)
     end
@@ -201,9 +203,10 @@ module Katello
     param :url, String, :desc => N_("the feed url of the original repository ")
     param :docker_upstream_name, String, :desc => N_("name of the upstream docker repository")
     param :download_policy, ["immediate", "on_demand", "background"], :desc => N_("download policy for yum repos (either 'immediate', 'on_demand', or 'background')")
+    param :ostree_branches, Array,  :desc => N_("list of ostree branch refs associated to an rpm ostree repository")
     def update
       repo_params = repository_params
-      repo_params[:url] = nil if repository_params[:url].blank?
+      repo_params[:url] = nil if repository_params[:url].blank? && !@repository.ostree?
       sync_task(::Actions::Katello::Repository::Update, @repository, repo_params)
       respond_for_show(:resource => @repository)
     end
@@ -331,7 +334,7 @@ module Katello
     end
 
     def repository_params
-      keys = [:url, :gpg_key_id, :unprotected, :name, :checksum_type, :docker_upstream_name, :download_policy]
+      keys = [:url, :gpg_key_id, :unprotected, :name, :checksum_type, :docker_upstream_name, :download_policy, :ostree_branches => []]
       keys += [:label, :content_type] if params[:action] == "create"
       params.require(:repository).permit(*keys)
     end

--- a/app/helpers/katello/providers_helper.rb
+++ b/app/helpers/katello/providers_helper.rb
@@ -12,6 +12,7 @@ module Katello
         {:id => :beta, :name => _('Beta'), :products => {}},
         {:id => :isos, :name => _('ISOs'), :products => {}},
         {:id => :docker_manifests, :name => _('Docker Manifests'), :products => {}},
+        {:id => :ostree, :name => _('OSTree'), :products => {}},
         {:id => :other, :name => _('Other'), :products => {}}
       ]
     end
@@ -25,6 +26,8 @@ module Katello
           name = prod_content.content.name
           if prod_content.content.type == ::Katello::Repository::CANDLEPIN_DOCKER_TYPE
             key = :docker_manifests
+          elsif prod_content.content.type == ::Katello::Repository::CANDLEPIN_OSTREE_TYPE
+            key = :ostree
           elsif name.include?(" Beta ")
             key = :beta
           elsif name.include?("(Source RPMs)")

--- a/app/lib/actions/katello/repository/clone_ostree_content.rb
+++ b/app/lib/actions/katello/repository/clone_ostree_content.rb
@@ -1,0 +1,17 @@
+module Actions
+  module Katello
+    module Repository
+      class CloneOstreeContent < Actions::Base
+        def plan(source_repo, target_repo)
+          sequence do
+            plan_action(Pulp::Repository::CopyOstreeBranch,
+                        source_pulp_id: source_repo.pulp_id,
+                        target_pulp_id: target_repo.pulp_id)
+            plan_action(Katello::Repository::MetadataGenerate, target_repo)
+            plan_action(Katello::Repository::IndexContent, id: target_repo.id)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/repository/clone_to_environment.rb
+++ b/app/lib/actions/katello/repository/clone_to_environment.rb
@@ -9,7 +9,7 @@ module Actions
 
           sequence do
             if clone.new_record?
-              plan_action(Repository::Create, clone, true)
+              plan_action(Repository::Create, clone, true, false, repository.ostree_branch_names)
             else
               plan_action(Repository::Clear, clone)
             end
@@ -18,6 +18,8 @@ module Actions
               plan_action(Repository::CloneYumContent, repository, clone, [], false)
             elsif repository.docker?
               plan_action(Repository::CloneDockerContent, repository, clone)
+            elsif repository.ostree?
+              plan_action(Repository::CloneOstreeContent, repository, clone)
             end
           end
         end

--- a/app/lib/actions/katello/repository/clone_to_version.rb
+++ b/app/lib/actions/katello/repository/clone_to_version.rb
@@ -11,13 +11,15 @@ module Actions
           self.new_repository = repository.build_clone(content_view: content_view,
                                                        version: content_view_version)
           sequence do
-            plan_action(Repository::Create, new_repository, true)
+            plan_action(Repository::Create, new_repository, true, false, repository.ostree_branch_names)
 
             if new_repository.yum?
               plan_action(Repository::CloneYumContent, repository, new_repository, filters, !incremental,
                           :generate_metadata => !incremental, :index_content => !incremental, :simple_clone => incremental)
             elsif new_repository.docker?
               plan_action(Repository::CloneDockerContent, repository, new_repository)
+            elsif new_repository.ostree?
+              plan_action(Repository::CloneOstreeContent, repository, new_repository)
             end
           end
         end

--- a/app/lib/actions/katello/repository/create.rb
+++ b/app/lib/actions/katello/repository/create.rb
@@ -3,8 +3,11 @@ module Actions
     module Repository
       class Create < Actions::EntryAction
         # rubocop:disable MethodLength
-        def plan(repository, clone = false, plan_create = false)
+        def plan(repository, clone = false, plan_create = false, ostree_branches = [])
           repository.save!
+          ostree_branches.each do |branch_name|
+            repository.ostree_branches.create!(:name => branch_name)
+          end if ostree_branches
           action_subject(repository)
 
           org = repository.organization
@@ -25,7 +28,8 @@ module Actions
                                         checksum_type: repository.checksum_type,
                                         path: path,
                                         download_policy: repository.download_policy,
-                                        with_importer: true)
+                                        with_importer: true,
+                                        ostree_branches: repository.ostree_branch_names)
 
             return if create_action.error
 

--- a/app/lib/actions/katello/repository/metadata_generate.rb
+++ b/app/lib/actions/katello/repository/metadata_generate.rb
@@ -30,6 +30,8 @@ module Actions
             [Runcible::Models::IsoDistributor]
           when ::Katello::Repository::DOCKER_TYPE
             [Runcible::Models::DockerDistributor]
+          when ::Katello::Repository::OSTREE_TYPE
+            [Runcible::Models::OstreeDistributor]
           end
         end
       end

--- a/app/lib/actions/katello/repository/update.rb
+++ b/app/lib/actions/katello/repository/update.rb
@@ -6,6 +6,9 @@ module Actions
 
         def plan(repository, repo_params)
           action_subject repository
+          ostree_branches = repo_params.delete(:ostree_branches)
+          repository.update_ostree_branches!(ostree_branches) if ostree_branches
+          repository = repository.reload
           repository.update_attributes!(repo_params)
 
           if update_content?(repository)

--- a/app/lib/actions/pulp/repository/copy_ostree_branch.rb
+++ b/app/lib/actions/pulp/repository/copy_ostree_branch.rb
@@ -1,0 +1,11 @@
+module Actions
+  module Pulp
+    module Repository
+      class CopyOstreeBranch < Pulp::Repository::AbstractCopyContent
+        def content_extension
+          pulp_extensions.ostree_branch
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp/repository/presenters/ostree_presenter.rb
+++ b/app/lib/actions/pulp/repository/presenters/ostree_presenter.rb
@@ -1,0 +1,78 @@
+module Actions
+  module Pulp
+    module Repository
+      module Presenters
+        class OstreePresenter < AbstractSyncPresenter
+          def progress
+            return 0.01 unless task_progress_details
+
+            completion = 0.0
+            completion += 0.4 if content_completed?(details("import_create_repository"))
+            completion += 0.3 if content_completed?(details("import_pull"))
+            completion += 0.3 if content_completed?(details("import_add_unit"))
+            completion
+          end
+
+          private
+
+          def humanized_details
+            ret = []
+            ret << _("Cancelled") if cancelled?
+
+            if pending?
+              ret << case current_step["step_type"]
+                     when "import_create_repository"
+                       _("Creating local repository")
+                     when "import_pull"
+                       _("Pulling remote branches")
+                     when "import_add_unit"
+                       _("Adding content units")
+                     end
+            end
+
+            if task_result
+              ret << _("Branches updated")
+            end
+
+            ret << sync_error if sync_error
+            ret.join("\n")
+          end
+
+          def details(step_type)
+            task_progress_details.find do |step|
+              step[:step_type] == step_type
+            end
+          end
+
+          def content_completed?(content_details)
+            content_details && content_details[:state] == 'FINISHED'
+          end
+
+          def task_progress
+            sync_task['progress_report']
+          end
+
+          def task_progress_details
+            task_progress && task_progress['ostree_web_importer']
+          end
+
+          def pending?
+            sync_task["state"] == 'running'
+          end
+
+          def current_step
+            task_progress_details.detect { |step| step["state"] == "IN_PROGRESS" }
+          end
+
+          def finished?
+            sync_task["state"] == 'finished'
+          end
+
+          def sync_error
+            task_result && task_result["error_message"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp/repository/sync.rb
+++ b/app/lib/actions/pulp/repository/sync.rb
@@ -89,6 +89,8 @@ module Actions
             Presenters::IsoPresenter.new(self)
           elsif repo.try(:docker?)
             Presenters::DockerPresenter.new(self)
+          elsif repo.try(:ostree?)
+            Presenters::OstreePresenter.new(self)
           end
         end
 

--- a/app/models/katello/candlepin/content.rb
+++ b/app/models/katello/candlepin/content.rb
@@ -51,29 +51,41 @@ module Katello
       end
 
       def build_repository
-        ::Katello::Repository.new(:environment => product.organization.library,
-                                 :product => product,
-                                 :pulp_id => pulp_id,
-                                 :cp_label => content.label,
-                                 :content_id => content.id,
-                                 :arch => arch,
-                                 :major => major,
-                                 :minor => minor,
-                                 :relative_path => relative_path,
-                                 :name => name,
-                                 :label => label,
-                                 :url => feed_url,
-                                 :feed_ca => ca,
-                                 :feed_cert => product.certificate,
-                                 :feed_key => product.key,
-                                 :content_type => katello_content_type,
-                                 :preserve_metadata => true, #preserve repo metadata when importing from cp
-                                 :unprotected => unprotected?,
-                                 :download_policy => download_policy,
-                                 :content_view_version => product.organization.library.default_content_view_version)
+        repository = Repository.new(
+          :environment => product.organization.library,
+          :product => product,
+          :pulp_id => pulp_id,
+          :cp_label => content.label,
+          :content_id => content.id,
+          :arch => arch,
+          :major => major,
+          :minor => minor,
+          :relative_path => relative_path,
+          :name => name,
+          :label => label,
+          :url => feed_url,
+          :feed_ca => ca,
+          :feed_cert => product.certificate,
+          :feed_key => product.key,
+          :content_type => katello_content_type,
+          :preserve_metadata => true, #preserve repo metadata when importing from cp
+          :unprotected => unprotected?,
+          :download_policy => download_policy,
+          :content_view_version => product.organization.
+                                  library.default_content_view_version
+        )
+
+        if katello_content_type == Repository::OSTREE_TYPE
+          # TODO
+          # add a hard coded config entry branch for now
+          # we will add pull all once the summary files functionality is available
+          repository.ostree_branches.new(:name => Setting[:default_cdn_ostree_branch_name], :repository => repository)
+        end
+        repository
       end
 
       def validate!
+        return if katello_content_type == Repository::OSTREE_TYPE
         substitutor.valid_substitutions(content, substitutions)
       end
 

--- a/app/models/katello/content_view_repository.rb
+++ b/app/models/katello/content_view_repository.rb
@@ -2,7 +2,10 @@ module Katello
   class ContentViewRepository < Katello::Model
     self.include_root_in_json = false
 
-    ALLOWED_REPOSITORY_TYPES = [Repository::YUM_TYPE, Repository::DOCKER_TYPE]
+    ALLOWED_REPOSITORY_TYPES = [Repository::YUM_TYPE,
+                                Repository::DOCKER_TYPE,
+                                Repository::OSTREE_TYPE
+                               ]
 
     belongs_to :content_view, :inverse_of => :content_view_repositories,
                               :class_name => "Katello::ContentView"

--- a/app/models/katello/glue/candlepin/content.rb
+++ b/app/models/katello/glue/candlepin/content.rb
@@ -1,6 +1,7 @@
 module Katello
   module Glue::Candlepin::Content
     CANDLEPIN_DOCKER_TYPE = "containerimage"
+    CANDLEPIN_OSTREE_TYPE = "ostree"
 
     def self.included(base)
       base.send :include, InstanceMethods

--- a/app/models/katello/ostree_branch.rb
+++ b/app/models/katello/ostree_branch.rb
@@ -1,0 +1,14 @@
+module Katello
+  class OstreeBranch < Katello::Model
+    belongs_to :repository, :class_name => "Katello::Repository", :inverse_of => :ostree_branches
+    validates :name, presence: true, uniqueness: {scope: :repository_id}
+    validates :repository, :presence => true
+    validate :ensure_ostree_repository
+
+    def ensure_ostree_repository
+      unless self.repository.ostree?
+        errors.add(:base, _("Branch cannot be created since it does not belong to an RPM OSTree repository."))
+      end
+    end
+  end
+end

--- a/app/models/setting/katello.rb
+++ b/app/models/setting/katello.rb
@@ -4,6 +4,7 @@ class Setting::Katello < Setting
 
     self.transaction do
       [
+        self.set('default_cdn_ostree_branch_name', N_("Name of the default OSTree branch when enabling a Red Hat OSTree repo"), 'rhel-atomic-host/7/x86_64/standard'),
         self.set('katello_default_provision', N_("Default provisioning template for new Operating Systems"), 'Katello Kickstart Default'),
         self.set('katello_default_finish', N_("Default finish template for new Operating Systems"), 'Katello Kickstart Default Finish'),
         self.set('katello_default_user_data', N_("Default user data for new Operating Systems"), 'Katello Kickstart Default User Data'),

--- a/app/views/katello/api/v2/repositories/show.json.rabl
+++ b/app/views/katello/api/v2/repositories/show.json.rabl
@@ -16,6 +16,7 @@ attributes :gpg_key_id
 attributes :content_id, :content_view_version_id, :library_instance_id
 attributes :product_type
 attributes :promoted? => :promoted
+attributes :ostree_branch_names => :ostree_branches
 
 if @resource.is_a?(Katello::Repository)
   if @resource.distribution_version || @resource.distribution_arch || @resource.distribution_family || @resource.distribution_variant

--- a/db/migrate/20150513034751_add_ostree_branches.rb
+++ b/db/migrate/20150513034751_add_ostree_branches.rb
@@ -1,0 +1,25 @@
+class AddOstreeBranches < ActiveRecord::Migration
+  def up
+    create_table :katello_ostree_branches do |t|
+      t.string :name, :null => false
+      t.references :repository, :null => false
+      t.timestamps
+    end
+
+    add_index :katello_ostree_branches, [:repository_id],
+              :name => :index_branches_on_repository
+
+    add_foreign_key :katello_ostree_branches,
+                    :katello_repositories,
+                    :column => "repository_id",
+                    :name => "katello_ostree_branches_repository_id_fk"
+
+    add_index :katello_ostree_branches, [:repository_id, :name],
+              :name => :katello_ostree_branches_repo_branch, :unique => true
+  end
+
+  def down
+    remove_foreign_key :katello_ostree_branches, :name => "katello_ostree_branches_repository_id_fk"
+    drop_table :katello_ostree_branches
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/content-views.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/content-views.routes.js
@@ -214,6 +214,25 @@ angular.module('Bastion.content-views').config(['$stateProvider', function ($sta
         controller: 'ContentViewAvailableDockerRepositoriesController',
         templateUrl: 'content-views/details/views/content-view-docker-repositories.html'
     })
+    .state('content-views.details.repositories.ostree', {
+        abstract: true,
+        collapsed: true,
+        template: '<div ui-view></div>'
+    })
+    .state('content-views.details.repositories.ostree.list', {
+        collapsed: true,
+        url: '/repositories/ostree',
+        permission: 'view_content_views',
+        controller: 'ContentViewOstreeRepositoriesListController',
+        templateUrl: 'content-views/details/views/content-view-ostree-repositories.html'
+    })
+    .state('content-views.details.repositories.ostree.available', {
+        collapsed: true,
+        url: '/repositories/ostree/available',
+        permission: 'view_content_views',
+        controller: 'ContentViewAvailableOstreeRepositoriesController',
+        templateUrl: 'content-views/details/views/content-view-ostree-repositories.html'
+    })
     .state('content-views.details.history', {
         collapsed: true,
         url: '/history',

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-ostree-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-ostree-repositories.controller.js
@@ -1,0 +1,39 @@
+/**
+ * @ngdoc object
+ * @name  Bastion.content-views.controller:ContentViewAvailableOstreeRepositoriesController
+ *
+ * @requires $scope
+ * @requires Repository
+ * @requires Nutupane
+ * @requires CurrentOrganization
+ * @requires ContentViewRepositoriesUtil
+ *
+ * @description
+ *    Provides UI functionality add ostree repositories to a content view
+ */
+angular.module('Bastion.content-views').controller('ContentViewAvailableOstreeRepositoriesController',
+    ['$scope', 'Repository', 'Nutupane', 'CurrentOrganization', 'ContentViewRepositoriesUtil',
+    function ($scope, Repository, Nutupane, CurrentOrganization, ContentViewRepositoriesUtil) {
+
+        var nutupane;
+
+        ContentViewRepositoriesUtil($scope);
+
+        nutupane = new Nutupane(Repository, {
+            'organization_id': CurrentOrganization,
+            'library': true,
+            'content_type': 'ostree',
+            'content_view_id': $scope.$stateParams.contentViewId,
+            'available_for': 'content_view'
+        },
+        'queryUnpaged');
+
+        nutupane.load();
+
+        $scope.repositoriesTable = nutupane.table;
+
+        $scope.addRepositories = function (contentView) {
+            $scope.addSelectedRepositoriesToContentView(nutupane, contentView);
+        };
+    }]
+);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-ostree-repositories-list.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-ostree-repositories-list.controller.js
@@ -1,0 +1,37 @@
+/**
+ * @ngdoc object
+ * @name  Bastion.content-views.controller:ContentViewOstreeRepositoriesListController
+ *
+ * @requires $scope
+ * @requires Repository
+ * @requires Nutupane
+ * @requires CurrentOrganization
+ * @requires ContentViewRepositoriesUtil
+ *
+ * @description
+ *    Provides UI functionality list/remove ostree repositories from a content view
+ */
+angular.module('Bastion.content-views').controller('ContentViewOstreeRepositoriesListController',
+    ['$scope', 'Repository', 'Nutupane', 'CurrentOrganization', 'ContentViewRepositoriesUtil',
+    function ($scope, Repository, Nutupane, CurrentOrganization, ContentViewRepositoriesUtil) {
+        var nutupane;
+
+        ContentViewRepositoriesUtil($scope);
+
+        nutupane = new Nutupane(Repository, {
+            'organization_id': CurrentOrganization,
+            'content_view_id': $scope.$stateParams.contentViewId,
+            'content_type': 'ostree'
+
+        },
+        'queryUnpaged');
+
+        nutupane.load();
+
+        $scope.repositoriesTable = nutupane.table;
+
+        $scope.removeRepositories = function () {
+            $scope.removeSelectedRepositoriesFromContentView(nutupane, $scope.contentView);
+        };
+    }]
+);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-details.html
@@ -111,6 +111,13 @@
         </a>
       </li>
 
+      <li ng-class="{active: stateIncludes('content-views.details.repositories.ostree')}"
+          ng-hide="contentView.composite">
+        <a ui-sref="content-views.details.repositories.ostree.list" translate>
+          OSTree Content
+        </a>
+      </li>
+
       <li ng-class="{active: isState('content-views.details.history')}">
         <a ui-sref="content-views.details.history" translate>
           History

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-ostree-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-ostree-repositories.html
@@ -1,0 +1,118 @@
+<span page-title ng-model="contentView">{{ 'Repositories for Content View:' | translate }} {{ contentView.name }}</span>
+
+<div class="details details-full">
+
+  <h3 translate>
+    Repository Selection
+  </h3>
+
+  <nav>
+    <ul class="nav nav-tabs">
+      <li ng-class="{active: isState('content-views.details.repositories.ostree.list')}">
+        <a ui-sref="content-views.details.repositories.ostree.list">
+          <span translate>
+            List/Remove
+          </span>
+        </a>
+      </li>
+
+      <li ng-class="{active: isState('content-views.details.repositories.ostree.available')}" ng-show="!contentView.permissions.editable">
+        <a ui-sref="content-views.details.repositories.ostree.available" translate>
+          Add
+        </a>
+      </li>
+    </ul>
+  </nav>
+
+  <div class="details-header row">
+    <div class="col-sm-8">
+      <div class="input-group">
+
+        <span class="input-group-addon">
+          <select ng-model="product" ng-options="product.name for (id, product) in products">
+          </select>
+        </span>
+
+        <input type="text"
+               class="form-control filter-input"
+               placeholder="{{ 'Filter' | translate }}"
+               ng-model="repositorySearch"/>
+
+      </div>
+    </div>
+
+    <div class="col-sm-4">
+      <button class="btn btn-primary fr"
+              ng-disabled="repositoriesTable.numSelected === 0"
+              ng-show="isState('content-views.details.repositories.ostree.list') && permitted('edit_content_views', contentView)"
+              ng-click="removeRepositories(contentView)">
+        <i class="fa fa-trash-o"></i>
+        <span translate>Remove Repositories</span>
+      </button>
+      <button class="btn btn-primary fr"
+              ng-disabled="repositoriesTable.numSelected === 0"
+              ng-show="isState('content-views.details.repositories.ostree.available') && permitted('edit_content_views', contentView)"
+              ng-click="addRepositories(contentView)">
+        <i class="fa fa-plus"></i>
+        <span translate>Add Repositories</span>
+      </button>
+    </div>
+  </div>
+
+  <div bst-table="repositoriesTable" class="nutupane">
+
+    <div ng-show="repositoriesTable.rows.length === 0 && !repositoriesTable.working">
+      <p bst-alert="info" ng-show="isState('content-views.details.repositories.ostree.list')">
+        <span translate>
+          There are currently no repositories associated with this Content View, you can add some by clicking on the "Add" tab above.
+        </span>
+      </p>
+      <p bst-alert="info" ng-show="isState('content-views.details.repositories.ostree.available')">
+        <span translate>There are currently no repositories to add to this Content View,</span>
+        <a ui-sref="products.index" translate>add some repositories.</a>
+      </p>
+    </div>
+
+    <div class="loading-mask loading-mask-panel" ng-show="repositoriesTable.working">
+      <i class="fa fa-spinner fa-spin"></i>
+      {{ "Loading..." | translate }}
+    </div>
+
+    <table ng-show="repositoriesTable.rows.length > 0"  class="table table-bordered table-striped">
+      <thead>
+        <tr bst-table-head row-select>
+          <th bst-table-column translate>Name</th>
+          <th bst-table-column translate>Product</th>
+          <th bst-table-column translate>Last Sync</th>
+          <th bst-table-column translate>Sync State</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr bst-table-row
+            row-select="repository"
+            ng-repeat="repository in repositoriesTable.rows | filter:repositorySearch | filter:repositoryFilter | as:'filteredItems'">
+          <td bst-table-cell>
+            <a ui-sref="products.details.repositories.info({productId: repository.product.id, repositoryId: repository.id})">
+              {{ repository.name }}
+            </a>
+          </td>
+          <td bst-table-cell>{{ repository.product.name }}</td>
+          <td bst-table-cell>
+            <span ng-show="repository.url">
+              {{ repository.last_sync.ended_at | date:"short" }}
+            </span>
+            <span ng-hide="repository.url" translate>N/A</span>
+          </td>
+          <td bst-table-cell>
+            <span ng-show="repository.url">
+              <a href="/foreman_tasks/tasks/{{repository.last_sync.id}}">{{ repository.last_sync.result | capitalize }}</a>
+            </span>
+            <span ng-hide="repository.url" translate>N/A</span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+</div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.module.js
@@ -185,6 +185,13 @@ angular.module('Bastion.products').config(['$stateProvider', function ($statePro
         permission: 'view_products',
         collapsed: true,
         templateUrl: 'repositories/details/views/repository-manage-docker-manifests.html'
+    })
+    .state('products.details.repositories.manage-ostree-branches', {
+        url: '/repositories/:repositoryId/content/ostree_branches',
+        permission: 'view_products',
+        collapsed: true,
+        controller: 'RepositoryManageOstreeBranchesController',
+        templateUrl: 'repositories/details/views/repository-manage-ostree-branches.html'
     });
 
     $stateProvider.state('products.details.tasks', {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/repository-details-manage-ostree-branches.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/repository-details-manage-ostree-branches.controller.js
@@ -1,0 +1,137 @@
+/**
+ * @ngdoc object
+ * @name  Bastion.repositories.controller:RepositoryManageContentController
+ *
+ * @requires $scope
+ * @requires translate
+ * @requires Repository
+ *
+ * @description
+ *   Provides the functionality for the repository details pane.
+ */
+angular.module('Bastion.repositories').controller('RepositoryManageOstreeBranchesController',
+    ['$scope', 'translate', 'Repository',
+    function ($scope, translate, Repository) {
+
+        function resetBranches() {
+            $scope.branch = {
+                editMode: false,
+                working: false
+            };
+        }
+
+        function saveBranches(branches, success, errors) {
+            var successfulUpdate, erroredUpdate;
+            successfulUpdate = function (repository) {
+                $scope.successMessages = [translate('Repository Branches Updated.')];
+                $scope.wrap(repository);
+                if (success) {
+                    success(repository);
+                }
+            };
+
+            erroredUpdate = function (response) {
+                _.each(response.data.errors, function (errorMessage) {
+                    $scope.errorMessages.push(translate("An error occurred saving the Repository: ") + errorMessage);
+                });
+                if (errors) {
+                    errors(response);
+                }
+            };
+
+            $scope.repository["ostree_branches"] = branches;
+            $scope.repository.$update(successfulUpdate, erroredUpdate);
+        }
+
+        $scope.wrap = function (repository) {
+            var branches = repository["ostree_branches"];
+            if (angular.isUndefined(branches)) {
+                branches = [];
+            }
+            $scope.branchObjects = _.map(branches, function (branch) {
+                return {name: branch};
+            });
+        };
+
+        resetBranches();
+        $scope.repository = Repository.get({id: $scope.$stateParams.repositoryId});
+
+        $scope.repository.$promise.then($scope.wrap);
+
+        $scope.removeBranches = function () {
+            var branches,
+                branchObjectsToRemove = _.reject($scope.branchObjects, function (branch) {
+                return branch.selected;
+            });
+
+            branches = _.map(branchObjectsToRemove, function (branchObj) {
+                return branchObj.name;
+            });
+
+            saveBranches(branches);
+        };
+
+        $scope.backupPrevious = function (currentBranch) {
+            currentBranch.previous = {};
+            angular.copy(currentBranch, currentBranch.previous);
+        };
+
+        $scope.restorePrevious = function (currentBranch) {
+            angular.copy(currentBranch.previous, currentBranch);
+            currentBranch.previous = {};
+        };
+
+        $scope.isValid = function (currentBranch) {
+            return !_.isEmpty(currentBranch.name);
+        };
+
+        $scope.addBranch = function (currentBranch) {
+            var branches = [currentBranch.name], success, error;
+            _.each($scope.branchObjects, function (branchObj) {
+                branches.push(branchObj.name);
+            });
+
+            success = function () {
+                resetBranches();
+            };
+            error = function () {
+                resetBranches();
+            };
+
+            saveBranches(branches, success, error);
+        };
+
+        $scope.updateBranch = function (currentBranch) {
+            var success,
+                error,
+                branches = _.map($scope.branchObjects, function (branchObj) {
+                return branchObj.name;
+            });
+
+             // Need access to the original branch
+            success = function () {
+                currentBranch.previous = {};
+                currentBranch.editMode = false;
+                currentBranch.working = false;
+            };
+
+            error = function () {
+                currentBranch.working = false;
+            };
+
+            saveBranches(branches, success, error);
+        };
+
+        $scope.getSelectedBranches = function () {
+            return _.select($scope.branchObjects, function (branch) {
+                return branch.selected;
+            });
+        };
+
+        $scope.selectAll = function (val) {
+            _.each($scope.branchObjects, function (branch) {
+                branch.selected = val;
+            });
+        };
+    }]
+);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-info.html
@@ -8,7 +8,6 @@
   </a>
 
   <div class="fr">
-
     <button class="btn btn-default"
             ui-sref="products.details.repositories.manage-content.packages({productId: product.id, repositoryId: repository.id})"
             ng-hide="repository.content_type !== 'yum' || product.readonly">
@@ -25,6 +24,12 @@
             ui-sref="products.details.repositories.manage-content.docker-manifests({productId: product.id, repositoryId: repository.id})"
             ng-hide="repository.content_type !== 'docker' || product.readonly">
       <span translate>Manage Docker Manifests</span>
+    </button>
+
+    <button class="btn btn-default"
+            ui-sref="products.details.repositories.manage-ostree-branches({productId: product.id, repositoryId: repository.id})"
+            ng-hide="repository.content_type !== 'ostree' || product.readonly">
+      <span translate>Manage Branches</span>
     </button>
 
     <button class="btn btn-default"
@@ -241,7 +246,7 @@
             </a>
           </td>
         </tr>
-        <tr ng-show="repository.content_type == 'yum'">
+        <tr ng-show="repository.content_type === 'yum'">
           <td translate>Package Groups</td>
           <td class="align-center">
             <a ui-sref="products.details.repositories.manage-content.package-groups({productId: product.id, repositoryId: repository.id})">
@@ -249,7 +254,7 @@
             </a>
           </td>
         </tr>
-        <tr ng-show="repository.content_type == 'puppet'">
+        <tr ng-show="repository.content_type === 'puppet'">
           <td translate>Puppet Modules</td>
           <td class="align-center">
             <a ui-sref="products.details.repositories.manage-content.puppet-modules({productId: product.id, repositoryId: repository.id})">
@@ -257,21 +262,48 @@
             </a>
           </td>
         </tr>
-        <tr ng-show="repository.content_type == 'docker'">
+
+        <tr ng-show="repository.content_type === 'docker'">
             <td translate>Docker Manifests</td>
             <td class="align-center">{{ repository.content_counts.docker_manifest || 0 }}</td>
         </tr>
-        <tr ng-show="repository.content_type == 'docker'">
+        <tr ng-show="repository.content_type === 'docker'">
           <td translate>Docker Tags</td>
           <td class="align-center">{{ repository.content_counts.docker_tag || 0 }}</td>
+        </tr>
+        <tr ng-show="repository.content_type === 'ostree'">
+          <td translate>OSTree Units</td>
+          <td class="align-center">{{ repository.content_counts.ostree || 0 }}</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="divider" ng-if="repository.content_type === 'ostree'"/>
+  </section>
+
+  <section  ng-if="repository.content_type === 'ostree'">
+      <table class="table table-striped">
+      <thead>
+        <tr>
+          <th translate>Branches</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr ng-if ="repository.ostree_branches === undefined || repository.ostree_branches.length === 0">
+          <td translate> No Branches </td>
+        </tr>
+
+        <tr ng-repeat="branch in repository.ostree_branches" row-select="branch">
+          <td>{{ branch }}</td>
         </tr>
       </tbody>
     </table>
   </section>
 
-  <section class="well" ng-if="permitted('edit_products', product) && !product.redhat && repository.content_type != 'docker'">
-    <h5 translate ng-show="repository.content_type == 'puppet'">Upload Puppet Module</h5>
-    <h5 translate ng-show="repository.content_type == 'yum'">Upload Package</h5>
+  <section class="well" ng-if="permitted('edit_products', product) && !product.redhat && repository.content_type !== 'docker' && repository.content_type !== 'ostree'">
+    <h5 translate ng-show="repository.content_type === 'puppet'">Upload Puppet Module</h5>
+    <h5 translate ng-show="repository.content_type === 'yum'">Upload Package</h5>
 
     <div bst-alerts success-messages="uploadSuccessMessages" error-messages="uploadErrorMessages"></div>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-manage-ostree-branches.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-manage-ostree-branches.html
@@ -1,0 +1,105 @@
+<span page-title ng-model="repository">{{ 'Manage Branches for Repository:' | translate }} {{ repository.name }}</span>
+
+<a ui-sref="products.details.repositories.info({productId: product.id, repositoryId: repository.id})">
+  <i class="fa fa-angle-double-left"></i>
+  {{ "Back to Repository Details" | translate }}
+</a>
+
+<div>
+  <div data-block="header">
+    <h3 translate>Branches in {{ repository.name }}</h3>
+  </div>
+
+  <div data-block="messages">
+    <div bst-alerts success-messages="successMessages" error-messages="errorMessages"></div>
+  </div>
+
+  <div data-block="actions">
+    <div bst-modal="removeBranches()">
+      <div data-block="modal-header"
+           translate-n="getSelectedBranches().length"
+           translate-plural="Remove {{ getSelectedBranches().length }} Branches?">
+        Remove {{ getSelectedBranches().length  }} Branches?
+      </div>
+      <div data-block="modal-body"
+           translate-n="getSelectedBranches().length"
+           translate-plural="Are you sure you want to remove the {{ getSelectedBranches().length }} Branches selected?">
+        Are you sure you want to remove the {{ getSelectedBranches().length }} Branches selected?
+      </div>
+    </div>
+    <div class = "fr">
+      <button class="btn btn-default"
+              ng-click="openModal()"
+              ng-hide="denied('edit_products')"
+              ng-disabled="getSelectedBranches().length === 0">
+        <span translate>Remove Branches</span>
+      </button>
+    </div>
+  </div>
+
+  <div data-block="table">
+    <table class="table table-striped table-bordered" >
+      <thead>
+        <tr>
+          <th class="row-select">
+            <input type="checkbox"
+                   ng-model="allSelected"
+                   ng-change="selectAll(allSelected)"
+                   ng-disabled = "branchObjects.length === 0"
+                   ng-hide="denied('edit_products')"/>
+          </th>
+          <th translate>Branch Name</th>
+          <th></th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td></td><!-- Empty cell since the first row is special -->
+          <td>
+            <input type="text"
+                   class="form-control"
+                   ng-model="branch.name"/>
+          </td>
+          <td class="action-cell">
+            <button class="btn btn-default"
+                    ng-click="branch.working = true; addBranch(branch)"
+                    ng-hide="denied('edit_products')"
+                    ng-disabled="branch.working || !isValid(branch)">
+              <i class="fa fa-plus"></i>
+              <span translate>Add</span>
+            </button>
+          </td>
+        </tr>
+
+        <tr ng-repeat="branchObject in branchObjects" row-select="branchObject">
+          <td class="row-select">
+            <input type="checkbox"
+                   ng-hide="denied('edit_products')"
+                   ng-model="branchObject.selected"/>
+          </td>
+          <td>
+            <input class="form-control"
+                   ng-hide="denied('edit_products')"
+                   ng-model="branchObject.name"
+                   ng-readonly="!branchObject.editMode"/>
+          </td>
+         <td class="action-cell">
+            <button class="btn btn-default" ng-click="branchObject.editMode = true; backupPrevious(branchObject)" ng-hide="denied('edit_products') || branchObject.editMode">
+              <i class="fa fa-edit"></i>
+              <span translate>Edit</span>
+            </button>
+
+            <button bst-save-control
+                    on-cancel="restorePrevious(branchObject); branchObject.editMode = false"
+                    on-save="updateBranch(branchObject)"
+                    working="branchObject.working"
+                    ng-show="permitted('edit_products') && branchObject.editMode">
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+</div>

--- a/engines/bastion_katello/test/content-views/details/content-view-available-ostree-repositories.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/content-view-available-ostree-repositories.controller.test.js
@@ -1,0 +1,53 @@
+describe('Controller: ContentViewAvailableOstreeRepositoriesController', function() {
+    var $scope;
+
+    beforeEach(module('Bastion.content-views', 'Bastion.test-mocks', 'Bastion.i18n'));
+
+    beforeEach(inject(function($injector) {
+        var Nutupane,
+            $controller = $injector.get('$controller'),
+            ContentViewRepositoriesUtil = $injector.get('ContentViewRepositoriesUtil'),
+            Repository = $injector.get('MockResource').$new(),
+            ContentView = $injector.get('MockResource').$new();
+
+        Nutupane = function () {
+            this.getAllSelectedResults = function () {
+                return {included: {ids: [1, 2]}};
+            };
+            this.load = function () {};
+            this.table = {};
+        };
+
+        $scope = $injector.get('$rootScope').$new();
+        $scope.contentView = ContentView.get({id: 1});
+        $scope.contentView['repository_ids'] = [];
+        $scope.save = function () {
+            return {
+                then: function () {}
+            };
+        };
+
+        spyOn($scope, 'save').andCallThrough();
+
+        $controller('ContentViewAvailableRepositoriesController', {
+            $scope: $scope,
+            Repository: Repository,
+            Nutupane: Nutupane,
+            CurrentOrganization: 'ACME_Corporation',
+            ContentViewRepositoriesUtil: ContentViewRepositoriesUtil
+        });
+    }));
+
+    it("puts a repositories table on the scope", function() {
+        expect($scope.repositoriesTable).toBeDefined();
+    });
+
+    it('provides a method to add repositories to a content view', function() {
+        $scope.filteredItems = [{id: 1}];
+        $scope.addRepositories($scope.contentView);
+
+        expect($scope.save).toHaveBeenCalled();
+        expect($scope.contentView['repository_ids'].length).toBe(1);
+    });
+
+});

--- a/engines/bastion_katello/test/content-views/details/content-view-ostree-repositories-list.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/content-view-ostree-repositories-list.controller.test.js
@@ -1,0 +1,54 @@
+describe('Controller: ContentViewOstreeRepositoriesListController', function() {
+    var $scope;
+
+    beforeEach(module('Bastion.content-views', 'Bastion.test-mocks', 'Bastion.i18n'));
+
+    beforeEach(inject(function($injector) {
+        var Nutupane,
+            $controller = $injector.get('$controller'),
+            ContentViewRepositoriesUtil = $injector.get('ContentViewRepositoriesUtil'),
+            Repository = $injector.get('MockResource').$new(),
+            ContentView = $injector.get('MockResource').$new();
+
+        Nutupane = function () {
+            this.getAllSelectedResults = function () {
+                return {included: {ids: [1, 2]}};
+            };
+
+            this.load = function () {};
+            this.table = {};
+        };
+
+        $scope = $injector.get('$rootScope').$new();
+        $scope.contentView = ContentView.get({id: 1});
+        $scope.contentView['repository_ids'] = [1, 2, 3];
+        $scope.save = function () {
+            return {
+                then: function () {}
+            };
+        };
+
+        spyOn($scope, 'save').andCallThrough();
+
+        $controller('ContentViewRepositoriesListController', {
+            $scope: $scope,
+            Repository: Repository,
+            Nutupane: Nutupane,
+            CurrentOrganization: 'ACME_Corporation',
+            ContentViewRepositoriesUtil: ContentViewRepositoriesUtil
+        });
+    }));
+
+    it("puts a repositories table on the scope", function() {
+        expect($scope.repositoriesTable).toBeDefined();
+    });
+
+    it('provides a method to add repositories to a content view', function() {
+        $scope.filteredItems = [{id: 1}];
+        $scope.removeRepositories($scope.contentView);
+
+        expect($scope.save).toHaveBeenCalled();
+        expect($scope.contentView['repository_ids'].length).toBe(2);
+    });
+
+});

--- a/engines/bastion_katello/test/repositories/details/repository-details-manage-ostree-branches.controller.test.js
+++ b/engines/bastion_katello/test/repositories/details/repository-details-manage-ostree-branches.controller.test.js
@@ -1,0 +1,47 @@
+describe('Controller: RepositoryManageOstreeBranchesController', function() {
+    var $scope, translate, Repository;
+
+    beforeEach(module(
+        'Bastion.repositories',
+        'Bastion.test-mocks'
+    ));
+
+    beforeEach(inject(function($injector) {
+        var $controller = $injector.get('$controller'),
+            $state = $injector.get('$state');
+
+        Repository = $injector.get('MockResource').$new();
+
+        $scope = $injector.get('$rootScope').$new();
+        $scope.$stateParams = {
+            productId: 1,
+            repositoryId: 1,
+        };
+
+        translate = function(message) {
+            return message;
+        };
+
+        $controller('RepositoryManageOstreeBranchesController', {
+            $scope: $scope,
+            translate: translate,
+            Repository: Repository
+        });
+    }));
+
+    it('sets up the ostree branch objects correctly', function() {
+        var expectedBranches = ["redhat-atomic-host/el7.0/x86_64/base,redhat-atomic-host/el7.0/x86_64/medium",
+                                "redhat-atomic-host/el7.0/x86_64/base,redhat-atomic-host/el7.0/x86_64/base"]
+
+        $scope.wrap({id: 1, ostree_branches: expectedBranches});
+        _.each(expectedBranches, function (branch) {
+            expect($scope.branchObjects).toContain({name: branch});
+        });
+    });
+
+    it('sets up the empty ostree branch objects correctly', function() {
+        $scope.wrap({id: 1});
+        expect($scope.branchObjects).toBeDefined();
+        expect($scope.branchObjects.length).toBe(0);
+    });
+});

--- a/lib/katello/repository_types/ostree.rb
+++ b/lib/katello/repository_types/ostree.rb
@@ -1,0 +1,1 @@
+Katello::RepositoryTypeManager.register(::Katello::Repository::OSTREE_TYPE)

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -344,6 +344,38 @@ module ::Actions::Katello::Repository
     end
   end
 
+  class CloneOstreeContentTest  < TestBase
+    let(:action_class) { ::Actions::Katello::Repository::CloneOstreeContent }
+    let(:source_repo) { katello_repositories(:ostree) }
+    let(:target_repo) { katello_repositories(:ostree_view1) }
+
+    it 'plans' do
+      action = create_action action_class
+      plan_action(action, source_repo, target_repo)
+      assert_action_planed_with(action, ::Actions::Pulp::Repository::CopyOstreeBranch,
+                                source_pulp_id: source_repo.pulp_id,
+                                target_pulp_id: target_repo.pulp_id)
+      assert_action_planed_with(action, ::Actions::Katello::Repository::MetadataGenerate, target_repo)
+      assert_action_planed_with(action, ::Actions::Katello::Repository::IndexContent, id: target_repo.id)
+    end
+  end
+
+  class CloneOstreeContentEnvironmentTest  < TestBase
+    let(:action_class) { ::Actions::Katello::Repository::CloneToEnvironment }
+    let(:source_repo) { katello_repositories(:ostree) }
+
+    it 'plans' do
+      action = create_action action_class
+      env = mock
+      clone = mock
+      action.expects(:find_or_build_environment_clone).returns(clone)
+      clone.expects(:new_record?).returns(false)
+      plan_action(action, source_repo, env)
+      assert_action_planed_with(action, ::Actions::Katello::Repository::Clear, clone)
+      assert_action_planed_with(action, ::Actions::Katello::Repository::CloneOstreeContent, source_repo, clone)
+    end
+  end
+
   class CapsuleGenerateAndSyncTest < TestBase
     include Support::CapsuleSupport
 

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -232,7 +232,7 @@ module Katello
       product.expect(:organization, @organization)
       product.expect(:redhat?, false)
       product.expect(:unprotected?, true)
-      assert_sync_task(::Actions::Katello::Repository::Create, @repository, false, true)
+      assert_sync_task(::Actions::Katello::Repository::Create, @repository, false, true, nil)
 
       Product.stub(:find, product) do
         post :create, :name => 'Fedora Repository',
@@ -262,7 +262,7 @@ module Katello
       product.expect(:gpg_key, nil)
       product.expect(:organization, @organization)
       product.expect(:redhat?, false)
-      assert_sync_task(::Actions::Katello::Repository::Create, @repository, false, true)
+      assert_sync_task(::Actions::Katello::Repository::Create, @repository, false, true, nil)
 
       Product.stub(:find, product) do
         post :create, :name => 'Fedora Repository',
@@ -294,7 +294,7 @@ module Katello
       ])
       product.expect(:organization, @organization)
       product.expect(:redhat?, false)
-      assert_sync_task(::Actions::Katello::Repository::Create, @repository, false, true)
+      assert_sync_task(::Actions::Katello::Repository::Create, @repository, false, true, nil)
 
       Product.stub(:find, product) do
         post :create, :name => 'Fedora Repository',
@@ -324,7 +324,7 @@ module Katello
       product.expect(:gpg_key, nil)
       product.expect(:organization, @organization)
       product.expect(:redhat?, false)
-      assert_sync_task(::Actions::Katello::Repository::Create, @repository, false, true)
+      assert_sync_task(::Actions::Katello::Repository::Create, @repository, false, true, nil)
 
       Product.stub(:find, product) do
         post :create, :name => 'Fedora Repository',
@@ -355,7 +355,7 @@ module Katello
       product.expect(:gpg_key, nil)
       product.expect(:organization, @organization)
       product.expect(:redhat?, false)
-      assert_sync_task(::Actions::Katello::Repository::Create, @repository, false, true)
+      assert_sync_task(::Actions::Katello::Repository::Create, @repository, false, true, nil)
 
       Product.stub(:find, product) do
         post :create, :name => 'Fedora Repository',
@@ -387,7 +387,7 @@ module Katello
       product.expect(:organization, @organization)
       product.expect(:redhat?, false)
       product.expect(:unprotected?, false)
-      assert_sync_task(::Actions::Katello::Repository::Create, @repository, false, true)
+      assert_sync_task(::Actions::Katello::Repository::Create, @repository, false, true, nil)
 
       Product.stub(:find, product) do
         post :create, :name => 'Fedora Repository',
@@ -421,7 +421,7 @@ module Katello
       product.expect(:redhat?, false)
       product.expect(:unprotected?, true)
       product.expect(:docker_upstream_name, docker_upstream_name)
-      assert_sync_task(::Actions::Katello::Repository::Create, @repository, false, true)
+      assert_sync_task(::Actions::Katello::Repository::Create, @repository, false, true, nil)
 
       Product.stub(:find, product) do
         post :create, :name => 'Fedora Repository',
@@ -429,6 +429,39 @@ module Katello
                       :url => 'http://hub.registry.com',
                       :content_type => 'docker',
                       :docker_upstream_name => "busybox"
+
+        assert_response :success
+        assert_template 'api/v2/repositories/show'
+      end
+    end
+
+    def test_create_with_ostree
+      product = MiniTest::Mock.new
+      product.expect(:add_repo, @repository, [
+        'Fedora_Repository',
+        'Fedora Repository',
+        'http://hub.registry.com',
+        'ostree',
+        true,
+        nil,
+        nil,
+        nil
+      ])
+
+      product.expect(:editable?, @product.editable?)
+      product.expect(:gpg_key, nil)
+      product.expect(:organization, @organization)
+      product.expect(:redhat?, false)
+      branches = ["branch1", "branch2"]
+
+      assert_sync_task(::Actions::Katello::Repository::Create, @repository, false, true, branches)
+
+      Product.stub(:find, product) do
+        post :create, :name => 'Fedora Repository',
+                      :product_id => @product.id,
+                      :url => 'http://hub.registry.com',
+                      :content_type => 'ostree',
+                      :ostree_branches => branches
 
         assert_response :success
         assert_template 'api/v2/repositories/show'

--- a/test/fixtures/models/katello_products.yml
+++ b/test/fixtures/models/katello_products.yml
@@ -22,6 +22,14 @@ puppet_product:
   provider_id:  <%= ActiveRecord::FixtureSet.identify(:puppet_labs) %>
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
 
+ostree_product:
+  name:         OSTree Product
+  description:  A product for ostree content
+  cp_id:        ostree
+  label:        ostree_product
+  provider_id:  <%= ActiveRecord::Fixtures.identify(:anonymous) %>
+  organization_id: <%= ActiveRecord::Fixtures.identify(:empty_organization) %>
+
 empty_product:
   name:         Empty Product
   cp_id:        empty_product

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -330,6 +330,18 @@ iso:
   gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_view_version_1) %>
 
+ostree_rhel7:
+  name:                 ostree_rhel7
+  pulp_id:              "Default_Organization-Test-ostree"
+  content_id:           1
+  content_type:         ostree
+  label:                ostree_rhel7
+  relative_path:        '/ACME_Corporation/library/LibraryView/ostree_rhel7'
+  environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>
+  product_id:           <%= ActiveRecord::FixtureSet.identify(:ostree_product) %>
+  content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>
+  url:                  "http://cdn.qa.redhat.com/content/htb/rhel/server/7/x86_64/extras/ostree/"
+
 redis:
   name:                 redis
   pulp_id:              "Default_Organization-Test-redis"
@@ -398,3 +410,34 @@ rhel_6_x86_64_composite_view_version_1:
   gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:composite_view_version_1) %>
   download_policy: on_demand
+
+ostree:
+  name:                 ostree
+  pulp_id:              "Default_Organization-Test-ostree"
+  content_id:           1
+  content_type:         ostree
+  label:                ostree
+  relative_path:        '/ACME_Corporation/library/ostree'
+  environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>
+  product_id:           <%= ActiveRecord::FixtureSet.identify(:puppet_product) %>
+  gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
+  content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>
+  unprotected:           <%= true %>
+
+ostree_view1:
+  name:                 ostree
+  pulp_id:              "Default_Organization-Test-ostree"
+  content_id:           1
+  content_type:         ostree
+  library_instance:     ostree
+  label:                ostree
+  relative_path:        '/ACME_Corporation/library/ostree'
+  environment_id:
+  product_id:           <%= ActiveRecord::FixtureSet.identify(:puppet_product) %>
+  gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
+  content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_view_version_1) %>
+  unprotected:           <%= true %>
+  environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>
+  product_id:           <%= ActiveRecord::FixtureSet.identify(:redhat) %>
+  gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
+  content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:composite_view_version_1) %>

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -95,8 +95,11 @@ module Katello
     end
 
     def test_syncable_content
+      products_with_syncable_repos = Product.all.select do |prod|
+        prod.repositories.any? { |r| r.url.present? }
+      end
       products = Katello::Product.syncable_content
-      assert_equal 2, products.length
+      assert_equal products_with_syncable_repos.length, products.length
       products.each { |prod| assert prod.syncable_content? }
     end
 


### PR DESCRIPTION
Squashing every thing in the OSTree branch into 1 huge commit.

Stories covered by this PR

Fixes #10042 - Enable ostree repos in the CDN -
Katello#5455

Fixes #11611 - Copy over ostree branches on publish and promote -
Katello#5449

Ref #10040 - Minor fixes for the ostree repo create code -
Katello#5448

Fixes #10066 - Support promoting ostree repos -
Katello#5447

Refs #10040 - Ostree branch change now updates pulp -
Katello#5431

Fixes #10063 - Allow publishing of ostree repos in content views -
Katello#5415

Fixes #11567 - Fix relative_path for ostree repos -
Katello#5442

Fixes #10040 - UI Bindings to CRUD rpm-ostree -
Katello#5394
Includes adding/updating/removing  branches

Fixes #10044 - UI to remove/add ostree repos to CVs -
Katello#5361
Fixes #10056 - Adding ostree sync -
Katello#5306
Refs #10062 - Allow users to add/remove ostree repos - Katello#5337

Refs #10055 - Initial model bindings for OSTREE CRUD -
Katello#5240
