### PR TITLE
Fixes #14141 - Change repoids to repository_ids in puppet_module#destroy

### DIFF
--- a/app/controllers/katello/api/v2/host_autocomplete_controller.rb
+++ b/app/controllers/katello/api/v2/host_autocomplete_controller.rb
@@ -1,0 +1,25 @@
+module Katello
+  class Api::V2::HostAutocompleteController < ::Api::V2::BaseController
+    include ::Api::TaxonomyScope
+    include Foreman::Controller::AutoCompleteSearch
+
+    before_filter :find_optional_nested_object
+
+    resource_description do
+      api_version 'v2'
+      api_base_url "/api"
+    end
+
+    def resource_name(_resource = nil)
+      'host'
+    end
+
+    def model_of_controller
+      ::Host::Managed
+    end
+
+    def action_permission
+      'view'
+    end
+  end
+end

--- a/app/controllers/katello/api/v2/ostree_branches_controller.rb
+++ b/app/controllers/katello/api/v2/ostree_branches_controller.rb
@@ -1,0 +1,16 @@
+module Katello
+  class Api::V2::OstreeBranchesController < Api::V2::ApiController
+    apipie_concern_subst(:a_resource => N_("an ostree branch"), :resource => "ostree_branches")
+    include Katello::Concerns::Api::V2::RepositoryContentController
+
+    def default_sort
+      %w(version_date desc)
+    end
+
+    private
+
+    def resource_class
+      OstreeBranch
+    end
+  end
+end

--- a/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
+++ b/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
@@ -198,6 +198,8 @@ module Katello
           _("Docker Manifest")
         when "Katello::DockerTag"
           _("Docker Tag")
+        when "Katello::OstreeBranch"
+          _("OSTree Branch")
         else
           fail "Can't find resource class: #{resource_class}"
         end

--- a/app/controllers/katello/concerns/operatingsystems_controller_extensions.rb
+++ b/app/controllers/katello/concerns/operatingsystems_controller_extensions.rb
@@ -4,16 +4,18 @@ module Katello
       extend ActiveSupport::Concern
 
       def available_kickstart_repo
-        host = Host.new
-        operatingsystem = Operatingsystem.find(params[:id])
-        host.operatingsystem = operatingsystem
+        host = ::Host.new
+        host.operatingsystem = Operatingsystem.find(params[:id])
         host.architecture = Architecture.find(params[:architecture_id])
-        host.content_facet.new(:lifecycle_environment => Katello::KTEnvironment.find(params[:lifecycle_environment_id]),
-                                :content_view => Katello::ContentView.find(params[:content_view_id]))
+
+        lifecycle_env = Katello::KTEnvironment.find(params[:lifecycle_environment_id])
+        content_view = Katello::ContentView.find(params[:content_view_id])
+        host.content_facet = Host::ContentFacet.new(:lifecycle_environment_id => lifecycle_env.id,
+                                                    :content_view_id => content_view.id)
         host.content_source = SmartProxy.find(params[:content_source_id])
 
-        if operatingsystem.is_a?(Redhat)
-          render :json => operatingsystem.kickstart_repo(host)
+        if  host.operatingsystem.is_a?(Redhat)
+          render :json =>  host.operatingsystem.kickstart_repo(host)
         else
           render :json => nil
         end

--- a/app/lib/actions/katello/content_view_puppet_module/destroy.rb
+++ b/app/lib/actions/katello/content_view_puppet_module/destroy.rb
@@ -10,8 +10,9 @@ module Actions
           # puppet modules that are referring to it
           repository.puppet_modules.each do |puppet_module|
             # first, process content view puppet modules that have been specified by version
-            library_repos = ::Katello::Repository.in_environment(repository.organization.library).
-                                                  where(:pulp_id => puppet_module.repoids)
+            library_repos = ::Katello::Repository.
+              in_environment(repository.organization.library).
+              where(:pulp_id => puppet_module.repository_ids)
 
             if library_repos.length == 1
               content_view_puppet_modules = ::Katello::ContentViewPuppetModule.joins(:content_view).
@@ -29,9 +30,8 @@ module Actions
             if content_view_puppet_modules.any?
               puppet_repoids = ::Katello::Repository.puppet_type.in_environment(repository.organization.library).
                   pluck(:pulp_id).reject { |repoid| repoid == repository.pulp_id }
-              found_puppet_module = ::Katello::PuppetModule.latest_modules_search([{:name => puppet_module.name,
-                                                                                    :author => puppet_module.author}],
-                                                                                  puppet_repoids).first
+              found_puppet_module = ::Katello::PuppetModule
+                .latest_module(puppet_module.name, puppet_module.author, puppet_repoids)
 
               content_view_puppet_modules.destroy_all unless found_puppet_module
             end

--- a/app/lib/actions/katello/repository/incremental_import.rb
+++ b/app/lib/actions/katello/repository/incremental_import.rb
@@ -15,6 +15,10 @@ module Actions
 
           rpm_files = Dir.glob(File.join(import_location, "*rpm"))
 
+          rpm_filepaths = rpm_files.collect do |filepath|
+            {path: filepath, filename: File.basename(filepath)}
+          end
+
           json_files = Dir.glob(File.join(import_location, "*json"))
           pulp_units = json_files.map { |json_file| JSON.parse(File.read(json_file)) }
           errata = pulp_units.select { |pulp_unit| erratum? pulp_unit }
@@ -24,7 +28,7 @@ module Actions
             # everything to /tmp. It is better to just have Pulp generate
             # incrementals in the same way it publishes normally, vs optimizing
             # this call. https://pulp.plan.io/issues/1543
-            plan_action(Katello::Repository::UploadFiles, repo, rpm_files)
+            plan_action(Katello::Repository::UploadFiles, repo, rpm_filepaths)
             plan_action(Katello::Repository::UploadErrata, repo, errata)
           end
 

--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -107,7 +107,7 @@ module Katello
     end
 
     def available_content
-      self.products.map(&:available_content).flatten
+      self.products.map(&:available_content).flatten.uniq { |product| product.content.id }
     end
 
     def valid_content_label?(content_label)

--- a/app/models/katello/concerns/redhat_extensions.rb
+++ b/app/models/katello/concerns/redhat_extensions.rb
@@ -56,17 +56,15 @@ module Katello
         {:name => distro.name, :path => distro.full_path(host.content_source)} if distro && host.content_source
       end
 
-      private
-
       def distribution_repositories(host)
         content_view = host.content_facet.try(:content_view)
         lifecycle_environment = host.content_facet.try(:lifecycle_environment)
 
         if content_view && lifecycle_environment
