### PR TITLE
Fixes #13998 - Can't create a puppet module repo on capsule

### DIFF
--- a/app/lib/actions/katello/capsule_content/create_or_update.rb
+++ b/app/lib/actions/katello/capsule_content/create_or_update.rb
@@ -38,7 +38,7 @@ module Actions
                       path: relative_path,
                       with_importer: true,
                       docker_upstream_name: repository.try(:docker_upstream_name),
-                      download_policy: (repository.library_instance || repository).download_policy,
+                      download_policy: repository.capsule_download_policy,
                       capsule_id: capsule_content.capsule.id)
         end
 

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -750,6 +750,13 @@ module Katello
         self.content_type == Repository::OSTREE_TYPE
       end
 
+      def capsule_download_policy
+        if self.yum?
+          repo = self.library_instance || self
+          repo.download_policy
+        end
+      end
+
       protected
 
       def _get_most_recent_sync_status

--- a/test/actions/katello/capsule_content_test.rb
+++ b/test/actions/katello/capsule_content_test.rb
@@ -128,7 +128,7 @@ module ::Actions::Katello::CapsuleContent
                          ssl_client_cert: cert[:cert],
                          ssl_client_key: cert[:key],
                          unprotected: repository.unprotected,
-                         download_policy: repository.library_instance.download_policy,
+                         download_policy: repository.capsule_download_policy,
                          checksum_type: repository.checksum_type,
                          path: repository.relative_path,
                          with_importer: true,

--- a/test/models/repository_base.rb
+++ b/test/models/repository_base.rb
@@ -3,22 +3,22 @@ require 'katello_test_helper'
 module Katello
   class RepositoryTestBase < ActiveSupport::TestCase
     def setup
-      @acme_corporation              = get_organization
-
-      @fedora_17_x86_64              = katello_repositories(:fedora_17_x86_64)
-      @fedora_17_x86_64_dev          = katello_repositories(:fedora_17_x86_64_dev)
-      @fedora_17_library_library_view = katello_repositories(:fedora_17_library_library_view)
-      @fedora_17_dev_library_view     = katello_repositories(:fedora_17_dev_library_view)
-      @puppet_forge                  = katello_repositories(:p_forge)
-      @redis                         = katello_repositories(:redis)
-      @fedora                        = katello_products(:fedora)
-      @library                       = katello_environments(:library)
-      @dev                           = katello_environments(:dev)
-      @staging                       = katello_environments(:staging)
-      @unassigned_gpg_key            = katello_gpg_keys(:unassigned_gpg_key)
-      @library_dev_staging_view      = katello_content_views(:library_dev_staging_view)
-      @library_view                  = katello_content_views(:library_view)
-      @admin                         = users(:admin)
+      @acme_corporation                 = get_organization
+      @fedora_17_x86_64                 = katello_repositories(:fedora_17_x86_64)
+      @fedora_17_x86_64_dev             = katello_repositories(:fedora_17_x86_64_dev)
+      @fedora_17_library_library_view   = katello_repositories(:fedora_17_library_library_view)
+      @fedora_17_dev_library_view       = katello_repositories(:fedora_17_dev_library_view)
+      @puppet_forge                     = katello_repositories(:p_forge)
+      @redis                            = katello_repositories(:redis)
+      @fedora                           = katello_products(:fedora)
+      @library                          = katello_environments(:library)
+      @dev                              = katello_environments(:dev)
+      @staging                          = katello_environments(:staging)
+      @unassigned_gpg_key               = katello_gpg_keys(:unassigned_gpg_key)
+      @library_dev_staging_view         = katello_content_views(:library_dev_staging_view)
+      @library_view                     = katello_content_views(:library_view)
+      @content_view_puppet_environment  = katello_content_view_puppet_environments(:archive_view_puppet_environment)
+      @admin                            = users(:admin)
     end
   end
 end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -594,6 +594,12 @@ module Katello
       errata = @rhel6.errata.first
       assert_includes Repository.with_errata([errata]), @rhel6
     end
+
+    def test_capsule_download_policy
+      assert_equal @content_view_puppet_environment.capsule_download_policy, nil
+      assert_equal @puppet_forge.capsule_download_policy, nil
+      assert_not_nil @fedora_17_x86_64.download_policy
+    end
   end
 
   class RepositoryApplicabilityTest < RepositoryTestBase


### PR DESCRIPTION
To test you will need a capsule set up, then create a content view with a puppet module, and publish a cv version (make sure your capsule is associate with Library env)