### PR TITLE
Fixes #13571 - Remote execution integration

### DIFF
--- a/app/controllers/katello/remote_execution_controller.rb
+++ b/app/controllers/katello/remote_execution_controller.rb
@@ -1,0 +1,55 @@
+module Katello
+  if Katello.with_remote_execution?
+    class RemoteExecutionController < JobInvocationsController
+      def new
+        @composer = prepare_composer
+      end
+
+      def create
+        @composer = prepare_composer
+        if params[:customize] != 'true' && @composer.save
+          @composer.trigger
+          redirect_to job_invocation_path(@composer.job_invocation)
+        else
+          render :action => 'new'
+        end
+      end
+
+      private
+
+      def prepare_composer
+        JobInvocationComposer.for_feature(feature_name, hosts, inputs)
+      end
+
+      def hosts
+        if params[:scoped_search].present?
+          params[:scoped_search]
+        else
+          ::Host.where(:id => params[:host_ids])
+        end
+      end
+
+      def inputs
+        if feature_name == 'katello_errata_install'
+          { :errata => params[:name] }
+        else
+          { :package => params[:name] }
+        end
+      end
+
+      def feature_name
+        # getting packageInstall from UI, translating to 'katello_package_install' feature
+        "katello_#{params[:remote_action].underscore}"
+      end
+
+      # to overcome the isolated namespace engine difficulties with paths
+      helper Rails.application.routes.url_helpers
+      def _routes
+        Rails.application.routes
+      end
+    end
+  else
+    class RemoteExecutionController < ApplicationController
+    end
+  end
+end

--- a/app/models/setting/katello.rb
+++ b/app/models/setting/katello.rb
@@ -22,7 +22,8 @@ class Setting::Katello < Setting
         self.set('default_download_policy', N_("Default download policy for repositories (either 'immediate', 'on_demand', or 'background')"), "immediate"),
         self.set('pulp_export_destination', N_("On-disk location for exported repositories"), File.join(Rails.root, 'repo-exports')),
         self.set('pulp_client_key', N_("Path for ssl key used for pulp server auth"), "/etc/pki/katello/private/pulp-client.key"),
-        self.set('pulp_client_cert', N_("Path for ssl cert used for pulp server auth"), "/etc/pki/katello/certs/pulp-client.crt")
+        self.set('pulp_client_cert', N_("Path for ssl cert used for pulp server auth"), "/etc/pki/katello/certs/pulp-client.crt"),
+        self.set('remote_execution_by_default', N_("If set to true, use the remote execution over katello-agent for remote actions"), false)
       ].each { |s| self.create! s.update(:category => "Setting::Katello") }
     end
     true

--- a/app/views/foreman/job_templates/install_errata.erb
+++ b/app/views/foreman/job_templates/install_errata.erb
@@ -1,0 +1,18 @@
+<%#
+kind: job_template
+name: Install Errata - Katello SSH Default
+job_category: Katello
+description_format: 'Install errata %{errata}'
+feature: katello_errata_install
+provider_type: SSH
+template_inputs:
+- name: errata
+  description: A comma separated list of errata to install
+  input_type: user
+  required: true
+foreign_input_sets:
+- template: Package Action - SSH Default
+  exclude: action,package
+%>
+
+<%= render_template('Package Action - SSH Default', :action => 'update', :package => "--advisories=#{input(:errata)}") %>

--- a/app/views/foreman/job_templates/install_group.erb
+++ b/app/views/foreman/job_templates/install_group.erb
@@ -1,0 +1,13 @@
+<%#
+kind: job_template
+name: Install Group - Katello SSH Default
+job_category: Katello
+description_format: 'Install package group(s) %{package}'
+feature: katello_group_install
+provider_type: SSH
+foreign_input_sets:
+- template: Package Action - SSH Default
+  exclude: action
+%>
+
+<%= render_template('Package Action - SSH Default', :action => 'group install') %>

