### PR TITLE
Fixes #14144 - fix host by errata searching to be accurate

### DIFF
--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -32,6 +32,14 @@ module Katello
       assert_nil Katello::System.find_by_id(system_id)
     end
 
+    def test_full_text_search
+      other_host = FactoryGirl.create(:host)
+      found = ::Host.search_for(@foreman_host.name)
+
+      assert_includes found, @foreman_host
+      refute_includes found, other_host
+    end
+
     def test_smart_proxy_ids_with_katello
       content_source = FactoryGirl.create(:smart_proxy,
                                           :features => [Feature.where(:name => "Pulp Node").first_or_create])

--- a/test/models/host/content_facet_test.rb
+++ b/test/models/host/content_facet_test.rb
@@ -41,8 +41,12 @@ module Katello
     end
 
     def test_errata_searchable
+      other_host = FactoryGirl.create(:host)
       errata = katello_errata(:security)
-      assert_includes ::Host.search_for("applicable_errata = #{errata.errata_id}"), content_facet.host
+      found = ::Host.search_for("applicable_errata = #{errata.errata_id}")
+
+      assert_includes found, content_facet.host
+      refute_includes found, other_host
     end
 
     def test_available_and_applicable_errta


### PR DESCRIPTION
Previously the find_by_applicable_errata was clearly wrong, but threw no errors for some reason.  The result was that all hosts would be returned by any applicable_errata search and full text searching threw a sql error.  This resolves both issues and tests both scenarios