### PR TITLE
Fixes #13058 - Unsuccessful Errata install marked success

### DIFF
--- a/app/lib/actions/pulp/consumer/content_install.rb
+++ b/app/lib/actions/pulp/consumer/content_install.rb
@@ -20,6 +20,20 @@ module Actions
           task
         end
 
+        def finalize
+          check_error_details
+        end
+
+        def check_error_details
+          output[:pulp_tasks].each do |pulp_task|
+            error_details = pulp_task.try(:[], "result").try(:[], "details").try(:[], "rpm").try(:[], "details").try(:[], "trace")
+            error_message = pulp_task.try(:[], "result").try(:[], "details").try(:[], "rpm").try(:[], "details").try(:[], "message")
+            if error_details.include?("YumDownloadError") && error_message
+              fail _("An error occurred during the sync \n%{error_message}") % {:error_message => error_details}
+            end
+          end
+        end
+
         def presenter
           Consumer::ContentPresenter.new(self)
         end


### PR DESCRIPTION
The output for the failed task is:

```
{"pulp_tasks"=>
  [{"exception"=>nil,
    "task_type"=>nil,
    "_href"=>"/pulp/api/v2/tasks/4998baf9-4245-42ba-8e77-2fff28d31084/",
    "task_id"=>"4998baf9-4245-42ba-8e77-2fff28d31084",
    "tags"=>
     ["pulp:consumer:ac3023d2-ae5b-4070-a1ad-dedd5ecf0ff3",
      "pulp:action:unit_install"],
    "finish_time"=>"2016-03-17T15:37:03Z",
    "_ns"=>"task_status",
    "start_time"=>"2016-03-17T15:36:44Z",
    "traceback"=>nil,
    "spawned_tasks"=>[],
    "progress_report"=>
     {"steps"=>
       [["Refresh Repository Metadata", true],
        ["Downloading Packages", false]],
      "details"=>{}},
    "queue"=>"agent.dq",
    "state"=>"finished",
    "worker_name"=>"agent",
    "result"=>
     {"reboot"=>{"scheduled"=>false, "details"=>{}},
      "details"=>
       {"rpm"=>
         {"details"=>
           {"message"=>
             "[u'Errors were encountered while downloading packages.', u'walrus-5.21-1.noarch: [Errno 256] No more mirrors to try.']",
            "trace"=>
             "Traceback (most recent call last):\n\n  File \"/usr/lib/python2.7/site-packages/pulp/agent/lib/dispatcher.py\", line 61, in install\n    _report = handler.install(conduit, units, dict(options))\n\n  File \"/usr/lib/python2.7/site-packages/pulp_rpm/handlers/rpm.py\", line 100, in install\n    details = pkg.install(names)\n\n  File \"/usr/lib/python2.7/site-packages/pulp_rpm/handlers/rpmtools.py\", line 159, in install\n    yb.processTransaction()\n\n  File \"/usr/lib/python2.7/site-packages/pulp_rpm/handlers/rpmtools.py\", line 604, in processTransaction\n    YumBase.processTransaction(self, callback, rpmDisplay=display)\n\n  File \"/usr/lib/python2.7/site-packages/yum/__init__.py\", line 6473, in processTransaction\n    pkgs = self._downloadPackages(callback)\n\n  File \"/usr/lib/python2.7/site-packages/yum/__init__.py\", line 6508, in _downloadPackages\n    raise Errors.YumDownloadError, errstr\n\nYumDownloadError: [u'Errors were encountered while downloading packages.', u'walrus-5.21-1.noarch: [Errno 256] No more mirrors to try.']\n"},
          "succeeded"=>false}},
      "succeeded"=>false,
      "num_changes"=>0},
    "error"=>nil,
    "_id"=>{"$oid"=>"56eacf0c8c47e42969c505fc"},
    "id"=>"56eacf0c8c47e42969c505fc"}],
 "poll_attempts"=>{"total"=>12, "failed"=>1}}
```