--- a/app/views/foreman/job_templates/install_package.erb
+++ b/app/views/foreman/job_templates/install_package.erb
@@ -1,0 +1,13 @@
+<%#
+kind: job_template
+name: Install Package - Katello SSH Default
+job_category: Katello
+description_format: 'Install package(s) %{package}'
+feature: katello_package_install
+provider_type: SSH
+foreign_input_sets:
+- template: Package Action - SSH Default
+  exclude: action
+%>
+
+<%= render_template('Package Action - SSH Default', :action => 'install') %>

--- a/app/views/foreman/job_templates/remove_group.erb
+++ b/app/views/foreman/job_templates/remove_group.erb
@@ -1,0 +1,13 @@
+<%#
+kind: job_template
+name: Remove Group - Katello SSH Default
+job_category: Katello
+description_format: 'Remove package group(s) %{package}'
+feature: katello_group_remove
+provider_type: SSH
+foreign_input_sets:
+- template: Package Action - SSH Default
+  exclude: action
+%>
+
+<%= render_template('Package Action - SSH Default', :action => 'group remove') %>

--- a/app/views/foreman/job_templates/remove_package.erb
+++ b/app/views/foreman/job_templates/remove_package.erb
@@ -1,0 +1,13 @@
+<%#
+kind: job_template
+name: Remove Package - Katello SSH Default
+job_category: Katello
+description_format: 'Remove package(s) %{package}'
+feature: katello_package_remove
+provider_type: SSH
+foreign_input_sets:
+- template: Package Action - SSH Default
+  exclude: action
+%>
+
+<%= render_template('Package Action - SSH Default', :action => 'remove') %>

--- a/app/views/foreman/job_templates/update_group.erb
+++ b/app/views/foreman/job_templates/update_group.erb
@@ -1,0 +1,13 @@
+<%#
+kind: job_template
+name: Update Group - Katello SSH Default
+job_category: Katello
+description_format: 'Install package group(s) %{package}'
+feature: katello_group_update
+provider_type: SSH
+foreign_input_sets:
+- template: Package Action - SSH Default
+  exclude: action
+%>
+
+<%= render_template('Package Action - SSH Default', :action => 'group update') %>

--- a/app/views/foreman/job_templates/update_package.erb
+++ b/app/views/foreman/job_templates/update_package.erb
@@ -1,0 +1,13 @@
+<%#
+kind: job_template
+name: Update Package - Katello SSH Default
+job_category: Katello
+description_format: 'Update package(s) %{package}'
+feature: katello_package_update
+provider_type: SSH
+foreign_input_sets:
+- template: Package Action - SSH Default
+  exclude: action
+%>
+
+<%= render_template('Package Action - SSH Default', :action => 'update') %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,10 @@ Katello::Engine.routes.draw do
 
     match '/providers/:id' => 'providers#update', :via => [:put, :post]
 
+    if Katello.with_remote_execution?
+      match '/remote_execution' => 'remote_execution#create', :via => [:post]
+    end
+
     resources :organizations do
       collection do
         get :auto_complete_search

--- a/db/seeds.d/75-job_templates.rb
+++ b/db/seeds.d/75-job_templates.rb
@@ -1,0 +1,10 @@
+if Katello.with_remote_execution?
+  User.as_anonymous_admin do
+    JobTemplate.without_auditing do
+      Dir[File.join("#{Katello::Engine.root}/app/views/foreman/job_templates/**/*.erb")].each do |template|
+        sync = !Rails.env.test? && Setting[:remote_execution_sync_templates]
+        JobTemplate.import!(File.read(template), :default => true, :locked => true, :update => sync)
+      end
+    end
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/bulk-actions-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/bulk-actions-errata.html
@@ -25,19 +25,40 @@
     <div data-block="header" translate>Content Host Errata Management</div>
 
     <div data-block="actions">