-          Katello::Repository.where(:distribution_version => host.os.release,
-                                    :distribution_arch => host.architecture.name,
-                                    :distribution_bootable => true
-                                    )
+          Katello::Repository.in_environment(lifecycle_environment).in_content_views([content_view]).
+              where(:distribution_version => host.os.release,
+                    :distribution_arch => host.architecture.name,
+                    :distribution_bootable => true)
         else
           []
         end

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -216,6 +216,10 @@ module Katello
       Katello::Rpm.in_repositories(self.repositories.archived).count
     end
 
+    def ostree_branch_count
+      ostree_branches.count
+    end
+
     def docker_manifest_count
       manifest_counts = repositories.archived.docker_type.map do |repo|
         repo.docker_manifests.count
@@ -238,6 +242,10 @@ module Katello
       errata = Erratum.in_repositories(archived_repos).uniq
       errata = errata.of_type(errata_type) if errata_type
       errata
+    end
+
+    def ostree_branches
+      OstreeBranch.in_repositories(archived_repos).uniq
     end
 
     def docker_manifests

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -483,6 +483,26 @@ module Katello
         Katello.pulp_server.extensions.repository.docker_manifest_ids(self.pulp_id)
       end
 
+      def pulp_ostree_branch_ids
+        Katello.pulp_server.extensions.repository.ostree_branch_ids(self.pulp_id)
+      end
+
+      def index_db_ostree_branches
+        ostree_branches_json.each do |ostree_branch_json|
+          branch = OstreeBranch.where(:uuid => ostree_branch_json[:_id]).first_or_create
+          branch.update_from_json(ostree_branch_json)
+        end
+        OstreeBranch.sync_repository_associations(self, pulp_ostree_branch_ids)
+      end
+
+      def ostree_branches_json
+        ostree_branches = []
+        pulp_ostree_branch_ids.each_slice(SETTINGS[:katello][:pulp][:bulk_load_size]) do |sub_list|
+          ostree_branches.concat(Katello.pulp_server.extensions.ostree_branch.find_all_by_unit_ids(sub_list))
+        end
+        ostree_branches
+      end
+
       def sync_schedule(date_and_time)
         if date_and_time
           Katello.pulp_server.extensions.repository.create_or_update_schedule(self.pulp_id, importer_type, date_and_time)
@@ -788,6 +808,8 @@ module Katello
         "#{scheme}://#{pulp_uri.host.downcase}/pulp/isos/#{pulp_id}"
       elsif puppet?
         "#{scheme}://#{pulp_uri.host.downcase}/pulp/puppet/#{pulp_id}"
+      elsif ostree?
+        "#{scheme}://#{pulp_uri.host.downcase}/pulp/ostree/web/#{pulp_id}"
       else
         "#{scheme}://#{pulp_uri.host.downcase}/pulp/repos/#{relative_path}"
       end
@@ -799,6 +821,7 @@ module Katello
       self.index_db_docker_manifests
       self.index_db_puppet_modules
       self.index_db_package_groups
+      self.index_db_ostree_branches if Katello::RepositoryTypeManager.find(Repository::OSTREE_TYPE).present?
       self.import_distribution_data
       true
     end

--- a/app/models/katello/ostree_branch.rb
+++ b/app/models/katello/ostree_branch.rb
@@ -1,14 +1,29 @@
 module Katello
   class OstreeBranch < Katello::Model
-    belongs_to :repository, :class_name => "Katello::Repository", :inverse_of => :ostree_branches
-    validates :name, presence: true, uniqueness: {scope: :repository_id}
-    validates :repository, :presence => true
-    validate :ensure_ostree_repository
+    include Concerns::PulpDatabaseUnit
 
-    def ensure_ostree_repository
-      unless self.repository.ostree?
-        errors.add(:base, _("Branch cannot be created since it does not belong to an RPM OSTree repository."))
-      end
+    has_many :repository_ostree_branches, :dependent => :destroy
+    has_many :repositories, :through => :repository_ostree_branches, :inverse_of => :ostree_branches
+
+    scoped_search :on => :name, :complete_value => true
+    scoped_search :on => :version, :complete_value => true
+    scoped_search :on => :commit, :complete_value => true
+    scoped_search :on => :uuid, :complete_value => true
+    scoped_search :on => :version_date, :complete_value => true, :rename => :created
+    scoped_search :in => :repositories, :on => :name, :rename => :repository, :complete_value => true
+
+    CONTENT_TYPE = Pulp::OstreeBranch::CONTENT_TYPE
+
+    def self.repository_association_class
+      RepositoryOstreeBranch
+    end
+
+    def update_from_json(json)
+      update_attributes(:name => json[:branch],
+                        :version => json[:metadata][:version],
+                        :commit => json[:commit],
+                        :version_date => json[:_created].to_datetime
+                       )
     end
   end
 end

--- a/app/models/katello/pool.rb
+++ b/app/models/katello/pool.rb
@@ -9,6 +9,8 @@ module Katello
     has_many :activation_keys, :through => :pool_activation_keys, :class_name => "Katello::ActivationKey"
     has_many :pool_activation_keys, :class_name => "Katello::PoolActivationKey", :dependent => :destroy, :inverse_of => :pool
 
+    scope :in_org, -> (org_id) { joins(:subscription).where("#{Katello::Subscription.table_name}.organization_id = ?", org_id) }
+
     self.include_root_in_json = false
 
     include Glue::Candlepin::Pool

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -50,7 +50,8 @@ module Katello
 
     has_many :docker_tags, :dependent => :destroy, :class_name => "Katello::DockerTag"
 
-    has_many :ostree_branches, :class_name => "Katello::OstreeBranch", :dependent => :destroy
+    has_many :repository_ostree_branches, :class_name => "Katello::RepositoryOstreeBranch", :dependent => :destroy
+    has_many :ostree_branches, :through => :repository_ostree_branches
 
     has_many :system_repositories, :class_name => "Katello::SystemRepository", :dependent => :destroy
     has_many :systems, :through => :system_repositories
@@ -102,6 +103,7 @@ module Katello
     scope :file_type, -> { where(:content_type => FILE_TYPE) }
     scope :puppet_type, -> { where(:content_type => PUPPET_TYPE) }
     scope :docker_type, -> { where(:content_type => DOCKER_TYPE) }
+    scope :ostree_type, -> { where(:content_type => OSTREE_TYPE) }
     scope :non_puppet, -> { where("content_type != ?", PUPPET_TYPE) }
     scope :non_archived, -> { where('environment_id is not NULL') }
     scope :archived, -> { where('environment_id is NULL') }
