### PR TITLE
Fixes #13659 - handle 'nil' from computed_version

### DIFF
--- a/app/models/katello/content_view_puppet_module.rb
+++ b/app/models/katello/content_view_puppet_module.rb
@@ -31,7 +31,7 @@ module Katello
         )
       end
 
-      puppet_module.version
+      puppet_module.try(:version)
     end
 
     before_save :set_attributes

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/content-view-puppet-modules.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/content-view-puppet-modules.controller.js
@@ -24,7 +24,12 @@ angular.module('Bastion.content-views').controller('ContentViewPuppetModulesCont
         $scope.errorMessages = [];
 
         $scope.versionText = function (module) {
-            var version = translate("Latest (Currently %s)").replace('%s', module['computed_version']);
+            var version;
+            if (module['computed_version']) {
+                version = translate("Latest (Currently %s)").replace('%s', module['computed_version']);
+            } else {
+                version = translate("Unable to determine version");
+            }
             if (module['puppet_module']) {
                 version = module['puppet_module'].version;
             }

--- a/test/models/content_view_puppet_module_test.rb
+++ b/test/models/content_view_puppet_module_test.rb
@@ -42,5 +42,21 @@ module Katello
     def test_search_author
       assert_includes ContentViewPuppetModule.search_for("author = \"#{@puppet_module.author}\""), @puppet_module
     end
+
+    def test_computed_version
+      content_view_puppet_module = ContentViewPuppetModule.new(
+        :uuid => katello_puppet_modules(:foreman_proxy).uuid,
+        :content_view => @library_view
+      )
+      assert_equal "1.0", content_view_puppet_module.computed_version
+    end
+
+    def test_computed_version_nil
+      content_view_puppet_module = ContentViewPuppetModule.new(
+        :uuid => nil,
+        :content_view => @library_view
+      )
+      assert_equal nil, content_view_puppet_module.computed_version
+    end
   end
 end


### PR DESCRIPTION
The computed_version method assumed that there would always be a found puppet
module, and thus assumed 'version' was always populated.

This patch allows it to return nil when no version is found. Additionally, the
JS now gracefully handles nil.