### PR TITLE
fixes #14118 - red hat repositories ui - make repo set name appear clickable

### DIFF
--- a/app/views/katello/providers/redhat/_repo_sets.html.erb
+++ b/app/views/katello/providers/redhat/_repo_sets.html.erb
@@ -31,7 +31,7 @@
                     <% if !orphaned || product.repositories.detect {|repo| repo.cp_label == product_content.content.label} %>
                       <tr class="collapsed repo_set" id="repo_set_<%= product_content.content.id %>">
                         <td>
-                          <span class="expander_area"
+                          <span class="expander_area clickable"
                                 data-url="<%= available_repositories_product_path(product.id)%>"
                                 data-content-id="<%= product_content.content.id %>"
                                 data-orphaned="<%= orphaned.to_s %>">


### PR DESCRIPTION
The repo set name is clickable today, but it needs the pointer to be consistent with the product names on the page.