### PR TITLE
Fixes #13630 - add oauth as an option for pulp authentication

### DIFF
--- a/app/models/setting/katello.rb
+++ b/app/models/setting/katello.rb
@@ -24,7 +24,8 @@ class Setting::Katello < Setting
         self.set('pulp_export_destination', N_("On-disk location for exported repositories"), File.join(Rails.root, 'tmp', 'repo-exports')),
         self.set('pulp_client_key', N_("Path for ssl key used for pulp server auth"), "/etc/pki/katello/private/pulp-client.key"),
         self.set('pulp_client_cert', N_("Path for ssl cert used for pulp server auth"), "/etc/pki/katello/certs/pulp-client.crt"),
-        self.set('remote_execution_by_default', N_("If set to true, use the remote execution over katello-agent for remote actions"), false)
+        self.set('remote_execution_by_default', N_("If set to true, use the remote execution over katello-agent for remote actions"), false),
+        self.set('use_pulp_oauth', N_("use oauth authentication for pulp instead of the default cert based authentication"), false)
       ].each { |s| self.create! s.update(:category => "Setting::Katello") }
     end
     true

--- a/app/services/katello/pulp/server.rb
+++ b/app/services/katello/pulp/server.rb
@@ -4,23 +4,33 @@ module Katello
       def self.config(url, user_remote_id)
         uri = URI.parse(url)
 
-        Runcible::Instance.new(
+        runcible_params = {
           :url => "#{uri.scheme}://#{uri.host.downcase}",
           :api_path => uri.path,
           :user => user_remote_id,
           :timeout => SETTINGS[:katello][:rest_client_timeout],
           :open_timeout => SETTINGS[:katello][:rest_client_timeout],
-          :cert_auth => {
-            :ssl_client_cert => ::Cert::Certs.ssl_client_cert,
-            :ssl_client_key => ::Cert::Certs.ssl_client_key
-          },
           :logging => {
             :logger => ::Foreman::Logging.logger('katello/pulp_rest'),
             :exception => true,
             :info => true,
             :debug => true
           }
-        )
+        }
+
+        if Setting[:use_pulp_oauth]
+          runcible_params[:oauth] = {
+            :oauth_secret => SETTINGS[:katello][:pulp][:oauth_secret],
+            :oauth_key => SETTINGS[:katello][:pulp][:oauth_key]
+          }
+        else
+          runcible_params[:cert_auth] = {
+            :ssl_client_cert => ::Cert::Certs.ssl_client_cert,
+            :ssl_client_key => ::Cert::Certs.ssl_client_key
+          }
+        end
+
+        Runcible::Instance.new(runcible_params)
       end
     end
   end


### PR DESCRIPTION
Pulp authentication was converted from oauth to cert-based authentication recently, this adds oauth as a fallback option for troubleshooting or user preference.