@@ -527,6 +529,8 @@ module Katello
         self.rpms -= units
       elsif puppet?
         self.puppet_modules -= units
+      elsif ostree?
+        self.ostree_branches -= units
       elsif docker?
         remove_docker_content(units)
       end
@@ -558,6 +562,8 @@ module Katello
         self.docker_manifests
       elsif puppet?
         self.puppet_modules
+      elsif ostree?
+        self.ostree_branches
       else
         fail "Content type not supported for removal"
       end

--- a/app/models/katello/repository_ostree_branch.rb
+++ b/app/models/katello/repository_ostree_branch.rb
@@ -1,0 +1,9 @@
+module Katello
+  class RepositoryOstreeBranch < Katello::Model
+    self.include_root_in_json = false
+
+    # Do not use active record callbacks in this join model.  Direct INSERTs and DELETEs are done
+    belongs_to :repository, :inverse_of => :repository_ostree_branches, :class_name => 'Katello::Repository'
+    belongs_to :ostree_branch, :inverse_of => :repository_ostree_branches
+  end
+end

--- a/app/services/katello/pulp/ostree_branch.rb
+++ b/app/services/katello/pulp/ostree_branch.rb
@@ -1,0 +1,7 @@
+module Katello
+  module Pulp
+    class OstreeBranch < PulpContentUnit
+      CONTENT_TYPE = "ostree"
+    end
+  end
+end

--- a/app/views/dashboard/_content_views_widget.html.erb
+++ b/app/views/dashboard/_content_views_widget.html.erb
@@ -21,7 +21,7 @@
       <% histories.each do |history| %>
         <tr>
           <td>
-            <a href="/content_views/<%= history.content_view_version.content_view.id %>/versions/<%= history.content_view_version.id %>">
+            <a href="/content_views/<%= history.content_view_version.content_view.id %>/versions/<%= history.content_view_version.id %>/details">
               <%= history.content_view_version.content_view.name %> <%= history.content_view_version.version %>
             </a>
           </td>

--- a/app/views/dashboard/_subscription_status_widget.html.erb
+++ b/app/views/dashboard/_subscription_status_widget.html.erb
@@ -3,7 +3,7 @@
 </h4>
 
 <% organizations = Organization.current.present? ? [Organization.current] : User.current.allowed_organizations %>
-<% subscriptions = organizations.collect { |org| org.redhat_provider.index_subscriptions }.flatten %>
+<% subscriptions = organizations.collect { |org| Katello::Pool.in_org(org.id) }.flatten %>
 <% total_active_subscriptions = Katello::Pool.active(subscriptions).count %>
 <% total_expiring_subscriptions = Katello::Pool.expiring_soon(subscriptions).count %>
 <% total_recently_expired_subscriptions = Katello::Pool.recently_expired(subscriptions).count %>

--- a/app/views/katello/api/v2/ostree_branches/index.json.rabl
+++ b/app/views/katello/api/v2/ostree_branches/index.json.rabl
@@ -1,0 +1,7 @@
+object false
+
+extends "katello/api/v2/common/metadata"
+
+child @collection[:results] => :results do
+  extends 'katello/api/v2/ostree_branches/show'
+end

--- a/app/views/katello/api/v2/ostree_branches/show.json.rabl
+++ b/app/views/katello/api/v2/ostree_branches/show.json.rabl
@@ -1,0 +1,4 @@
+object @resource
+
+attributes :uuid, :id
+attributes :name, :version, :commit, :version_date