-      <button class="btn btn-default"
+      <button class="btn btn-default fl"
               ng-disabled="table.numSelected === 0 || detailsTable.working"
               ng-click="fetchErrata()">
         <i class="fa fa-refresh"></i>
         {{ "Refresh Table" | translate }}
       </button>
 
-      <button class="btn btn-primary"
-              ng-disabled="table.numSelected === 0 || detailsTable.working || detailsTable.numSelected === 0"
-              ng-click="showConfirmDialog()">
-        <i class="fa fa-plus"></i>
-        {{ "Install Selected" | translate }}
-      </button>
+      <span class="input-group-btn">
+        <button class="btn btn-primary"
+                ng-disabled="table.numSelected === 0 || detailsTable.working || detailsTable.numSelected === 0"
+                ng-click="showConfirmDialog()">
+          <i class="fa fa-plus"></i>
+          {{ "Install Selected" | translate }}
+        </button>
+        <button class="btn btn-primary dropdown-toggle"
+                ng-hide="!remoteExecutionPresent"
+                ng-disabled="table.numSelected === 0 || detailsTable.working || detailsTable.numSelected === 0"
+                type="button" id="use-remote-execution" data-toggle="dropdown">
+          <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu" role="menu" aria-labelledby="use-remote-execution">
+          <li role="presentation"><a ng-click="installErrataViaKatelloAgent()" role="menuitem" tabindex="-1" href="#" translate>via Katello agent</a></li>
+          <li role="presentation"><a ng-click="installErrataViaRemoteExecution(false)" role="menuitem" tabindex="-1" href="#" translate>via remote execution</a></li>
+          <li role="presentation"><a ng-click="installErrataViaRemoteExecution(true)" role="menuitem" tabindex="-1" href="#" translate>via remote execution - customize first</a></li>
+        </ul>
+        <form id="errataBulkActionForm" name="errataBulkActionForm" class="form" method="post" action="/katello/remote_execution">
+          <input type="hidden" name="name" ng-value="errataActionFormValues.errata"/>
+          <input type="hidden" name="remote_action" ng-value="errataActionFormValues.remoteAction"/>
+          <input type="hidden" name="scoped_search" ng-value="errataActionFormValues.search"/>
+          <input type="hidden" name="host_ids" ng-value="errataActionFormValues.hostIds"/>
+          <input type="hidden" name="authenticity_token" ng-value="errataActionFormValues.authenticityToken"/>
+          <input type="hidden" name="customize" ng-value="errataActionFormValues.customize"/>
+        </form>
+      </span>
     </div>
 
     <span data-block="no-rows-message" translate>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/bulk-actions-packages.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/bulk-actions-packages.html
@@ -4,18 +4,25 @@
   <section>
     <h4 translate>Content Host Package Management</h4>
 
+    <form id="packageActionForm" name="packageActionForm" class="form" method="post" action="/katello/remote_execution">
+      <input type="hidden" name="name" ng-value="content.content"/>
+      <input type="hidden" name="remote_action" ng-value="packageActionFormValues.remoteAction"/>
+      <input type="hidden" name="scoped_search" ng-value="packageActionFormValues.search"/>
+      <input type="hidden" name="host_ids" ng-value="packageActionFormValues.hostIds"/>
+      <input type="hidden" name="authenticity_token" ng-value="packageActionFormValues.authenticityToken"/>
+      <input type="hidden" name="customize" ng-value="packageActionFormValues.customize"/>
+    </form>
 
     <form name="systemContentForm" class="form" ng-hide="content.workingMode || denied('edit_content_hosts', contentHost)">
-
       <div>
-        <input type="radio"
+        <input id="package" type="radio"
                ng-model="content.contentType"
                ng-change="updatePlaceholder(content.contentType)"
                ng-disabled="content.confirm"
                value="package"/>
         <label for="package" translate>Package</label>
 
-        <input type="radio"
+        <input id="package_group" type="radio"
                ng-model="content.contentType"
                ng-change="updatePlaceholder(content.contentType)"
                ng-disabled="content.confirm"
