### PR TITLE
Fixes #13987 - Capsule Sync Optimization

### DIFF
--- a/app/lib/actions/katello/capsule_content/configure_capsule.rb
+++ b/app/lib/actions/katello/capsule_content/configure_capsule.rb
@@ -5,7 +5,7 @@ module Actions
         def plan(capsule, environment, content_view)
           sequence do
             plan_action(RemoveUnneededRepos, capsule)
-            plan_action(CreateOrUpdate, capsule, environment, content_view)
+            plan_action(CreateRepos, capsule, environment, content_view)
           end
         end
       end

--- a/app/lib/actions/katello/capsule_content/create_repos.rb
+++ b/app/lib/actions/katello/capsule_content/create_repos.rb
@@ -1,7 +1,7 @@
 module Actions
   module Katello
     module CapsuleContent
-      class CreateOrUpdate < ::Actions::EntryAction
+      class CreateRepos < ::Actions::EntryAction
         # @param capsule_content [::Katello::CapsuleContent]
         def plan(capsule_content, environment = nil, content_view = nil)
           fail _("Action not allowed for the default capsule.") if capsule_content.default_capsule?
@@ -9,14 +9,9 @@ module Actions
           current_repos_on_capsule = capsule_content.current_repositories(environment, content_view)
           list_of_repos_to_sync = capsule_content.repos_available_to_capsule(environment, content_view)
           need_creation =  list_of_repos_to_sync - current_repos_on_capsule
-          need_update = current_repos_on_capsule & list_of_repos_to_sync
 
           need_creation.each do |repo|
             create_repo_in_pulp(capsule_content, repo)
-          end
-
-          need_update.each do |repo|
-            plan_action(Pulp::Repository::Refresh, repo, capsule_id: capsule_content.capsule.id)
           end
         end
 
@@ -37,7 +32,7 @@ module Actions
                       checksum_type: checksum_type,
                       path: relative_path,
                       with_importer: true,
-                      docker_upstream_name: repository.try(:docker_upstream_name),
+                      docker_upstream_name: repository.pulp_id,
                       download_policy: repository.capsule_download_policy,
                       capsule_id: capsule_content.capsule.id)
         end

--- a/app/lib/katello/capsule_content.rb
+++ b/app/lib/katello/capsule_content.rb
@@ -140,6 +140,12 @@ module Katello
       self.capsule.url + "/pulp/api/v2/"
     end
 
+    def pulp_repo_facts(pulp_id)
+      self.pulp_server.extensions.repository.retrieve_with_details(pulp_id)
+    rescue RestClient::ResourceNotFound
+      nil
+    end
+
     def self.with_environment(environment, include_default = false)
       features = [SmartProxy::PULP_NODE_FEATURE]
       features << SmartProxy::PULP_FEATURE if include_default

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -778,7 +778,7 @@ module Katello
       end
 
       def distributors_match?(capsule_distributors)
-        generated_distributors = self.generate_distributors.map { |dist| object_to_hash(dist) }
+        generated_distributors = self.generate_distributors.map(&:as_json)
         capsule_distributors.each do |dist|
           dist.merge!(dist["config"])
           dist.delete("config")
@@ -792,7 +792,7 @@ module Katello
       end
 
       def importer_matches?(capsule_importer)
-        generated_importer = object_to_hash(self.generate_importer(true))
+        generated_importer = self.generate_importer(true).as_json
         (generated_importer.to_a - capsule_importer.to_a).empty?
       end
 

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -130,7 +130,7 @@ module Katello
           Runcible::Models::IsoImporter.new(importer_ssl_options(capsule).merge(:feed => importer_feed_url(capsule)))
         when Repository::PUPPET_TYPE
           options = {}
-          options[:feed] = importer_feed_url(capsule) if self.respond_to?(:url)
+          options[:feed] = importer_feed_url(capsule)
           Runcible::Models::PuppetImporter.new(options)
         when Repository::DOCKER_TYPE
           options = {}
@@ -777,7 +777,32 @@ module Katello
         end
       end
 
