### PR TITLE
fixes #14111 - docker repository: update create to require url and upstream name

### DIFF
--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -572,9 +572,7 @@ module Katello
     end
 
     def ensure_valid_docker_attributes
-      if url.blank? != docker_upstream_name.blank?
-        field = url.blank? ? :url : :docker_upstream_name
-        errors.add(field, N_("cannot be blank. Either provide all or no sync information."))
+      if url.blank? || docker_upstream_name.blank?
         errors.add(:base, N_("Repository URL or Upstream Name is empty. Both are required for syncing from the upstream."))
       end
     end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/views/repository-new.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/views/repository-new.html
@@ -50,7 +50,8 @@
                name="url"
                ng-model="repository.url"
                type="text"
-               tabindex="5"/>
+               tabindex="5"
+               ng-required="repository.content_type === 'docker'"/>
         <h6 ng-show="repository.content_type === 'docker'" translate>
           URL of the registry you want to sync. Example: https://registry-1.docker.io/
         </h6>
@@ -62,7 +63,8 @@
                name="docker_upstream_name"
                ng-model="repository.docker_upstream_name"
                type="text"
-               tabindex="1"/>
+               tabindex="1"
+               ng-required="repository.content_type === 'docker'"/>
         <h6 translate>
           Name of the upstream repository you want to sync. Example: 'busybox' or 'fedora/ssh'.
         </h6>

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -39,6 +39,8 @@ module Katello
       @repo.content_type = 'docker'
       @repo.download_policy = nil
       @repo.docker_upstream_name = ""
+      @repo.url = ""
+      refute @repo.valid?
       @repo.url = "http://registry.com"
       refute @repo.valid?
       @repo.docker_upstream_name = "justin"
@@ -50,7 +52,7 @@ module Katello
       refute @repo.valid?
       @repo.url = nil
       @repo.docker_upstream_name = nil
-      assert @repo.valid?
+      refute @repo.valid?
     end
 
     def test_docker_repository_docker_upstream_name_format


### PR DESCRIPTION
With these changes, when a docker repo is created, the user must specify
a URL and upstream docker name for the repo.  Without it, if a user
created repo without specifying them, they were unable to add them.

Note: making these required for docker repos is Ok, since katello is
no longer able to allow the user to upload content to a repository.