@@ -26,7 +33,6 @@
 
       <div class="form-group">
         <input class="form-control"
-               name="label"
                type="text"
                placeholder="{{ content.placeholder }}"
                ng-model="content.content"
@@ -35,30 +41,69 @@
       </div>
 
       <div>
-        <button class="btn btn-default"
-                translate
-                ng-hide="denied('edit_content_hosts', contentHost)"
-                ng-click="confirmContentAction('install', content)"
-                ng-disabled="(table.numSelected === 0) || !systemContentForm.$valid || content.confirm">
-          Install
-        </button>
+        <span class="input-group-btn">
+          <button class="btn btn-default"
+                  translate
+                  ng-hide="denied('edit_content_hosts', contentHost)"
+                  ng-click="confirmContentAction('install', content)"
+                  ng-disabled="(table.numSelected === 0) || !packageActionForm.$valid || content.confirm">
+            Install
+          </button>
+          <button class="btn btn-default dropdown-toggle"
+                  ng-hide="!remoteExecutionPresent"
+                  ng-disabled="(table.numSelected === 0) || !packageActionForm.$valid || content.confirm"
+                  type="button" id="install-use-remote-execution" data-toggle="dropdown">
+            <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu" role="menu" aria-labelledby="install-use-remote-execution">
+            <li role="presentation"><a ng-click="performViaKatelloAgent('install', content)" role="menuitem" tabindex="-1" href="#" translate>via Katello Agent</a></li>
+            <li role="presentation"><a ng-click="performViaRemoteExecution('install', false)" role="menuitem" tabindex="-1" href="#" translate>via remote execution</a></li>
+            <li role="presentation"><a ng-click="performViaRemoteExecution('install', true)" role="menuitem" tabindex="-1" href="#" translate>via remote execution - customize first</a></li>
+          </ul>
+        </span>
 
-        <button class="btn btn-default"
-                translate
-                ng-hide="denied('edit_content_hosts', contentHost)"
-                ng-click="confirmContentAction('update', content)"
-                ng-disabled="(table.numSelected === 0) || !systemContentForm.$valid || content.confirm"
-                ng-hide="content.contentType == 'errata'">
-          Update
-        </button>
+        <span class="input-group-btn">
+          <button class="btn btn-default"
+                  translate
+                  ng-hide="denied('edit_content_hosts', contentHost)"
+                  ng-click="confirmContentAction('update', content)"
+                  ng-disabled="(table.numSelected === 0) || !packageActionForm.$valid || content.confirm"
+                  ng-hide="content.contentType == 'errata'">
+            Update
+          </button>
+          <button class="btn btn-default dropdown-toggle"
+                  ng-hide="!remoteExecutionPresent || denied('edit_content_hosts', contentHost)"
+                  ng-disabled="(table.numSelected === 0) || !packageActionForm.$valid || content.confirm"
+                  type="button" id="update-use-remote-execution" data-toggle="dropdown">
+            <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu" role="menu" aria-labelledby="update-use-remote-execution">
+            <li role="presentation"><a ng-click="performViaKatelloAgent('update', content)" role="menuitem" tabindex="-1" href="#" translate>via Katello Agent</a></li>
+            <li role="presentation"><a ng-click="performViaRemoteExecution('update', false)" role="menuitem" tabindex="-1" href="#" translate>via remote execution</a></li>
+            <li role="presentation"><a ng-click="performViaRemoteExecution('update', true)" role="menuitem" tabindex="-1" href="#" translate>via remote execution - customize first</a></li>
+          </ul>
+        </span>
 
