### PR TITLE
Fixes #14025 - Explicitly setting string limits

### DIFF
--- a/db/migrate/20131014135042_katello_tables.rb
+++ b/db/migrate/20131014135042_katello_tables.rb
@@ -3,7 +3,7 @@ class KatelloTables < ActiveRecord::Migration
   def self.up
 
     create_table "katello_activation_keys", :force => true do |t|
-      t.string   "name"
+      t.string   "name", :limit => 255
       t.text     "description"
       t.integer  "organization_id",                 :null => false
       t.integer  "environment_id",                  :null => false
@@ -39,14 +39,14 @@ class KatelloTables < ActiveRecord::Migration
 
     create_table "katello_changesets", :force => true do |t|
       t.integer  "environment_id"
-      t.string   "name"
+      t.string   "name", :limit => 255
       t.datetime "created_at",                                       :null => false
       t.datetime "updated_at",                                       :null => false
       t.datetime "promotion_date"
-      t.string   "state",          :default => "new",                :null => false
+      t.string   "state",          :default => "new",                :null => false, :limit => 255
       t.integer  "task_status_id"
       t.text     "description"
-      t.string   "type",           :default => "Katello::PromotionChangeset"
+      t.string   "type",           :default => "Katello::PromotionChangeset", :limit => 255
     end
 
     add_index "katello_changesets", ["environment_id"], :name => "index_changesets_on_environment_id"
@@ -63,14 +63,14 @@ class KatelloTables < ActiveRecord::Migration
     add_index "katello_component_content_views", ["content_view_definition_id", "content_view_id"], :name => "component_content_views_index"
 
     create_table "katello_content_view_definition_bases", :force => true do |t|
-      t.string   "name"
-      t.string   "label",                              :null => false
+      t.string   "name", :limit => 255
+      t.string   "label",                              :null => false, :limit => 255
       t.text     "description"
       t.integer  "organization_id"
       t.datetime "created_at",                         :null => false
       t.datetime "updated_at",                         :null => false
       t.boolean  "composite",       :default => false, :null => false
-      t.string   "type"
+      t.string   "type", :limit => 255
       t.integer  "source_id"
     end
 
@@ -95,9 +95,9 @@ class KatelloTables < ActiveRecord::Migration
     add_index "katello_content_view_definition_repositories", ["content_view_definition_id", "repository_id"], :name => "cvd_repo_index"
 
     create_table "katello_content_view_environments", :force => true do |t|
-      t.string   "name"
-      t.string   "label",           :null => false
-      t.string   "cp_id"
+      t.string   "name", :limit => 255
+      t.string   "label",           :null => false, :limit => 255
+      t.string   "cp_id", :limit => 255
       t.integer  "content_view_id"
       t.datetime "created_at",      :null => false
       t.datetime "updated_at",      :null => false
@@ -129,8 +129,8 @@ class KatelloTables < ActiveRecord::Migration
     add_index "katello_content_view_versions", ["id", "content_view_id"], :name => "cvv_cv_index"
 
     create_table "katello_content_views", :force => true do |t|
-      t.string   "name"
-      t.string   "label",                                         :null => false
+      t.string   "name", :limit => 255
+      t.string   "label",                                         :null => false, :limit => 255
       t.text     "description"
       t.integer  "content_view_definition_id"
       t.integer  "organization_id"
@@ -145,10 +145,10 @@ class KatelloTables < ActiveRecord::Migration
     add_index "katello_content_views", ["organization_id"], :name => "index_content_views_on_organization_id"
 
     create_table "katello_custom_info", :force => true do |t|
-      t.string   "keyname"
-      t.string   "value",           :default => ""
+      t.string   "keyname", :limit => 255
+      t.string   "value",           :default => "", :limit => 255
       t.integer  "informable_id"
-      t.string   "informable_type"
+      t.string   "informable_type", :limit => 255
       t.datetime "created_at",                         :null => false
       t.datetime "updated_at",                         :null => false
       t.boolean  "org_default",     :default => false
@@ -164,19 +164,19 @@ class KatelloTables < ActiveRecord::Migration
       t.datetime "run_at"
       t.datetime "locked_at"
       t.datetime "failed_at"
-      t.string   "locked_by"
+      t.string   "locked_by", :limit => 255
       t.datetime "created_at",                :null => false
       t.datetime "updated_at",                :null => false
-      t.string   "queue"
+      t.string   "queue", :limit => 255
     end
 
     add_index "delayed_jobs", ["priority", "run_at"], :name => "delayed_jobs_priority"
 
     create_table "katello_distributors", :force => true do |t|
-      t.string   "uuid"
-      t.string   "name"
+      t.string   "uuid", :limit => 255
+      t.string   "name", :limit => 255
       t.text     "description"
-      t.string   "location"
+      t.string   "location", :limit => 255
       t.integer  "environment_id"
       t.datetime "created_at",      :null => false
       t.datetime "updated_at",      :null => false
@@ -195,13 +195,13 @@ class KatelloTables < ActiveRecord::Migration
     add_index "katello_environment_priors", ["prior_id"], :name => "index_environment_priors_on_prior_id"
 
     create_table "katello_environments", :force => true do |t|
-      t.string   "name",                               :null => false
+      t.string   "name",                               :null => false, :limit => 255
       t.text     "description"
       t.boolean  "library",         :default => false, :null => false
       t.integer  "organization_id",                    :null => false
       t.datetime "created_at",                         :null => false
       t.datetime "updated_at",                         :null => false
-      t.string   "label",                              :null => false
+      t.string   "label",                              :null => false, :limit => 255
     end
 
     add_index "katello_environments", ["label", "organization_id"], :name => "index_environments_on_label_and_organization_id", :unique => true
@@ -209,7 +209,7 @@ class KatelloTables < ActiveRecord::Migration
     add_index "katello_environments", ["organization_id"], :name => "index_environments_on_organization_id"
 
     create_table "katello_filter_rules", :force => true do |t|
