### PR TITLE
Fixes #13623 - Temporarily default to immediate for download_policy

### DIFF
--- a/app/models/setting/katello.rb
+++ b/app/models/setting/katello.rb
@@ -19,7 +19,7 @@ class Setting::Katello < Setting
         self.set('pulp_sync_node_action_finish_timeout', N_("Time in seconds to wait for a pulp node to finish sync"), 12.hours.to_i),
         self.set('check_services_before_actions', N_("Whether or not to check the status of backend services such as pulp and candlepin prior to performing some actions."), true),
         self.set('force_post_sync_actions', N_("Force post sync actions such as indexing and email even if no content was available."), false),
-        self.set('default_download_policy', N_("Default download policy for repositories (either 'immediate', 'on_demand', or 'background')"), "on_demand"),
+        self.set('default_download_policy', N_("Default download policy for repositories (either 'immediate', 'on_demand', or 'background')"), "immediate"),
         self.set('pulp_export_destination', N_("On-disk location for exported repositories"), "/tmp/katello-repo-exports")
       ].each { |s| self.create! s.update(:category => "Setting::Katello") }
     end


### PR DESCRIPTION
Lazy sync was added to master (and thus the nightlies) but without squid,
pulp-streamer, etc setup and configured, nightly katello can't use lazy sync.
Let's default to immediate until we get the installer changes in.