### PR TITLE
Fixes #13120 - Modal headers and bodys display properly.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-details.html
@@ -31,7 +31,7 @@
           {{ "Close" | translate }}
         </button>
 
-        <div bst-modal="removeActivationKey(activationKey)">
+        <div bst-modal="removeActivationKey(activationKey)" model="activationKey">
           <div data-block="modal-header" translate>Remove Activation Key "{{ activationKey.name }}"?</div>
           <div data-block="modal-body" translate>Are you sure you want to remove Activation Key "{{ activationKey.name }}"?</div>
         </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
@@ -50,7 +50,7 @@
 
     <span data-block="actions" bst-feature-flag="remote_actions">
 
-        <div bst-modal="applySelected()">
+        <div bst-modal="applySelected()" model="host">
           <div data-block="modal-header" translate>Apply Errata to Content Host "{{host.name}}"?</div>
           <div data-block="modal-body" translate>Are you sure you want to apply Errata to content host "{{ host.name }}"?</div>
           <div data-block="modal-confirm-button" translate>Apply</div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-details.html
@@ -10,21 +10,21 @@
 
   <div ng-hide="panel.error">
     <header class="details-header">
-      <h2 class="fl" translate>Content Host {{ contentHost.name }}</h2>
+      <h2 class="fl" translate>Content Host {{ host.name }}</h2>
 
       <div class="fr">
 
-        <div bst-modal="unregisterContentHost(contentHost)">
+        <div bst-modal="unregisterContentHost(host)" model="host" >
           <div data-block="modal-header" translate>
-            Unregister Content Host "{{contentHost.name}}"?
+            Unregister Content Host "{{ host.name }}"?
           </div>
           <div data-block="modal-body" translate>
-            Are you sure you want to unregister content host "{{ contentHost.name }}"?
+            Are you sure you want to unregister content host "{{ host.name }}"?
           </div>
       </div>
 
         <button class="btn btn-default"
-                ng-hide="denied('destroy_hosts', contentHost)"
+                ng-hide="denied('destroy_hosts', host)"
                 ng-click="openModal()" translate>Unregister Content Host</button>
         <button class="btn btn-default" ui-sref="content-hosts.index">
           <i class="fa fa-remove"></i>
@@ -97,7 +97,7 @@
             Product Content
           </a>
         </li>
-        <li ng-repeat="menuItem in menuExpander.getMenu('contentHost')">
+        <li ng-repeat="menuItem in menuExpander.getMenu('host')">
           <a href="{{ menuItem.url }}">
             {{ menuItem.label }}
           </a>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-promotion.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-promotion.html
@@ -40,7 +40,7 @@
       Cancel
     </a>
 
-    <div bst-modal="promote()">
+    <div bst-modal="promote()" model="selectedEnvironment" model="selectedEnvironment">
       <div data-block="modal-header" translate>Force Promote?</div>
       <div data-block="modal-body" translate>Promote version to {{ selectedEnvironment.name }}?<br /><br />{{ suggestedEnvironmentMessage() }}</div>
       <div data-block="modal-confirm-button" translate>Promote</div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/details/views/gpg-key-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/details/views/gpg-key-details.html
@@ -20,7 +20,7 @@
           <span translate>Close</span>
         </button>
 
-        <div bst-modal="removeGPGKey(gpgKey)">
+        <div bst-modal="removeGPGKey(gpgKey)" model="gpgKey">
           <div data-block="modal-header" translate>Remove GPG Key {{ gpgKey.name }}</div>
           <div data-block="modal-body" translate>Are you sure you want to remove GPG key {{ gpgKey.name }}?</div>
         </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-details.html
@@ -32,7 +32,7 @@
           {{ "Close" | translate }}
         </button>
 
-        <div bst-modal="removeHostCollection(hostCollection)">
+        <div bst-modal="removeHostCollection(hostCollection)" model="hostCollection">
           <div data-block="modal-header" translate>Remove Host Collection "{{ hostCollection.name }}"?</div>
           <div data-block="modal-body" translate>Are you sure you want to remove Host Collection "{{ hostCollection.name }}"?</div>
         </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/views/bulk-actions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/views/bulk-actions.html