-      t.string   "type"
+      t.string   "type", :limit => 255
       t.text     "parameters"
       t.integer  "filter_id",                    :null => false
       t.boolean  "inclusion",  :default => true
@@ -221,7 +221,7 @@ class KatelloTables < ActiveRecord::Migration
 
     create_table "katello_filters", :force => true do |t|
       t.integer  "content_view_definition_id"
-      t.string   "name",                       :null => false
+      t.string   "name",                       :null => false, :limit => 255
       t.datetime "created_at",                 :null => false
       t.datetime "updated_at",                 :null => false
     end
@@ -248,7 +248,7 @@ class KatelloTables < ActiveRecord::Migration
     add_index "katello_filters_repositories", ["repository_id"], :name => "index_filters_repositories_on_repository_id"
 
     create_table "katello_gpg_keys", :force => true do |t|
-      t.string   "name",            :null => false
+      t.string   "name",            :null => false, :limit => 255
       t.integer  "organization_id", :null => false
       t.text     "content",         :null => false
       t.datetime "created_at",      :null => false
@@ -258,7 +258,7 @@ class KatelloTables < ActiveRecord::Migration
     add_index "katello_gpg_keys", ["organization_id", "name"], :name => "index_gpg_keys_on_organization_id_and_name", :unique => true
 
     create_table "katello_help_tips", :force => true do |t|
-      t.string   "key"
+      t.string   "key", :limit => 255
       t.integer  "user_id"
       t.datetime "created_at", :null => false
       t.datetime "updated_at", :null => false
@@ -276,8 +276,8 @@ class KatelloTables < ActiveRecord::Migration
 
     create_table "katello_jobs", :force => true do |t|
       t.integer "job_owner_id"
-      t.string  "job_owner_type"
-      t.string  "pulp_id",        :null => false
+      t.string  "job_owner_type", :limit => 255
+      t.string  "pulp_id",        :null => false, :limit => 255
     end
 
     add_index "katello_jobs", ["job_owner_id"], :name => "index_jobs_on_job_owner_id"
@@ -311,17 +311,17 @@ class KatelloTables < ActiveRecord::Migration
       t.string   "text",            :limit => 1024,                    :null => false
       t.text     "details"
       t.boolean  "global",                          :default => false, :null => false
-      t.string   "level",                                              :null => false
+      t.string   "level",                                              :null => false, :limit => 255
       t.datetime "created_at",                                         :null => false
       t.datetime "updated_at",                                         :null => false
-      t.string   "request_type"
+      t.string   "request_type", :limit => 255
       t.integer  "organization_id"
     end
 
     add_index "katello_notices", ["organization_id"], :name => "index_notices_on_organization_id"
 
     create_table "katello_pools", :force => true do |t|
-      t.string   "cp_id",      :null => false
+      t.string   "cp_id",      :null => false, :limit => 255
       t.datetime "created_at", :null => false
       t.datetime "updated_at", :null => false
     end
@@ -329,17 +329,17 @@ class KatelloTables < ActiveRecord::Migration
     add_index "katello_pools", ["cp_id"], :name => "index_pools_on_cp_id"
 
     create_table "katello_products", :force => true do |t|
-      t.string   "name"
+      t.string   "name", :limit => 255
       t.text     "description"
-      t.string   "cp_id"
+      t.string   "cp_id", :limit => 255
       t.integer  "multiplier"
       t.integer  "provider_id",                               :null => false
       t.datetime "created_at",                                :null => false
       t.datetime "updated_at",                                :null => false
       t.integer  "gpg_key_id"
-      t.string   "type",               :default => "Katello::Product", :null => false
+      t.string   "type",               :default => "Katello::Product", :null => false, :limit => 255
       t.integer  "sync_plan_id"
-      t.string   "label",                                     :null => false
+      t.string   "label",                                     :null => false, :limit => 255
       t.boolean  "cdn_import_success", :default => true,      :null => false
     end
 
@@ -349,15 +349,15 @@ class KatelloTables < ActiveRecord::Migration
     add_index "katello_products", ["sync_plan_id"], :name => "index_products_on_sync_plan_id"
 
     create_table "katello_providers", :force => true do |t|
-      t.string   "name"
+      t.string   "name", :limit => 255
       t.text     "description"
-      t.string   "repository_url"
-      t.string   "provider_type"
+      t.string   "repository_url", :limit => 255
+      t.string   "provider_type", :limit => 255
       t.integer  "organization_id"
       t.datetime "created_at",        :null => false
       t.datetime "updated_at",        :null => false
       t.integer  "task_status_id"
-      t.string   "discovery_url"
+      t.string   "discovery_url", :limit => 255
       t.text     "discovered_repos"
       t.integer  "discovery_task_id"
     end
@@ -367,24 +367,24 @@ class KatelloTables < ActiveRecord::Migration
     add_index "katello_providers", ["task_status_id"], :name => "index_providers_on_task_status_id"
 
     create_table "katello_repositories", :force => true do |t|
-      t.string   "name"
-      t.string   "pulp_id",                                       :null => false
+      t.string   "name", :limit => 255
+      t.string   "pulp_id",                                       :null => false, :limit => 255
       t.boolean  "enabled",                 :default => true
       t.datetime "created_at",                                    :null => false
       t.datetime "updated_at",                                    :null => false
       t.integer  "major"
-      t.string   "minor"
+      t.string   "minor", :limit => 255
       t.integer  "gpg_key_id"
-      t.string   "cp_label"
+      t.string   "cp_label", :limit => 255
       t.integer  "library_instance_id"
