### PR TITLE
 Fixes #13856 - Update with content hosts no longer in Candlepin breaks the migration

### DIFF
--- a/db/migrate/20150930183738_migrate_content_hosts.rb
+++ b/db/migrate/20150930183738_migrate_content_hosts.rb
@@ -106,6 +106,9 @@ class MigrateContentHosts < ActiveRecord::Migration
 
     def backend_data
       @data ||= ::Katello::Resources::Candlepin::Consumer.get(uuid)
+    rescue RestClient::ResourceNotFound
+      logger.info("Tried to fetch Candlepin data for #{name} but its uuid (#{uuid}) was not found.")
+      { :facts => { 'network.hostname' => name } }
     end
 
     def facts
@@ -186,7 +189,7 @@ class MigrateContentHosts < ActiveRecord::Migration
     subscription_facet.activation_keys = system.activation_keys
     subscription_facet.uuid = system.uuid
 
-    if system.backend_data
+    if system.backend_data && system.backend_data['serviceLevel']
       subscription_facet.service_level = system.backend_data['serviceLevel']
       subscription_facet.release_version = system.backend_data['releaseVer']['releaseVer']
       subscription_facet.last_checkin = system.backend_data['lastCheckin']


### PR DESCRIPTION
If you have some hosts no longer in Candlepin and Katello didn't keep
track of it, the migration that creates content host facets will fail.
Instead, we should avoid creating these facets for hosts whose UUID 404s
on Candlepin.