@@ -24,9 +24,19 @@
         {{ "Close" | translate }}
       </button>
 
-      <div bst-modal="removeProducts()">
-        <div data-block="modal-header" translate>Remove {{ productTable.getSelected().length }} Products?</div>
-        <div data-block="modal-body" translate>Are you sure you want to remove the {{ productTable.getSelected().length }} products(s) selected?</div>
+      <div bst-modal="removeProducts()" model="productTable">
+        <div data-block="modal-header" 
+             translate
+             translate-n="productTable.getSelected().length"
+             translate-plural="Remove {{ productTable.getSelected().length }} products?">
+             Remove product?
+        </div>
+        <div data-block="modal-body" 
+             translate
+             translate-n="productTable.getSelected().length" 
+             translate-plural="Are you sure you want to remove {{ productTable.getSelected().length }} products selected?"> 
+             Are you sure you want to remove {{ productTable.getSelected()[0].name }}?
+        </div>
       </div>
     </div>
   </header>
@@ -57,6 +67,7 @@
     <div class="alert warning alert-warning" ng-show="table.numSelected == 0">
       <i class="fa fa-exclamation-sign"></i>
       {{ 'At least one product needs to be selected in order to perform a bulk action.' | translate }}
+      {{ products.length }}
     </div>
 
     <span ng-hide="table.numSelected == 0">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-details.html
@@ -14,7 +14,7 @@
 
       <div class="fr">
 
-        <div bst-modal="removeProduct(product)">
+        <div bst-modal="removeProduct(product)" model="product">
           <div data-block="modal-header" translate>Remove Product "{{ product.name }}"?</div>
           <div data-block="modal-body" translate>Are you sure you want to remove product "{{ product.name }}"?</div>
         </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-repositories.html
@@ -23,9 +23,19 @@
     </div>
 
     <div data-block="actions">
-      <div bst-modal="removeSelectedRepositories()">
-        <div data-block="modal-header" translate>Remove {{ detailsTable.numSelected  }} Repositories?</div>
-        <div data-block="modal-body" translate>Are you sure you want to remove the {{ detailsTable.numSelected }} repositories selected?</div>
+      <div bst-modal="removeSelectedRepositories()" model="detailsTable">
+        <div data-block="modal-header" 
+             translate 
+             translate-n="detailsTable.numSelected" 
+             translate-plural="Remove {{ detailsTable.numSelected }} repostories?">
+          Remove repository?
+        </div>
+        <div data-block="modal-body" 
+             translate 
+             translate-n="detailsTable.numSelected" 
+             translate-plural="Remove {{ detailsTable.numSelected }} repostories?">
+             Are you sure you want to remove {{ detailsTable.getSelected()[0].name }}?
+        </div>
       </div>
 
       <span ng-switch="getRepositoriesNonDeletableReason(product)" bst-feature-flag="custom_products">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-info.html
@@ -46,7 +46,7 @@
         <span translate>Sync Now</span>
       </button>
 
-      <div bst-modal="removeRepository(repository)">
+      <div bst-modal="removeRepository(repository)" model="repository">
         <div data-block="modal-header" translate>Remove Repository "{{ repository.name }}"?</div>
         <div data-block="modal-body" translate>Are you sure you want to remove repository "{{ repository.name }}"?</div>
       </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-manage-docker-manifests.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-manage-docker-manifests.html
@@ -26,13 +26,15 @@
   </div>
 
   <div data-block="actions">
-    <div bst-modal="removeContent()">
+    <div bst-modal="removeContent()" model="detailsTable">
       <div data-block="modal-header"
+           translate
            translate-n="detailsTable.numSelected"
            translate-plural="Remove {{ detailsTable.numSelected  }} Docker Manifests?">
         Remove {{ detailsTable.numSelected  }} Docker Manifest?
       </div>
       <div data-block="modal-body"