-      t.string   "content_id",                                    :null => false
-      t.string   "arch",                    :default => "noarch", :null => false
-      t.string   "label",                                         :null => false
+      t.string   "content_id",                                    :null => false, :limit => 255
+      t.string   "arch",                    :default => "noarch", :null => false, :limit => 255
+      t.string   "label",                                         :null => false, :limit => 255
       t.integer  "content_view_version_id",                       :null => false
-      t.string   "relative_path",                                 :null => false
-      t.string   "feed"
+      t.string   "relative_path",                                 :null => false, :limit => 255
+      t.string   "feed", :limit => 255
       t.boolean  "unprotected",             :default => false,    :null => false
-      t.string   "content_type",            :default => "yum",    :null => false
+      t.string   "content_type",            :default => "yum",    :null => false, :limit => 255
       t.integer  "product_id"
       t.integer  "environment_id"
     end
@@ -398,8 +398,8 @@ class KatelloTables < ActiveRecord::Migration
     add_index "katello_repositories", ["pulp_id"], :name => "index_repositories_on_pulp_id"
 
     create_table "katello_search_favorites", :force => true do |t|
-      t.string   "params"
-      t.string   "path"
+      t.string   "params", :limit => 255
+      t.string   "path", :limit => 255
       t.integer  "user_id"
       t.datetime "created_at", :null => false
       t.datetime "updated_at", :null => false
@@ -408,8 +408,8 @@ class KatelloTables < ActiveRecord::Migration
     add_index "katello_search_favorites", ["user_id"], :name => "index_search_favorites_on_user_id"
 
     create_table "katello_search_histories", :force => true do |t|
-      t.string   "params"
-      t.string   "path"
+      t.string   "params", :limit => 255
+      t.string   "path", :limit => 255
       t.integer  "user_id"
       t.datetime "created_at", :null => false
       t.datetime "updated_at", :null => false
@@ -418,10 +418,10 @@ class KatelloTables < ActiveRecord::Migration
     add_index "katello_search_histories", ["user_id"], :name => "index_search_histories_on_user_id"
 
     create_table "katello_sync_plans", :force => true do |t|
-      t.string   "name"
+      t.string   "name", :limit => 255
       t.text     "description"
       t.datetime "sync_date"
-      t.string   "interval"
+      t.string   "interval", :limit => 255
       t.integer  "organization_id", :null => false
       t.datetime "created_at",      :null => false
       t.datetime "updated_at",      :null => false
@@ -439,7 +439,7 @@ class KatelloTables < ActiveRecord::Migration
     add_index "katello_system_activation_keys", ["system_id"], :name => "index_system_activation_keys_on_system_id"
 
     create_table "katello_system_groups", :force => true do |t|
-      t.string   "name",                            :null => false
+      t.string   "name",                            :null => false, :limit => 255
       t.text     "description"
       t.integer  "max_systems",     :default => -1, :null => false
       t.integer  "organization_id",                 :null => false
@@ -461,14 +461,14 @@ class KatelloTables < ActiveRecord::Migration
     add_index "katello_system_system_groups", ["system_id"], :name => "index_system_system_groups_on_system_id"
 
     create_table "katello_systems", :force => true do |t|
-      t.string   "uuid"
-      t.string   "name"
+      t.string   "uuid", :limit => 255
+      t.string   "name", :limit => 255
       t.text     "description"
-      t.string   "location"
+      t.string   "location", :limit => 255
       t.integer  "environment_id"
       t.datetime "created_at",                            :null => false
       t.datetime "updated_at",                            :null => false
-      t.string   "type",            :default => "Katello::System"
+      t.string   "type",            :default => "Katello::System", :limit => 255
       t.integer  "content_view_id"
     end
 
@@ -476,10 +476,10 @@ class KatelloTables < ActiveRecord::Migration
     add_index "katello_systems", ["environment_id"], :name => "index_systems_on_environment_id"
 
     create_table "katello_task_statuses", :force => true do |t|
-      t.string   "type"
+      t.string   "type", :limit => 255
       t.integer  "organization_id"
       t.string   "uuid",                           :null => false
-      t.string   "state"
+      t.string   "state", :limit => 255
       t.text     "result"
       t.text     "progress"
       t.datetime "start_time"
@@ -487,10 +487,10 @@ class KatelloTables < ActiveRecord::Migration
       t.datetime "created_at",                     :null => false
       t.datetime "updated_at",                     :null => false
       t.text     "parameters"
-      t.string   "task_type"
+      t.string   "task_type", :limit => 255
       t.integer  "user_id",         :default => 0, :null => false
       t.integer  "task_owner_id"
-      t.string   "task_owner_type"
+      t.string   "task_owner_type", :limit => 255
     end
 
     add_index "katello_task_statuses", ["organization_id"], :name => "index_task_statuses_on_organization_id"

--- a/db/migrate/20131014225132_add_users_fields.rb
+++ b/db/migrate/20131014225132_add_users_fields.rb
@@ -5,6 +5,6 @@ class AddUsersFields < ActiveRecord::Migration
     add_column :users, :page_size, :integer, :default => 25, :null => false
     add_column :users, :disabled, :boolean, :default => false
     add_column :users, :preferences, :text
-    add_column :users, :remote_id, :string
+    add_column :users, :remote_id, :string, :limit => 255
   end
 end

--- a/db/migrate/20131120225132_add_organization_fields.rb
+++ b/db/migrate/20131120225132_add_organization_fields.rb
@@ -1,7 +1,7 @@
 class AddOrganizationFields < ActiveRecord::Migration
   def change
     add_column :taxonomies, :description, :text unless column_exists?(:taxonomies, :description)
-    add_column :taxonomies, :label, :string
+    add_column :taxonomies, :label, :string, :limit => 255
     add_column :taxonomies, :deletion_task_id, :integer
     add_column :taxonomies, :default_info, :text
     add_column :taxonomies, :apply_info_task_id, :integer

