### PR TITLE
Fixes #13744 - Use include? instead of has_key?

### DIFF
--- a/test/models/content_view_filter_test.rb
+++ b/test/models/content_view_filter_test.rb
@@ -26,7 +26,7 @@ module Katello
     def test_bad_name
       filter = FactoryGirl.build(:katello_content_view_filter, :name => "")
       assert filter.invalid?
-      assert filter.errors.has_key?(:name) # rubocop:disable Style/DeprecatedHashMethods
+      assert filter.errors.include?(:name)
     end
 
     def test_duplicate_name

--- a/test/models/kt_environment_test.rb
+++ b/test/models/kt_environment_test.rb
@@ -67,7 +67,7 @@ module Katello
       refute env.save
       assert_equal 1, env.errors.size
       # this an ActiveModel::Errors object; not a Hash
-      assert env.errors.has_key?(:label) # rubocop:disable Style/DeprecatedHashMethods
+      assert env.errors.include?(:label)
     end
 
     def test_content_view_label_excludes_content_dir
@@ -76,7 +76,7 @@ module Katello
       refute env.save
       assert_equal 1, env.errors.size
       # this an ActiveModel::Errors object; not a Hash
-      assert env.errors.has_key?(:label) # rubocop:disable Style/DeprecatedHashMethods
+      assert env.errors.include?(:label)
     end
   end
 end


### PR DESCRIPTION
`has_key?` is an alias of `include?` in Rails 4.