### PR TITLE
Fixes #14056 - Limiting docker tags to readable repos

### DIFF
--- a/app/controllers/katello/api/v2/docker_tags_controller.rb
+++ b/app/controllers/katello/api/v2/docker_tags_controller.rb
@@ -6,7 +6,10 @@ module Katello
     def index
       if params[:grouped]
         # group docker tags by name, repo, and product
-        collection = Katello::DockerTag.grouped
+        repos = Repository.readable
+        repos = repos.in_organization(@organization) if @organization
+        collection = Katello::DockerTag.in_repositories(repos).grouped
+
         respond(:collection => scoped_search(collection, "name", "DESC"))
       else
         super

--- a/test/controllers/api/v2/docker_tags_controller_test.rb
+++ b/test/controllers/api/v2/docker_tags_controller_test.rb
@@ -27,6 +27,20 @@ module Katello
       assert_template "katello/api/v2/docker_tags/index"
     end
 
+    def test_grouped_index
+      organization = @repo.organization
+      repos_stub = stub(:in_organization => [@repo])
+      Repository.expects(:readable).returns(repos_stub)
+      get :index, :organization_id => organization.id,
+        :grouped => true
+
+      assert_response :success
+      assert_template 'api/v2/docker_tags/index'
+
+      results = JSON.parse(response.body)["results"].map { |tag| tag["name"] }
+      assert_equal ['wat'], results
+    end
+
     def test_show
       get :show, :repository_id => @repo.id, :id => @tag.id
 


### PR DESCRIPTION
Considered reusing the index_relation method to filter these but most other filters (content view, env, etc) would not make sense or even work since these are grouped across views/environments.

This grouped param is not documented and is used only by the UI page to show a collection of all tags in the organization.