### PR TITLE
Fixes #13992 - Updated Dockerhub url

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/views/repository-new.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/views/repository-new.html
@@ -52,7 +52,7 @@
                  type="text"
                  tabindex="5"/>
           <h6 ng-show="repository.content_type === 'docker'" translate>
-            URL of the registry you want to sync. Example: https://registry.hub.docker.com
+            URL of the registry you want to sync. Example: https://registry-1.docker.io/
           </h6>
 
         </div>


### PR DESCRIPTION
Changed https://registry.hub.docker.com to https://registry-1.docker.io to provide a more current example URL.
