### PR TITLE
Fixes #14074 - Select all selects only visible

### DIFF
--- a/app/views/katello/sync_management/_product.html.erb
+++ b/app/views/katello/sync_management/_product.html.erb
@@ -8,7 +8,9 @@
     </td>
     <td class="max_width start_time"></td>
     <td class="max_width duration"></td>
-    <td></td>
+    <td class="max_width details" data-total="<%= prod[:repos].count %>" data-selected="0">
+      <%= _("Selected repositories: %{selected}/%{total}") % { :selected => 0, :total => prod[:repos].count } %>
+    </td>
     <td class="result" id="table_<%= pid %>"></td>
     <% if @show_org %>
       <td><%= prod[:organization] %></td>


### PR DESCRIPTION
With this patch `select all` selects only visible checkboxes, should this also modify the `select none` so it would deselect only the visible ones? 
