### PR TITLE
Fixes #14089 - Forces protection for Ostree Repos

### DIFF
--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -95,6 +95,7 @@ module Katello
     validate :ensure_valid_docker_attributes, :if => :docker?
     validate :ensure_docker_repo_unprotected, :if => :docker?
     validate :ensure_has_url_for_ostree, :if => :ostree?
+    validate :ensure_ostree_repo_protected, :if => :ostree?
 
     scope :has_url, -> { where('url IS NOT NULL') }
     scope :in_default_view, -> { joins(:content_view_version => :content_view).where("#{Katello::ContentView.table_name}.default" => true) }
@@ -599,6 +600,12 @@ module Katello
     def ensure_has_url_for_ostree
       return true if url.present? || library_instance_id
       errors.add(:url, N_("cannot be blank. RPM OSTree Repository URL required for syncing from the upstream."))
+    end
+
+    def ensure_ostree_repo_protected
+      if unprotected
+        errors.add(:base, N_("OSTree Repositories cannot be unprotected."))
+      end
     end
 
     def remove_docker_content(manifests)

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-info.html
@@ -150,7 +150,7 @@
         <span class="info-value" translate>Yes</span>
       </div>
 
-      <div class="detail">
+      <div class="detail" ng-hide="repository.content_type === 'ostree'">
         <span class="info-label" translate>Publish via HTTP</span>
         <span class="info-value"
               bst-edit-checkbox="repository.unprotected"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/new-repository.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/new-repository.controller.js
@@ -64,6 +64,9 @@ angular.module('Bastion.repositories').controller('NewRepositoryController',
         });
 
         $scope.save = function (repository) {
+            if (repository.content_type === 'ostree') {
+                repository.unprotected = false;
+            }
             repository.$save(success, error);
         };
 

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -190,6 +190,14 @@ module Katello
       @repo.url = ""
       refute @repo.save
     end
+
+    def test_ostree_unprotected
+      @repo.content_type = Repository::OSTREE_TYPE
+      @repo.url = "http://foo.com"
+      @repo.download_policy = nil
+      @repo.unprotected = true
+      refute @repo.save
+    end
   end
 
   class RepositorySearchTest < RepositoryTestBase


### PR DESCRIPTION
Pulp at this point doesnot permit unprotected repos for ostree.
So this should be always on