### PR TITLE
Fixes #13695,11612 - Shows ostree branches for a repo

### DIFF
--- a/app/controllers/katello/api/v2/ostree_branches_controller.rb
+++ b/app/controllers/katello/api/v2/ostree_branches_controller.rb
@@ -1,0 +1,16 @@
+module Katello
+  class Api::V2::OstreeBranchesController < Api::V2::ApiController
+    apipie_concern_subst(:a_resource => N_("an ostree branch"), :resource => "ostree_branches")
+    include Katello::Concerns::Api::V2::RepositoryContentController
+
+    def default_sort
+      %w(version_date desc)
+    end
+
+    private
+
+    def resource_class
+      OstreeBranch
+    end
+  end
+end

--- a/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
+++ b/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
@@ -198,6 +198,8 @@ module Katello
           _("Docker Manifest")
         when "Katello::DockerTag"
           _("Docker Tag")
+        when "Katello::OstreeBranch"
+          _("OSTree Branch")
         else
           fail "Can't find resource class: #{resource_class}"
         end

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -216,6 +216,10 @@ module Katello
       Katello::Rpm.in_repositories(self.repositories.archived).count
     end
 
+    def ostree_branch_count
+      ostree_branches.count
+    end
+
     def docker_manifest_count
       manifest_counts = repositories.archived.docker_type.map do |repo|
         repo.docker_manifests.count
@@ -238,6 +242,10 @@ module Katello
       errata = Erratum.in_repositories(archived_repos).uniq
       errata = errata.of_type(errata_type) if errata_type
       errata
+    end
+
+    def ostree_branches
+      OstreeBranch.in_repositories(archived_repos).uniq
     end
 
     def docker_manifests

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -483,6 +483,26 @@ module Katello
         Katello.pulp_server.extensions.repository.docker_manifest_ids(self.pulp_id)
       end
 
+      def pulp_ostree_branch_ids
+        Katello.pulp_server.extensions.repository.ostree_branch_ids(self.pulp_id)
+      end
+
+      def index_db_ostree_branches
+        ostree_branches_json.each do |ostree_branch_json|
+          branch = OstreeBranch.where(:uuid => ostree_branch_json[:_id]).first_or_create
+          branch.update_from_json(ostree_branch_json)
+        end
+        OstreeBranch.sync_repository_associations(self, pulp_ostree_branch_ids)
+      end
+
+      def ostree_branches_json
+        ostree_branches = []
+        pulp_ostree_branch_ids.each_slice(SETTINGS[:katello][:pulp][:bulk_load_size]) do |sub_list|
+          ostree_branches.concat(Katello.pulp_server.extensions.ostree_branch.find_all_by_unit_ids(sub_list))
+        end
+        ostree_branches
+      end
+
       def sync_schedule(date_and_time)
         if date_and_time
           Katello.pulp_server.extensions.repository.create_or_update_schedule(self.pulp_id, importer_type, date_and_time)
@@ -788,6 +808,8 @@ module Katello
         "#{scheme}://#{pulp_uri.host.downcase}/pulp/isos/#{pulp_id}"
       elsif puppet?
         "#{scheme}://#{pulp_uri.host.downcase}/pulp/puppet/#{pulp_id}"
+      elsif ostree?
+        "#{scheme}://#{pulp_uri.host.downcase}/pulp/ostree/web/#{pulp_id}"
       else
         "#{scheme}://#{pulp_uri.host.downcase}/pulp/repos/#{relative_path}"
       end
@@ -799,6 +821,7 @@ module Katello
       self.index_db_docker_manifests
       self.index_db_puppet_modules
       self.index_db_package_groups
+      self.index_db_ostree_branches if Katello::RepositoryTypeManager.find(Repository::OSTREE_TYPE).present?
       self.import_distribution_data
       true
     end

--- a/app/models/katello/ostree_branch.rb
+++ b/app/models/katello/ostree_branch.rb
@@ -1,14 +1,29 @@
 module Katello
   class OstreeBranch < Katello::Model
