### PR TITLE
Fixes #14043 - Activation Key available_content returns unique content.

### DIFF
--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -107,7 +107,7 @@ module Katello
     end
 
     def available_content
-      self.products.map(&:available_content).flatten
+      self.products.map(&:available_content).flatten.uniq { |product| product.content.id }
     end
 
     def valid_content_label?(content_label)


### PR DESCRIPTION
To replicate this create an organization and give it a manifest. Then when enable multiple repositories for one products version  in the red hat repositories tab. Then run hammer activation-key product-content --id [id of activation-key here]