-        <button class="btn btn-default"
-                translate
-                ng-hide="content.contentType == 'errata' || denied('edit_content_hosts', contentHost)"
-                ng-click="confirmContentAction('remove', content)"
-                ng-disabled="(table.numSelected === 0) || !systemContentForm.$valid || content.confirm">
-          Remove
-        </button>
+        <span class="input-group-btn">
+          <button class="btn btn-default"
+                  translate
+                  ng-hide="content.contentType == 'errata' || denied('edit_content_hosts', contentHost)"
+                  ng-click="confirmContentAction('remove', content)"
+                  ng-disabled="(table.numSelected === 0) || !packageActionForm.$valid || content.confirm">
+            Remove
+          </button>
+          <button class="btn btn-default dropdown-toggle"
+                  ng-hide="!remoteExecutionPresent || denied('edit_content_hosts', contentHost)"
+                  ng-disabled="(table.numSelected === 0) || !packageActionForm.$valid || content.confirm"
+                  type="button" id="remove-use-remote-execution" data-toggle="dropdown">
+            <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu" role="menu" aria-labelledby="remove-use-remote-execution">
+            <li role="presentation"><a ng-click="performViaKatelloAgent('remove', content)" role="menuitem" tabindex="-1" href="#" translate>via Katello Agent</a></li>
+            <li role="presentation"><a ng-click="performViaRemoteExecution('remove', false)" role="menuitem" tabindex="-1" href="#" translate>via remote execution</a></li>
+            <li role="presentation"><a ng-click="performViaRemoteExecution('remove', true)" role="menuitem" tabindex="-1" href="#" translate>via remote execution - customize first</a></li>
+          </ul>
+        </span>
       </div>
 
       <div class="inline-confirmation" ng-show="content.confirm">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
@@ -3,16 +3,19 @@
  * @name  Bastion.content-hosts.controller:ContentHostErrataController
  *
  * @requires $scope
+ * @resource $timeout
+ * @resource $window
  * @requires HostErratum
  * @requires Nutupane
