### PR TITLE
Fixes #13993 - only index one candlepin org when reindexing

### DIFF
--- a/app/models/katello/pool.rb
+++ b/app/models/katello/pool.rb
@@ -9,6 +9,8 @@ module Katello
     has_many :activation_keys, :through => :pool_activation_keys, :class_name => "Katello::ActivationKey"
     has_many :pool_activation_keys, :class_name => "Katello::PoolActivationKey", :dependent => :destroy, :inverse_of => :pool
 
+    scope :in_org, -> (org_id) { joins(:subscription).where("#{Katello::Subscription.table_name}.organization_id = ?", org_id) }
+
     self.include_root_in_json = false
 
     include Glue::Candlepin::Pool

--- a/app/views/dashboard/_subscription_status_widget.html.erb
+++ b/app/views/dashboard/_subscription_status_widget.html.erb
@@ -3,7 +3,7 @@
 </h4>
 
 <% organizations = Organization.current.present? ? [Organization.current] : User.current.allowed_organizations %>
-<% subscriptions = organizations.collect { |org| org.redhat_provider.index_subscriptions }.flatten %>
+<% subscriptions = organizations.collect { |org| Katello::Pool.in_org(org.id) }.flatten %>
 <% total_active_subscriptions = Katello::Pool.active(subscriptions).count %>
 <% total_expiring_subscriptions = Katello::Pool.expiring_soon(subscriptions).count %>
 <% total_recently_expired_subscriptions = Katello::Pool.recently_expired(subscriptions).count %>


### PR DESCRIPTION
The "Current Subscription Status" dashboard widget currently refreshes
Katello's subscription and pool stats to match candlepin's current stats.

Previously, this looped over all organizations, even though the dashboard was
just asking for stats for one org. This patch narrows down the set of
subscriptions and pools to examine so it's just those associated with the org
in question.