### PR TITLE
Fixes #12952 - Disassociate proxy from content host before removing it

### DIFF
--- a/db/migrate/20150930183738_migrate_content_hosts.rb
+++ b/db/migrate/20150930183738_migrate_content_hosts.rb
@@ -212,6 +212,10 @@ class MigrateContentHosts < ActiveRecord::Migration
 
     systems_to_remove.each do |system|
       logger.info("Content Host #{system.uuid} doesn't have candlepin information, unregistering.")
+      if (system_proxy = SmartProxy.find_by_content_host_id(system.id))
+        system_proxy.content_host = nil
+        system_proxy.save
+      end
       systems.delete(system)
       unregister_system(system)
     end


### PR DESCRIPTION
On the content hosts migration, when a content host is going to be
removed, it first needs to be disassociated from the proxy it belongs
to. Otherwise it fails with the foreign_key problem mentioned in
redmine.