### PR TITLE
Fixes #14109 - use correct parameters when calling UploadFiles

### DIFF
--- a/app/lib/actions/katello/repository/incremental_import.rb
+++ b/app/lib/actions/katello/repository/incremental_import.rb
@@ -15,6 +15,10 @@ module Actions
 
           rpm_files = Dir.glob(File.join(import_location, "*rpm"))
 
+          rpm_filepaths = rpm_files.collect do |filepath|
+            {path: filepath, filename: File.basename(filepath)}
+          end
+
           json_files = Dir.glob(File.join(import_location, "*json"))
           pulp_units = json_files.map { |json_file| JSON.parse(File.read(json_file)) }
           errata = pulp_units.select { |pulp_unit| erratum? pulp_unit }
@@ -24,7 +28,7 @@ module Actions
             # everything to /tmp. It is better to just have Pulp generate
             # incrementals in the same way it publishes normally, vs optimizing
             # this call. https://pulp.plan.io/issues/1543
-            plan_action(Katello::Repository::UploadFiles, repo, rpm_files)
+            plan_action(Katello::Repository::UploadFiles, repo, rpm_filepaths)
             plan_action(Katello::Repository::UploadErrata, repo, errata)
           end
 

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -193,10 +193,10 @@ module ::Actions::Katello::Repository
       import_dir = File.join(::Katello::Engine.root, "test", "fixtures", "files")
       plan_action action, custom_repository, import_dir
 
-      assert_action_planed_with action, ::Actions::Katello::Repository::UploadFiles do |repo, rpm_files|
+      assert_action_planed_with action, ::Actions::Katello::Repository::UploadFiles do |repo, rpm_filepaths|
         repo.must_equal custom_repository
-        rpm_files.length.must_equal 1
-        rpm_files.first.must_include "squirrel"
+        rpm_filepaths.length.must_equal 1
+        rpm_filepaths.first[:filename].must_include "squirrel"
       end
 
       assert_action_planed_with action, ::Actions::Katello::Repository::UploadErrata do |repo, errata|


### PR DESCRIPTION
Previously, I was passing an array of file paths to UploadFiles. This was
switched to a `{path: <PATH>, filename: <basename>}` format.

This commit switches up the call to UploadFiles to use the new format, and
updates a test.