### PR TITLE
Fixes #13918 - change bastion minimum version to 3.2

### DIFF
--- a/engines/bastion_katello/bastion_katello.gemspec
+++ b/engines/bastion_katello/bastion_katello.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,lib}/**/*"] + ["README"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "bastion", ">= 3.0.0", "< 4.0.0"
+  s.add_dependency "bastion", ">= 3.2.0", "< 4.0.0"
 end

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |gem|
   # UI
   gem.add_dependency "deface", '>= 1.0.0', '< 2.0.0'
   gem.add_dependency "jquery-ui-rails"
-  gem.add_dependency "bastion", ">= 3.0.1", "< 4.0.0"
+  gem.add_dependency "bastion", ">= 3.2.0", "< 4.0.0"
 
   # Testing
   gem.add_development_dependency "factory_girl_rails"


### PR DESCRIPTION
Bastion has a new [Global Notification feature](https://github.com/Katello/bastion/pull/91) that [Katello uses now](https://github.com/Katello/katello/pull/5732)