### PR TITLE
Fixes #12140 - unreported scoped search errors on 500 field

### DIFF
--- a/app/views/katello/api/v2/common/_metadata.json.rabl
+++ b/app/views/katello/api/v2/common/_metadata.json.rabl
@@ -4,6 +4,7 @@ node(:total)    { @collection[:total] }
 node(:subtotal) { @collection[:subtotal] }
 node(:page)     { @collection[:page] }
 node(:per_page) { @collection[:per_page] }
+node(:error)    { @collection[:error] }
 node(:search)   { params[:search] }
 node(:sort) do
   {

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -36,7 +36,7 @@ module Katello
       assert_response :success
       assert_template 'api/v2/activation_keys/index'
 
-      assert_equal results.keys.sort, ['page', 'per_page', 'results', 'search', 'sort', 'subtotal', 'total']
+      assert_equal results.keys.sort, ['error', 'page', 'per_page', 'results', 'search', 'sort', 'subtotal', 'total']
       assert_equal results['results'].size, 6
       assert_includes results['results'].collect { |item| item['id'] }, @activation_key.id
     end

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -56,7 +56,7 @@ module Katello
       assert_response :success
       assert_template 'api/v2/content_view_versions/index'
 
-      assert_equal ['page', 'per_page', 'results', 'search', 'sort', 'subtotal', 'total'], results.keys.sort
+      assert_equal ['error', 'page', 'per_page', 'results', 'search', 'sort', 'subtotal', 'total'], results.keys.sort
       assert_equal 1, results['results'].size
       assert_equal expected_version.id, results['results'][0]['id']
     end
@@ -81,7 +81,7 @@ module Katello
       assert_response :success
       assert_template 'api/v2/content_view_versions/index'
 
-      assert_equal ['page', 'per_page', 'results', 'search', 'sort', 'subtotal', 'total'], results.keys.sort
+      assert_equal ['error', 'page', 'per_page', 'results', 'search', 'sort', 'subtotal', 'total'], results.keys.sort
       assert_equal 1, results['results'].size
       assert_equal expected_version.id, results['results'][0]['id']
     end

--- a/test/controllers/api/v2/host_collections_controller_test.rb
+++ b/test/controllers/api/v2/host_collections_controller_test.rb
@@ -26,7 +26,7 @@ module Katello
       assert_response :success
       assert_template 'api/v2/host_collections/index'
 
-      assert_equal results.keys.sort, ['page', 'per_page', 'results', 'search', 'sort', 'subtotal', 'total']
+      assert_equal results.keys.sort, ['error', 'page', 'per_page', 'results', 'search', 'sort', 'subtotal', 'total']
       assert_equal results['results'].size, 3
       assert_includes results['results'].map { |r| r['id'] }, @host_collection.id
     end


### PR DESCRIPTION
This will report scoped search errors in a notification in the UI