### PR TITLE
Fixes #13843 - Enables registration of Atomic Instances

### DIFF
--- a/app/helpers/katello/katello_urls_helper.rb
+++ b/app/helpers/katello/katello_urls_helper.rb
@@ -5,14 +5,15 @@ module Katello
       URI(url).host unless url.nil?
     end
 
-    def subscription_manager_configuration_url(host = nil)
+    def subscription_manager_configuration_url(host = nil, rpm = true)
       prefix = if host && host.content_source
                  "http://#{@host.content_source.hostname}"
                else
                  Setting[:foreman_url].sub(/\Ahttps/, 'http')
                end
+      config = rpm ? SETTINGS[:katello][:consumer_cert_rpm] : SETTINGS[:katello][:consumer_cert_sh]
 
-      "#{prefix}/pub/#{SETTINGS[:katello][:consumer_cert_rpm]}"
+      "#{prefix}/pub/#{config}"
     end
   end
 end

--- a/app/views/foreman/unattended/kickstart-katello-atomic.erb
+++ b/app/views/foreman/unattended/kickstart-katello-atomic.erb
@@ -1,0 +1,41 @@
+<%#
+kind: provision
+name: Katello Atomic Kickstart default
+%>
+
+lang <%= @host.params['lang'] || 'en_US.UTF-8' %>
+keyboard <%= @host.params['keyboard'] || 'us' %>
+timezone --utc <%= @host.params['time-zone'] || 'UTC' %>
+
+# Partition table should create /boot and a volume atomicos
+<% if @dynamic -%>
+%include /tmp/diskpart.cfg
+<% else -%>
+<%= @host.diskLayout %>
+<% end -%>
+
+bootloader --timeout=3
+text
+
+<% if @host.os.name.match /.*fedora.*/i -%>
+ostreesetup --nogpg --osname=fedora-atomic --remote=fedora-atomic --url=<%= @host.param_true?('atomic-upstream') ? "https://dl.fedoraproject.org/pub/fedora/linux/atomic/#{@host.os.major}/" : "#{@host.operatingsystem.medium_uri(@host)}/content/repo/" %> --ref=fedora-atomic/f<%= @host.os.major %>/<%= @host.architecture %>/docker-host
+<% elsif @host.os.name.match /.*centos.*/i -%>
+ostreesetup --nogpg --osname=centos-atomic-host --remote=centos-atomic-host --url=<%= @host.param_true?('atomic-upstream') ? "http://mirror.centos.org/centos/#{@host.os.major}/atomic/#{@host.architecture}/repo/" : @host.operatingsystem.medium_uri(@host) %> --ref=centos-atomic-host/<%= @host.os.major %>/<%= @host.architecture %>/standard
+<% else -%>
+ostreesetup --nogpg --osname=rhel-atomic-host --remote=rhel-atomic-host --url=file:///install/ostree --ref=rhel-atomic-host/<%= @host.os.major %>/<%= @host.architecture %>/standard
+<% end -%>
+services --disabled cloud-init,cloud-config,cloud-final,cloud-init-local
+rootpw --iscrypted <%= root_pass %>
+
+reboot
+
+%post
+<%= snippet "subscription_manager_registration" %>
+(
+# Report success back to Foreman
+curl -s -o /dev/null --insecure <%= foreman_url %>
+) 2>&1 | tee /mnt/sysimage/root/install.post.log
+
+exit 0
+
+%end

--- a/app/views/foreman/unattended/snippets/_subscription_manager_registration.erb
+++ b/app/views/foreman/unattended/snippets/_subscription_manager_registration.erb
@@ -1,12 +1,18 @@
 <% if @host.params['kt_activation_keys'] %>
-# add subscription manager
-yum -t -y -e 0 install subscription-manager
-rpm -ivh <%= subscription_manager_configuration_url(@host) %>
+  # add subscription manager
+ <% if @host.operatingsystem.name.match(/.*atomic.*/i) %>
+  curl -s <%= subscription_manager_configuration_url(@host, false) %> | IS_ATOMIC=true bash
+ <% else %>
+  yum -t -y -e 0 install subscription-manager
+  rpm -ivh <%= subscription_manager_configuration_url(@host) %>
+ <% end %>
 
