### PR TITLE
Fixes #13861 - Enabled host group to store activation keys

### DIFF
--- a/app/assets/javascripts/katello/hosts/activation_key_edit.js
+++ b/app/assets/javascripts/katello/hosts/activation_key_edit.js
@@ -77,7 +77,7 @@ function ktSetParam(name, value) {
     var paramContainer = ktFindParamContainer(name);
     if(value) {
         if(! paramContainer) { // we create the param for kt_activation_keys
-            $("div#parameters a.btn-success").click();
+            $("div#parameters a[target~='#global_parameters_table']").click();
             paramContainer = $("div#parameters .fields").last();
             paramContainer.find("input").val(name);
         }


### PR DESCRIPTION
Due to a pattern fly change btn-success got renamed to btn-primary in
https://github.com/theforeman/foreman/blob/develop/app/views/hostgroups/_form.html.erb#L74
This caused the Deface to break not allowing AK to get properly stored as a param.

This commit should fix that