--- a/db/migrate/20131216212621_add_cp_id_to_katello_activation_keys.rb
+++ b/db/migrate/20131216212621_add_cp_id_to_katello_activation_keys.rb
@@ -1,7 +1,7 @@
 class AddCpIdToKatelloActivationKeys < ActiveRecord::Migration
   def change
-    add_column :katello_activation_keys, :cp_id, :string
-    add_column :katello_activation_keys, :label, :string
+    add_column :katello_activation_keys, :cp_id, :string, :limit => 255
+    add_column :katello_activation_keys, :label, :string, :limit => 255
     add_index :katello_activation_keys, :cp_id
     add_index :katello_activation_keys, :label, :name => "index_activation_keys_on_label", :unique => true
   end

--- a/db/migrate/20140110000001_update_environments_add_katello_id.rb
+++ b/db/migrate/20140110000001_update_environments_add_katello_id.rb
@@ -1,6 +1,6 @@
 class UpdateEnvironmentsAddKatelloId < ActiveRecord::Migration
   def up
-    add_column :environments, :katello_id, :string
+    add_column :environments, :katello_id, :string, :limit => 255
     add_index :environments, :katello_id
   end
 

--- a/db/migrate/20140117160939_refactor_content_views.rb
+++ b/db/migrate/20140117160939_refactor_content_views.rb
@@ -37,20 +37,20 @@ class RefactorContentViews < ActiveRecord::Migration
     rename_column :katello_content_view_filters_repositories, :filter_id, :content_view_filter_id
 
     rename_column :katello_content_view_filters, :content_view_definition_id, :content_view_id
-    add_column :katello_content_view_filters, :type, :string
+    add_column :katello_content_view_filters, :type, :string, :limit => 255
     add_column :katello_content_view_filters, :inclusion, :boolean, :default => false, :null => false
   end
 
   def down
     create_table "katello_content_view_definition_bases", :force => true do |t|
-      t.string "name"
-      t.string "label",                              :null => false
+      t.string "name", :limit => 255
+      t.string "label",                              :null => false, :limit => 255
       t.text "description"
       t.integer "organization_id"
       t.datetime "created_at",                         :null => false
       t.datetime "updated_at",                         :null => false
       t.boolean "composite",       :default => false, :null => false
-      t.string "type"
+      t.string "type", :limit => 255
       t.integer "source_id"
     end
 
@@ -67,7 +67,7 @@ class RefactorContentViews < ActiveRecord::Migration
     end
 
     create_table "katello_filter_rules", :force => true do |t|
-      t.string "type"
+      t.string "type", :limit => 255
       t.text "parameters"
       t.integer "filter_id",                    :null => false
       t.boolean "inclusion",  :default => true

--- a/db/migrate/20140206200439_create_content_view_puppet_modules.rb
+++ b/db/migrate/20140206200439_create_content_view_puppet_modules.rb
@@ -2,9 +2,9 @@ class CreateContentViewPuppetModules < ActiveRecord::Migration
   def change
     create_table :katello_content_view_puppet_modules do |t|
       t.references :content_view
-      t.string :name
-      t.string :author
-      t.string :uuid
+      t.string :name, :limit => 255
+      t.string :author, :limit => 255
+      t.string :uuid, :limit => 255
 
       t.timestamps
     end

--- a/db/migrate/20140212131812_create_content_view_package_filter_rules.rb
+++ b/db/migrate/20140212131812_create_content_view_package_filter_rules.rb
@@ -2,10 +2,10 @@ class CreateContentViewPackageFilterRules < ActiveRecord::Migration
   def change
     create_table :katello_content_view_package_filter_rules do |t|
       t.references :content_view_filter
-      t.string :name
-      t.string :version
-      t.string :min_version
-      t.string :max_version
+      t.string :name, :limit => 255
+      t.string :version, :limit => 255
+      t.string :min_version, :limit => 255
+      t.string :max_version, :limit => 255
 
       t.timestamps
     end

--- a/db/migrate/20140212143454_create_content_view_package_group_filter_rules.rb
+++ b/db/migrate/20140212143454_create_content_view_package_group_filter_rules.rb
@@ -2,7 +2,7 @@ class CreateContentViewPackageGroupFilterRules < ActiveRecord::Migration
   def change
     create_table :katello_content_view_package_group_filter_rules do |t|
       t.references :content_view_filter
-      t.string :name
+      t.string :name, :limit => 255
 
       t.timestamps
     end

--- a/db/migrate/20140212143642_create_content_view_erratum_filter_rules.rb
+++ b/db/migrate/20140212143642_create_content_view_erratum_filter_rules.rb
@@ -2,10 +2,10 @@ class CreateContentViewErratumFilterRules < ActiveRecord::Migration
   def change
     create_table :katello_content_view_erratum_filter_rules do |t|
       t.references :content_view_filter
-      t.string :errata_id
-      t.string :start_date
-      t.string :end_date
-      t.string :types
+      t.string :errata_id, :limit => 255
+      t.string :start_date, :limit => 255
+      t.string :end_date, :limit => 255
+      t.string :types, :limit => 255
 
       t.timestamps
     end

--- a/db/migrate/20140217160132_create_content_view_history.rb
+++ b/db/migrate/20140217160132_create_content_view_history.rb
@@ -3,9 +3,9 @@ class CreateContentViewHistory < ActiveRecord::Migration
     create_table 'katello_content_view_histories' do |t|
       t.references :katello_content_view_version, :null => false
       t.references :katello_environment, :null => true
-      t.string :task_id, :null => true
-      t.string :user, :null => false
-      t.string :status, :null => false
+      t.string :task_id, :null => true, :limit => 255
+      t.string :user, :null => false, :limit => 255
+      t.string :status, :null => false, :limit => 255
       t.text :notes
       t.timestamps
     end

--- a/db/migrate/20140222022712_remove_provider_discovery.rb
+++ b/db/migrate/20140222022712_remove_provider_discovery.rb
@@ -6,7 +6,7 @@ class RemoveProviderDiscovery < ActiveRecord::Migration
   end
 
   def down