-    belongs_to :repository, :class_name => "Katello::Repository", :inverse_of => :ostree_branches
-    validates :name, presence: true, uniqueness: {scope: :repository_id}
-    validates :repository, :presence => true
-    validate :ensure_ostree_repository
+    include Concerns::PulpDatabaseUnit
 
-    def ensure_ostree_repository
-      unless self.repository.ostree?
-        errors.add(:base, _("Branch cannot be created since it does not belong to an RPM OSTree repository."))
-      end
+    has_many :repository_ostree_branches, :dependent => :destroy
+    has_many :repositories, :through => :repository_ostree_branches, :inverse_of => :ostree_branches
+
+    scoped_search :on => :name, :complete_value => true
+    scoped_search :on => :version, :complete_value => true
+    scoped_search :on => :commit, :complete_value => true
+    scoped_search :on => :uuid, :complete_value => true
+    scoped_search :on => :version_date, :complete_value => true, :rename => :created
+    scoped_search :in => :repositories, :on => :name, :rename => :repository, :complete_value => true
+
+    CONTENT_TYPE = Pulp::OstreeBranch::CONTENT_TYPE
+
+    def self.repository_association_class
+      RepositoryOstreeBranch
+    end
+
+    def update_from_json(json)
+      update_attributes(:name => json[:branch],
+                        :version => json[:metadata][:version],
+                        :commit => json[:commit],
+                        :version_date => json[:_created].to_datetime
+                       )
     end
   end
 end

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -50,7 +50,8 @@ module Katello
 
     has_many :docker_tags, :dependent => :destroy, :class_name => "Katello::DockerTag"
 
-    has_many :ostree_branches, :class_name => "Katello::OstreeBranch", :dependent => :destroy
+    has_many :repository_ostree_branches, :class_name => "Katello::RepositoryOstreeBranch", :dependent => :destroy
+    has_many :ostree_branches, :through => :repository_ostree_branches
 
     has_many :system_repositories, :class_name => "Katello::SystemRepository", :dependent => :destroy
     has_many :systems, :through => :system_repositories
@@ -102,6 +103,7 @@ module Katello
     scope :file_type, -> { where(:content_type => FILE_TYPE) }
     scope :puppet_type, -> { where(:content_type => PUPPET_TYPE) }
     scope :docker_type, -> { where(:content_type => DOCKER_TYPE) }
+    scope :ostree_type, -> { where(:content_type => OSTREE_TYPE) }
     scope :non_puppet, -> { where("content_type != ?", PUPPET_TYPE) }
     scope :non_archived, -> { where('environment_id is not NULL') }
     scope :archived, -> { where('environment_id is NULL') }
@@ -527,6 +529,8 @@ module Katello
         self.rpms -= units
       elsif puppet?
         self.puppet_modules -= units
+      elsif ostree?
+        self.ostree_branches -= units
       elsif docker?
         remove_docker_content(units)
       end
@@ -558,6 +562,8 @@ module Katello
         self.docker_manifests
       elsif puppet?
         self.puppet_modules
+      elsif ostree?
+        self.ostree_branches
       else
         fail "Content type not supported for removal"
       end

--- a/app/models/katello/repository_ostree_branch.rb
+++ b/app/models/katello/repository_ostree_branch.rb
@@ -1,0 +1,9 @@
+module Katello
+  class RepositoryOstreeBranch < Katello::Model
+    self.include_root_in_json = false
+
+    # Do not use active record callbacks in this join model.  Direct INSERTs and DELETEs are done
+    belongs_to :repository, :inverse_of => :repository_ostree_branches, :class_name => 'Katello::Repository'
+    belongs_to :ostree_branch, :inverse_of => :repository_ostree_branches
+  end
+end

--- a/app/services/katello/pulp/ostree_branch.rb
+++ b/app/services/katello/pulp/ostree_branch.rb
@@ -1,0 +1,7 @@
+module Katello
+  module Pulp
+    class OstreeBranch < PulpContentUnit
+      CONTENT_TYPE = "ostree"
+    end
+  end
+end