--- a/app/views/katello/api/v2/repositories/base.json.rabl
+++ b/app/views/katello/api/v2/repositories/base.json.rabl
@@ -13,6 +13,7 @@ end
 
 node :content_counts do |repo|
   {
+    :ostree_branch => repo.ostree_branches.count,
     :docker_manifest => repo.docker_manifests.count,
     :docker_tag => repo.docker_tags.count,
     :rpm => repo.rpms.count,

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -108,6 +108,12 @@ Katello::Engine.routes.draw do
           end
         end
 
+        api_resources :ostree_branches, :only => [:index, :show] do
+          collection do
+            get :auto_complete_search
+          end
+        end
+
         api_resources :docker_manifests, :only => [:index, :show]
         api_resources :docker_tags, :only => [:index, :show] do
           collection do
@@ -316,6 +322,8 @@ Katello::Engine.routes.draw do
           end
           api_resources :docker_manifests, :only => [:index, :show]
           api_resources :docker_tags, :only => [:index, :show]
+
+          api_resources :ostree_branches, :only => [:index, :show]
 
           api_resources :content_uploads, :controller => :content_uploads, :only => [:create, :destroy, :update]
 

--- a/config/routes/overrides.rb
+++ b/config/routes/overrides.rb
@@ -54,6 +54,7 @@ Foreman::Application.routes.draw do
           end
 
           collection do
+            match '/auto_complete_search' => 'host_autocomplete#auto_complete_search', :via => :get
             match '/bulk/add_host_collections' => 'hosts_bulk_actions#bulk_add_host_collections', :via => :put
             match '/bulk/remove_host_collections' => 'hosts_bulk_actions#bulk_remove_host_collections', :via => :put
             match '/bulk/install_content' => 'hosts_bulk_actions#install_content', :via => :put

--- a/db/migrate/20160301070319_add_version_ostree_branches.rb
+++ b/db/migrate/20160301070319_add_version_ostree_branches.rb
@@ -1,0 +1,42 @@
+class AddVersionOstreeBranches < ActiveRecord::Migration
+  def up
+    drop_table :katello_ostree_branches if ActiveRecord::Base.connection.table_exists? "katello_ostree_branches"
+
+    create_table :katello_ostree_branches do |t|
+      t.string :version, :limit => 255
+      t.string :name, :limit => 255
+      t.string :uuid, :null => false, :limit => 255
+      t.string :commit, :limit => 255
+      t.timestamp :version_date
+      t.timestamps
+    end
+
+    create_table :katello_repository_ostree_branches do |t|
+      t.references :ostree_branch, :null => false
+      t.references :repository, :null => true
+      t.timestamps
+    end
+
+    add_index :katello_repository_ostree_branches, [:ostree_branch_id, :repository_id],
+              :name => :katello_repo_ostree_branch_repo_id, :unique => true
+
+    add_foreign_key :katello_repository_ostree_branches, :katello_repositories,
+                    :column => :repository_id
+  end
+
+  def down
+    drop_table :katello_repository_ostree_branches
+    drop_table :katello_ostree_branches
+    create_table :katello_ostree_branches do |t|
+      t.string :name, :null => false, :limits => 255
+      t.references :repository, :null => false
+      t.timestamps
+    end
+
+    add_index :katello_ostree_branches, [:repository_id],
+              :name => :index_branches_on_repository
+
+    add_index :katello_ostree_branches, [:repository_id, :name],
+              :name => :katello_ostree_branches_repo_branch, :unique => true
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-add-subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-add-subscriptions.html
@@ -36,12 +36,12 @@
 
       <tbody>
         <tr bst-table-row ng-repeat-start="(name, subscriptions) in groupedSubscriptions">
-          <td class="row-select"></td>
-          <td bst-table-cell colspan="8">
-            <a href='/subscriptions/{{ subscription.id }}/info'>
+          <td class="row-select">
+            <a href='/subscriptions/{{ subscription.id }}/info' class='confined-text'>
               {{ name }}
             </a>
           </td>
+          <td bst-table-cell colspan="8"></td>
         </tr>
         <tr bst-table-row ng-repeat-end ng-repeat="subscription in subscriptions" row-select="subscription">
           <td bst-table-cell>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-subscriptions-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-subscriptions-list.html
@@ -48,12 +48,12 @@
 
       <tbody>
         <tr bst-table-row ng-repeat-start="(name, subscriptions) in groupedSubscriptions | groupedFilter: subscriptionSearch">
-          <td class="row-select"></td>
-          <td bst-table-cell colspan="8" >
-            <a href='/subscriptions/{{ subscription.id }}/info'>
+          <td class="row-select">
+            <a href='/subscriptions/{{ subscription.id }}/info' class="confined-text">
               {{ name }}
             </a>
           </td>
+          <td bst-table-cell colspan="8" ></td>
         </tr>
         <tr bst-table-row ng-repeat-end ng-repeat="subscription in subscriptions" row-select="subscription">
           <td bst-table-cell>{{ subscription | subscriptionAttachAmountFilter }}</td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/bastion-katello-bootstrap.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/bastion-katello-bootstrap.js
@@ -7,6 +7,7 @@ BASTION_MODULES.push(
     'Bastion.docker-tags',
     'Bastion.hosts',
     'Bastion.puppet-modules',
+    'Bastion.ostree-branches',
     'Bastion.environments',
     'Bastion.gpg-keys',
     'Bastion.hosts',

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/bastion_katello.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/bastion_katello.js
@@ -25,6 +25,9 @@
 //= require "bastion_katello/docker-tags/docker-tags.module.js"
 //= require_tree "./docker-tags"
 
+//= require "bastion_katello/ostree-branches/ostree-branches.module.js"
+//= require_tree "./ostree-branches"
+
 //= require "bastion_katello/errata/errata.module"
 //= require_tree "./errata"
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
@@ -34,7 +34,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsController',
         $scope.contentHostTable = nutupane.table;
         $scope.removeRow = nutupane.removeRow;
         $scope.nutupane = nutupane;
-        $scope.controllerName = 'katello_systems';
+        $scope.controllerName = 'hosts';
 
         // @TODO begin hack necessary because of foreman API bug http://projects.theforeman.org/issues/13877
         $scope.contentHostTable.sortBy = function (column) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-add-subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-add-subscriptions.html
@@ -34,12 +34,12 @@
 
        <tbody>
          <tr bst-table-row ng-repeat-start="(name, subscriptions) in groupedSubscriptions">
-          <td class="row-select"></td>
-           <td bst-table-cell colspan="8">
-             <a href='/subscriptions/{{ subscription.id }}/info'>
+           <td class="row-select">
+             <a href='/subscriptions/{{ subscription.id }}/info' class="confined-text">
               {{ name }}
              </a>
            </td>
+           <td bst-table-cell colspan="8"></td>
          </tr>
          <tr bst-table-row ng-repeat-end ng-repeat="subscription in subscriptions" row-select="subscription">
            <td bst-table-cell>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions-list.html
@@ -45,12 +45,12 @@
 
       <tbody>
         <tr bst-table-row ng-repeat-start="(name, subscriptions) in groupedSubscriptions | groupedFilter: subscriptionSearch">
-          <td class="row-select"></td>
-          <td bst-table-cell colspan="8">
-            <a href='/subscriptions/{{ subscription.id }}/info'>
+          <td class="row-select">
+            <a href='/subscriptions/{{ subscription.id }}/info' class="confined-text">
               {{ name }}
             </a>
           </td>
+          <td bst-table-cell colspan="8"></td>
         </tr>
         <tr bst-table-row ng-repeat-end ng-repeat="subscription in subscriptions" row-select="subscription">
           <td bst-table-cell>{{ subscription | subscriptionAttachAmountFilter}}</td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/host.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/host.factory.js
@@ -11,7 +11,8 @@ angular.module('Bastion.hosts').factory('Host',
     ['BastionResource', function (BastionResource) {
         var resource = BastionResource('/api/v2/hosts/:id/:action', {id: '@id'}, {
             update: {method: 'PUT'},
-            updateHostCollections: {method: 'PUT', params: {action: 'host_collections'}}
+            updateHostCollections: {method: 'PUT', params: {action: 'host_collections'}},
+            autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}}
         });
         resource.prototype.hasContent = function () {
             return angular.isDefined(this.content) && angular.isDefined(this.content.uuid);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/ostree-branches/ostree-branch.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/ostree-branches/ostree-branch.factory.js
@@ -1,0 +1,27 @@
+(function () {
+    'use strict';
+
+    /**
+     * @ngdoc factory
+     * @name  Bastion.ostree-branches.factory:OstreeBranch
+     *
+     * @description
+     *   Provides a BastionResource for interacting with Ostree Branches
+     */
+    function OstreeBranch(BastionResource) {
+        return BastionResource('/katello/api/v2/ostree_branches/:id',
+            {'id': '@id'},
+            {
+                autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}}
+            }
+
+        );
+    }
+
+    angular
+        .module('Bastion.ostree-branches')
+        .factory('OstreeBranch', OstreeBranch);
+
+    OstreeBranch.$inject = ['BastionResource'];
+
+})();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/ostree-branches/ostree-branches.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/ostree-branches/ostree-branches.module.js
@@ -1,0 +1,11 @@
+/**
+ * @ngdoc module
+ * @name  Bastion.ostree-branches
+ *
+ * @description
+ *   Module for Ostree Branch related functionality.
+ */
+angular.module('Bastion.ostree-branches', [
+    'Bastion',
+    'Bastion.common'
+]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-repositories.html
@@ -149,6 +149,15 @@
                   </span>
                 </div>
               </span>
+
+              <span ng-show="repository.content_type == 'ostree'">
+                <div>
+                  <span translate>
+                    {{ repository.content_counts.ostree_branch || 0 }} OSTree Branches
+                  </span>
+                </div>
+              </span>
+
             </td>
           </tr>
         </tbody>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.module.js
@@ -185,6 +185,12 @@ angular.module('Bastion.products').config(['$stateProvider', function ($statePro
         permission: 'view_products',
         collapsed: true,
         templateUrl: 'repositories/details/views/repository-manage-docker-manifests.html'
+    })
+    .state('products.details.repositories.manage-content.ostree-branches', {
+        url: '/repositories/:repositoryId/content/ostree_branches',
+        permission: 'view_products',
+        collapsed: true,
+        templateUrl: 'repositories/details/views/repository-manage-ostree-branches.html'
     });
 
     $stateProvider.state('products.details.tasks', {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/repository-details-manage-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/repository-details-manage-content.controller.js
@@ -11,13 +11,14 @@
  * @requires PackageGroup
  * @requires PuppetModule
  * @requires DockerManifest
+ * @requires OstreeBranch
  *
  * @description
  *   Provides the functionality for the repository details pane.
  */
 angular.module('Bastion.repositories').controller('RepositoryManageContentController',
-    ['$scope', '$state', 'translate', 'Nutupane', 'Repository', 'Package', 'PackageGroup', 'PuppetModule', 'DockerManifest',
-    function ($scope, $state, translate, Nutupane, Repository, Package, PackageGroup, PuppetModule, DockerManifest) {
+    ['$scope', '$state', 'translate', 'Nutupane', 'Repository', 'Package', 'PackageGroup', 'PuppetModule', 'DockerManifest', 'OstreeBranch',
+    function ($scope, $state, translate, Nutupane, Repository, Package, PackageGroup, PuppetModule, DockerManifest, OstreeBranch) {
         var currentState, contentTypes;
 
         function success(response, selected) {
@@ -48,7 +49,8 @@ angular.module('Bastion.repositories').controller('RepositoryManageContentContro
             'packages': { type: Package },
             'package-groups': { type: PackageGroup },
             'puppet-modules': { type: PuppetModule },
-            'docker-manifests': { type: DockerManifest }
+            'docker-manifests': { type: DockerManifest },
+            'ostree-branches': { type: OstreeBranch }
         };
 
         $scope.contentNutupane = new Nutupane(contentTypes[currentState].type, {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-info.html
@@ -12,7 +12,7 @@
       <i class="fa fa-double-angle-left"></i>
       {{ "Back to Repository List" | translate }}
     </a>
-  
+
     <div class="fr">
       <button class="btn btn-default"
               ui-sref="products.details.repositories.manage-content.packages({productId: product.id, repositoryId: repository.id})"
@@ -29,7 +29,13 @@
       <button class="btn btn-default"
             ui-sref="products.details.repositories.manage-content.docker-manifests({productId: product.id, repositoryId: repository.id})"
             ng-hide="repository.content_type !== 'docker' || denied('edit_products', product)">
-      <span translate>Manage Docker Manifests</span>
+        <span translate>Manage Docker Manifests</span>
+      </button>
+
+      <button class="btn btn-default"
+              ui-sref="products.details.repositories.manage-content.ostree-branches({productId: product.id, repositoryId: repository.id})"
+              ng-hide="repository.content_type !== 'ostree' || denied('edit_products', product)">
+        <span translate>View Branches</span>
       </button>
 
       <button class="btn btn-default"
@@ -280,8 +286,8 @@
           <td class="align-center">{{ repository.content_counts.docker_tag || 0 }}</td>
         </tr>
         <tr ng-show="repository.content_type === 'ostree'">
-          <td translate>OSTree Units</td>
-          <td class="align-center">{{ repository.content_counts.ostree || 0 }}</td>
+          <td translate>OSTree Branches</td>
+          <td class="align-center">{{ repository.content_counts.ostree_branch || 0 }}</td>
         </tr>
         </tbody>
       </table>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-manage-ostree-branches.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-manage-ostree-branches.html
@@ -1,0 +1,60 @@
+<span page-title ng-model="repository">{{ 'Manage OSTree Branches for Repository:' | translate }} {{ repository.name }}</span>
+
+<a ui-sref="products.details.repositories.info({productId: product.id, repositoryId: repository.id})">
+  <i class="fa fa-angle-double-left"></i>
+  {{ "Back to Repository Details" | translate }}
+</a>
+
+<div data-extend-template="layouts/details-nutupane.html">
+
+  <div data-block="pane-loading"></div>
+
+  <div data-block="messages">
+    <div bst-alerts success-messages="successMessages" error-messages="errorMessages"></div>
+
+    <div bst-alert="success" ng-hide="generationTaskId === undefined">
+      <button type="button" class="close" ng-click="clearTaskId()">&times;</button>
+      <p translate>
+        OSTree Branch metadata generation has been initiated in the background.  Click
+        <a ng-href="{{ taskUrl() }}">Here</a> to monitor the progress.
+      </p>
+    </div>
+  </div>
+
+  <div data-block="header">
+    <h3 translate>Ostree Branches in {{ repository.name }}</h3>
+  </div>
+  <div data-block="selection-summary"></div>
+  <div data-block="table">
+    <table class="table table-striped table-bordered" >
+
+      <thead>
+        <tr bst-table-head>
+          <th bst-table-column><span translate>Branch Name</span></th>
+          <th bst-table-column><span translate>Version</span></th>
+          <th bst-table-column><span translate>Commit</span></th>
+          <th bst-table-column><span translate>Date</span></th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr bst-table-row ng-repeat="item in detailsTable.rows">
+          <td bst-table-cell>
+            {{ item.name }}
+          </td>
+          <td bst-table-cell>
+            {{ item.version }}
+          </td>
+          <td bst-table-cell>
+            {{ item.commit }}
+          </td>
+          <td bst-table-cell>
+            {{ item.version_date }}
+          </td>
+        </tr>
+      </tbody>
+
+    </table>
+  </div>
+
+</div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/views/repository-new.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/views/repository-new.html
@@ -80,7 +80,7 @@
         </select>
       </div>
 
-      <div bst-form-group label="{{ 'Mirror On Sync' | translate }}">
+      <div bst-form-group label="{{ 'Mirror On Sync' | translate }}" ng-show="repository.content_type === 'yum'">
         <input id="mirror_on_sync"
                name="mirror_on_sync"
                ng-model="repository.mirror_on_sync"

--- a/engines/bastion_katello/app/assets/stylesheets/bastion_katello/bastion_katello.scss
+++ b/engines/bastion_katello/app/assets/stylesheets/bastion_katello/bastion_katello.scss
@@ -5,6 +5,12 @@
   @import "environments";
   @import "errata";
 
+  a {
+    &.confined-text {
+      white-space: nowrap;
+    }
+  }
+
   .center-paragraph {
     text-align: center;
   }

--- a/engines/bastion_katello/test/ostree-branches/ostree-branch.factory.test.js
+++ b/engines/bastion_katello/test/ostree-branches/ostree-branch.factory.test.js
@@ -1,0 +1,36 @@
+describe('Factory: OstreeBranch', function () {
+    var $httpBackend,
+        ostreeBranches;
+
+    beforeEach(module('Bastion.ostree-branches', 'Bastion.test-mocks'));
+
+    beforeEach(module(function ($provide) {
+        ostreeBranches = {
+            records: [
+                { name: 'abc123', id: 1 }
+            ],
+            total: 2,
+            subtotal: 1
+        };
+    }));
+
+    beforeEach(inject(function ($injector) {
+        $httpBackend = $injector.get('$httpBackend');
+        OstreeBranch = $injector.get('OstreeBranch');
+    }));
+
+    afterEach(function () {
+        $httpBackend.flush();
+        $httpBackend.verifyNoOutstandingExpectation();
+        $httpBackend.verifyNoOutstandingRequest();
+    });
+
+    it('provides a way to get a list of repositories', function () {
+        $httpBackend.expectGET('/katello/api/v2/ostree_branches').respond(ostreeBranches);
+
+        OstreeBranch.queryPaged(function (ostreeBranches) {
+            expect(ostreeBranches.records.length).toBe(1);
+        });
+    });
+
+});

--- a/engines/bastion_katello/test/repositories/details/repository-details-manage-content.controller.test.js
+++ b/engines/bastion_katello/test/repositories/details/repository-details-manage-content.controller.test.js
@@ -1,5 +1,5 @@
 describe('Controller: RepositoryManageContentController', function() {
-    var $scope, translate, Repository, Nutupane, PuppetModule, Package, PackageGroup, DockerManifest;
+    var $scope, translate, Repository, Nutupane, PuppetModule, Package, PackageGroup, DockerManifest, OstreeBranch;
 
     beforeEach(module(
         'Bastion.repositories',
@@ -42,6 +42,7 @@ describe('Controller: RepositoryManageContentController', function() {
             Package: Package,
             PackageGroup: PackageGroup,
             DockerManifest: DockerManifest,
+            OstreeBranch: OstreeBranch,
         });
     }));
 

--- a/lib/katello/permissions/host_permissions.rb
+++ b/lib/katello/permissions/host_permissions.rb
@@ -21,6 +21,7 @@ Foreman::AccessControl.permission(:edit_hosts).actions.concat [
 
 Foreman::AccessControl.permission(:view_hosts).actions.concat [
   'hosts/puppet_environment_for_content_view',
+  'katello/api/v2/host_autocomplete/auto_complete_search',
   'katello/api/v2/host_errata/index',
   'katello/api/v2/host_errata/show',
   'katello/api/v2/host_errata/auto_complete_search',

--- a/lib/katello/tasks/reindex.rake
+++ b/lib/katello/tasks/reindex.rake
@@ -72,7 +72,7 @@ namespace :katello do
           notes = []
           facts = fetch_resource { object.pulp_facts }
           notes << "Pulp Consumer #{object.uuid} was not found." if facts.nil?
-          candlepin_consumer_info = fetch_resource { Katello::Resources::Candlepin::Consumer.get(object.uuid) } 
+          candlepin_consumer_info = fetch_resource { Katello::Resources::Candlepin::Consumer.get(object.uuid) }
           notes << "Candlepin Consumer was not available for #{object.name}." if candlepin_consumer_info.nil?
           notes << "Foreman Host was not available for #{object.name}." if object.foreman_host.nil?
 
@@ -136,6 +136,7 @@ namespace :katello do
     Katello::Erratum.import_all
     Katello::PackageGroup.import_all
     Katello::PuppetModule.import_all
+    Katello::OstreeBranch.import_all if Katello::RepositoryTypeManager.find(Katello::Repository::OSTREE_TYPE).present?
     Katello::Subscription.import_all
     Katello::Pool.import_all
 

--- a/test/actions/katello/content_view_puppet_module_test.rb
+++ b/test/actions/katello/content_view_puppet_module_test.rb
@@ -18,7 +18,7 @@ module ::Actions::Katello::ContentViewPuppetModule
     it 'plans' do
       puppet_module = ::Katello::ContentViewPuppetModule.find(katello_content_view_puppet_modules(:library_view_module_by_uuid))
       puppet_repository.stubs(:puppet_modules).returns([OpenStruct.new(:id => puppet_module.uuid,
-                                                                       :repoids => [puppet_repository.pulp_id])])
+                                                                       :repository_ids => [puppet_repository.pulp_id])])
       action.expects(:action_subject).with(puppet_repository)
       plan_action action, puppet_repository
 

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -193,10 +193,10 @@ module ::Actions::Katello::Repository
       import_dir = File.join(::Katello::Engine.root, "test", "fixtures", "files")
       plan_action action, custom_repository, import_dir
 
-      assert_action_planed_with action, ::Actions::Katello::Repository::UploadFiles do |repo, rpm_files|
+      assert_action_planed_with action, ::Actions::Katello::Repository::UploadFiles do |repo, rpm_filepaths|
         repo.must_equal custom_repository
-        rpm_files.length.must_equal 1
-        rpm_files.first.must_include "squirrel"
+        rpm_filepaths.length.must_equal 1
+        rpm_filepaths.first[:filename].must_include "squirrel"
       end
 
       assert_action_planed_with action, ::Actions::Katello::Repository::UploadErrata do |repo, errata|

--- a/test/controllers/api/v2/host_autocomplete_controller_test.rb
+++ b/test/controllers/api/v2/host_autocomplete_controller_test.rb
@@ -1,0 +1,41 @@
+# encoding: utf-8
+
+require "katello_test_helper"
+
+module Katello
+  class Api::V2::HostAutocompleteControllerTest < ActionController::TestCase
+    tests ::Katello::Api::V2::HostAutocompleteController
+
+    def permissions
+      @view_permission = :view_hosts
+      @create_permission = :create_hosts
+      @update_permission = :edit_hosts
+      @destroy_permission = :destroy_hosts
+    end
+
+    def setup
+      setup_controller_defaults_api
+      login_user(users(:admin))
+
+      @host = hosts(:one)
+
+      setup_foreman_routes
+      permissions
+    end
+
+    def test_install_package
+      get :auto_complete_search, :search => "name "
+
+      assert_response :success
+    end
+
+    def test_permissions
+      good_perms = [@view_permission]
+      bad_perms = [@update_permission, @create_permission, @destroy_permission]
+
+      assert_protected_action(:auto_complete_search, good_perms, bad_perms) do
+        get :auto_complete_search, :search => "name "
+      end
+    end
+  end
+end

--- a/test/controllers/api/v2/ostree_branches_controller_test.rb
+++ b/test/controllers/api/v2/ostree_branches_controller_test.rb
@@ -1,0 +1,46 @@
+require "katello_test_helper"
+
+module Katello
+  class Api::V2::OstreeBranchesControllerTest < ActionController::TestCase
+    def models
+      @repo = Repository.find(katello_repositories(:ostree_rhel7))
+      @branch = @repo.ostree_branches.create!(:name => "abc123", :uuid => "123xyz")
+    end
+
+    def setup
+      setup_controller_defaults_api
+      models
+    end
+
+    def test_index
+      get :index
+      assert_response :success
+      assert_template "katello/api/v2/ostree_branches/index"
+    end
+
+    def test_index_with_repository
+      get :index, :repository_id => @repo.id
+      assert_response :success
+      assert_template "katello/api/v2/ostree_branches/index"
+    end
+
+    def test_index_with_organization
+      get :index, :organization_id => @repo.organization.id
+      assert_response :success
+      assert_template "katello/api/v2/ostree_branches/index"
+    end
+
+    def test_index_with_content_view_version
+      get :index, :content_view_version_id => ContentViewVersion.last
+      assert_response :success
+      assert_template "katello/api/v2/ostree_branches/index"
+    end
+
+    def test_show
+      get :show, :repository_id => @repo.id, :id => @branch.uuid
+
+      assert_response :success
+      assert_template "katello/api/v2/ostree_branches/show"
+    end
+  end
+end

--- a/test/controllers/foreman/operatingsystems_controller_test.rb
+++ b/test/controllers/foreman/operatingsystems_controller_test.rb
@@ -1,0 +1,45 @@
+require 'katello_test_helper'
+
+class OperatingsystemsControllerTest < ActionController::TestCase
+  def models
+    @library = katello_environments(:library)
+    @library_view = katello_content_views(:library_view)
+    @repo_with_dist = katello_repositories(:fedora_17_library_library_view)
+    @x86_64 = architectures(:x86_64)
+    @sparc = architectures(:sparc)
+
+    @redhat = operatingsystems(:redhat)
+
+    @repo_with_dist.distribution_bootable = true
+    @repo_with_dist.distribution_arch = @x86_64.name
+    @repo_with_dist.unprotected = true
+    @repo_with_dist.distribution_version = @redhat.release
+    @repo_with_dist.save!
+    @capsule = SmartProxy.create!(:name => "foobar", :url => "http://capsule.com/")
+  end
+
+  def setup
+    setup_controller_defaults(false)
+    setup_foreman_routes
+    login_user(User.find(users(:admin)))
+    models
+  end
+
+  def test_available_kickstart_repo
+    response = get :available_kickstart_repo, :content_view_id => @library_view.id, :lifecycle_environment_id => @library.id,
+        :architecture_id => @x86_64.id, :id => @redhat.id, :content_source_id => @capsule.id
+    body = JSON.parse(response.body)
+
+    assert_response :success
+    assert body['path'].ends_with?(@repo_with_dist.relative_path)
+    assert_includes body['path'], @capsule.url
+  end
+
+  def test_nonavailable_kickstart_repo
+    response = get :available_kickstart_repo, :content_view_id => @library_view.id, :lifecycle_environment_id => @library.id,
+        :architecture_id => @sparc.id, :id => @redhat.id, :content_source_id => @capsule.id
+
+    assert_response :success
+    assert_equal 'null', response.body
+  end
+end

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -10,7 +10,7 @@ fedora_17_x86_64:
   gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
   url:                 "http://myrepo.com"
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>
-  distribution_arch: "test_arch"
+  distribution_arch: "x86_64"
   distribution_version: "2.1"
   distribution_family: 'Red Hat Enterprise Linux'
   distribution_variant: "TestVariant"
@@ -31,7 +31,7 @@ fedora_17_x86_64_dev:
   gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_dev_view_version) %>
   url:                 "http://myrepo.com"
-  distribution_arch: "test_arch"
+  distribution_arch: "x86_64"
   distribution_version: "2.1"
   distribution_family: "Test Family"
   distribution_variant: "TestVariant"
@@ -51,7 +51,7 @@ fedora_17_x86_64_duplicate:
   gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>
   url:                 "http://myrepo.com"
-  distribution_arch: "test_arch"
+  distribution_arch: "x86_64"
   distribution_version: "2.1"
   distribution_family: "Test Family"
   distribution_variant: "TestVariant"
@@ -72,6 +72,12 @@ fedora_17_library_library_view:
   gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_view_version_1) %>
   url:                 "http://myrepo.com"
+  distribution_arch: "x86_64"
+  distribution_version: "2.1"
+  distribution_family: "Test Family"
+  distribution_variant: "TestVariant"
+  distribution_bootable: true
+  distribution_uuid: 'xyz123'
   download_policy: immediate
 
 fedora_17_dev_library_view:
@@ -116,7 +122,7 @@ rhel_7_x86_64:
   gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>
   url:                 'https://cdn.example.com/rhel/7/os'
-  distribution_arch: "test_arch"
+  distribution_arch: "x86_64"
   distribution_version: "3.0"
   distribution_family: "Other Family"
   distribution_variant: "TestVariant"
@@ -137,7 +143,7 @@ rhel_6_x86_64:
   gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>
   url:                 'https://cdn.example.com/rhel/6/os'
-  distribution_arch: "test_arch"
+  distribution_arch: "x86_64"
   distribution_version: "2.1"
   distribution_family: "Other Family"
   distribution_variant: "TestVariant"

--- a/test/fixtures/pulp/ostree_branch.yml
+++ b/test/fixtures/pulp/ostree_branch.yml
@@ -1,0 +1,16 @@
+branch1:
+  _storage_path: "/var/lib/pulp/content/shared/ostree/48868e83e4a50500d16c6adac1dfa68bb50d72ec87311aa4be87f01796293958/links/664eb5e7-da47-4d37-a260-0161bab1d88f"
+  _href: "/pulp/api/v2/content/units/ostree/664eb5e7-da47-4d37-a260-0161bab1d88f/"
+  _last_updated: '2016-03-02T00:45:08Z'
+  remote_id: "2c5b6e07fe47d0b626a417d5dbb855a4aa8c991177e930213a3a80514d3e1a14"
+  _content_type_id: "ostree"
+  pulp_user_metadata: {}
+  branch: "fedora-atomic/f23/x86_64/docker-host"
+  _created: '2016-03-02T00:45:08Z'
+  commit: "954bdbeebebfa87b625d9d7bd78c81400bdd6756fcc3205987970af4b64eb678"
+  _id: "664eb5e7-da47-4d37-a260-0161bab1d88f"
+  children:  {}
+  metadata: {
+              version: '23.74',
+              rpmostree-inputhash: "cefa153b7f2ec7f2ee2cc6f4b2bb18ac34ef5128cf4a56cbcb6998e8a35b63ca"
+            }

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -32,6 +32,14 @@ module Katello
       assert_nil Katello::System.find_by_id(system_id)
     end
 
+    def test_full_text_search
+      other_host = FactoryGirl.create(:host)
+      found = ::Host.search_for(@foreman_host.name)
+
+      assert_includes found, @foreman_host
+      refute_includes found, other_host
+    end
+
     def test_smart_proxy_ids_with_katello
       content_source = FactoryGirl.create(:smart_proxy,
                                           :features => [Feature.where(:name => "Pulp Node").first_or_create])

--- a/test/models/concerns/medium_extensions_test.rb
+++ b/test/models/concerns/medium_extensions_test.rb
@@ -18,7 +18,6 @@ module Katello
 
     def test_update_media_with_distro
       assert_nil Operatingsystem.where(:name => @distro.name).first
-      assert_nil Architecture.where(:name => @distro.arch).first
       assert_nil Medium.where(:name => @medium_name).first
 
       Medium.update_media(@repo)

--- a/test/models/concerns/redhat_extensions_test.rb
+++ b/test/models/concerns/redhat_extensions_test.rb
@@ -7,7 +7,7 @@ module Katello
     def setup
       User.current = User.find(users(:admin))
       @my_distro = OpenStruct.new(:name => 'RedHat', :family => 'Red Hat Enterprise Linux', :version => '9.0')
-      @repo_with_distro = Repository.find(katello_repositories(:fedora_17_x86_64))
+      @repo_with_distro = katello_repositories(:fedora_17_x86_64)
     end
 
     def test_find_or_create_operating_system
@@ -38,6 +38,22 @@ module Katello
     def test_construct_name
       assert_equal ::Redhat.construct_name('Red Hat Enterprise Linux'), 'RedHat'
       assert_equal ::Redhat.construct_name('My Custom Linux'), 'My_Custom_Linux'
+    end
+
+    def test_distribution_repositories
+      version = @repo_with_distro.distribution_version.split('.')
+      os = ::Redhat.create_operating_system(@my_distro.name, version[0], version[1])
+      other_repo = katello_repositories(:fedora_17_library_library_view)
+      host = ::Host.new(:architecture => architectures(:x86_64), :operatingsystem => os,
+                        :content_facet_attributes => {:lifecycle_environment_id => @repo_with_distro.environment.id,
+                                                      :content_view_id => @repo_with_distro.content_view.id})
+
+      assert_equal @repo_with_distro.distribution_arch, other_repo.distribution_arch
+      assert_equal @repo_with_distro.distribution_version, other_repo.distribution_version
+
+      repo_list = os.distribution_repositories(host)
+      assert_includes repo_list, @repo_with_distro
+      refute_includes repo_list, other_repo
     end
   end
 end

--- a/test/models/host/content_facet_test.rb
+++ b/test/models/host/content_facet_test.rb
@@ -41,8 +41,12 @@ module Katello
     end
 
     def test_errata_searchable
+      other_host = FactoryGirl.create(:host)
       errata = katello_errata(:security)
-      assert_includes ::Host.search_for("applicable_errata = #{errata.errata_id}"), content_facet.host
+      found = ::Host.search_for("applicable_errata = #{errata.errata_id}")
+
+      assert_includes found, content_facet.host
+      refute_includes found, other_host
     end
 
     def test_available_and_applicable_errta

--- a/test/models/ostree_branch_test.rb
+++ b/test/models/ostree_branch_test.rb
@@ -1,0 +1,26 @@
+require 'katello_test_helper'
+
+module Katello
+  class OstreeBranchTest < ActiveSupport::TestCase
+    REPO_ID = "Default_Organization-Test-ostree"
+    BRANCHES = File.join(Katello::Engine.root, "test", "fixtures", "pulp", "ostree_branch.yml")
+
+    def setup
+      @branches = YAML.load_file(BRANCHES).values.map(&:deep_symbolize_keys)
+      @repo = Repository.find(katello_repositories(:ostree_rhel7))
+
+      ids = @branches.map { |attrs| attrs[:_id] }
+      ::Katello::Repository.any_instance.stubs(:pulp_ostree_branch_ids).returns(ids)
+      Runcible::Extensions::OstreeBranch.any_instance.stubs(:find_all_by_unit_ids).
+        with(ids).returns(@branches)
+    end
+
+    def test_index_db_ostree_branches
+      @repo.index_db_ostree_branches
+      assert_equal 1, OstreeBranch.count
+      assert_equal 1, @repo.ostree_branches.count
+      branch_names = @branches.map { |b| b[:branch] }
+      assert_equal branch_names.sort, OstreeBranch.all.map(&:name).sort
+    end
+  end
+end

--- a/test/models/repository_base.rb
+++ b/test/models/repository_base.rb
@@ -10,6 +10,7 @@ module Katello
       @fedora_17_dev_library_view       = katello_repositories(:fedora_17_dev_library_view)
       @puppet_forge                     = katello_repositories(:p_forge)
       @redis                            = katello_repositories(:redis)
+      @ostree_rhel7                     = katello_repositories(:ostree_rhel7)
       @fedora                           = katello_products(:fedora)
       @library                          = katello_environments(:library)
       @dev                              = katello_environments(:dev)


### PR DESCRIPTION
- Update the associated test
- Fix deprecated use of method `latest_modules_search` inside the same class