### PR TITLE
fixes #13808 - launch db:seed in a new process so rails is reloaded

### DIFF
--- a/lib/katello/tasks/setup.rake
+++ b/lib/katello/tasks/setup.rake
@@ -41,11 +41,8 @@ namespace :katello do
     Rake::Task['db:drop'].invoke
     Rake::Task['db:create'].invoke
 
-    # Otherwise migration fails since it currently requires a reloaded environment
+    # Otherwise migration and seeds fail because they require a reloaded environment
     system('rake db:migrate')
-
-    # Load configuration needed by db:seed first
-    require './config/initializers/foreman.rb'
-    Rake::Task['db:seed'].invoke
+    system('rake db:seed')
   end
 end


### PR DESCRIPTION
katello:reset clears the database, so the registered features from the plugin initializer are deleted.  We need to run db:seed in a separate process like we do for migrate, so rails is properly reloaded.