### PR TITLE
Fixes #13789 - Update content host attribute service_level, release_ver and last_checking using API

### DIFF
--- a/app/controllers/katello/api/v2/systems_controller.rb
+++ b/app/controllers/katello/api/v2/systems_controller.rb
@@ -3,7 +3,7 @@ module Katello
     include Katello::Concerns::FilteredAutoCompleteSearch
     respond_to :json
 
-    wrap_parameters :include => (System.attribute_names + %w(type autoheal facts guest_ids host_collection_ids installed_products content_view environment))
+    wrap_parameters :include => (System.attribute_names + %w(type autoheal facts guest_ids host_collection_ids installed_products content_view environment service_level release_ver last_checkin))
 
     skip_before_filter :set_default_response_format, :only => :report
 

--- a/test/controllers/api/v2/systems_controller_test.rb
+++ b/test/controllers/api/v2/systems_controller_test.rb
@@ -157,6 +157,22 @@ module Katello
       assert_response :success
     end
 
+    def test_update_service_level
+      input = {
+        :id => @system.id,
+        :service_level => 'standard'
+      }
+      where_stub = System.where(:id => @system.id)
+      System.stubs(:where).returns(where_stub)
+      System.any_instance.stubs(:first).returns(@system)
+      @controller.expects(:system_params).returns(input)
+      subscription_facet = { :service_level => 'standard' }
+      ::Host::Managed.any_instance.stubs(:update_attributes!).once.with(:subscription_facet_attributes => subscription_facet)
+      put :update, input
+
+      assert_response :success
+    end
+
     def test_search_by_name
       systems = System.search_for("name = \"#{@system.name}\"")
       assert_includes systems, @system


### PR DESCRIPTION
This will allow to update service_level, release_ver and last_checking using API