### PR TITLE
Fixes #14196 - convert system destroy host-based destroy

### DIFF
--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -35,6 +35,14 @@ module Katello
       respond_for_index :collection => collection
     end
 
+    api :DELETE, "/hosts/:host_id/subscriptions/", N_("Unregister the host as a subscription consumer")
+    param :host_id, Integer, :desc => N_("Id of the host"), :required => true
+    def destroy
+      sync_task(::Actions::Katello::Host::Unregister, @host)
+      @host.reload
+      respond_for_destroy(:resource => @host)
+    end
+
     api :PUT, "/hosts/:host_id/subscriptions/remove_subscriptions"
     param :host_id, Integer, :desc => N_("Id of the host"), :required => true
     param :subscriptions, Array, :desc => N_("Array of subscriptions to remove") do

--- a/app/controllers/katello/api/v2/systems_controller.rb
+++ b/app/controllers/katello/api/v2/systems_controller.rb
@@ -7,7 +7,7 @@ module Katello
 
     skip_before_filter :set_default_response_format, :only => :report
 
-    before_filter :find_system, :only => [:destroy, :show, :update, :enabled_repos, :releases, :tasks,
+    before_filter :find_system, :only => [:show, :update, :enabled_repos, :releases, :tasks,
                                           :content_override, :product_content]
     before_filter :find_environment, :only => [:index, :report]
     before_filter :find_optional_organization, :only => [:create, :index, :report]
@@ -109,13 +109,6 @@ module Katello
     param :id, String, :desc => N_("UUID of the content host"), :required => true
     def show
       respond
-    end
-
-    api :DELETE, "/systems/:id", N_("Unregister a content host"), :deprecated => true
-    param :id, String, :desc => N_("UUID of the content host"), :required => true
-    def destroy
-      sync_task(::Actions::Katello::System::Destroy, @system, :unregistering => true)
-      respond :message => _("Deleted content host '%s'") % params[:id], :status => 204
     end
 
     api :GET, "/systems/:id/releases", N_("Show releases available for the content host"), :deprecated => true

--- a/config/routes/overrides.rb
+++ b/config/routes/overrides.rb
@@ -85,6 +85,7 @@ Foreman::Application.routes.draw do
               put :content_override
               put :remove_subscriptions
               put :add_subscriptions
+              delete :destroy
             end
           end
         end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
@@ -75,14 +75,6 @@ angular.module('Bastion.content-hosts').controller('ContentHostsController',
 
         $scope.table = $scope.contentHostTable;
 
-        $scope.unregisterContentHost = function (contentHost) {
-            contentHost.$remove(function () {
-                $scope.removeRow(contentHost.id);
-                $scope.successMessages.push(translate('Content Host %s has been deleted.').replace('%s', contentHost.name));
-                $scope.transitionTo('content-hosts.index');
-            });
-        };
-
         $scope.reloadSearch = function (search) {
             $scope.table.search(search);
             $state.go('content-hosts.index');

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-details.html
@@ -13,19 +13,41 @@
       <h2 class="fl" translate>Content Host {{ host.name }}</h2>
 
       <div class="fr">
-
-        <div bst-modal="unregisterContentHost(host)" model="host" >
+        <div bst-modal="unregisterContentHost(host)" model="host">
           <div data-block="modal-header" translate>
-            Unregister Content Host "{{ host.name }}"?
+            Unregister Host "{{host.name}}"?
           </div>
-          <div data-block="modal-body" translate>
-            Are you sure you want to unregister content host "{{ host.name }}"?
+          <div data-block="modal-body">
+            <p translate>
+              Unregister Options:
+            </p>
+
+            <p ng-show="host.hasSubscription()">
+              <label>
+                <input name="delete"
+                       ng-model="host.unregisterDelete"
+                       ng-value="false"
+                       type="radio" />
+                Unregister the host as a subscription consumer.  Provisioning and configuration information is preserved.
+              </label>
+            </p>
+            <p>
+              <label>
+                <input name="delete"
+                       ng-model="host.unregisterDelete"
+                       ng-value="true"
+                       type="radio" />
+                Completely deletes the host record and removes all reporting, provisioning, and configuration information.
+              </label>
+            </p>
           </div>
-      </div>
+        </div>
 
         <button class="btn btn-default"
+                ng-disabled="host.deleting"
                 ng-hide="denied('destroy_hosts', host)"
-                ng-click="openModal()" translate>Unregister Content Host</button>
+                ng-click="openModal()" translate>Unregister Host</button>
+
         <button class="btn btn-default" ui-sref="content-hosts.index">
           <i class="fa fa-remove"></i>
           {{ "Close" | translate }}

--- a/engines/bastion_katello/test/content-hosts/content-hosts.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content-hosts.controller.test.js
@@ -37,22 +37,4 @@ describe('Controller: ContentHostsController', function() {
         $scope.contentHostTable.closeItem();
         expect($scope.transitionTo).toHaveBeenCalledWith('content-hosts.index');
     });
-
-    it("provides a way to unregister content hosts.", function() {
-        var testContentHost = {
-            uuid: 'abcde',
-            name: 'test',
-            $remove: function(callback) {
-                callback();
-            }
-        };
-
-        spyOn($scope, "transitionTo");
-
-        $scope.unregisterContentHost(testContentHost);
-
-        expect($scope.transitionTo).toHaveBeenCalledWith('content-hosts.index');
-        expect($scope.successMessages[0]).toBe('Content Host test has been deleted.');
-
-    });
 });

--- a/test/controllers/api/v2/host_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/host_subscriptions_controller_test.rb
@@ -176,5 +176,12 @@ module Katello
 
       assert_response 400
     end
+
+    def test_destroy
+      assert_sync_task(::Actions::Katello::Host::Unregister, @host)
+      delete :destroy, :host_id => @host.id
+
+      assert_response :success
+    end
   end
 end


### PR DESCRIPTION
This commits does a few different things:
* removes the systems destroy api
* adds a host subscription destroy to provide a way to unsubscribe a host from the ui
* changes the Ui to give the user a choice (if available) to unsubscribe the host or
    delete the host entirely