### PR TITLE
Fixes #13760 - delete subscription facet when unregistering

### DIFF
--- a/app/controllers/katello/api/v2/systems_controller.rb
+++ b/app/controllers/katello/api/v2/systems_controller.rb
@@ -147,7 +147,7 @@ module Katello
     api :DELETE, "/systems/:id", N_("Unregister a content host"), :deprecated => true
     param :id, String, :desc => N_("UUID of the content host"), :required => true
     def destroy
-      sync_task(::Actions::Katello::System::Destroy, @system, :destroy_object => false)
+      sync_task(::Actions::Katello::System::Destroy, @system, :unregistering => true)
       respond :message => _("Deleted content host '%s'") % params[:id], :status => 204
     end
 

--- a/app/lib/actions/katello/host/destroy.rb
+++ b/app/lib/actions/katello/host/destroy.rb
@@ -6,8 +6,7 @@ module Actions
 
         def plan(host, options = {})
           skip_candlepin = options.fetch(:skip_candlepin, false)
-          destroy_facets = options.fetch(:destroy_facets, true)
-          destroy_object = options.fetch(:destroy_object, true)
+          unregistering = options.fetch(:unregistering, false)
 
           action_subject(host)
 
@@ -18,37 +17,27 @@ module Actions
             plan_action(Pulp::Consumer::Destroy, uuid: host.content_facet.uuid) if host.content_facet.try(:uuid)
           end
 
-          if destroy_facets
-            host.subscription_facet.try(:destroy!)
-            host.content_facet.try(:destroy!)
-          else
-            unregister_host(host)
-          end
-
           if host.content_host
             pool_ids = host.content_host.pools.map { |p| p["id"] }
             plan_self(:pool_ids => pool_ids)
             host.content_host.destroy!
           end
 
-          if destroy_object
+          host.subscription_facet.try(:destroy!)
+
+          if unregistering
+            if host.content_facet
+              host.content_facet.uuid = nil
+              host.content_facet.save!
+            end
+
+            host.get_status(::Katello::ErrataStatus).destroy
+            host.get_status(::Katello::SubscriptionStatus).destroy
+          else
+            host.content_facet.try(:destroy!)
             unless host.destroy
               fail host.errors.full_messages.join('; ')
             end
-          else
-            host.get_status(::Katello::ErrataStatus).destroy
-            host.get_status(::Katello::SubscriptionStatus).destroy
-          end
-        end
-
-        def unregister_host(host)
-          if host.subscription_facet
-            host.subscription_facet.uuid = nil
-            host.subscription_facet.save!
-          end
-          if host.content_facet
-            host.content_facet.uuid = nil
-            host.content_facet.save!
           end
         end
 

--- a/app/lib/actions/katello/host/unregister.rb
+++ b/app/lib/actions/katello/host/unregister.rb
@@ -5,7 +5,7 @@ module Actions
         middleware.use ::Actions::Middleware::RemoteAction
 
         def plan(host, options = {})
-          plan_action(Katello::Host::Destroy, host, options.merge(:destroy_object => false, :destroy_facets => false))
+          plan_action(Katello::Host::Destroy, host, options.merge(:unregistering => true))
         end
 
         def humanized_name

--- a/test/actions/katello/host/unregister_test.rb
+++ b/test/actions/katello/host/unregister_test.rb
@@ -22,7 +22,7 @@ module Katello::Host
 
         plan_action action, @host
 
-        assert_action_planed_with action, Actions::Katello::Host::Destroy, @host, :destroy_object => false, :destroy_facets => false
+        assert_action_planed_with action, Actions::Katello::Host::Destroy, @host, :unregistering => true
       end
     end
   end


### PR DESCRIPTION
This simplifies the host deletion action by using a unregister option which
deletes the subscription aspect.  The content aspect remains so that provisioning
can still use content view and lifecycle env