### PR TITLE
Fixes #13856: remove backend call in content host facet migration.

### DIFF
--- a/db/migrate/20150930183738_migrate_content_hosts.rb
+++ b/db/migrate/20150930183738_migrate_content_hosts.rb
@@ -185,14 +185,6 @@ class MigrateContentHosts < ActiveRecord::Migration
     subscription_facet = host.subscription_facet = MigrateContentHosts::SubscriptionFacet.new
     subscription_facet.activation_keys = system.activation_keys
     subscription_facet.uuid = system.uuid
-
-    if system.backend_data
-      subscription_facet.service_level = system.backend_data['serviceLevel']
-      subscription_facet.release_version = system.backend_data['releaseVer']['releaseVer']
-      subscription_facet.last_checkin = system.backend_data['lastCheckin']
-      subscription_facet.autoheal = system.backend_data['autoheal']
-    end
-
     subscription_facet.save!
   end
 
@@ -317,7 +309,7 @@ class MigrateContentHosts < ActiveRecord::Migration
       if hosts.empty? # no host exists
         logger.info("No host exists with hostname #{hostname}, creating new host.")
         host = MigrateContentHosts::Host.new(:name => system.facts['network.hostname'], :organization => system.environment.organization,
-                                             :location => MigrateContentHosts::Location.default_location, :managed => false)
+                                             :type => "Host::Managed", :location => MigrateContentHosts::Location.default_location, :managed => false)
         host.save!
 
         create_content_facet(host, system)

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -242,7 +242,7 @@ module Katello
       load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/2.4/import_subscriptions.rake"
       load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/3.0/add_export_distributor.rake"
       load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/3.0/delete_docker_v1_content.rake"
-      load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/3.0/update_subscription_facet_registered_at.rake"
+      load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/3.0/update_subscription_facet_backend_data.rake"
     end
   end
 

--- a/lib/katello/tasks/upgrades/3.0/update_subscription_facet_backend_data.rake
+++ b/lib/katello/tasks/upgrades/3.0/update_subscription_facet_backend_data.rake
@@ -1,9 +1,9 @@
 namespace :katello do
   namespace :upgrades do
     namespace '3.0' do
-      task :update_subscription_facet_registered_at => ["environment"]  do
+      task :update_subscription_facet_backend_data => ["environment"]  do
         User.current = User.anonymous_api_admin
-        puts _("Updating registered at time for subscription facets")
+        puts _("Updating backend data for subscription facets")
 
         Katello::Host::SubscriptionFacet.find_each do |subscription_facet|
           begin
@@ -11,6 +11,7 @@ namespace :katello do
           rescue RestClient::Exception => exception
             Rails.logger.error exception
           end
+          subscription_facet.host = ::Host::Managed.find(subscription_facet.host_id)
           subscription_facet.save!
         end
       end


### PR DESCRIPTION
Update subscription facet via a rake task instead of using a backend
service in the content host migration.

http://projects.theforeman.org/issues/13856