### PR TITLE
Fixes #14048 - do not parse iso8601 date twice

### DIFF
--- a/app/lib/actions/katello/content_view_version/export.rb
+++ b/app/lib/actions/katello/content_view_version/export.rb
@@ -6,7 +6,6 @@ module Actions
 
         def plan(content_view_version, export_to_iso, since, iso_size)
           # assemble data to feed to Pulp
-          start_date = since ? since.iso8601 : nil
           content_view = ::Katello::ContentView.find(content_view_version.content_view_id)
           org_label = ::Organization.find_by(:id => content_view.organization_id).label
           group_id = "#{org_label}-#{content_view.label}-"\
@@ -20,7 +19,7 @@ module Actions
                                                           :status => ::Katello::ContentViewHistory::IN_PROGRESS,
                                                           :task => self.task)
 
-          plan_action(Katello::Repository::Export, repos, export_to_iso, start_date, iso_size,
+          plan_action(Katello::Repository::Export, repos, export_to_iso, since, iso_size,
                                                    group_id)
           plan_self(:history_id => history.id)
         end

--- a/test/actions/katello/content_view_version_test.rb
+++ b/test/actions/katello/content_view_version_test.rb
@@ -71,5 +71,16 @@ module ::Actions::Katello::ContentViewVersion
       assert_action_planed_with(action, ::Actions::Katello::Repository::Export, [library_repo],
                                 false, nil, 0, "-published_library_view-v2.0")
     end
+
+    it 'plans with date' do
+      stub_remote_user
+
+      task = ForemanTasks::Task::DynflowTask.create!(state: :success, result: "good")
+      action.stubs(:task).returns(task)
+      # the date should not be converted to an iso8601 when fed to Repository::Export.
+      plan_action(action, content_view_version, false, '1841-01-01', 0)
+      assert_action_planed_with(action, ::Actions::Katello::Repository::Export, [library_repo],
+                                false, '1841-01-01', 0, "-published_library_view-v2.0")
+    end
   end
 end


### PR DESCRIPTION
The repo export task will covert a date string to iso8601 format. The CV export
task was doing this as well, and then passing the date object to the repo
export task to get re-converted, which resulted in an error.

Instead, just pass the string through directly for later conversion.