### PR TITLE
Fixes #13650 - remove system_errata table.

### DIFF
--- a/app/lib/actions/katello/host/generate_applicability.rb
+++ b/app/lib/actions/katello/host/generate_applicability.rb
@@ -15,7 +15,6 @@ module Actions
         def finalize
           ::Host.where(:id => input[:host_ids]).each do |host|
             host.content_facet.try(:import_applicability)
-            host.content_host.try(:import_applicability)
             host.get_status(::Katello::ErrataStatus).refresh!
           end
         end

--- a/db/migrate/20160211134035_remove_system_errata.rb
+++ b/db/migrate/20160211134035_remove_system_errata.rb
@@ -1,0 +1,20 @@
+class RemoveSystemErrata < ActiveRecord::Migration
+  def up
+    drop_table "katello_system_errata"
+  end
+
+  def down
+    create_table "katello_system_errata" do |t|
+      t.references :erratum, :null => false
+      t.references :system, :null => false
+    end
+
+    add_index :katello_system_errata, [:erratum_id, :system_id], :unique => true,
+              :name => :katello_system_errata_eid_sid
+
+    add_foreign_key "katello_system_errata", "katello_errata",
+                    :name => "katello_system_errata_errata_id", :column => "erratum_id"
+    add_foreign_key "katello_system_errata", "katello_systems",
+                    :name => "katello_system_errata_system_id", :column => "system_id"
+  end
+end


### PR DESCRIPTION
When deleting a system the foreign key to system_errata causes
the delete of the system to fail. This table is now unused and
should be removed.

http://projects.theforeman.org/issues/13650