### PR TITLE
Fixes #10177 - Sync details can be edited properly.

### DIFF
--- a/app/models/katello/sync_plan.rb
+++ b/app/models/katello/sync_plan.rb
@@ -53,6 +53,11 @@ module Katello
       date_obj.strftime('%I:%M %p')
     end
 
+    def plan_date_time(localtime = true)
+      date_obj = localtime ? self.zone_converted : self.sync_date
+      date_obj.strftime('%m/%d/%Y %I:%M:%p')
+    end
+
     def schedule_format
       if (self.interval != DURATION[self.interval])
         format = self.sync_date.iso8601 << "/P" << DURATION[self.interval]

--- a/app/views/katello/api/v2/sync_plans/show.json.rabl
+++ b/app/views/katello/api/v2/sync_plans/show.json.rabl
@@ -2,7 +2,7 @@ object @resource
 
 attributes :id, :organization_id
 attributes :name, :description
-attributes :sync_date, :interval, :next_sync
+attributes :interval, :next_sync
 attributes :created_at, :updated_at
 attributes :enabled
 
@@ -25,4 +25,8 @@ node :permissions do |sync_plan|
     :edit_sync_plans => sync_plan.editable?,
     :destroy_sync_plans => sync_plan.deletable?
   }
+end
+
+node :sync_date do |sync_plan|
+  sync_plan.plan_date_time
 end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/sync-plan-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/sync-plan-details-info.controller.js
@@ -25,11 +25,15 @@ angular.module('Bastion.sync-plans').controller('SyncPlanDetailsInfoController',
             $scope.menuExpander = MenuExpander;
             $scope.panel = $scope.panel || {loading: false};
 
+            function updateSyncPlan(syncPlan) {
+                syncPlan.syncDate = syncPlan.syncTime = syncPlan['sync_date'];
+                $scope.syncPlan = syncPlan;
+            }
+
             SyncPlan.get({id: $scope.$stateParams.syncPlanId}, function (syncPlan) {
                 $scope.panel.loading = false;
 
-                syncPlan.syncDate = syncPlan.syncTime = syncPlan['sync_date'];
-                $scope.syncPlan = syncPlan;
+                updateSyncPlan(syncPlan);
             });
 
             $scope.save = function (syncPlan) {
@@ -43,6 +47,7 @@ angular.module('Bastion.sync-plans').controller('SyncPlanDetailsInfoController',
                 syncPlan['sync_date'] = syncDate.toString();
 
                 syncPlan.$update(function (response) {
+                    updateSyncPlan(syncPlan);
                     deferred.resolve(response);
                     $scope.successMessages.push(translate('Sync Plan Saved'));
                 }, function (response) {


### PR DESCRIPTION
Before if you tried to edit information on a sync plan, other than the sync date, it would  cause the sync date to become invalid making it unable to saved. To test try creating a sync plan and editing each of the features.