### PR TITLE
fixes #14049: update reindex to include docker content

### DIFF
--- a/app/services/katello/pulp/docker_manifest.rb
+++ b/app/services/katello/pulp/docker_manifest.rb
@@ -1,7 +1,7 @@
 module Katello
   module Pulp
     class DockerManifest < PulpContentUnit
-      CONTENT_TYPE = "docker"
+      CONTENT_TYPE = "docker_manifest"
     end
   end
 end

--- a/lib/katello/tasks/reindex.rake
+++ b/lib/katello/tasks/reindex.rake
@@ -146,5 +146,10 @@ namespace :katello do
     reindex_helper.index_objects(Katello::Rpm) do
       Katello::Rpm.import_all
     end
+
+    # For docker repositories, index all associated manifests and tags
+    Katello::Repository.docker_type.each do |docker_repo|
+      docker_repo.index_db_docker_manifests
+    end
   end
 end


### PR DESCRIPTION
This commit updates the 'rake katello:reindex' to include indexing
the docker manifests and tags.  The behavior is slightly different
than other content units; however, this is due to the relationship
of tags to a manifest.  For this reason, we will simply perform
the same indexing step that we do within the logic when a repository
is synced...etc. which will recreate, if needed, the manifests
and/org tags.