### PR TITLE
Fixes #14043 - Product Content can be filtered by Organization

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -4,7 +4,7 @@ module Katello
 
     before_filter :verify_presence_of_organization_or_environment, :only => [:index]
     before_filter :find_environment, :only => [:index, :create, :update]
-    before_filter :find_optional_organization, :only => [:index, :create, :show]
+    before_filter :find_optional_organization, :only => [:index, :create, :show, :product_content]
     before_filter :find_activation_key, :only => [:show, :update, :destroy, :available_releases, :copy, :product_content,
                                                   :available_host_collections, :add_host_collections, :remove_host_collections,
                                                   :content_override, :add_subscriptions, :remove_subscriptions,
@@ -130,8 +130,13 @@ module Katello
 
     api :GET, "/activation_keys/:id/product_content", N_("Show content available for an activation key")
     param :id, String, :desc => N_("ID of the activation key"), :required => true
+    param :organization_id, :number, :desc => N_("organization identifier to associate with activation key")
     def product_content
-      content = @activation_key.available_content
+      if params.key?(:organization_id)
+        content = @activation_key.organization == @organization ? @activation_key.available_content : []
+      else
+        content = @activation_key.available_content
+      end
       response = {
         :results => content,
         :total => content.size,

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -174,6 +174,16 @@ module Katello
       assert_template 'api/v2/activation_keys/product_content'
     end
 
+    def test_product_content_organization_filter
+      @activation_key.organization = @organization
+      organization2 = Organization.find(taxonomies(:organization2))
+      response = get :product_content, :id => @activation_key.id, :organization_id => organization2.id
+      assert_equal JSON.parse(response.body)['results'], []
+
+      assert_response :success
+      assert_template 'api/v2/activation_keys/product_content'
+    end
+
     def test_content_override_protected
       allowed_perms = [@update_permission]
       denied_perms = [@view_permission, @create_permission, @destroy_permission]


### PR DESCRIPTION
In Hammer it let me return product content from an activation key even if I entered an Organization-ID that the activation key does not belong to. It should filter correctly now.