### PR TITLE
Fixes #13910 - Auto populate env, cv on new host

### DIFF
--- a/app/helpers/katello/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/katello/hosts_and_hostgroups_helper.rb
@@ -34,13 +34,27 @@ module Katello
       end
     end
 
+    def fetch_lifecycle_environment(host, options = {})
+      selected_host_group = options.fetch(:selected_host_group, nil)
+      selected_env = lifecycle_environment(host)
+      return selected_env if selected_env.present?
+      lifecycle_environment(selected_host_group) if selected_host_group.present?
+    end
+
+    def fetch_content_view(host, options = {})
+      selected_host_group = options.fetch(:selected_host_group, nil)
+      selected_content_view = content_view(host)
+      return selected_content_view if selected_content_view.present?
+      content_view(selected_host_group) if selected_host_group.present?
+    end
+
     def lifecycle_environment_options(host, options = {})
       include_blank = options.fetch(:include_blank, nil)
       if include_blank == true #check for true specifically
         include_blank = '<option></option>'
       end
+      selected_id = fetch_lifecycle_environment(host, options).try(:id)
 
-      selected_id = lifecycle_environment(host).try(:id)
       orgs = Organization.current ? [Organization.current] : Organization.my_organizations
       all_options = []
       orgs.each do |org|
@@ -67,9 +81,8 @@ module Katello
       if include_blank == true #check for true specifically
         include_blank = '<option></option>'
       end
-
-      content_view = content_view(host)
-      lifecycle_environment = lifecycle_environment(host)
+      lifecycle_environment = fetch_lifecycle_environment(host, options)
+      content_view = fetch_content_view(host, options)
 
       views = []
       if lifecycle_environment

--- a/app/views/overrides/activation_keys/_host_environment_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_environment_select.html.erb
@@ -4,29 +4,39 @@
     option.kt-cv  { margin-left: 1em; }
 </style>
 
-<% env_select_id =  @hostgroup ? :hostgroup_lifecycle_environment_id : :host_lifecycle_environment_id %>
-<% env_select_name =  @hostgroup ? 'hostgroup[lifecycle_environment_id]' : 'host[content_facet_attributes][lifecycle_environment_id]' %>
-<% env_select_attr = @hostgroup ? 'lifecycle_environment' : 'content_facet.lifecycle_environment' %>
+<% using_hostgroups_page = @host.nil? %>
+
+<% env_select_id = using_hostgroups_page ? :hostgroup_lifecycle_environment_id : :host_lifecycle_environment_id %>
+<% env_select_name =  using_hostgroups_page ? 'hostgroup[lifecycle_environment_id]' : 'host[content_facet_attributes][lifecycle_environment_id]' %>
+<% env_select_attr = using_hostgroups_page ? 'lifecycle_environment' : 'content_facet.lifecycle_environment' %>
 
 <%= field(f, env_select_attr, {:label => _("Lifecycle Environment")}) do
-  select_tag env_select_id, lifecycle_environment_options(@host || @hostgroup, :include_blank => blank_or_inherit_with_id(f, :lifecycle_environment)),
-             :class => 'form-control',  :name => env_select_name
+  if using_hostgroups_page
+    select_tag env_select_id, lifecycle_environment_options(@hostgroup, :include_blank => blank_or_inherit_with_id(f, :lifecycle_environment)),
+               :class => 'form-control',  :name => env_select_name
+  else
+    select_tag env_select_id, lifecycle_environment_options(@host, :selected_host_group => @hostgroup, :include_blank => blank_or_inherit_with_id(f, :lifecycle_environment)), :class => 'form-control',  :name => env_select_name
+  end
 end %>
 
 
-<% cv_select_id =  @hostgroup ? :hostgroup_content_view_id : :host_content_view_id %>
-<% cv_select_name =  @hostgroup ? 'hostgroup[content_view_id]' : 'host[content_facet_attributes][content_view_id]' %>
-<% cv_select_attr = @hostgroup ? 'content_view' : 'content_facet.content_view' %>
+<% cv_select_id =  using_hostgroups_page ? :hostgroup_content_view_id : :host_content_view_id %>
+<% cv_select_name =  using_hostgroups_page ? 'hostgroup[content_view_id]' : 'host[content_facet_attributes][content_view_id]' %>
+<% cv_select_attr = using_hostgroups_page ? 'content_view' : 'content_facet.content_view' %>
 <%= field(f, cv_select_attr, {:label => _("Content View")}) do
-  select_tag cv_select_id,  content_views_for_host(@host || @hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_view)),
-             :class => 'form-control',  :name => cv_select_name
+  if using_hostgroups_page
+    select_tag cv_select_id,  content_views_for_host(@hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_view)),
+               :class => 'form-control',  :name => cv_select_name
+  else
+    select_tag cv_select_id,  content_views_for_host(@host, :selected_host_group => @hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_view)), :class => 'form-control',  :name => cv_select_name
+  end
 end %>
 
 <% if @host %>
   <input type="hidden" name="host[content_facet_attributes][id]" value="<%= @host.content_facet.try(:id) %>">
 <% end %>
 
-<% data_url = @hostgroup ? environment_selected_hostgroups_path : hostgroup_or_environment_selected_hosts_path %>
+<% data_url = using_hostgroups_page ? environment_selected_hostgroups_path : hostgroup_or_environment_selected_hosts_path %>
 <%= select_f f, :environment_id, Environment.all, :id, :to_label, {:include_blank => blank_or_inherit_f(f, :environment)},
   {:label => _("Puppet Environment"), :onchange => 'update_puppetclasses(this);', 'data-url'=> data_url,
    'data-content_puppet_match' => (@host || @hostgroup).new_record? || (@host || @hostgroup).content_and_puppet_match?,


### PR DESCRIPTION
Adds logic to auto populate env, cv on new hosts page when a host group
is selected