### PR TITLE
fixes #14186 - dashboard - update usage of ellipsis

### DIFF
--- a/app/views/dashboard/_content_views_widget.html.erb
+++ b/app/views/dashboard/_content_views_widget.html.erb
@@ -9,7 +9,7 @@
 <% if histories.empty? %>
   <p class="ca"><%= _("No content view history events found.") %></p>
 <% else %>
-  <table class="table table-striped ellipsis table-bordered">
+  <table class="table table-fixed table-striped table-bordered">
     <thead>
       <tr>
         <th>Content View</th>
@@ -20,7 +20,7 @@
     <tbody>
       <% histories.each do |history| %>
         <tr>
-          <td>
+          <td class='ellipsis'>
             <a href="/content_views/<%= history.content_view_version.content_view.id %>/versions/<%= history.content_view_version.id %>/details">
               <%= history.content_view_version.content_view.name %> <%= history.content_view_version.version %>
             </a>

--- a/app/views/dashboard/_errata_widget.html.erb
+++ b/app/views/dashboard/_errata_widget.html.erb
@@ -9,7 +9,7 @@
 <% if errata.empty? %>
   <p class="ca"><%= _("There are no errata that need to be applied to registered content hosts.") %></p>
 <% else %>
-  <table class="table table-striped ellipsis">
+  <table class="table table-fixed table-striped">
     <thead>
       <tr>
         <th>Type</th>

--- a/app/views/dashboard/_host_collection_widget.html.erb
+++ b/app/views/dashboard/_host_collection_widget.html.erb
@@ -9,7 +9,7 @@
 <% if host_collections.empty? %>
   <p class="ca"><%= _("No host collections found.") %></p>
 <% else %>
-  <table class="table table-striped ellipsis table-bordered">
+  <table class="table table-fixed table-striped table-bordered">
     <thead>
       <tr>
         <th>Updates</th>
@@ -29,7 +29,7 @@
               <a href="/host_collections/<%= host_collection.id %>/actions" style="text-align: center"><i class="label label-success">&nbsp;</i></a>
             <% end %>
           </td>
-          <td><%= host_collection.name %></td>
+          <td class='ellipsis'><%= host_collection.name %></td>
           <td style="text-align: right"><%= host_collection.hosts.length %></td>
         </tr>
       <% end %>

--- a/app/views/dashboard/_subscription_status_widget.html.erb
+++ b/app/views/dashboard/_subscription_status_widget.html.erb
@@ -8,7 +8,7 @@
 <% total_expiring_subscriptions = Katello::Pool.expiring_soon(subscriptions).count %>
 <% total_recently_expired_subscriptions = Katello::Pool.recently_expired(subscriptions).count %>
 
-<table class="table table-striped ellipsis table-bordered">
+<table class="table table-fixed table-striped table-bordered">
   <thead>
     <tr>
       <th>Subscription Status</th>

--- a/app/views/dashboard/_subscription_widget.html.erb
+++ b/app/views/dashboard/_subscription_widget.html.erb
@@ -9,7 +9,7 @@
 <% valid_consumer_count = owner_infos.map(&:total_valid_compliance_consumers).reduce(:+) %>
 <% total_count = owner_infos.map(&:total_consumers).reduce(:+) %>
 
-<table class="table table-striped ellipsis table-bordered">
+<table class="table table-fixed table-striped table-bordered">
   <thead>
     <tr>
       <th></th>

--- a/app/views/dashboard/_sync_widget.html.erb
+++ b/app/views/dashboard/_sync_widget.html.erb
@@ -11,7 +11,7 @@
 <% if products.empty? %>
   <p class="ca"><%= _("No recently synced products") %></p>
 <% else %>
-  <table class="table table-striped ellipsis table-bordered">
+  <table class="table table-fixed table-striped table-bordered">
     <thead>
       <tr>
         <th>Product</th>
@@ -22,7 +22,7 @@
     <tbody>
       <% products.each do |product| %>
         <tr>
-          <td><%= product.name %></td>
+          <td class='ellipsis'><%= product.name %></td>
           <td><%= product.sync_status[:state] %></td>
           <td><%= product.sync_status[:finish_time] %></td>
         </tr>


### PR DESCRIPTION
Prior to this commit, hovering on one of the katello widgets would
show all content of the widget.  This was due to 'ellipsis' being
applied to the table vs the cell.

This commit will move the 'ellipsis' to those cells where we may
have really long strings (e.g. names).  In addition, it adds the
'table-fixed' class for consistency and to ensure that 'ellipsis'
are used, when needed.