### PR TITLE
fixes #13950 - update org create api to return org object

### DIFF
--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -77,7 +77,7 @@ module Katello
       @organization = Organization.new(params[:organization])
       sync_task(::Actions::Katello::Organization::Create, @organization)
       @organization.reload
-      process_response @organization
+      respond_for_show :resource => @organization
     rescue
       process_resource_error
     end

--- a/app/views/katello/api/v2/organizations/show.json.rabl
+++ b/app/views/katello/api/v2/organizations/show.json.rabl
@@ -1,4 +1,4 @@
-object @taxonomy
+object @organization
 
 extends "api/v2/taxonomies/show"
 

--- a/test/controllers/api/v2/organizations_controller_test.rb
+++ b/test/controllers/api/v2/organizations_controller_test.rb
@@ -66,6 +66,10 @@ module Katello
     end
 
     def test_create
+      Organization.any_instance.stubs(:redhat_repository_url)
+      Organization.any_instance.stubs(:default_content_view).returns(OpenStruct.new(id: 1))
+      Organization.any_instance.stubs(:library).returns(OpenStruct.new(id: 10))
+
       name = "Michaelangelo"
       assert_sync_task ::Actions::Katello::Organization::Create do |org|
         org.name.must_equal name


### PR DESCRIPTION
Small change so that when a new organization is created via the API,
it is returned to the user in the response.  Prior to this change, the user
would get an empty object ({}).