### PR TITLE
fixes #14192 - activation key - update to reflect the move from systems to subscription_facets

### DIFF
--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -41,9 +41,9 @@ module Katello
           record.errors[attr] << _("cannot be nil")
         elsif value <= 0
           record.errors[attr] << _("cannot be less than one")
-        elsif value < record.systems.length
+        elsif value < record.subscription_facets.length
           # we don't let users to set usage limit lower than current in-use
-          record.errors[attr] << _("cannot be lower than current usage count (%s)" % record.systems.length)
+          record.errors[attr] << _("cannot be lower than current usage count (%s)" % record.subscription_facets.length)
         end
       end
     end
@@ -67,7 +67,7 @@ module Katello
     end
 
     def usage_count
-      system_activation_keys.count
+      subscription_facet_activation_keys.count
     end
 
     def related_resources
@@ -112,16 +112,6 @@ module Katello
 
     def valid_content_label?(content_label)
       self.available_content.map(&:content).any? { |content| content.label == content_label }
-    end
-
-    # sets up system when registering with this activation key - must be executed in a transaction
-    def apply_to_system(system)
-      if !max_content_hosts.nil? && !self.unlimited_content_hosts && usage_count >= max_content_hosts
-        fail Errors::MaxContentHostsReachedException, _("Max Content Hosts (%{limit}) reached for activation key '%{name}'") % {:limit => max_content_hosts, :name => name}
-      end
-      system.environment_id = self.environment_id if self.environment_id
-      system.content_view_id = self.content_view_id if self.content_view_id
-      system.system_activation_keys.build(:activation_key => self)
     end
 
     def calculate_consumption(product, pools, _allocate)

--- a/spec/models/activation_key_spec.rb
+++ b/spec/models/activation_key_spec.rb
@@ -106,44 +106,5 @@ module Katello
         ActivationKey.find(@akey.id).host_collections.must_include @host_collection
       end
     end
-
-    describe "#apply_to_system" do
-      before(:each) do
-        Katello.pulp_server.extensions.consumer.stubs(:create).returns(:id => "1234")
-        Resources::Candlepin::Consumer.stubs(:create).returns(:uuid => "1234", :owner => {:key => "1234"})
-        @content_view = katello_content_views(:library_dev_view)
-        @system = System.new(:name => "test", :cp_type => "system", :content_view_id => @content_view.id, :facts => {"distribution.name" => "Fedora"})
-        @system2 = System.new(:name => "test2", :cp_type => "system", :facts => {"distribution.name" => "Fedora"})
-        @akey_limit1 = ActivationKey.create(:name => "max_content_hosts_key1", :max_content_hosts => 1, :unlimited_content_hosts => false,
-                                            :organization => @organization, :environment => @environment_1)
-      end
-
-      it "assignes environment to the system" do
-        @akey.apply_to_system(@system)
-        @system.environment.must_equal @akey.environment
-      end
-
-      it "creates an association between the activation key and the system" do
-        @akey.apply_to_system(@system)
-        @system.save!
-        @system.activation_keys.must_include(@akey)
-      end
-
-      it "apply once for limit 1" do
-        @akey_limit1.apply_to_system(@system)
-        @system.save!
-        @system.activation_keys.must_include(@akey_limit1)
-      end
-
-      it "not apply twice for limit 1" do
-        @akey_limit1.apply_to_system(@system)
-        @system.save!
-        @system.activation_keys.must_include(@akey_limit1)
-        apply_limit = lambda do
-          @akey_limit1.apply_to_system(@system2)
-        end
-        apply_limit.must_raise Katello::Errors::MaxContentHostsReachedException
-      end
-    end
   end
 end

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -117,9 +117,9 @@ module Katello
     end
 
     def test_update_limit_below_consumed
-      content_host1 = System.find(katello_systems(:simple_server))
-      content_host2 = System.find(katello_systems(:simple_server2))
-      @activation_key.system_ids = [content_host1.id, content_host2.id]
+      subscription_facet1 = Host::SubscriptionFacet.find(katello_subscription_facets(:one))
+      subscription_facet2 = Host::SubscriptionFacet.find(katello_subscription_facets(:two))
+      @activation_key.subscription_facet_ids = [subscription_facet1.id, subscription_facet2.id]
 
       results = JSON.parse(put(:update, :id => @activation_key.id, :organization_id => @organization.id,
                                :activation_key => {:max_content_hosts => 1}).body)

--- a/test/fixtures/models/katello_subscription_facets.yml
+++ b/test/fixtures/models/katello_subscription_facets.yml
@@ -1,0 +1,5 @@
+one:
+  host_id:  <%= ActiveRecord::FixtureSet.identify(:one) %>
+
+two:
+  host_id:  <%= ActiveRecord::FixtureSet.identify(:two) %>

--- a/test/models/activation_key_test.rb
+++ b/test/models/activation_key_test.rb
@@ -111,5 +111,19 @@ module Katello
       @dev_key.stubs(:available_content).returns([OpenStruct.new(:content => OpenStruct.new(:label => 'some-label'))])
       assert @dev_key.valid_content_label?('some-label')
     end
+
+    def test_max_hosts_not_exceeded
+      @dev_key.unlimited_content_hosts = false
+      @dev_key.max_content_hosts = 1
+      @dev_key.stubs(:subscription_facets).returns(['host one', 'host two'])
+      refute @dev_key.valid?
+    end
+
+    def test_max_hosts_exceeded
+      @dev_key.unlimited_content_hosts = false
+      @dev_key.max_content_hosts = 10
+      @dev_key.stubs(:subscription_facets).returns(['host one', 'host two'])
+      assert @dev_key.valid?
+    end
   end
 end

--- a/test/support/fixtures_support.rb
+++ b/test/support/fixtures_support.rb
@@ -36,6 +36,7 @@ module Katello
       :katello_rpms => Katello::Rpm,
       :katello_repository_rpms => Katello::RepositoryRpm,
       :katello_content_facets => Katello::Host::ContentFacet,
+      :katello_subscription_facets => Katello::Host::SubscriptionFacet,
       :katello_system_activation_keys => Katello::SystemActivationKey
     }
 


### PR DESCRIPTION
This commit contains 2 small changes that are needed now that the
systems/system_activation_keys relation has been replaced with
subscription_facets/subscription_facet_activation_keys.

Note: the defunct relation will be removed with a later commit