### PR TITLE
fixes #13958 - activation key: unable to copy a key that contains subscriptions

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -96,7 +96,7 @@ module Katello
       @activation_key.content_overrides.each do |content|
         @new_activation_key.set_content_override(content['contentLabel'], content[:name], content[:value])
       end
-      @activation_key.get_key_pools.each do |pool|
+      @activation_key.pools.each do |pool|
         @new_activation_key.subscribe(pool[:id], pool[:amount])
       end
       respond_for_show(:resource => @new_activation_key)


### PR DESCRIPTION
This change is to fix an error that occurred when copying an activation key
that contains a subscription.  The issue was a mismatch between using candlepin's
cp_id and katello's pool id when locating the pool.