### PR TITLE
fixes #13733, #13734 - remove dir timestamp, update task info

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -186,7 +186,7 @@ module Katello
         end
       end
 
-      task = async_task(::Actions::Katello::Repository::Export, [@repository.pulp_id],
+      task = async_task(::Actions::Katello::Repository::Export, [@repository],
                         ::Foreman::Cast.to_bool(params[:export_to_iso]),
                         params[:since].try(:to_datetime),
                         params[:iso_mb_size],

--- a/app/lib/actions/katello/content_view_version/export.rb
+++ b/app/lib/actions/katello/content_view_version/export.rb
@@ -11,16 +11,16 @@ module Actions
           org_label = ::Organization.find_by(:id => content_view.organization_id).label
           group_id = "#{org_label}-#{content_view.label}-"\
                      "v#{content_view_version.major}.#{content_view_version.minor}"
+          action_subject(content_view_version)
 
-          repo_pulp_ids = content_view_version.archived_repos.
-                            select { |r| r.content_type == 'yum' }.collect { |r| r.pulp_id }
+          repos = content_view_version.archived_repos.select { |r| r.content_type == 'yum' }
 
           history = ::Katello::ContentViewHistory.create!(:content_view_version => content_view_version,
                                                           :user => ::User.current.login,
                                                           :status => ::Katello::ContentViewHistory::IN_PROGRESS,
                                                           :task => self.task)
 
-          plan_action(Katello::Repository::Export, repo_pulp_ids, export_to_iso, start_date, iso_size,
+          plan_action(Katello::Repository::Export, repos, export_to_iso, start_date, iso_size,
                                                    group_id)
           plan_self(:history_id => history.id)
         end

--- a/app/lib/actions/katello/repository/export.rb
+++ b/app/lib/actions/katello/repository/export.rb
@@ -11,10 +11,13 @@ module Actions
 
         EXPORT_OUTPUT_BASEDIR = "/var/lib/pulp/published/yum/master/group_export_distributor/"
 
-        def plan(repo_pulp_ids, export_to_iso, since, iso_size, group_id)
-          # assemble data to feed to Pulp
-          start_date = since ? since.iso8601 : nil
+        def plan(repos, export_to_iso, since, iso_size, group_id)
+          repo_pulp_ids = repos.collect do |repo|
+            action_subject(repo)
+            repo.pulp_id
+          end
 
+          start_date = since ? since.iso8601 : nil
           unless since.nil?
             group_id += "-incremental"
           end
@@ -25,8 +28,7 @@ module Actions
           # Additionally, we want Pulp to export to dirs that Pulp owns, and
           # then Katello can copy it over as needed. This is needed for SELinux
           # reasons.
-          export_directory = File.join(EXPORT_OUTPUT_BASEDIR, group_id,
-                                       Time.now.getutc.to_f.round(2).to_s)
+          export_directory = File.join(EXPORT_OUTPUT_BASEDIR, group_id)
 
           sequence do
             plan_action(Pulp::RepositoryGroup::Create, :id => group_id,
@@ -47,7 +49,7 @@ module Actions
           # Pulp do the deletion as part of repo group delete since it's under
           # /v/l/p.
           export_location = File.join(EXPORT_OUTPUT_BASEDIR, input[:group_id])
-          FileUtils.cp_r(export_location, Setting['pulp_export_destination'])
+          FileUtils.cp_r(export_location, Setting['pulp_export_destination'], :remove_destination => true)
         end
 
         def humanized_name

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -3,6 +3,7 @@ module Katello
     self.include_root_in_json = false
 
     include Authorization::ContentViewVersion
+    include ForemanTasks::Concerns::ActionSubject
 
     before_destroy :validate_destroyable!
 
@@ -271,6 +272,10 @@ module Katello
 
     def remove_environment(env)
       content_view.remove_environment(env) unless content_view.content_view_versions.in_environment(env).count > 1
+    end
+
+    def related_resources
+      [self.content_view]
     end
   end
 end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-details.controller.js
@@ -107,7 +107,8 @@ angular.module('Bastion.content-views').controller('ContentViewDetailsController
             publish: "Actions::Katello::ContentView::Publish",
             promotion: "Actions::Katello::ContentView::Promote",
             deletion: "Actions::Katello::ContentView::Remove",
-            incrementalUpdate: "Actions::Katello::ContentView::IncrementalUpdates"
+            incrementalUpdate: "Actions::Katello::ContentView::IncrementalUpdates",
+            export: "Actions::Katello::ContentViewVersion::Export"
         };
 
         $scope.copy = function (newName) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/histories/content-view-history.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/histories/content-view-history.controller.js
@@ -34,6 +34,8 @@ angular.module('Bastion.content-views').controller('ContentViewHistoryController
                 message = translate("Promoted to %s").replace('%s', history.environment.name);
             } else if (taskType === taskTypes.publish) {
                 message = translate("Published new version");
+            } else if (taskType === taskTypes.export) {
+                message = translate("Exported content view");
             }
 
             return message;

--- a/test/actions/katello/content_view_version_test.rb
+++ b/test/actions/katello/content_view_version_test.rb
@@ -58,7 +58,7 @@ module ::Actions::Katello::ContentViewVersion
     end
 
     let(:library_repo) do
-      katello_repositories(:rhel_7_x86_64)
+      katello_repositories(:fedora_17_x86_64_library_view_2)
     end
 
     it 'plans' do
@@ -68,8 +68,8 @@ module ::Actions::Katello::ContentViewVersion
       action.stubs(:task).returns(task)
       plan_action(action, content_view_version, false, nil, 0)
       # verify everything bubbles through to the export action as we expect
-      assert_action_planed_with(action, ::Actions::Katello::Repository::Export, ["3"], false, nil,
-                                0, "-published_library_view-v2.0")
+      assert_action_planed_with(action, ::Actions::Katello::Repository::Export, [library_repo],
+                                false, nil, 0, "-published_library_view-v2.0")
     end
   end
 end

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -396,14 +396,15 @@ module ::Actions::Katello::Repository
     let(:repository) { katello_repositories(:rhel_6_x86_64) }
 
     it 'plans' do
-      plan_action(action, [repository.pulp_id], false, nil, 0, repository.pulp_id)
+      action.stubs(:action_subject)
+      plan_action(action, [repository], false, nil, 0, repository.pulp_id)
 
       # ensure arguments get transformed and bubble through to pulp actions.
       # Org label defaults to blank for this test, hence the group ID starts
       # with '-'.
       assert_action_planed_with(action, ::Actions::Pulp::RepositoryGroup::Create,
                                 :id => "8",
-                                :pulp_ids => ["8"])
+                                :pulp_ids => [repository.pulp_id])
       assert_action_planed_with(action, ::Actions::Pulp::RepositoryGroup::Export) do |(inputs)|
         inputs[:id].must_equal "8"
         inputs[:export_to_iso].must_equal false


### PR DESCRIPTION
+ export dir now does not include timestamp
+ content view and repository export tasks are more detailed