+      def distributors_match?(capsule_distributors)
+        generated_distributors = self.generate_distributors.map { |dist| object_to_hash(dist) }
+        capsule_distributors.each do |dist|
+          dist.merge!(dist["config"])
+          dist.delete("config")
+        end
+
+        generated_distributors.any? do |gen_dist|
+          capsule_distributors.any? do |cap_dist|
+            (gen_dist.to_a - cap_dist.to_a).empty?
+          end
+        end
+      end
+
+      def importer_matches?(capsule_importer)
+        generated_importer = object_to_hash(self.generate_importer(true))
+        (generated_importer.to_a - capsule_importer.to_a).empty?
+      end
+
       protected
+
+      def object_to_hash(object)
+        hash = {}
+        object.instance_variables.each { |var| hash[var.to_s.delete("@")] = object.instance_variable_get(var) }
+        hash
+      end
 
       def _get_most_recent_sync_status
         begin

--- a/test/actions/katello/capsule_content_test.rb
+++ b/test/actions/katello/capsule_content_test.rb
@@ -53,14 +53,22 @@ module ::Actions::Katello::CapsuleContent
 
     it 'plans' do
       capsule_content.add_lifecycle_environment(environment)
+      action_class.any_instance.expects(:repos_needing_updates).returns([repository])
       capsule_content_sync = plan_action(action, capsule_content)
+
       synced_repos = synced_repos(capsule_content_sync, capsule_content.repos_available_to_capsule)
 
       assert_equal synced_repos.sort.uniq, capsule_content.repos_available_to_capsule.map { |repo| repo.pulp_id }.sort.uniq
+      assert_action_planed_with(action,
+                                ::Actions::Pulp::Repository::Refresh,
+                                repository,
+                                :capsule_id => capsule_content.capsule.id
+                                )
     end
 
     it 'allows limiting scope of the syncing to one environment' do
       capsule_content.add_lifecycle_environment(dev_environment)
+      action_class.any_instance.expects(:repos_needing_updates).returns([])
       capsule_content_sync = plan_action(action, capsule_content, :environment => dev_environment)
       synced_repos = synced_repos(capsule_content_sync, capsule_content.repos_available_to_capsule)
 
@@ -73,6 +81,7 @@ module ::Actions::Katello::CapsuleContent
         plan_action(action, capsule_content, :environment => dev_environment)
       end
     end
+
     it 'fails when trying to sync a lifecyle environment that is not attached' do
       capsule_content.add_lifecycle_environment(environment)
 
@@ -83,10 +92,10 @@ module ::Actions::Katello::CapsuleContent
     end
   end
 
-  class CreateOrUpdateTest < TestBase
+  class CreateReposTest < TestBase
     include VCR::TestCase
 
-    let(:action_class) { ::Actions::Katello::CapsuleContent::CreateOrUpdate }
+    let(:action_class) { ::Actions::Katello::CapsuleContent::CreateRepos }
 
     let(:cert) do
       {
@@ -132,22 +141,10 @@ module ::Actions::Katello::CapsuleContent
                          checksum_type: repository.checksum_type,
                          path: repository.relative_path,
                          with_importer: true,
-                         docker_upstream_name: repository.try(:docker_upstream_name),
+                         docker_upstream_name: repository.pulp_id,
                          capsule_id: capsule_content.capsule.id
                         )
       end
-    end
-
-    it "updates repos on the capsule" do
-      capsule_content.stubs(:current_repositories).returns([repository])
-      capsule_content.stubs(:repos_available_to_capsule).returns([repository])
-
-      action = create_and_plan_action(action_class, capsule_content)
-      assert_action_planed_with(action,
-                                ::Actions::Pulp::Repository::Refresh,
-                                repository,
-                                :capsule_id => capsule_content.capsule.id
-                                )
     end
   end
 


### PR DESCRIPTION
Capsule sync should check if importers or distributors in repos need updating before updating them ( as opposed to blindly updating all of them as it does now). This will speed up capsule syncs and use less dynflow actions.