### PR TITLE
fixes #14280 - incremental_update - fix for propagate_all_composites

### DIFF
--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -178,14 +178,14 @@ module Katello
           @composite_version_environments << version_environment
         else
           @version_environments << version_environment
-          @composite_version_environments += lookup_all_composites(version) if params[:propagate_all_composites]
+          @composite_version_environments += lookup_all_composites(version_environment[:content_view_version]) if params[:propagate_all_composites]
         end
       end
       @composite_version_environments.uniq! { |cve| cve[:content_view_version] }
     end
 
     def lookup_all_composites(component)
-      component.composites.select { |c| c.environment.any? }.map do |composite|
+      component.composites.select { |c| c.environments.any? }.map do |composite|
         {
           :content_view_version => composite,
           :environments =>  composite.environments


### PR DESCRIPTION
This commit contains a fix for errors when performing an incremental update
with the 'propagate_all_composites' option.  When this error occurs,
the new compontent content view version (e.g. 1.1) will not be published
and the composite view versions that it should be propagated to will
not be published (e.g. 2.1)

If the incremental update is performed using the CLI, the user would
observe an error similar to the following:

hammer> content-view version incremental-update --propagate-all-composites=true --content-view-version-id=5 --puppet-module-ids=5 --environment-ids=2
An error occurred incrementally updating the content view:
  undefined local variable or method `version' for #<Katello::Api::V2::ContentViewVersionsController:0x007fe4683e4190>