### PR TITLE
Fixes #11028 - Reduce chances of duplicate key error on applicability…

### DIFF
--- a/app/lib/actions/katello/repository/import_applicability.rb
+++ b/app/lib/actions/katello/repository/import_applicability.rb
@@ -1,0 +1,23 @@
+module Actions
+  module Katello
+    module Repository
+      class ImportApplicability < Actions::Base
+        middleware.use Actions::Middleware::ExecuteIfContentsChanged
+
+        input_format do
+          param :repo_id
+          param :contents_changed
+        end
+
+        def run
+          repo = ::Katello::Repository.find(input[:repo_id])
+          repo.import_host_applicability
+        end
+
+        def rescue_strategy_for_self
+          Dynflow::Action::Rescue::Skip
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/repository/sync.rb
+++ b/app/lib/actions/katello/repository/sync.rb
@@ -45,6 +45,7 @@ module Actions
               plan_self(:id => repo.id, :sync_result => output, :user_id => ::User.current.id, :contents_changed => contents_changed)
               plan_action(Pulp::Repository::RegenerateApplicability, :pulp_id => repo.pulp_id, :contents_changed => contents_changed)
             end
+            plan_action(Katello::Repository::ImportApplicability, :repo_id => repo.id, :contents_changed => contents_changed)
           end
         end
 
@@ -69,14 +70,6 @@ module Actions
 
         def rescue_strategy
           Dynflow::Action::Rescue::Skip
-        end
-
-        def finalize
-          ::User.current = ::User.anonymous_admin
-          repo = ::Katello::Repository.find(input[:id])
-          repo.import_system_applicability
-        ensure
-          ::User.current = nil
         end
       end
     end

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -219,6 +219,7 @@ module ::Actions::Katello::Repository
       assert_action_planed_with(action, pulp_action_class,
                                 pulp_id: repository.pulp_id, task_id: nil, source_url: nil)
       assert_action_planed action, ::Actions::Katello::Repository::IndexContent
+      assert_action_planed action, ::Actions::Katello::Repository::ImportApplicability
       assert_action_planed_with action, ::Actions::Katello::Repository::ErrataMail do |repo, _task_id, contents_changed|
         contents_changed.must_be_kind_of Dynflow::ExecutionPlan::OutputReference
         repo.id.must_equal repository.id
@@ -390,6 +391,16 @@ module ::Actions::Katello::Repository
     it 'plans' do
       plan_action(action, repository)
       assert_action_planed_with(action, ::Actions::Katello::CapsuleContent::Sync, capsule_content, :repository => repository)
+    end
+  end
+
+  class ImportApplicabilityTest < TestBase
+    let(:action_class) { ::Actions::Katello::Repository::ImportApplicability }
+
+    it 'runs' do
+      Katello::Repository.any_instance.expects(:import_host_applicability)
+
+      ForemanTasks.sync_task(action_class, :repo_id => repository.id, :contents_changed => true)
     end
   end
 

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -590,31 +590,29 @@ module Katello
   class RepositoryApplicabilityTest < RepositoryTestBase
     def setup
       super
-      @lib_system = System.find(katello_systems(:simple_server))
-      @lib_repo =  @fedora_17_x86_64
-      @lib_system.environment = @fedora_17_x86_64.environment
-      @lib_system.bound_repositories = [@lib_repo]
-      @lib_system.save!
+      @lib_host = FactoryGirl.create(:host, :with_content, :content_view => @fedora_17_x86_64.content_view,
+                                     :lifecycle_environment =>  @fedora_17_x86_64.environment)
 
-      @view_system = System.find(katello_systems(:simple_server2))
+      @lib_host.content_facet.bound_repositories << @fedora_17_x86_64
+      @lib_host.content_facet.save!
+
       @view_repo = Repository.find(katello_repositories(:fedora_17_x86_64_library_view_1))
-      @view_system.bound_repositories = [@view_repo]
-      @view_system.save!
 
-      @dev_system =  System.find(katello_systems(:errata_server_dev))
+      @view_host = FactoryGirl.create(:host, :with_content, :content_view => @fedora_17_x86_64.content_view,
+                                     :lifecycle_environment =>  @fedora_17_x86_64.environment)
+      @view_host.content_facet.bound_repositories = [@view_repo]
+      @view_host.content_facet.save!
     end
 
-    def test_systems_with_applicability
-      assert_includes @lib_repo.systems_with_applicability, @lib_system
-      assert_includes @view_repo.systems_with_applicability, @view_system
+    def test_host_with_applicability
+      assert_includes @fedora_17_x86_64.hosts_with_applicability, @lib_host
+      assert_includes @fedora_17_x86_64.hosts_with_applicability, @view_host
     end
 
-    def test_import_system_applicability
-      mock_active_records(@lib_system, @view_system, @dev_system)
-      @lib_system.expects(:import_applicability)
-      @view_system.expects(:import_applicability)
-      @dev_system.expects(:import_applicability)
-      @lib_repo.import_system_applicability
+    def test_import_host_applicability
+      Host::ContentFacet.any_instance.expects(:import_applicability).twice
+
+      @fedora_17_x86_64.import_host_applicability
     end
   end
 end


### PR DESCRIPTION
… generation

this commit does a couple things:
* Moves applicability importing for a repo from the finalize phase to the run phase
  of repo syncing.  This along with some other changes  means that the transaction is
  open for a single host and not the entire set of hosts.
* Moves the fetching of pulp errata uuids outside of the transaction