+           translate
            translate-n="detailsTable.numSelected"
            translate-plural="Are you sure you want to remove the {{ detailsTable.numSelected }} Docker manifests selected?">
         Are you sure you want to remove the {{ detailsTable.numSelected }} Docker manifest selected?

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-manage-packages.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-manage-packages.html
@@ -11,7 +11,7 @@
 
   <div data-block="messages">
     <div bst-alerts success-messages="successMessages" error-messages="errorMessages"></div>
-
+ 
     <div bst-alert="success" ng-hide="generationTaskId === undefined">
       <button type="button" class="close" ng-click="clearTaskId()">&times;</button>
       <p translate>
@@ -25,16 +25,18 @@
   </div>
 
   <div data-block="actions">
-    <div bst-modal="removeContent()">
+    <div bst-modal="removeContent()" model="detailsTable">
       <div data-block="modal-header"
+           translate
            translate-n="detailsTable.numSelected"
-           translate-plural="Remove {{ detailsTable.numSelected  }} Packages?">
-        Remove {{ detailsTable.numSelected  }} Package?
+           translate-plural="Remove {{ detailsTable.numSelected }} packages?">
+        Remove Package?
       </div>
       <div data-block="modal-body"
+           translate
            translate-n="detailsTable.numSelected"
            translate-plural="Are you sure you want to remove the {{ detailsTable.numSelected }} packages selected?">
-        Are you sure you want to remove the {{ detailsTable.numSelected }} package selected?
+        Are you sure you want to remove the {{ detailsTable.getSelected()[0].name }}?
       </div>
     </div>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-manage-puppet-modules.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-manage-puppet-modules.html
@@ -26,16 +26,18 @@
   </div>
 
   <div data-block="actions">
-    <div bst-modal="removeContent()">
+    <div bst-modal="removeContent()" model="detailsTable">
       <div data-block="modal-header"
+           translate
            translate-n="detailsTable.numSelected"
            translate-plural="Remove {{ detailsTable.numSelected  }} Puppet Modules?">
-        Remove {{ detailsTable.numSelected  }} Puppet Module?
+        Remove Puppet Module?
       </div>
       <div data-block="modal-body"
+           translate
            translate-n="detailsTable.numSelected"
            translate-plural="Are you sure you want to remove the {{ detailsTable.numSelected }} Puppet modules selected?">
-        Are you sure you want to remove the {{ detailsTable.numSelected }} Puppet module selected?
+        Are you sure you want to remove the {{ detailsTable.getSelected()[0].name }}?
       </div>
     </div>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/views/sync-plan-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/views/sync-plan-details.html
@@ -14,7 +14,7 @@
       <h2 class="fl" translate>Sync Plan {{ syncPlan.name }}</h2>
 
       <div class="fr">
-        <div bst-modal="removeSyncPlan(syncPlan)">
+        <div bst-modal="removeSyncPlan(syncPlan)" model="syncPlan">
           <div data-block="modal-header" translate>Remove Sync Plan "{{ syncPlan.name }}"?</div>
           <div data-block="modal-body" translate>Are you sure you want to remove Sync Plan "{{ syncPlan.name }}"?</div>
         </div>


### PR DESCRIPTION
This change is meant to fix many of the modals. Right now they do not properly display any text provided from an interpolated object. 

This is an example of what these looked like before the change:
![before1](https://cloud.githubusercontent.com/assets/8502976/13784020/0c3164ec-eaa4-11e5-93d6-2c916f675583.png)

This is an example of after:
![after1](https://cloud.githubusercontent.com/assets/8502976/13784008/002aed4e-eaa4-11e5-9073-57dbf0541d32.png)

I also noticed that pluralization was not working properly in the modals, so I fixed that as well.

Here is what they looked like before this:
![before2](https://cloud.githubusercontent.com/assets/8502976/13784024/0e8c5468-eaa4-11e5-814e-85b778f6bd58.png)

Here is what they look like now:
![after2](https://cloud.githubusercontent.com/assets/8502976/13784032/12267c34-eaa4-11e5-9b2c-06dd9000160a.png)