### PR TITLE
Fixes #14272 - ActivationKey uses new attributes.

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -352,9 +352,9 @@ module Katello
           activation_key = organization.activation_keys.find_by(:name => ak_name)
           fail HttpErrors::NotFound, _("Couldn't find activation key '%s'") % ak_name unless activation_key
 
-          if !activation_key.unlimited_content_hosts && activation_key.usage_count >= activation_key.max_content_hosts
-            fail Errors::MaxContentHostsReachedException, _("Max Content Hosts (%{limit}) reached for activation key '%{name}'") %
-                { :limit => activation_key.max_content_hosts, :name => activation_key.name }
+          if !activation_key.unlimited_hosts && activation_key.usage_count >= activation_key.max_hosts
+            fail Errors::MaxHostsReachedException, _("Max Hosts (%{limit}) reached for activation key '%{name}'") %
+                { :limit => activation_key.max_hosts, :name => activation_key.name }
           end
           activation_key
         end

--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -33,8 +33,8 @@ module Katello
     param :environment, Hash, :desc => N_("environment")
     param :environment_id, :identifier, :desc => N_("environment id")
     param :content_view_id, :identifier, :desc => N_("content view id")
-    param :max_content_hosts, :number, :desc => N_("maximum number of registered content hosts")
-    param :unlimited_content_hosts, :bool, :desc => N_("can the activation key have unlimited content hosts")
+    param :max_hosts, :number, :desc => N_("maximum number of registered content hosts")
+    param :unlimited_hosts, :bool, :desc => N_("can the activation key have unlimited hosts")
     def create
       @activation_key = ActivationKey.new(activation_key_params) do |activation_key|
         activation_key.environment = @environment if @environment
@@ -53,8 +53,8 @@ module Katello
     param :description, String, :desc => N_("description")
     param :environment_id, :identifier, :desc => N_("environment id")
     param :content_view_id, :identifier, :desc => N_("content view id")
-    param :max_content_hosts, :number, :desc => N_("maximum number of registered content hosts")
-    param :unlimited_content_hosts, :bool, :desc => N_("can the activation key have unlimited content hosts")
+    param :max_hosts, :number, :desc => N_("maximum number of registered content hosts")
+    param :unlimited_hosts, :bool, :desc => N_("can the activation key have unlimited hosts")
     param :release_version, String, :desc => N_("content release version")
     param :service_level, String, :desc => N_("service level")
     param :auto_attach, :bool, :desc => N_("auto attach subscriptions upon registration")
@@ -302,22 +302,22 @@ module Katello
                                                           :release_version,
                                                           :service_level,
                                                           :auto_attach,
-                                                          :max_content_hosts,
-                                                          :unlimited_content_hosts,
+                                                          :max_hosts,
+                                                          :unlimited_hosts,
                                                           :content_overrides => [],
                                                           :host_collection_ids => [])
 
       key_params[:environment_id] = params[:environment][:id] if params[:environment].try(:[], :id)
       key_params[:content_view_id] = params[:content_view][:id] if params[:content_view].try(:[], :id)
-      unlimited = params[:activation_key].try(:[], :unlimited_content_hosts)
-      max_hosts = params[:activation_key].try(:[], :max_content_hosts)
+      unlimited = params[:activation_key].try(:[], :unlimited_hosts)
+      max_hosts = params[:activation_key].try(:[], :max_hosts)
 
       if unlimited && max_hosts
-        key_params[:unlimited_content_hosts] = true
-        key_params[:max_content_hosts] = nil
+        key_params[:unlimited_hosts] = true
+        key_params[:max_hosts] = nil
       else
-        key_params[:unlimited_content_hosts] = false if max_hosts
-        key_params[:max_content_hosts] = nil if unlimited
+        key_params[:unlimited_hosts] = false if max_hosts
+        key_params[:max_hosts] = nil if unlimited
       end
 
       key_params

--- a/app/lib/actions/katello/host/register.rb
+++ b/app/lib/actions/katello/host/register.rb
@@ -77,7 +77,7 @@ module Actions
             if !host_collection.unlimited_hosts && host_collection.max_hosts >= 0 &&
                host_collection.systems.length >= host_collection.max_hosts
               fail _("Host collection '%{name}' exceeds maximum usage limit of '%{limit}'") %
-                       {:limit => host_collection.max_content_hosts, :name => host_collection.name}
+                       {:limit => host_collection.max_hosts, :name => host_collection.name}
             end
           end
           host.host_collection_ids = host_collection_ids

--- a/app/lib/katello/api/v2/error_handling.rb
+++ b/app/lib/katello/api/v2/error_handling.rb
@@ -19,7 +19,7 @@ module Katello
           rescue_from Errors::SecurityViolation, :with => :rescue_from_security_violation
           rescue_from Errors::ConflictException, :with => :rescue_from_conflict_exception
           rescue_from Errors::UnsupportedActionException, :with => :rescue_from_unsupported_action_exception