+ * @requires BastionConfig
  *
  * @description
  *   Provides the functionality for the content host package list and actions.
  */
 /*jshint camelcase:false*/
 angular.module('Bastion.content-hosts').controller('ContentHostErrataController',
-    ['$scope', 'translate', 'HostErratum', 'Nutupane', 'Organization', 'Environment',
-    function ($scope, translate, HostErratum, Nutupane, Organization, Environment) {
+    ['$scope', '$timeout', '$window', 'translate', 'HostErratum', 'Nutupane', 'Organization', 'Environment', 'BastionConfig',
+    function ($scope, $timeout, $window, translate, HostErratum, Nutupane, Organization, Environment, BastionConfig) {
         var errataNutupane, params = {
             'sort_by': 'updated',
             'sort_order': 'DESC',
@@ -34,6 +37,12 @@ angular.module('Bastion.content-hosts').controller('ContentHostErrataController'
             return item.type.indexOf(searchText) >= 0 ||
                 item.errata_id.indexOf(searchText) >= 0 ||
                 item.title.indexOf(searchText) >= 0;
+        };
+
+        $scope.remoteExecutionPresent = BastionConfig.remoteExecutionPresent;
+        $scope.remoteExecutionByDefault = BastionConfig.remoteExecutionByDefault;
+        $scope.errataActionFormValues = {
+            authenticityToken: $window.AUTH_TOKEN.replace(/&quot;/g, '')
         };
 
         $scope.selectedErrataOption = 'current';
@@ -94,18 +103,42 @@ angular.module('Bastion.content-hosts').controller('ContentHostErrataController'
             $scope.transitionTo('content-hosts.details.errata.details', {errataId: erratum.errata_id});
         };
 
-        $scope.applySelected = function () {
-            var selected, errataIds = [];
-            selected = $scope.detailsTable.getSelected();
-            if (selected.length > 0) {
-                angular.forEach(selected, function (value) {
-                    errataIds.push(value.errata_id);
-                });
+        $scope.selectedErrataIds = function () {
+            var errataIds = [], selected = $scope.detailsTable.getSelected();
+            angular.forEach(selected, function (value) {
+                errataIds.push(value.errata_id);
+            });
+            return errataIds;
+        };
+
+        $scope.performViaKatelloAgent = function () {
+            var errataIds = $scope.selectedErrataIds();
+            if (errataIds.length > 0) {
                 HostErratum.apply({id: $scope.host.id, 'errata_ids': errataIds},
                                    function (task) {
                                         $scope.detailsTable.selectAll(false);
                                         $scope.transitionTo('content-hosts.details.tasks.details', {taskId: task.id});
                                     });
+            }
+        };
+
+        $scope.performViaRemoteExecution = function(customize) {
+            var errataIds = $scope.selectedErrataIds();
+            $scope.errataActionFormValues.errata = errataIds.join(',');
+            $scope.errataActionFormValues.customize = customize;
+            $scope.errataActionFormValues.hostIds = $scope.contentHost.host.id;
+            $scope.errataActionFormValues.customize = customize;
+
+            $timeout(function () {
+                angular.element('#errataActionForm').submit();
+            }, 0);
+        };
+
+        $scope.applySelected = function () {
+            if ($scope.remoteExecutionByDefault) {
+                $scope.performViaRemoteExecution(false);
+            } else {
+                $scope.performViaKatelloAgent();
             }
         };
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
@@ -57,13 +57,33 @@
         </div>
 
         <div ng-hide="contentHost.readonly" class="fr">
-           <button class="btn btn-primary"
-                   translate
-                   ng-hide="denied('edit_content_hosts', contentHost)"
-                   ng-disabled="detailsTable.getSelected().length == 0"
-                   ng-click="openModal()">
-             Apply Selected
-           </button>
+          <span class="input-group-btn">
+            <button class="btn btn-primary"
+                    translate
+                    ng-hide="denied('edit_content_hosts', contentHost)"
+                    ng-disabled="detailsTable.getSelected().length == 0"
+                    ng-click="openModal()">
+              Apply Selected
+            </button>
+            <button class="btn btn-primary dropdown-toggle"
+                    ng-hide="!remoteExecutionPresent || denied('edit_content_hosts', contentHost)"
+                    ng-disabled="detailsTable.getSelected().length == 0"
+                    type="button" id="use-remote-execution" data-toggle="dropdown">
+              <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu" role="menu" aria-labelledby="use-remote-execution">
+              <li role="presentation"><a ng-click="performViaKatelloAgent()" role="menuitem" tabindex="-1" href="#" translate>via Katello agent</a></li>
+              <li role="presentation"><a ng-click="performViaRemoteExecution(false)" role="menuitem" tabindex="-1" href="#" translate>via remote execution</a></li>
+              <li role="presentation"><a ng-click="performViaRemoteExecution(true)" role="menuitem" tabindex="-1" href="#" translate>via remote execution - customize first</a></li>
+            </ul>
+            <form id="errataActionForm" method="post" action="/katello/remote_execution">
+              <input type="hidden" name="remote_action" value="errata_install"/>
+              <input type="hidden" name="name" ng-value="errataActionFormValues.errata"/>
+              <input type="hidden" name="host_ids" ng-value="errataActionFormValues.hostIds"/>
+              <input type="hidden" name="customize" ng-value="errataActionFormValues.customize"/>
+              <input type="hidden" name="authenticity_token" ng-value="errataActionFormValues.authenticityToken"/>
+            </form>
+          </span>
         </div>
     </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages.html
@@ -12,10 +12,19 @@
     </span>
   </p>
   <section>
+
+    <form role="form" class="row" id="packageActionForm" method="post" action="/katello/remote_execution">
+      <input type="hidden" name="name" ng-value="packageActionFormValues.package"/>
+      <input type="hidden" name="remote_action" ng-value="packageActionFormValues.remoteAction"/>
+      <input type="hidden" name="host_ids" ng-value="packageActionFormValues.hostIds"/>
+      <input type="hidden" name="customize" ng-value="packageActionFormValues.customize"/>
+      <input type="hidden" name="authenticity_token" ng-value="packageActionFormValues.authenticityToken"/>
+    </form>
+
     <form ng-submit="performPackageAction()" role="form" class="row">
 
       <div class="col-sm-2">
-        <select class="form-control" ng-model="packageAction.actionType" required>
+        <select class="form-control" ng-model="packageAction.actionType" name="remote_action" required>
           <option value="packageInstall" translate>Package Install</option>
           <option value="packageUpdate" translate>Package Update</option>
           <option value="packageRemove" translate>Package Remove</option>
@@ -36,6 +45,17 @@
                   ng-disabled="working || packageAction.term === undefined || packageAction.term.length === 0"
                   translate>
             Perform</button>
+            <button class="btn btn-default dropdown-toggle"
+                    ng-hide="!remoteExecutionPresent || denied('edit_content_hosts', contentHost)"
+                    ng-disabled="working || packageAction.term === undefined || packageAction.term.length === 0"
+                    type="button" id="use-remote-execution" data-toggle="dropdown">
+              <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu" role="menu" aria-labelledby="use-remote-execution">
+              <li role="presentation"><a ng-click="performViaKatelloAgent()" role="menuitem" tabindex="-1" href="#" translate>via Katello agent</a></li>
+              <li role="presentation"><a ng-click="performViaRemoteExecution(false)" role="menuitem" tabindex="-1" href="#" translate>via remote execution</a></li>
+              <li role="presentation"><a ng-click="performViaRemoteExecution(true)" role="menuitem" tabindex="-1" href="#" translate>via remote execution - customize first</a></li>
+            </ul>
         </span>
       </div>
     </form>

--- a/engines/bastion_katello/lib/bastion_katello/engine.rb
+++ b/engines/bastion_katello/lib/bastion_katello/engine.rb
@@ -32,7 +32,9 @@ module BastionKatello
           select_organization
         ),
         :config => {
-          'consumerCertRPM' => consumer_cert_rpm
+          'consumerCertRPM' => consumer_cert_rpm,
+          'remoteExecutionPresent' => ::Katello.with_remote_execution?,
+          'remoteExecutionByDefault' => ::Katello.with_remote_execution? && Setting['remote_execution_by_default']
         }
       )
     end

--- a/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-action-errata.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-action-errata.controller.test.js
@@ -21,7 +21,8 @@ describe('Controller: ContentHostsBulkActionErrataController', function() {
         };
     });
 
-    beforeEach(inject(function($controller, $rootScope, $q) {
+    beforeEach(inject(function($controller, $rootScope, $q, $window) {
+        $window.AUTH_TOKEN = 'secret_token';
         $scope = $rootScope.$new();
         $scope.nutupane = {
             table: {

--- a/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-action-packages.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-action-packages.controller.test.js
@@ -29,7 +29,8 @@ describe('Controller: ContentHostsBulkActionPackagesController', function() {
         selected = {included: {ids: [1, 2, 3]}}
     });
 
-    beforeEach(inject(function($controller, $rootScope, $q) {
+    beforeEach(inject(function($controller, $rootScope, $q, $window) {
+        $window.AUTH_TOKEN = 'secret_token';
         $scope = $rootScope.$new();
         $scope.nutupane = {};
         $scope.nutupane.getAllSelectedResults = function () { return selected }

--- a/engines/bastion_katello/test/content-hosts/content/content-host-errata.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content/content-host-errata.controller.test.js
@@ -50,7 +50,8 @@ describe('Controller: ContentHostErrataController', function() {
         };
     });
 
-    beforeEach(inject(function($controller, $rootScope, $injector) {
+    beforeEach(inject(function($controller, $rootScope, $injector, $window) {
+        $window.AUTH_TOKEN = 'secret_token';
         $scope =  $rootScope.$new();
         $scope.host = host;
 

--- a/engines/bastion_katello/test/content-hosts/content/content-host-packages.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content/content-host-packages.controller.test.js
@@ -39,7 +39,8 @@ describe('Controller: ContentHostPackagesController', function() {
 
     });
 
-    beforeEach(inject(function($controller, $rootScope, MockResource) {
+    beforeEach(inject(function($controller, $rootScope, $window, MockResource) {
+        $window.AUTH_TOKEN = 'secret_token';
         $scope = $rootScope.$new();
         $scope.host = mockHost;
         $scope.$stateParams = {hostId: mockHost.id};

--- a/engines/bastion_katello/test/test-mocks.module.js
+++ b/engines/bastion_katello/test/test-mocks.module.js
@@ -12,8 +12,8 @@ angular.module('Bastion.test-mocks').config(['$provide', function ($provide) {
 
 }]);
 
-angular.module('Bastion.test-mocks').run(['$state', '$stateParams', '$rootScope',
-    function($state, $stateParams, $rootScope) {
+angular.module('Bastion.test-mocks').run(['$state', '$stateParams', '$rootScope', '$window',
+    function($state, $stateParams, $rootScope, $window) {
 
         $rootScope.transitionTo = function(state, params) {};
         $rootScope.$state = $state;

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -244,4 +244,9 @@ module Katello
       load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/3.0/delete_docker_v1_content.rake"
     end
   end
+
+  # check whether foreman_remote_execution to integrate is available in the system
+  def self.with_remote_execution?
+    (RemoteExecutionFeature rescue false) ? true : false
+  end
 end

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -182,4 +182,14 @@ Foreman::Plugin.register :katello do
                    :partial => 'smart_proxies/show/storage',
                    :onlyif => proc { |proxy| proxy.has_feature?(SmartProxy::PULP_FEATURE) || proxy.has_feature?(SmartProxy::PULP_NODE_FEATURE) }
   end
+
+  if Katello.with_remote_execution?
+    RemoteExecutionFeature.register(:katello_package_install, N_("Katello: Install Package"), :description => N_("Install package via Katello interface"), :provided_inputs => ['package'])
+    RemoteExecutionFeature.register(:katello_package_update, N_("Katello: Update Package"), :description => N_("Update package via Katello interface"), :provided_inputs => ['package'])
+    RemoteExecutionFeature.register(:katello_package_remove, N_("Katello: Remove Package"), :description => N_("Remove package via Katello interface"), :provided_inputs => ['package'])
+    RemoteExecutionFeature.register(:katello_group_install, N_("Katello: Install Package Group"), :description => N_("Install package group via Katello interface"), :provided_inputs => ['package'])
+    RemoteExecutionFeature.register(:katello_group_update, N_("Katello: Update Package Group"), :description => N_("Update package group via Katello interface"), :provided_inputs => ['package'])
+    RemoteExecutionFeature.register(:katello_group_remove, N_("Katello: Remove Package Group"), :description => N_("Remove package group via Katello interface"), :provided_inputs => ['package'])
+    RemoteExecutionFeature.register(:katello_errata_install, N_("Katello: Install Errata"), :description => N_("Install errata via Katello interface"), :provided_inputs => ['errata'])
+  end
 end


### PR DESCRIPTION
Add ability to use the Remote Execution tooling for the content actions
on hosts.

First, we need to use the developer API to define the remote execution features
and templates.

Then, there is ability in UI to jump into the remote execution UI
from the appropriate places.

![katello-rex-1](https://cloud.githubusercontent.com/assets/190443/12832345/a40c78c6-cb99-11e5-90c5-fd33881b7d03.gif)

![katello-rex-2](https://cloud.githubusercontent.com/assets/190443/12832348/a9bcfb56-cb99-11e5-9ad4-9eeaead54f28.gif)


Depends on https://github.com/theforeman/foreman_remote_execution/pull/149.

- [x] - detect if Remote Execution plugin is installed and make the option available only when presented
- [x] - errata support