-    add_column :katello_providers, :discovery_url, :string
+    add_column :katello_providers, :discovery_url, :string, :limit => 255
     add_column :katello_providers, :discovered_repos, :text
     add_column :katello_providers, :discovery_task_id, :integer
   end

--- a/db/migrate/20140305101813_allow_null_for_repository_content_id.rb
+++ b/db/migrate/20140305101813_allow_null_for_repository_content_id.rb
@@ -1,5 +1,6 @@
 class AllowNullForRepositoryContentId < ActiveRecord::Migration
   def change
-    change_column :katello_repositories, :content_id, :string, null: true
+    change_column :katello_repositories, :content_id, :string, null: true,
+      :limit => 255
   end
 end

--- a/db/migrate/20140306132108_create_content_view_puppet_environments.rb
+++ b/db/migrate/20140306132108_create_content_view_puppet_environments.rb
@@ -3,8 +3,8 @@ class CreateContentViewPuppetEnvironments < ActiveRecord::Migration
     create_table :katello_content_view_puppet_environments do |t|
       t.references :content_view_version
       t.references :environment
-      t.string :name
-      t.string :pulp_id, :null => false
+      t.string :name, :limit => 255
+      t.string :pulp_id, :null => false, :limit => 255
       t.timestamps
     end
 

--- a/db/migrate/20140310102051_repository_add_checksum_type.rb
+++ b/db/migrate/20140310102051_repository_add_checksum_type.rb
@@ -1,6 +1,7 @@
 class RepositoryAddChecksumType < ActiveRecord::Migration
   def up
-    add_column :katello_repositories, :checksum_type, :string, :null => true
+    add_column :katello_repositories, :checksum_type, :string, :null => true,
+      :limit => 255
   end
 
   def down

--- a/db/migrate/20140429193743_add_release_version_to_activation_keys.rb
+++ b/db/migrate/20140429193743_add_release_version_to_activation_keys.rb
@@ -1,5 +1,5 @@
 class AddReleaseVersionToActivationKeys < ActiveRecord::Migration
   def change
-    add_column :katello_activation_keys, :release_version, :string
+    add_column :katello_activation_keys, :release_version, :string, :limit => 255
   end
 end

--- a/db/migrate/20140610170142_add_uuid_to_content_view_package_group_filter_rule.rb
+++ b/db/migrate/20140610170142_add_uuid_to_content_view_package_group_filter_rule.rb
@@ -1,5 +1,6 @@
 class AddUuidToContentViewPackageGroupFilterRule < ActiveRecord::Migration
   def change
-    add_column :katello_content_view_package_group_filter_rules, :uuid, :string
+    add_column :katello_content_view_package_group_filter_rules, :uuid,
+      :string, :limit => 255
   end
 end

--- a/db/migrate/20140617100300_add_description_to_content_view_filter_rules.rb
+++ b/db/migrate/20140617100300_add_description_to_content_view_filter_rules.rb
@@ -1,6 +1,6 @@
 class AddDescriptionToContentViewFilterRules < ActiveRecord::Migration
   def up
-    add_column :katello_content_view_filters, :description, :string
+    add_column :katello_content_view_filters, :description, :string, :limit => 255
   end
 
   def down

--- a/db/migrate/20140624184401_remove_label_from_activation_key.rb
+++ b/db/migrate/20140624184401_remove_label_from_activation_key.rb
@@ -4,6 +4,6 @@ class RemoveLabelFromActivationKey < ActiveRecord::Migration
   end
 
   def down
-    add_column :katello_activation_keys, :label, :string
+    add_column :katello_activation_keys, :label, :string, :limit => 255
   end
 end

--- a/db/migrate/20140811141742_remove_delayed_jobs.rb
+++ b/db/migrate/20140811141742_remove_delayed_jobs.rb
@@ -12,10 +12,10 @@ class RemoveDelayedJobs < ActiveRecord::Migration
       t.datetime "run_at"
       t.datetime "locked_at"
       t.datetime "failed_at"
-      t.string "locked_by"
+      t.string "locked_by", :limit => 255
       t.datetime "created_at",                :null => false
       t.datetime "updated_at",                :null => false
-      t.string "queue"
+      t.string "queue", :limit => 255
     end
 
     add_index "delayed_jobs", %w(priority run_at), :name => "delayed_jobs_priority"

--- a/db/migrate/20140930170628_add_errata.rb
+++ b/db/migrate/20140930170628_add_errata.rb
@@ -2,14 +2,14 @@ class AddErrata < ActiveRecord::Migration
   # rubocop:disable MethodLength
   def up
     create_table "katello_errata" do |t|
-      t.string "uuid", :null => false
-      t.string "errata_id"
+      t.string "uuid", :null => false, :limit => 255
+      t.string "errata_id", :limit => 255
       t.timestamps
       t.datetime 'issued'
       t.datetime 'updated'
-      t.string 'errata_type'
-      t.string 'severity'
-      t.string 'title'
+      t.string 'errata_type', :limit => 255
+      t.string 'severity', :limit => 255
+      t.string 'title', :limit => 255
       t.text 'solution'
       t.text 'description'
       t.text 'summary'
@@ -20,9 +20,9 @@ class AddErrata < ActiveRecord::Migration
 
     create_table "katello_erratum_packages" do |t|
       t.references :erratum, :null => false
-      t.string :nvrea, :null => false
-      t.string :name, :null => false
-      t.string :filename
+      t.string :nvrea, :null => false, :limit => 255
+      t.string :name, :null => false, :limit => 255
+      t.string :filename, :limit => 255
     end
 
     add_index :katello_erratum_packages, [:erratum_id, :nvrea, :name, :filename], :unique => true,