-          rescue_from Errors::MaxContentHostsReachedException, :with => :rescue_from_max_content_hosts_reached_exception
+          rescue_from Errors::MaxHostsReachedException, :with => :rescue_from_max_hosts_reached_exception
           rescue_from Errors::CdnSubstitutionError, :with => :rescue_from_bad_data
           rescue_from ActionController::ParameterMissing, :with => :rescue_from_missing_param
         end
@@ -79,7 +79,7 @@ module Katello
           respond_for_exception(exception, :status => :unprocessable_entity)
         end
 
-        def rescue_from_max_content_hosts_reached_exception(exception)
+        def rescue_from_max_hosts_reached_exception(exception)
           respond_for_exception(exception, :status => :conflict, :with_logging => false)
         end
 

--- a/app/lib/katello/errors.rb
+++ b/app/lib/katello/errors.rb
@@ -37,7 +37,7 @@ module Katello
 
     class ConnectionRefusedException < StandardError; end
 
-    class MaxContentHostsReachedException < StandardError; end
+    class MaxHostsReachedException < StandardError; end
 
     class OrganizationDestroyException < StandardError; end
 

--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -30,11 +30,11 @@ module Katello
     validates :name, :presence => true
     validates :name, :uniqueness => {:scope => :organization_id}
     validate :environment_exists
-    validates :max_content_hosts, :numericality => {:less_than => 2**31, :allow_nil => true}
-    validates_each :max_content_hosts do |record, attr, value|
-      if record.unlimited_content_hosts
+    validates :max_hosts, :numericality => {:less_than => 2**31, :allow_nil => true}
+    validates_each :max_hosts do |record, attr, value|
+      if record.unlimited_hosts
         unless value.nil?
-          record.errors[attr] << _("cannot be set because unlimited content hosts is set")
+          record.errors[attr] << _("cannot be set because unlimited hosts is set")
         end
       else
         if value.nil?
@@ -178,7 +178,7 @@ module Katello
     def copy(new_name)
       new_key = ActivationKey.new
       new_key.name = new_name
-      new_key.attributes = self.attributes.slice("description", "environment_id", "organization_id", "content_view_id", "max_content_hosts", "unlimited_content_hosts")
+      new_key.attributes = self.attributes.slice("description", "environment_id", "organization_id", "content_view_id", "max_hosts", "unlimited_hosts")
       new_key.host_collection_ids = self.host_collection_ids
       new_key
     end

--- a/app/views/katello/api/v2/activation_keys/show.json.rabl
+++ b/app/views/katello/api/v2/activation_keys/show.json.rabl
@@ -1,6 +1,6 @@
 object @resource
 
-attributes :id, :name, :description, :unlimited_content_hosts, :auto_attach
+attributes :id, :name, :description, :unlimited_hosts, :auto_attach
 
 extends 'katello/api/v2/common/org_reference'
 
@@ -15,7 +15,7 @@ child :environment => :environment do
 end
 attributes :environment_id
 
-attributes :usage_count, :user_id, :max_content_hosts, :system_template_id, :release_version,
+attributes :usage_count, :user_id, :max_hosts, :system_template_id, :release_version,
            :service_level, :auto_attach
 
 child :products => :products do |_product|

