### PR TITLE
Fixes #14222 - Hide Non Displayable Repos from CDN repos

### DIFF
--- a/app/controllers/katello/api/v2/repository_sets_controller.rb
+++ b/app/controllers/katello/api/v2/repository_sets_controller.rb
@@ -15,7 +15,7 @@ module Katello
     param :name, String, :required => false, :desc => N_("Repository set name to search on")
     def index
       collection = {}
-      collection[:results] = @product.productContent
+      collection[:results] = @product.displayable_product_contents
       # filter on name if it is provided
       collection[:results] = collection[:results].select { |pc| pc.content.name == params[:name] } if params[:name]
       collection[:subtotal] = collection[:results].size

--- a/app/helpers/katello/providers_helper.rb
+++ b/app/helpers/katello/providers_helper.rb
@@ -11,7 +11,6 @@ module Katello
         {:id => :debug, :name => _('Debug RPMs'), :products => {}},
         {:id => :beta, :name => _('Beta'), :products => {}},
         {:id => :isos, :name => _('ISOs'), :products => {}},
-        {:id => :docker_manifests, :name => _('Docker Manifests'), :products => {}},
         {:id => :ostree, :name => _('OSTree'), :products => {}},
         {:id => :other, :name => _('Other'), :products => {}}
       ]
@@ -22,11 +21,9 @@ module Katello
       redhat_repo_tabs.each { |tab| tabs[tab[:id]] = tab }
 
       provider.products.each do |product|
-        product.productContent.each do |prod_content|
+        product.displayable_product_contents.each do |prod_content|
           name = prod_content.content.name
-          if prod_content.content.type == ::Katello::Repository::CANDLEPIN_DOCKER_TYPE
-            key = :docker_manifests
-          elsif prod_content.content.type == ::Katello::Repository::CANDLEPIN_OSTREE_TYPE
+          if prod_content.content_type == ::Katello::Repository::CANDLEPIN_OSTREE_TYPE
             key = :ostree
           elsif name.include?(" Beta ")
             key = :beta

--- a/app/models/katello/candlepin/product_content.rb
+++ b/app/models/katello/candlepin/product_content.rb
@@ -34,5 +34,20 @@ module Katello
       override = activation_key.content_overrides.find { |pc| pc[:contentLabel] == content.label }
       override.nil? ? 'default' : override[:value]
     end
+
+    def content_type
+      self.content.type
+    end
+
+    def displayable?
+      case content_type
+      when ::Katello::Repository::CANDLEPIN_DOCKER_TYPE
+        false
+      when ::Katello::Repository::CANDLEPIN_OSTREE_TYPE
+        ::Katello::RepositoryTypeManager.enabled?(Repository::OSTREE_TYPE)
+      else
+        true
+      end
+    end
   end
 end

--- a/app/models/katello/glue/candlepin/product.rb
+++ b/app/models/katello/glue/candlepin/product.rb
@@ -65,6 +65,10 @@ module Katello
         super
       end
 
+      def displayable_product_contents
+        self.productContent.select(&:displayable?)
+      end
+
       def orphaned?
         self.provider.redhat_provider? && self.certificate.nil?
       end

--- a/app/services/katello/repository_type_manager.rb
+++ b/app/services/katello/repository_type_manager.rb
@@ -28,6 +28,10 @@ module Katello
       def find(repository_type)
         repository_types[repository_type.to_s]
       end
+
+      def enabled?(repository_type)
+        find(repository_type).present?
+      end
     end
   end
 end


### PR DESCRIPTION
CDN doesn't enforce Docker entitlements, so no point showing it in the UI