@@ -32,8 +32,8 @@ class AddErrata < ActiveRecord::Migration
 
     create_table "katello_erratum_cves" do |t|
       t.references :erratum, :null => false
-      t.string :cve_id, :null => false
-      t.string :href, :null => true
+      t.string :cve_id, :null => false, :limit => 255
+      t.string :href, :null => true, :limit => 255
     end
 
     add_index :katello_erratum_cves, [:erratum_id, :cve_id, :href], :unique => true
@@ -42,8 +42,8 @@ class AddErrata < ActiveRecord::Migration
 
     create_table "katello_erratum_bugzillas" do |t|
       t.references :erratum, :null => false
-      t.string :bug_id, :null => false
-      t.string :href, :null => true
+      t.string :bug_id, :null => false, :limit => 255
+      t.string :href, :null => true, :limit => 255
     end
 
     add_index :katello_erratum_bugzillas, [:erratum_id, :bug_id, :href], :unique => true, :name => 'katello_erratum_bz_eid_bid_href'

--- a/db/migrate/20141003210742_add_docker_container_registry_url_to_providers.rb
+++ b/db/migrate/20141003210742_add_docker_container_registry_url_to_providers.rb
@@ -1,6 +1,6 @@
 class AddDockerContainerRegistryUrlToProviders < ActiveRecord::Migration
   def up
-    add_column :katello_providers, :docker_registry_url, :string
+    add_column :katello_providers, :docker_registry_url, :string, :limit => 255
   end
 
   def down

--- a/db/migrate/20141015173220_add_docker_image_fields.rb
+++ b/db/migrate/20141015173220_add_docker_image_fields.rb
@@ -1,6 +1,6 @@
 class AddDockerImageFields < ActiveRecord::Migration
   def up
-    add_column :docker_images, :katello_uuid, :string
+    add_column :docker_images, :katello_uuid, :string, :limit => 255
     add_column :docker_images, :katello_repository_id, :integer
     add_column :docker_tags, :katello_repository_id, :integer
 

--- a/db/migrate/20141210173220_create_docker_tables.rb
+++ b/db/migrate/20141210173220_create_docker_tables.rb
@@ -1,13 +1,13 @@
 class CreateDockerTables < ActiveRecord::Migration
   def up
     create_table :katello_docker_images do |t|
-      t.string :image_id
+      t.string :image_id, :limit => 255
       t.integer :size
-      t.string :uuid
+      t.string :uuid, :limit => 255
       t.timestamps
     end
     create_table :katello_docker_tags do |t|
-      t.string :name
+      t.string :name, :limit => 255
       t.integer :docker_image_id
       t.integer :repository_id
       t.timestamps

--- a/db/migrate/20150114225023_add_upstream_name_to_repository.rb
+++ b/db/migrate/20150114225023_add_upstream_name_to_repository.rb
@@ -1,6 +1,6 @@
 class AddUpstreamNameToRepository < ActiveRecord::Migration
   def up
