### PR TITLE
Fixes #13923 - speed up repo list by not going to pulp for details

### DIFF
--- a/app/views/katello/api/v2/repositories/base.json.rabl
+++ b/app/views/katello/api/v2/repositories/base.json.rabl
@@ -17,7 +17,7 @@ node :content_counts do |repo|
     :docker_tag => repo.docker_tags.count,
     :rpm => repo.rpms.count,
     :package => repo.rpms.count,
-    :package_group => repo.package_group_count,
+    :package_group => repo.package_groups.count,
     :erratum => repo.errata.count,
     :puppet_module => repo.puppet_modules.count
   }

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -34,9 +34,6 @@ module Katello
       @request.env['HTTP_ACCEPT'] = 'application/json'
       models
       permissions
-      [:package_group_count, :package_count, :puppet_module_count].each do |content_type_count|
-        Repository.any_instance.stubs(content_type_count).returns(0)
-      end
     end
 
     def test_index


### PR DESCRIPTION
With this fix, i was able to speed up the repository list for a product from about 1 minute to around 400-1500 ms.

In my testing i had ~12 repositories with rhel 7.0 - 7Server and 6.1 - 6.7 all fully synced.