### PR TITLE
Fixes #13884 - Link to puppet module info in content view version

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/views/content-view-version-puppet-modules.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/views/content-view-version-puppet-modules.html
@@ -8,15 +8,15 @@
       <tr bst-table-head>
         <th bst-table-column translate>Name</th>
         <th bst-table-column translate>Author</th>
-        <th bst-table-column translate>Version</th>
       </tr>
     </thead>
 
     <tbody>
       <tr bst-table-row ng-repeat="puppetModule in detailsTable.rows">
-        <td bst-table-cell>{{ puppetModule.name }}</td>
+        <td bst-table-cell>
+          <a ui-sref="puppet-modules.details.info({puppetModuleId: puppetModule.id})">{{ puppetModule.name }}-{{ puppetModule.version }}</a>
+        </td>
         <td bst-table-cell>{{ puppetModule.author }}</td>
-        <td bst-table-cell>{{ puppetModule.version }}</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
Adding a link to puppet module info page when viewing the puppet modules on the content view version