### PR TITLE
Fixes #13893: Check if in migrate when setting remote default

### DIFF
--- a/engines/bastion_katello/lib/bastion_katello/engine.rb
+++ b/engines/bastion_katello/lib/bastion_katello/engine.rb
@@ -34,7 +34,8 @@ module BastionKatello
         :config => {
           'consumerCertRPM' => consumer_cert_rpm,
           'remoteExecutionPresent' => ::Katello.with_remote_execution?,
-          'remoteExecutionByDefault' => ::Katello.with_remote_execution? && Setting['remote_execution_by_default']
+          'remoteExecutionByDefault' => ::Katello.with_remote_execution? && !Foreman.in_rake?('db:migrate') &&
+                                          Setting['remote_execution_by_default']
         }
       )
     end


### PR DESCRIPTION
During migrate, if remote execution exists the check on the Setting
table will be performed but that table isn't guaranteed to exist
yet.