### PR TITLE
Fixes #13901: remove fixed width table CSS from environment tables.

### DIFF
--- a/engines/bastion_katello/app/assets/stylesheets/bastion_katello/environments.scss
+++ b/engines/bastion_katello/app/assets/stylesheets/bastion_katello/environments.scss
@@ -5,16 +5,6 @@
 .environment-table {
   margin-top: 10px;
 
-  tr > th:nth-last-child(n+2), tr > td:nth-last-child(n+2) {
-    width: 200px;
-    max-width: 200px;
-  }
-
-  tr > th:first-child,td:first-child {
-    width: 150px;
-    max-width: 150px;
-  }
-
   th {
     background: #F7F7F7;
   }


### PR DESCRIPTION
The fixed width tables for lifecycle environments were causing columns
to disappear under a certain width.  This commit removes the fixed width
css so that the tables will resize as appropriate when the width changes.

http://projects.theforeman.org/issues/13901