-echo "Registering the System"
-subscription-manager register --org="<%= @host.rhsm_organization_label %>" --name="<%= @host.name %>" --activationkey="<%= @host.params['kt_activation_keys'] %>"
+  echo "Registering the System"
+  subscription-manager register --org="<%= @host.rhsm_organization_label %>" --name="<%= @host.name %>" --activationkey="<%= @host.params['kt_activation_keys'] %>"
 
-echo "Installing Katello Agent"
-yum -t -y -e 0 install katello-agent
-chkconfig goferd on
+  <% unless @host.operatingsystem.name.match(/.*atomic.*/i) %>
+    echo "Installing Katello Agent"
+    yum -t -y -e 0 install katello-agent
+    chkconfig goferd on
+  <% end %>
 <% end %>

--- a/config/katello.yaml.example
+++ b/config/katello.yaml.example
@@ -12,6 +12,7 @@
   :redhat_repository_url: https://cdn.redhat.com
 
   :consumer_cert_rpm: 'katello-ca-consumer-latest.noarch.rpm'
+  :consumer_cert_sh:  'katello-rhsm-consumer'
 
   # Setup your candlepin environment here
   :candlepin:

--- a/db/seeds.d/103-provisioning_templates.rb
+++ b/db/seeds.d/103-provisioning_templates.rb
@@ -16,7 +16,8 @@ end
 templates = [{:name => "Katello Kickstart Default",           :source => "kickstart-katello.erb",      :template_kind => kinds[:provision]},
              {:name => "Katello Kickstart Default User Data", :source => "userdata-katello.erb",       :template_kind => kinds[:user_data]},
              {:name => "Katello Kickstart Default Finish",    :source => "finish-katello.erb",         :template_kind => kinds[:finish]},
-             {:name => "subscription_manager_registration",   :source => "snippets/_subscription_manager_registration.erb", :snippet => true}]
+             {:name => "subscription_manager_registration",   :source => "snippets/_subscription_manager_registration.erb", :snippet => true},
+             {:name => "Katello Atomic Kickstart Default",    :source => "kickstart-katello-atomic.erb", :template_kind => kinds[:provision]}]
 
 templates.each do |template|
   template[:template] = File.read(File.join(Katello::Engine.root, "app/views/foreman/unattended", template.delete(:source)))
@@ -29,6 +30,7 @@ templates.each do |template|
     pt.template_kind = template[:template_kind] if template[:template_kind]
     pt.snippet = template[:snippet] if template[:snippet]
   end
+  ProvisioningTemplate.find_by(name: template[:name]).update_attributes!(:template => template[:template])
 end
 
 # Ensure all default templates are seeded into the first org and loc

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -16,6 +16,7 @@ module Katello
         :redhat_repository_url => 'https://cdn.redhat.com',
         :post_sync_url => 'http://localhost:3000/katello/api/v2/repositories/sync_complete?token=katello',
         :consumer_cert_rpm => 'katello-ca-consumer-latest.noarch.rpm',
+        :consumer_cert_sh => 'katello-rhsm-consumer',
         :pulp => {
           :default_login => 'admin',
           :url => 'https://localhost/pulp/api/v2/',

--- a/test/lib/tasks/seeds_test.rb
+++ b/test/lib/tasks/seeds_test.rb
@@ -52,7 +52,7 @@ module Katello
     test "Make sure provisioning templates exist" do
       seed
       assert ProvisioningTemplate.where(:default => true).exists?
-      template_names = ["Katello Kickstart Default", "Katello Kickstart Default User Data", "Katello Kickstart Default Finish", "subscription_manager_registration"]
+      template_names = ["Katello Kickstart Default", "Katello Kickstart Default User Data", "Katello Kickstart Default Finish", "subscription_manager_registration", "Katello Atomic Kickstart Default"]
 
       ProvisioningTemplate.where(:default => true, :vendor => "Katello").each do |template|
         assert template_names.include?(template.name)


### PR DESCRIPTION
Added subscription manager bits to Atomic Provisioning templates
to consumer content from Katello