### PR TITLE
Fixes #14145 - Remove unneeded repos from disk on capsule

### DIFF
--- a/app/lib/actions/katello/capsule_content/remove_orphans.rb
+++ b/app/lib/actions/katello/capsule_content/remove_orphans.rb
@@ -1,0 +1,15 @@
+module Actions
+  module Katello
+    module CapsuleContent
+      class RemoveOrphans < Pulp::Abstract
+        input_format do
+          param :capsule_id
+        end
+
+        def run
+          pulp_resources.content.remove_orphans
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/capsule_content/remove_unneeded_repos.rb
+++ b/app/lib/actions/katello/capsule_content/remove_unneeded_repos.rb
@@ -3,13 +3,14 @@ module Actions
     module CapsuleContent
       class RemoveUnneededRepos < ::Actions::Base
         def plan(capsule_content)
-          repos_currently_on_capsule = capsule_content.current_repositories
-          repos_needed_on_capsule = capsule_content.repos_available_to_capsule
+          currently_on_capsule = capsule_content.current_repositories.map(&:pulp_id)
+          needed_on_capsule = capsule_content.repos_available_to_capsule.map(&:pulp_id)
 
-          need_removal = repos_currently_on_capsule - repos_needed_on_capsule
-          need_removal.each do |repo|
+          need_removal = currently_on_capsule - needed_on_capsule
+          need_removal += capsule_content.orphaned_repos
+          need_removal.each do |pulp_id|
             plan_action(Pulp::Repository::Destroy,
-                        :pulp_id => repo.pulp_id,
+                        :pulp_id => pulp_id,
                         :capsule_id => capsule_content.capsule.id)
           end
         end

--- a/app/lib/actions/katello/capsule_content/sync.rb
+++ b/app/lib/actions/katello/capsule_content/sync.rb
@@ -33,6 +33,7 @@ module Actions
                               repo_pulp_id: repo_id)
                 end
               end
+              plan_action(RemoveOrphans, :capsule_id => capsule_content.capsule.id)
             end
           end
         end

--- a/app/lib/katello/capsule_content.rb
+++ b/app/lib/katello/capsule_content.rb
@@ -105,6 +105,11 @@ module Katello
       @capsule.default_capsule?
     end
 
+    def orphaned_repos
+      @capsule.pulp_repositories.map { |x| x["id"] } - current_repositories.map { |x| x.pulp_id }
+    end
+
+    # shows repos available both in katello and on the capsule.
     def current_repositories(environment_id = nil, content_view_id = nil)
       @current_repositories ||= @capsule.pulp_repositories
       katello_repo_ids = []

--- a/test/actions/katello/capsule_content_test.rb
+++ b/test/actions/katello/capsule_content_test.rb
@@ -157,6 +157,18 @@ module ::Actions::Katello::CapsuleContent
     it "removes unneeded repos" do
       capsule_content.stubs(:current_repositories).returns([custom_repository, repository])
       capsule_content.stubs(:repos_available_to_capsule).returns([custom_repository])
+      capsule_content.stubs(:orphaned_repos).returns([])
+
+      action = create_and_plan_action(action_class, capsule_content)
+      assert_action_planed_with(action, ::Actions::Pulp::Repository::Destroy) do |(input)|
+        input.must_equal(:pulp_id => repository.pulp_id, :capsule_id => capsule_content.capsule.id)
+      end
+    end
+
+    it "removes deleted repos" do
+      capsule_content.stubs(:current_repositories).returns([custom_repository, repository])
+      capsule_content.stubs(:repos_available_to_capsule).returns([custom_repository])
+      capsule_content.stubs(:orphaned_repos).returns([repository.pulp_id])
 
       action = create_and_plan_action(action_class, capsule_content)
       assert_action_planed_with(action, ::Actions::Pulp::Repository::Destroy) do |(input)|


### PR DESCRIPTION
unneeded repos are not being removed from a capsule's disk when they are removed from katello.
