### PR TITLE
Fixes #13885 - verify export destination is a directory before exporting

### DIFF
--- a/app/lib/actions/katello/repository/export.rb
+++ b/app/lib/actions/katello/repository/export.rb
@@ -12,6 +12,14 @@ module Actions
         EXPORT_OUTPUT_BASEDIR = "/var/lib/pulp/published/yum/master/group_export_distributor/"
 
         def plan(repos, export_to_iso, since, iso_size, group_id)
+          unless File.directory?(Setting['pulp_export_destination'])
+            fail ::Foreman::Exception, N_("Unable to export, 'pulp_export_destination' setting is not set to a valid directory.")
+          end
+
+          unless File.writable?(Setting['pulp_export_destination'])
+            fail ::Foreman::Exception, N_("Unable to export, 'pulp_export_destination' setting is not a writable directory.")
+          end
+
           repo_pulp_ids = repos.collect do |repo|
             action_subject(repo)
             repo.pulp_id

--- a/app/models/setting/katello.rb
+++ b/app/models/setting/katello.rb
@@ -21,7 +21,7 @@ class Setting::Katello < Setting
         self.set('check_services_before_actions', N_("Whether or not to check the status of backend services such as pulp and candlepin prior to performing some actions."), true),
         self.set('force_post_sync_actions', N_("Force post sync actions such as indexing and email even if no content was available."), false),
         self.set('default_download_policy', N_("Default download policy for repositories (either 'immediate', 'on_demand', or 'background')"), "on_demand"),
-        self.set('pulp_export_destination', N_("On-disk location for exported repositories"), File.join(Rails.root, 'tmp', 'repo-exports')),
+        self.set('pulp_export_destination', N_("On-disk location for exported repositories"), N_("Please fill path in.")),
         self.set('pulp_client_key', N_("Path for ssl key used for pulp server auth"), "/etc/pki/katello/private/pulp-client.key"),
         self.set('pulp_client_cert', N_("Path for ssl cert used for pulp server auth"), "/etc/pki/katello/certs/pulp-client.crt"),
         self.set('remote_execution_by_default', N_("If set to true, use the remote execution over katello-agent for remote actions"), false),

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -396,6 +396,9 @@ module ::Actions::Katello::Repository
     let(:repository) { katello_repositories(:rhel_6_x86_64) }
 
     it 'plans' do
+      # required for export pre-run validation to succeed
+      Setting['pulp_export_destination'] = '/tmp'
+
       action.stubs(:action_subject)
       plan_action(action, [repository], false, nil, 0, repository.pulp_id)
 
@@ -413,6 +416,23 @@ module ::Actions::Katello::Repository
       end
       assert_action_planed_with(action, ::Actions::Pulp::RepositoryGroup::Delete,
                                 :id => "8")
+    end
+
+    it 'plans without export destination' do
+      action.stubs(:action_subject)
+
+      assert_raises(Foreman::Exception) do
+        plan_action(action, [repository], false, nil, 0, repository.pulp_id)
+      end
+    end
+
+    it 'plans without writable destination' do
+      Setting['pulp_export_destination'] = '/'
+      action.stubs(:action_subject)
+
+      assert_raises(Foreman::Exception) do
+        plan_action(action, [repository], false, nil, 0, repository.pulp_id)
+      end
     end
   end
 end

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -727,6 +727,7 @@ module Katello
     end
 
     def test_export
+      Setting['pulp_export_destination'] = '/tmp'
       post :export, :id => @repository.id
       assert_response :success
     end
@@ -737,11 +738,13 @@ module Katello
     end
 
     def test_export_with_date
+      Setting['pulp_export_destination'] = '/tmp'
       post :export, :id => @repository.id, :since => 'November 30, 1970'
       assert_response :success
     end
 
     def test_export_with_8601_date
+      Setting['pulp_export_destination'] = '/tmp'
       post :export, :id => @repository.id, :since => '2010-01-01T00:00:00'
       assert_response :success
     end


### PR DESCRIPTION
This patch makes two changes:

 * it alters the `pulp_export_destination` setting to a setting that must be
   filled in by the user prior to first export

 * it adds a check to the repository export task to ensure the above setting is
   set, and that the dir is writable.

Previously, users would perform an export and inadvertently fill up their tmpfs
space. There is not a good default production value for the export destionation
since an export could be multiple GB.