-    add_column :katello_repositories, :docker_upstream_name, :string
+    add_column :katello_repositories, :docker_upstream_name, :string, :limit => 255
     Katello::Repository.docker_type.each do |repo|
       next if repo.url.blank?
       update %(

--- a/db/migrate/20150224083608_remove_docker_registry_url.rb
+++ b/db/migrate/20150224083608_remove_docker_registry_url.rb
@@ -4,6 +4,6 @@ class RemoveDockerRegistryUrl < ActiveRecord::Migration
   end
 
   def down
-    add_column :katello_providers, :docker_registry_url, :string
+    add_column :katello_providers, :docker_registry_url, :string, :limit => 255
   end
 end

--- a/db/migrate/20150513034751_add_ostree_branches.rb
+++ b/db/migrate/20150513034751_add_ostree_branches.rb
@@ -1,7 +1,7 @@
 class AddOstreeBranches < ActiveRecord::Migration
   def up
     create_table :katello_ostree_branches do |t|
-      t.string :name, :null => false
+      t.string :name, :null => false, :limit => 255
       t.references :repository, :null => false
       t.timestamps
     end

--- a/db/migrate/20150602153753_remove_help_tips.rb
+++ b/db/migrate/20150602153753_remove_help_tips.rb
@@ -5,7 +5,7 @@ class RemoveHelpTips < ActiveRecord::Migration
 
   def down
     create_table "katello_help_tips", :force => true do |t|
-      t.string   "key"
+      t.string   "key", :limit => 255
       t.integer  "user_id"
       t.datetime "created_at", :null => false
       t.datetime "updated_at", :null => false

--- a/db/migrate/20150602153754_remove_search_histories.rb
+++ b/db/migrate/20150602153754_remove_search_histories.rb
@@ -5,8 +5,8 @@ class RemoveSearchHistories < ActiveRecord::Migration
 
   def down
     create_table "katello_search_histories", :force => true do |t|
-      t.string   "params"
-      t.string   "path"
+      t.string   "params", :limit => 255
+      t.string   "path", :limit => 255
       t.integer  "user_id"
       t.datetime "created_at", :null => false
       t.datetime "updated_at", :null => false

--- a/db/migrate/20150602153755_remove_search_favorites.rb
+++ b/db/migrate/20150602153755_remove_search_favorites.rb
@@ -5,8 +5,8 @@ class RemoveSearchFavorites < ActiveRecord::Migration
 
   def down
     create_table "katello_search_favorites", :force => true do |t|
-      t.string   "params"
-      t.string   "path"
+      t.string   "params", :limit => 255
+      t.string   "path", :limit => 255
       t.integer  "user_id"
       t.datetime "created_at", :null => false
       t.datetime "updated_at", :null => false

--- a/db/migrate/20150602153757_remove_notices.rb
+++ b/db/migrate/20150602153757_remove_notices.rb
@@ -8,10 +8,10 @@ class RemoveNotices < ActiveRecord::Migration
       t.string   "text",            :limit => 1024,                    :null => false
       t.text     "details"
       t.boolean  "global",                          :default => false, :null => false
-      t.string   "level",                                              :null => false
+      t.string   "level",                                              :null => false, :limit => 255
       t.datetime "created_at",                                         :null => false
       t.datetime "updated_at",                                         :null => false
-      t.string   "request_type"
+      t.string   "request_type", :limit => 255
       t.integer  "organization_id"
     end
 

--- a/db/migrate/20150603045418_remove_user_fields.rb
+++ b/db/migrate/20150603045418_remove_user_fields.rb
@@ -13,6 +13,6 @@ class RemoveUserFields < ActiveRecord::Migration
     add_column :users, :page_size, :integer, :default => 25, :null => false
     add_column :users, :disabled, :boolean, :default => false
     add_column :users, :preferences, :text
-    add_column :users, :remote_id, :string
+    add_column :users, :remote_id, :string, :limit => 255
   end
 end

--- a/db/migrate/20150606021722_create_puppet_modules.rb
+++ b/db/migrate/20150606021722_create_puppet_modules.rb
@@ -3,11 +3,11 @@ class CreatePuppetModules < ActiveRecord::Migration
   def up
     create_table 'katello_puppet_modules' do |t|
       t.timestamps
-      t.string "uuid", :null => false
-      t.string 'name'
-      t.string 'author'
-      t.string 'title'
-      t.string 'version'
+      t.string "uuid", :null => false, :limit => 255
+      t.string 'name', :limit => 255
+      t.string 'author', :limit => 255
+      t.string 'title', :limit => 255
+      t.string 'version', :limit => 255
       t.text 'summary'
     end
 

--- a/db/migrate/20150613134559_add_rpm.rb
+++ b/db/migrate/20150613134559_add_rpm.rb
@@ -1,19 +1,19 @@
 class AddRpm < ActiveRecord::Migration
   def up
     create_table "katello_rpms" do |t|
-      t.string "uuid", :null => false
+      t.string "uuid", :null => false, :limit => 255
       t.timestamps
-      t.string 'name'
-      t.string 'version'
-      t.string 'release'
-      t.string 'arch'
-      t.string 'epoch'
-      t.string 'filename'
-      t.string 'sourcerpm'
-      t.string 'checksum'
-      t.string 'version_sortable'
-      t.string 'release_sortable'
-      t.string 'summary'
+      t.string 'name', :limit => 255
+      t.string 'version', :limit => 255
+      t.string 'release', :limit => 255
+      t.string 'arch', :limit => 255
+      t.string 'epoch', :limit => 255
+      t.string 'filename', :limit => 255
+      t.string 'sourcerpm', :limit => 255
+      t.string 'checksum', :limit => 255
+      t.string 'version_sortable', :limit => 255
+      t.string 'release_sortable', :limit => 255
+      t.string 'summary', :limit => 255
     end
 
     add_index :katello_rpms, :uuid, :unique => true

--- a/db/migrate/20150623135424_create_package_groups.rb
+++ b/db/migrate/20150623135424_create_package_groups.rb
@@ -1,9 +1,9 @@
 class CreatePackageGroups < ActiveRecord::Migration
   def change
     create_table "katello_package_groups" do |t|
-      t.string "name"
-      t.string "uuid", :null => false
-      t.string "description"
+      t.string "name", :limit => 255
+      t.string "uuid", :null => false, :limit => 255
+      t.string "description", :limit => 255
       t.timestamps
     end
     add_index :katello_package_groups, :uuid, :unique => true

--- a/db/migrate/20150717142559_add_distributions_to_repository.rb
+++ b/db/migrate/20150717142559_add_distributions_to_repository.rb
@@ -1,10 +1,10 @@
 class AddDistributionsToRepository < ActiveRecord::Migration
   def change
-    add_column :katello_repositories, :distribution_version, :string
-    add_column :katello_repositories, :distribution_arch, :string
+    add_column :katello_repositories, :distribution_version, :string, :limit => 255
+    add_column :katello_repositories, :distribution_arch, :string, :limit => 255
     add_column :katello_repositories, :distribution_bootable, :boolean
-    add_column :katello_repositories, :distribution_family, :string
-    add_column :katello_repositories, :distribution_variant, :string
-    add_column :katello_repositories, :distribution_uuid, :string
+    add_column :katello_repositories, :distribution_family, :string, :limit => 255
+    add_column :katello_repositories, :distribution_variant, :string, :limit => 255
+    add_column :katello_repositories, :distribution_uuid, :string, :limit => 255
   end
 end

--- a/db/migrate/20150813185339_create_subscriptions.rb
+++ b/db/migrate/20150813185339_create_subscriptions.rb
@@ -2,9 +2,9 @@ class CreateSubscriptions < ActiveRecord::Migration
   # rubocop:disable MethodLength
   def change
     create_table "katello_subscriptions" do |t|
-      t.string  :name
-      t.string  :product_id
-      t.string  :cp_id
+      t.string  :name, :limit => 255
+      t.string  :product_id, :limit => 255
+      t.string  :cp_id, :limit => 255
       t.string  :support_level
       t.integer :organization_id
       t.integer :sockets
@@ -20,9 +20,9 @@ class CreateSubscriptions < ActiveRecord::Migration
     add_column :katello_pools, :contract_number, :integer
     add_column :katello_pools, :virtual, :boolean
     add_column :katello_pools, :quantity, :integer
-    add_column :katello_pools, :start_date, :string
-    add_column :katello_pools, :pool_type, :string
-    add_column :katello_pools, :end_date, :string
+    add_column :katello_pools, :start_date, :string, :limit => 255
+    add_column :katello_pools, :pool_type, :string, :limit => 255
+    add_column :katello_pools, :end_date, :string, :limit => 255
     add_column :katello_pools, :ram, :integer
     add_column :katello_pools, :multi_entitlement, :boolean
     add_column :katello_pools, :consumed, :integer

--- a/db/migrate/20150826165942_add_subscription_facet.rb
+++ b/db/migrate/20150826165942_add_subscription_facet.rb
@@ -2,10 +2,10 @@ class AddSubscriptionFacet < ActiveRecord::Migration
   def change
     create_table "katello_subscription_facets" do |t|
       t.references 'host', :null => false
-      t.string 'uuid'
+      t.string 'uuid', :limit => 255
       t.datetime 'last_checkin'
-      t.string 'service_level'
-      t.string 'release_version'
+      t.string 'service_level', :limit => 255
+      t.string 'release_version', :limit => 255
       t.boolean 'autoheal', :default => false
     end
 

--- a/db/migrate/20150826170004_add_content_facet.rb
+++ b/db/migrate/20150826170004_add_content_facet.rb
@@ -3,7 +3,7 @@ class AddContentFacet < ActiveRecord::Migration
   def change
     create_table "katello_content_facets" do |t|
       t.references 'host', :null => false
-      t.string 'uuid'
+      t.string 'uuid', :limit => 255
       t.references 'content_view', :null => false, :index => true
       t.references 'lifecycle_environment', :null => false, :index => true
     end
@@ -20,8 +20,8 @@ class AddContentFacet < ActiveRecord::Migration
                     :name => "katello_content_facets_life_environment_id", :column => "lifecycle_environment_id"
 
     create_table "katello_installed_packages" do |t|
-      t.string 'name', :null => false
-      t.string 'nvra', :null => false
+      t.string 'name', :null => false, :limit => 255
+      t.string 'nvra', :null => false, :limit => 255
     end
 
     create_table "katello_host_installed_packages" do |t|

--- a/db/migrate/20150901213759_remove_distributors.rb
+++ b/db/migrate/20150901213759_remove_distributors.rb
@@ -9,10 +9,10 @@ class RemoveDistributors < ActiveRecord::Migration
 
   def down
     create_table "katello_distributors", :force => true do |t|
-      t.string   "uuid"
-      t.string   "name"
+      t.string   "uuid", :limit => 255
+      t.string   "name", :limit => 255
       t.text     "description"
-      t.string   "location"
+      t.string   "location", :limit => 255
       t.integer  "environment_id"
       t.datetime "created_at",      :null => false
       t.datetime "updated_at",      :null => false

--- a/db/migrate/20150908222711_drop_marketing_engineering_products.rb
+++ b/db/migrate/20150908222711_drop_marketing_engineering_products.rb
@@ -16,6 +16,6 @@ class DropMarketingEngineeringProducts < ActiveRecord::Migration
       t.integer "engineering_product_id"
     end
 
-    add_column :katello_products, :type, :string
+    add_column :katello_products, :type, :string, :limit => 255
   end
 end

--- a/db/migrate/20151203230940_add_date_type_to_content_view_erratum_filter_rules.rb
+++ b/db/migrate/20151203230940_add_date_type_to_content_view_erratum_filter_rules.rb
@@ -1,6 +1,7 @@
 class AddDateTypeToContentViewErratumFilterRules < ActiveRecord::Migration
   def change
-    add_column :katello_content_view_erratum_filter_rules, :date_type, :string, :default => "updated", :null => false
+    add_column :katello_content_view_erratum_filter_rules, :date_type, :string,
+      :default => "updated", :null => false, :limit => 255
     update "UPDATE katello_content_view_erratum_filter_rules SET date_type = 'issued'"
   end
 end

--- a/db/migrate/20160129192548_add_docker_v2_schema.rb
+++ b/db/migrate/20160129192548_add_docker_v2_schema.rb
@@ -1,10 +1,10 @@
 class AddDockerV2Schema < ActiveRecord::Migration
   def up
     create_table :katello_docker_manifests do |t|
-      t.string :name
+      t.string :name, :limit => 255
       t.integer :schema_version
-      t.string :uuid
-      t.string :digest
+      t.string :uuid, :limit => 255
+      t.string :digest, :limit => 255
       t.boolean :downloaded
       t.timestamps
     end
@@ -15,7 +15,7 @@ class AddDockerV2Schema < ActiveRecord::Migration
       t.timestamps
     end
 
-    add_column :katello_docker_tags, :uuid, :string
+    add_column :katello_docker_tags, :uuid, :string, :limit => 255
     add_column :katello_docker_tags, :docker_manifest_id, :integer
 
     add_index :katello_docker_tags, :uuid, :unique => true

--- a/db/migrate/20160131182301_add_download_policy_to_katello_repositories.rb
+++ b/db/migrate/20160131182301_add_download_policy_to_katello_repositories.rb
@@ -3,7 +3,7 @@ class AddDownloadPolicyToKatelloRepositories < ActiveRecord::Migration
     self.table_name = "katello_repositories"
   end
   def change
-    add_column :katello_repositories, :download_policy, :string
+    add_column :katello_repositories, :download_policy, :string, :limit => 255
     DownloadPolicyRepository.where(content_type: 'yum').update_all(download_policy: 'immediate')
   end
 end

--- a/db/migrate/20160203195736_remove_docker_image_schema.rb
+++ b/db/migrate/20160203195736_remove_docker_image_schema.rb
@@ -9,9 +9,9 @@ class RemoveDockerImageSchema < ActiveRecord::Migration
     add_column :katello_docker_tags, :docker_image_id, :integer
 
     create_table :katello_docker_images do |t|
-      t.string :image_id
+      t.string :image_id, :limit => 255
       t.integer :size
-      t.string :uuid
+      t.string :uuid, :limit => 255
       t.timestamps
     end
 


### PR DESCRIPTION
In Rails 4.2 the default limit for PostgreSQL and SQLite adapters changes to unlimited from 255 characters.