### PR TITLE
Fixes #13194 - Check status of pulp server before capsule actions

### DIFF
--- a/spec/models/ping_spec.rb
+++ b/spec/models/ping_spec.rb
@@ -21,7 +21,7 @@ module Katello
           # pulp - with oauth
           Katello.pulp_server.resources.user.stubs(:retrieve_all).returns([])
 
-          Ping.expects(:pulp_without_oauth).returns(nil)
+          Ping.expects(:pulp_without_auth).returns(nil)
 
           subject.must_be_instance_of(String)
         end


### PR DESCRIPTION
The capsule's pulp server is not currently being checked before running any dynflow actions on the capsule (only the main katello pulp server is still being checked). This will perform a health check of the pulp server on the capsule before the actions are initiated