--- a/db/migrate/20160317171813_change_activation_key_column_names.rb
+++ b/db/migrate/20160317171813_change_activation_key_column_names.rb
@@ -1,0 +1,11 @@
+class ChangeActivationKeyColumnNames < ActiveRecord::Migration
+  def self.up
+    rename_column :katello_activation_keys, :max_content_hosts, :max_hosts
+    rename_column :katello_activation_keys, :unlimited_content_hosts, :unlimited_hosts
+  end
+
+  def self.down
+    rename_column :katello_activation_keys, :max_hosts, :max_content_hosts
+    rename_column :katello_activation_keys, :unlimited_hosts, :unlimited_content_hosts
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/activationKeyConsumed.filter.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/activationKeyConsumed.filter.js
@@ -6,7 +6,7 @@ angular.module('Bastion.activation-keys').filter('activationKeyConsumedFilter',
     ['$filter', 'translate',
     function ($filter, translate) {
         return function (activationKey) {
-            var quantity = $filter('unlimitedFilter')(activationKey['max_content_hosts'], activationKey['unlimited_content_hosts']);
+            var quantity = $filter('unlimitedFilter')(activationKey['max_hosts'], activationKey['unlimited_hosts']);
             return translate('%(consumed)s out of %(quantity)s')
                 .replace('%(consumed)s', activationKey['usage_count'])
                 .replace('%(quantity)s', quantity);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-info.html
@@ -36,9 +36,9 @@
         <span class="info-label" translate>Host Limit</span>
 
         <span class="info-value"
-              bst-edit-custom="activationKey.max_content_hosts"
+              bst-edit-custom="activationKey.max_hosts"
               formatter="unlimitedFilter"
-              formatter-options="activationKey.unlimited_content_hosts"
+              formatter-options="activationKey.unlimited_hosts"
               readonly="denied('edit_activation_keys', activationKey)"
               on-save="save(activationKey)">
 
@@ -47,17 +47,17 @@
               <span translate>
                 Unlimited Content Hosts:
               </span>
-              <input type='checkbox' ng-model="activationKey.unlimited_content_hosts"/>
+              <input type='checkbox' ng-model="activationKey.unlimited_hosts"/>
             </div>
-            <div ng-hide="activationKey.unlimited_content_hosts" >
+            <div ng-hide="activationKey.unlimited_hosts" >
               <span translate>
                 Limit:
               </span>
-              <input ng-model="activationKey.max_content_hosts"
-                     name="max_content_hosts"
+              <input ng-model="activationKey.max_hosts"
+                     name="max_hosts"
                      type="number"
                      min="1"
-                     ng-required="!activationKey.unlimited_content_hosts"
+                     ng-required="!activationKey.unlimited_hosts"
                      tabindex="2"/>
             </div>
           </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/new/new-activation-key.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/new/new-activation-key.controller.js
@@ -31,7 +31,7 @@ angular.module('Bastion.activation-keys').controller('NewActivationKeyController
         }
 
         $scope.activationKey = $scope.activationKey || new ActivationKey();
-        $scope.activationKey['unlimited_content_hosts'] = true;
+        $scope.activationKey['unlimited_hosts'] = true;
 
         $scope.panel = {loading: false};
         $scope.organization = CurrentOrganization;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/new/views/activation-key-new.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/new/views/activation-key-new.html
@@ -29,18 +29,18 @@
              required/>
     </div>
 
-    <div bst-form-group label="{{ 'Content Host Limit' | translate }}" field="max_content_hosts">
-      <span translate>Unlimited Content Hosts:</span>
+    <div bst-form-group label="{{ 'Host Limit' | translate }}" field="max_hosts">
+      <span translate>Unlimited Hosts:</span>
       <input type="checkbox"
              name="limit"
-             ng-model="activationKey.unlimited_content_hosts"/>
+             ng-model="activationKey.unlimited_hosts"/>
 
-      <div bst-form-group label="{{ 'Limit' | translate }}" ng-hide="activationKey.unlimited_content_hosts">
-        <input id="max_content_hosts"
-               name="max_content_hosts"
+      <div bst-form-group label="{{ 'Limit' | translate }}" ng-hide="activationKey.unlimited_hosts">
+        <input id="max_hosts"
+               name="max_hosts"
                class="form-control"
-               ng-model="activationKey.max_content_hosts"
-               ng-required="!activationKey.unlimited_content_hosts"
+               ng-model="activationKey.max_hosts"
+               ng-required="!activationKey.unlimited_hosts"
                type="number"
                min="1"
                max="2147483648"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/new/views/host-collection-new-form.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/new/views/host-collection-new-form.html
@@ -11,7 +11,7 @@
   </div>
 
   <div bst-form-group label="{{ 'Content Host Limit' | translate }}" field="max_hosts">
-    <span translate>Unlimited Content Hosts:</span>
+    <span translate>Unlimited Hosts:</span>
     <input type="checkbox"
            name="limit"
            ng-model="hostCollection.unlimited_hosts"/>

--- a/engines/bastion_katello/test/activation-keys/details/activation-key-add-host-collections.controller.test.js
+++ b/engines/bastion_katello/test/activation-keys/details/activation-key-add-host-collections.controller.test.js
@@ -37,7 +37,7 @@ describe('Controller: ActivationKeyAddHostCollectionsController', function() {
                     "updated_at": "2014-02-17T16:02:24Z",
                     "name": "Employee",
                     "organization_id": 3,
-                    "max_content_hosts": -1,
+                    "max_hosts": -1,
                     "description": null,
                     "total_content_hosts": 0,
                     "id": 14,

--- a/spec/models/activation_key_spec.rb
+++ b/spec/models/activation_key_spec.rb
@@ -18,8 +18,8 @@ module Katello
       @environment_1 = katello_environments(:dev)
       @environment_2 = katello_environments(:staging)
       @akey = ActivationKey.create(:name => aname, :description => adesc, :organization => @organization,
-                                   :environment_id => @environment_1.id, :unlimited_content_hosts => false,
-                                   :max_content_hosts => 1)
+                                   :environment_id => @environment_1.id, :unlimited_hosts => false,
+                                   :max_hosts => 1)
     end
 
     describe "in valid state" do

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -81,11 +81,11 @@ module Katello
     def test_create_unlimited
       ActivationKey.any_instance.expects(:reload)
       assert_sync_task(::Actions::Katello::ActivationKey::Create) do |activation_key|
-        activation_key.max_content_hosts.must_be_nil
+        activation_key.max_hosts.must_be_nil
       end
 
       post :create, :organization_id => @organization.id,
-                    :activation_key => {:name => 'Unlimited Key', :unlimited_content_hosts => true}
+                    :activation_key => {:name => 'Unlimited Key', :unlimited_hosts => true}
 
       assert_response :success
       assert_template 'katello/api/v2/common/create'
@@ -95,12 +95,12 @@ module Katello
       assert_sync_task(::Actions::Katello::ActivationKey::Update) do |activation_key, activation_key_params|
         assert_equal activation_key.id, @activation_key.id
         assert_equal activation_key_params[:name], 'New Name'
-        assert_equal activation_key_params[:max_content_hosts], "2"
-        assert_equal activation_key_params[:unlimited_content_hosts], false
+        assert_equal activation_key_params[:max_hosts], "2"
+        assert_equal activation_key_params[:unlimited_hosts], false
       end
 
       put :update, :id => @activation_key.id, :organization_id => @organization.id,
-         :activation_key => {:name => 'New Name', :max_content_hosts => 2}
+         :activation_key => {:name => 'New Name', :max_hosts => 2}
 
       assert_response :success
       assert_template 'api/v2/activation_keys/show'
@@ -122,10 +122,10 @@ module Katello
       @activation_key.subscription_facet_ids = [subscription_facet1.id, subscription_facet2.id]
 
       results = JSON.parse(put(:update, :id => @activation_key.id, :organization_id => @organization.id,
-                               :activation_key => {:max_content_hosts => 1}).body)
+                               :activation_key => {:max_hosts => 1}).body)
 
       assert_response 422
-      assert_includes results['errors']['max_content_hosts'][0], 'cannot be lower than current usage count'
+      assert_includes results['errors']['max_hosts'][0], 'cannot be lower than current usage count'
     end
 
     def test_destroy

--- a/test/models/activation_key_test.rb
+++ b/test/models/activation_key_test.rb
@@ -54,22 +54,22 @@ module Katello
       assert_equal new_key.host_collections, @dev_key.host_collections
       assert_equal new_key.content_view, @dev_key.content_view
       assert_equal new_key.organization, @dev_key.organization
-      assert_equal new_key.max_content_hosts, @dev_key.max_content_hosts
+      assert_equal new_key.max_hosts, @dev_key.max_hosts
     end
 
     test "unlimited hosts requires no max hosts" do
       key1 = ActivationKey.find(katello_activation_keys(:simple_key))
       org = key1.organization
       new_key = ActivationKey.new(:name => "JarJar", :organization => org)
-      new_key.unlimited_content_hosts = false
-      new_key.max_content_hosts = 100
+      new_key.unlimited_hosts = false
+      new_key.max_hosts = 100
       assert new_key.valid?
 
-      new_key.unlimited_content_hosts = true
-      new_key.max_content_hosts = nil
+      new_key.unlimited_hosts = true
+      new_key.max_hosts = nil
       assert new_key.valid?
 
-      new_key.max_content_hosts = 100
+      new_key.max_hosts = 100
       assert !new_key.valid?
     end
 
@@ -113,15 +113,15 @@ module Katello
     end
 
     def test_max_hosts_not_exceeded
-      @dev_key.unlimited_content_hosts = false
-      @dev_key.max_content_hosts = 1
+      @dev_key.unlimited_hosts = false
+      @dev_key.max_hosts = 1
       @dev_key.stubs(:subscription_facets).returns(['host one', 'host two'])
       refute @dev_key.valid?
     end
 
     def test_max_hosts_exceeded
-      @dev_key.unlimited_content_hosts = false
-      @dev_key.max_content_hosts = 10
+      @dev_key.unlimited_hosts = false
+      @dev_key.max_hosts = 10
       @dev_key.stubs(:subscription_facets).returns(['host one', 'host two'])
       assert @dev_key.valid?
     end


### PR DESCRIPTION
ActivationKey now uses max_hosts and unlimited_hosts instead of max_content_hosts and unlimited_content_hosts. Note: the larger changes in activation_key.rb and activation_key_spec.rb are both larger changes than I really made. I only changed unlimited_content_hosts and max_content_hosts to unlimited_hosts and max_hosts, it only looks like I made the changes because there was an issue while rebaseing. If it's an issue please let me know, but it seems to be working.