--- a/app/views/katello/api/v2/ostree_branches/index.json.rabl
+++ b/app/views/katello/api/v2/ostree_branches/index.json.rabl
@@ -1,0 +1,7 @@
+object false
+
+extends "katello/api/v2/common/metadata"
+
+child @collection[:results] => :results do
+  extends 'katello/api/v2/ostree_branches/show'
+end

--- a/app/views/katello/api/v2/ostree_branches/show.json.rabl
+++ b/app/views/katello/api/v2/ostree_branches/show.json.rabl
@@ -1,0 +1,4 @@
+object @resource
+
+attributes :uuid, :id
+attributes :name, :version, :commit, :version_date

--- a/app/views/katello/api/v2/repositories/base.json.rabl
+++ b/app/views/katello/api/v2/repositories/base.json.rabl
@@ -13,6 +13,7 @@ end
 
 node :content_counts do |repo|
   {
+    :ostree_branch => repo.ostree_branches.count,
     :docker_manifest => repo.docker_manifests.count,
     :docker_tag => repo.docker_tags.count,
     :rpm => repo.rpms.count,

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -108,6 +108,12 @@ Katello::Engine.routes.draw do
           end
         end
 
+        api_resources :ostree_branches, :only => [:index, :show] do
+          collection do
+            get :auto_complete_search
+          end
+        end
+
         api_resources :docker_manifests, :only => [:index, :show]
         api_resources :docker_tags, :only => [:index, :show] do
           collection do
@@ -316,6 +322,8 @@ Katello::Engine.routes.draw do
           end
           api_resources :docker_manifests, :only => [:index, :show]
           api_resources :docker_tags, :only => [:index, :show]
+
+          api_resources :ostree_branches, :only => [:index, :show]
 
           api_resources :content_uploads, :controller => :content_uploads, :only => [:create, :destroy, :update]
 

--- a/db/migrate/20160301070319_add_version_ostree_branches.rb
+++ b/db/migrate/20160301070319_add_version_ostree_branches.rb
@@ -1,0 +1,42 @@
+class AddVersionOstreeBranches < ActiveRecord::Migration
+  def up
+    drop_table :katello_ostree_branches if ActiveRecord::Base.connection.table_exists? "katello_ostree_branches"
+
+    create_table :katello_ostree_branches do |t|
+      t.string :version, :limit => 255
+      t.string :name, :limit => 255
+      t.string :uuid, :null => false, :limit => 255
+      t.string :commit, :limit => 255
+      t.timestamp :version_date
+      t.timestamps
+    end
+
+    create_table :katello_repository_ostree_branches do |t|
+      t.references :ostree_branch, :null => false
+      t.references :repository, :null => true
+      t.timestamps
+    end
+
+    add_index :katello_repository_ostree_branches, [:ostree_branch_id, :repository_id],
+              :name => :katello_repo_ostree_branch_repo_id, :unique => true
+
+    add_foreign_key :katello_repository_ostree_branches, :katello_repositories,
+                    :column => :repository_id
+  end
+
+  def down
+    drop_table :katello_repository_ostree_branches
+    drop_table :katello_ostree_branches
+    create_table :katello_ostree_branches do |t|
+      t.string :name, :null => false, :limits => 255
+      t.references :repository, :null => false
+      t.timestamps
+    end
+
+    add_index :katello_ostree_branches, [:repository_id],
+              :name => :index_branches_on_repository
+
+    add_index :katello_ostree_branches, [:repository_id, :name],
+              :name => :katello_ostree_branches_repo_branch, :unique => true
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/bastion-katello-bootstrap.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/bastion-katello-bootstrap.js
@@ -7,6 +7,7 @@ BASTION_MODULES.push(
     'Bastion.docker-tags',
     'Bastion.hosts',
     'Bastion.puppet-modules',
+    'Bastion.ostree-branches',
     'Bastion.environments',
     'Bastion.gpg-keys',
     'Bastion.hosts',

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/bastion_katello.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/bastion_katello.js
@@ -25,6 +25,9 @@
 //= require "bastion_katello/docker-tags/docker-tags.module.js"
 //= require_tree "./docker-tags"
 
+//= require "bastion_katello/ostree-branches/ostree-branches.module.js"
+//= require_tree "./ostree-branches"
+
 //= require "bastion_katello/errata/errata.module"
 //= require_tree "./errata"
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/ostree-branches/ostree-branch.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/ostree-branches/ostree-branch.factory.js
@@ -1,0 +1,27 @@
+(function () {
+    'use strict';
+
+    /**
+     * @ngdoc factory
+     * @name  Bastion.ostree-branches.factory:OstreeBranch
+     *
+     * @description
+     *   Provides a BastionResource for interacting with Ostree Branches
+     */
+    function OstreeBranch(BastionResource) {
+        return BastionResource('/katello/api/v2/ostree_branches/:id',
+            {'id': '@id'},
+            {
+                autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}}
+            }
+
+        );
+    }
+
+    angular
+        .module('Bastion.ostree-branches')
+        .factory('OstreeBranch', OstreeBranch);
+
+    OstreeBranch.$inject = ['BastionResource'];
+
+})();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/ostree-branches/ostree-branches.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/ostree-branches/ostree-branches.module.js
@@ -1,0 +1,11 @@
+/**
+ * @ngdoc module
+ * @name  Bastion.ostree-branches
+ *
+ * @description
+ *   Module for Ostree Branch related functionality.
+ */
+angular.module('Bastion.ostree-branches', [
+    'Bastion',
+    'Bastion.common'
+]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-repositories.html
@@ -149,6 +149,15 @@
                   </span>
                 </div>
               </span>
+
+              <span ng-show="repository.content_type == 'ostree'">
+                <div>
+                  <span translate>
+                    {{ repository.content_counts.ostree_branch || 0 }} OSTree Branches
+                  </span>
+                </div>
+              </span>
+
             </td>
           </tr>
         </tbody>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.module.js
@@ -185,6 +185,12 @@ angular.module('Bastion.products').config(['$stateProvider', function ($statePro
         permission: 'view_products',
         collapsed: true,
         templateUrl: 'repositories/details/views/repository-manage-docker-manifests.html'
+    })
+    .state('products.details.repositories.manage-content.ostree-branches', {
+        url: '/repositories/:repositoryId/content/ostree_branches',
+        permission: 'view_products',
+        collapsed: true,
+        templateUrl: 'repositories/details/views/repository-manage-ostree-branches.html'
     });
 
     $stateProvider.state('products.details.tasks', {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/repository-details-manage-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/repository-details-manage-content.controller.js
@@ -11,13 +11,14 @@
  * @requires PackageGroup
  * @requires PuppetModule
  * @requires DockerManifest
+ * @requires OstreeBranch
  *
  * @description
  *   Provides the functionality for the repository details pane.
  */
 angular.module('Bastion.repositories').controller('RepositoryManageContentController',
-    ['$scope', '$state', 'translate', 'Nutupane', 'Repository', 'Package', 'PackageGroup', 'PuppetModule', 'DockerManifest',
-    function ($scope, $state, translate, Nutupane, Repository, Package, PackageGroup, PuppetModule, DockerManifest) {
+    ['$scope', '$state', 'translate', 'Nutupane', 'Repository', 'Package', 'PackageGroup', 'PuppetModule', 'DockerManifest', 'OstreeBranch',
+    function ($scope, $state, translate, Nutupane, Repository, Package, PackageGroup, PuppetModule, DockerManifest, OstreeBranch) {
         var currentState, contentTypes;
 
         function success(response, selected) {
@@ -48,7 +49,8 @@ angular.module('Bastion.repositories').controller('RepositoryManageContentContro
             'packages': { type: Package },
             'package-groups': { type: PackageGroup },
             'puppet-modules': { type: PuppetModule },
-            'docker-manifests': { type: DockerManifest }
+            'docker-manifests': { type: DockerManifest },
+            'ostree-branches': { type: OstreeBranch }
         };
 
         $scope.contentNutupane = new Nutupane(contentTypes[currentState].type, {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-info.html
@@ -12,7 +12,7 @@
       <i class="fa fa-double-angle-left"></i>
       {{ "Back to Repository List" | translate }}
     </a>
-  
+
     <div class="fr">
       <button class="btn btn-default"
               ui-sref="products.details.repositories.manage-content.packages({productId: product.id, repositoryId: repository.id})"
@@ -29,7 +29,13 @@
       <button class="btn btn-default"
             ui-sref="products.details.repositories.manage-content.docker-manifests({productId: product.id, repositoryId: repository.id})"
             ng-hide="repository.content_type !== 'docker' || denied('edit_products', product)">
-      <span translate>Manage Docker Manifests</span>
+        <span translate>Manage Docker Manifests</span>
+      </button>
+
+      <button class="btn btn-default"
+              ui-sref="products.details.repositories.manage-content.ostree-branches({productId: product.id, repositoryId: repository.id})"
+              ng-hide="repository.content_type !== 'ostree' || denied('edit_products', product)">
+        <span translate>View Branches</span>
       </button>
 
       <button class="btn btn-default"
@@ -280,8 +286,8 @@
           <td class="align-center">{{ repository.content_counts.docker_tag || 0 }}</td>
         </tr>
         <tr ng-show="repository.content_type === 'ostree'">
-          <td translate>OSTree Units</td>
-          <td class="align-center">{{ repository.content_counts.ostree || 0 }}</td>
+          <td translate>OSTree Branches</td>
+          <td class="align-center">{{ repository.content_counts.ostree_branch || 0 }}</td>
         </tr>
         </tbody>
       </table>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-manage-ostree-branches.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-manage-ostree-branches.html
@@ -1,0 +1,60 @@
+<span page-title ng-model="repository">{{ 'Manage OSTree Branches for Repository:' | translate }} {{ repository.name }}</span>
+
+<a ui-sref="products.details.repositories.info({productId: product.id, repositoryId: repository.id})">
+  <i class="fa fa-angle-double-left"></i>
+  {{ "Back to Repository Details" | translate }}
+</a>
+
+<div data-extend-template="layouts/details-nutupane.html">
+
+  <div data-block="pane-loading"></div>
+
+  <div data-block="messages">
+    <div bst-alerts success-messages="successMessages" error-messages="errorMessages"></div>
+
+    <div bst-alert="success" ng-hide="generationTaskId === undefined">
+      <button type="button" class="close" ng-click="clearTaskId()">&times;</button>
+      <p translate>
+        OSTree Branch metadata generation has been initiated in the background.  Click
+        <a ng-href="{{ taskUrl() }}">Here</a> to monitor the progress.
+      </p>
+    </div>
+  </div>
+
+  <div data-block="header">
+    <h3 translate>Ostree Branches in {{ repository.name }}</h3>
+  </div>
+  <div data-block="selection-summary"></div>
+  <div data-block="table">
+    <table class="table table-striped table-bordered" >
+
+      <thead>
+        <tr bst-table-head>
+          <th bst-table-column><span translate>Branch Name</span></th>
+          <th bst-table-column><span translate>Version</span></th>
+          <th bst-table-column><span translate>Commit</span></th>
+          <th bst-table-column><span translate>Date</span></th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr bst-table-row ng-repeat="item in detailsTable.rows">
+          <td bst-table-cell>
+            {{ item.name }}
+          </td>
+          <td bst-table-cell>
+            {{ item.version }}
+          </td>
+          <td bst-table-cell>
+            {{ item.commit }}
+          </td>
+          <td bst-table-cell>
+            {{ item.version_date }}
+          </td>
+        </tr>
+      </tbody>
+
+    </table>
+  </div>
+
+</div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/views/repository-new.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/views/repository-new.html
@@ -80,7 +80,7 @@
         </select>
       </div>
 
-      <div bst-form-group label="{{ 'Mirror On Sync' | translate }}">
+      <div bst-form-group label="{{ 'Mirror On Sync' | translate }}" ng-show="repository.content_type === 'yum'">
         <input id="mirror_on_sync"
                name="mirror_on_sync"
                ng-model="repository.mirror_on_sync"

--- a/engines/bastion_katello/test/ostree-branches/ostree-branch.factory.test.js
+++ b/engines/bastion_katello/test/ostree-branches/ostree-branch.factory.test.js
@@ -1,0 +1,36 @@
+describe('Factory: OstreeBranch', function () {
+    var $httpBackend,
+        ostreeBranches;
+
+    beforeEach(module('Bastion.ostree-branches', 'Bastion.test-mocks'));
+
+    beforeEach(module(function ($provide) {
+        ostreeBranches = {
+            records: [
+                { name: 'abc123', id: 1 }
+            ],
+            total: 2,
+            subtotal: 1
+        };
+    }));
+
+    beforeEach(inject(function ($injector) {
+        $httpBackend = $injector.get('$httpBackend');
+        OstreeBranch = $injector.get('OstreeBranch');
+    }));
+
+    afterEach(function () {
+        $httpBackend.flush();
+        $httpBackend.verifyNoOutstandingExpectation();
+        $httpBackend.verifyNoOutstandingRequest();
+    });
+
+    it('provides a way to get a list of repositories', function () {
+        $httpBackend.expectGET('/katello/api/v2/ostree_branches').respond(ostreeBranches);
+
+        OstreeBranch.queryPaged(function (ostreeBranches) {
+            expect(ostreeBranches.records.length).toBe(1);
+        });
+    });
+
+});

--- a/engines/bastion_katello/test/repositories/details/repository-details-manage-content.controller.test.js
+++ b/engines/bastion_katello/test/repositories/details/repository-details-manage-content.controller.test.js
@@ -1,5 +1,5 @@
 describe('Controller: RepositoryManageContentController', function() {
-    var $scope, translate, Repository, Nutupane, PuppetModule, Package, PackageGroup, DockerManifest;
+    var $scope, translate, Repository, Nutupane, PuppetModule, Package, PackageGroup, DockerManifest, OstreeBranch;
 
     beforeEach(module(
         'Bastion.repositories',
@@ -42,6 +42,7 @@ describe('Controller: RepositoryManageContentController', function() {
             Package: Package,
             PackageGroup: PackageGroup,
             DockerManifest: DockerManifest,
+            OstreeBranch: OstreeBranch,
         });
     }));
 

--- a/lib/katello/tasks/reindex.rake
+++ b/lib/katello/tasks/reindex.rake
@@ -72,7 +72,7 @@ namespace :katello do
           notes = []
           facts = fetch_resource { object.pulp_facts }
           notes << "Pulp Consumer #{object.uuid} was not found." if facts.nil?
-          candlepin_consumer_info = fetch_resource { Katello::Resources::Candlepin::Consumer.get(object.uuid) } 
+          candlepin_consumer_info = fetch_resource { Katello::Resources::Candlepin::Consumer.get(object.uuid) }
           notes << "Candlepin Consumer was not available for #{object.name}." if candlepin_consumer_info.nil?
           notes << "Foreman Host was not available for #{object.name}." if object.foreman_host.nil?
 
@@ -136,6 +136,7 @@ namespace :katello do
     Katello::Erratum.import_all
     Katello::PackageGroup.import_all
     Katello::PuppetModule.import_all
+    Katello::OstreeBranch.import_all if Katello::RepositoryTypeManager.find(Katello::Repository::OSTREE_TYPE).present?
     Katello::Subscription.import_all
     Katello::Pool.import_all
 

--- a/test/controllers/api/v2/ostree_branches_controller_test.rb
+++ b/test/controllers/api/v2/ostree_branches_controller_test.rb
@@ -1,0 +1,46 @@
+require "katello_test_helper"
+
+module Katello
+  class Api::V2::OstreeBranchesControllerTest < ActionController::TestCase
+    def models
+      @repo = Repository.find(katello_repositories(:ostree_rhel7))
+      @branch = @repo.ostree_branches.create!(:name => "abc123", :uuid => "123xyz")
+    end
+
+    def setup
+      setup_controller_defaults_api
+      models
+    end
+
+    def test_index
+      get :index
+      assert_response :success
+      assert_template "katello/api/v2/ostree_branches/index"
+    end
+
+    def test_index_with_repository
+      get :index, :repository_id => @repo.id
+      assert_response :success
+      assert_template "katello/api/v2/ostree_branches/index"
+    end
+
+    def test_index_with_organization
+      get :index, :organization_id => @repo.organization.id
+      assert_response :success
+      assert_template "katello/api/v2/ostree_branches/index"
+    end
+
+    def test_index_with_content_view_version
+      get :index, :content_view_version_id => ContentViewVersion.last
+      assert_response :success
+      assert_template "katello/api/v2/ostree_branches/index"
+    end
+
+    def test_show
+      get :show, :repository_id => @repo.id, :id => @branch.uuid
+
+      assert_response :success
+      assert_template "katello/api/v2/ostree_branches/show"
+    end
+  end
+end

--- a/test/fixtures/pulp/ostree_branch.yml
+++ b/test/fixtures/pulp/ostree_branch.yml
@@ -1,0 +1,16 @@
+branch1:
+  _storage_path: "/var/lib/pulp/content/shared/ostree/48868e83e4a50500d16c6adac1dfa68bb50d72ec87311aa4be87f01796293958/links/664eb5e7-da47-4d37-a260-0161bab1d88f"
+  _href: "/pulp/api/v2/content/units/ostree/664eb5e7-da47-4d37-a260-0161bab1d88f/"
+  _last_updated: '2016-03-02T00:45:08Z'
+  remote_id: "2c5b6e07fe47d0b626a417d5dbb855a4aa8c991177e930213a3a80514d3e1a14"
+  _content_type_id: "ostree"
+  pulp_user_metadata: {}
+  branch: "fedora-atomic/f23/x86_64/docker-host"
+  _created: '2016-03-02T00:45:08Z'
+  commit: "954bdbeebebfa87b625d9d7bd78c81400bdd6756fcc3205987970af4b64eb678"
+  _id: "664eb5e7-da47-4d37-a260-0161bab1d88f"
+  children:  {}
+  metadata: {
+              version: '23.74',
+              rpmostree-inputhash: "cefa153b7f2ec7f2ee2cc6f4b2bb18ac34ef5128cf4a56cbcb6998e8a35b63ca"
+            }

--- a/test/models/ostree_branch_test.rb
+++ b/test/models/ostree_branch_test.rb
@@ -1,0 +1,26 @@
+require 'katello_test_helper'
+
+module Katello
+  class OstreeBranchTest < ActiveSupport::TestCase
+    REPO_ID = "Default_Organization-Test-ostree"
+    BRANCHES = File.join(Katello::Engine.root, "test", "fixtures", "pulp", "ostree_branch.yml")
+
+    def setup
+      @branches = YAML.load_file(BRANCHES).values.map(&:deep_symbolize_keys)
+      @repo = Repository.find(katello_repositories(:ostree_rhel7))
+
+      ids = @branches.map { |attrs| attrs[:_id] }
+      ::Katello::Repository.any_instance.stubs(:pulp_ostree_branch_ids).returns(ids)
+      Runcible::Extensions::OstreeBranch.any_instance.stubs(:find_all_by_unit_ids).
+        with(ids).returns(@branches)
+    end
+
+    def test_index_db_ostree_branches
+      @repo.index_db_ostree_branches
+      assert_equal 1, OstreeBranch.count
+      assert_equal 1, @repo.ostree_branches.count
+      branch_names = @branches.map { |b| b[:branch] }
+      assert_equal branch_names.sort, OstreeBranch.all.map(&:name).sort
+    end
+  end
+end

--- a/test/models/repository_base.rb
+++ b/test/models/repository_base.rb
@@ -10,6 +10,7 @@ module Katello
       @fedora_17_dev_library_view       = katello_repositories(:fedora_17_dev_library_view)
       @puppet_forge                     = katello_repositories(:p_forge)
       @redis                            = katello_repositories(:redis)
+      @ostree_rhel7                     = katello_repositories(:ostree_rhel7)
       @fedora                           = katello_products(:fedora)
       @library                          = katello_environments(:library)
       @dev                              = katello_environments(:dev)


### PR DESCRIPTION
This commit updates the base model for ostree and its repositories.
It also includes UI changes to display the branches available for an
ostree repo

