### PR TITLE
fixes #14027 - sync/promote should still succeed if mail notification fails

### DIFF
--- a/app/lib/actions/katello/content_view/errata_mail.rb
+++ b/app/lib/actions/katello/content_view/errata_mail.rb
@@ -13,7 +13,13 @@ module Actions
           environment = ::Katello::KTEnvironment.find(input[:environment])
           users = ::User.select { |user| user.receives?(:katello_promote_errata) && user.can?(:view_content_views, content_view) }
 
-          MailNotification[:katello_promote_errata].deliver(:users => users, :content_view => content_view, :environment  => environment) unless users.blank?
+          begin
+            MailNotification[:katello_promote_errata].deliver(:users => users, :content_view => content_view, :environment  => environment) unless users.blank?
+          rescue => e
+            message = _('Unable to send errata e-mail notification: %{error}' % {:error => e})
+            Rails.logger.error(message)
+            output[:result] = message
+          end
         end
 
         def finalize


### PR DESCRIPTION
Currently, even with the Skip strategy, e-mail notifications cause the entire
job to be in a warning state. It's misleading as syncs and promotes would
show incomplete.

ErrataMail actions should never fail, just log the failure in the action output
and rails log.

Note: If you want to test this, setup `email.yaml` to have an unresolvable hostname:

```
development:
  delivery_method: :smtp
  smtp_settings:
    address: smtp.exampl2345924582348e.com
    port: 25
    domain: example.com
    authentication: :none
```

You'll also need to enable delivery errors in development mode, in `config/environments/development.rb`, set:

```
config.action_mailer.raise_delivery_errors = true
```

And lastly, sync or promote a repo that has new errata.
