### PR TITLE
fixes #14305 - docker repos in content views should not require url and upstream name

### DIFF
--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -579,7 +579,7 @@ module Katello
     end
 
     def ensure_valid_docker_attributes
-      if url.blank? || docker_upstream_name.blank?
+      if library_instance? && (url.blank? || docker_upstream_name.blank?)
         errors.add(:base, N_("Repository URL or Upstream Name is empty. Both are required for syncing from the upstream."))
       end
     end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -55,6 +55,25 @@ module Katello
       refute @repo.valid?
     end
 
+    def test_docker_repository_in_content_view
+      # verify: url and docker_upstream_name are not required for repositories
+      # created as part of a content view
+      library_repo = Repository.find(katello_repositories(:busybox))
+      view_repo = build(:katello_repository,
+                        :content_type => 'docker',
+                        :name => 'view repo',
+                        :label => 'view_repo',
+                        :library_instance => library_repo,
+                        :environment => library_repo.environment,
+                        :product => library_repo.product,
+                        :content_view_version => library_repo.content_view_version,
+                        :unprotected => true,
+                        :download_policy => nil,
+                        :url => nil,
+                        :docker_upstream_name => nil)
+      assert view_repo.valid?
+    end
+
     def test_docker_repository_docker_upstream_name_format
       @repo.unprotected = true
       @repo.content_type = 'docker'


### PR DESCRIPTION
This commit fixes an error that occurs during content view publishing
of views containing docker repositories.  The error was on the validation
that required every docker repository to have a url and upstream_docker_name.
This validation is primarily needed for repositories in the library
that are used for syncing/mirroring that content from the upstream
repository; however, in the case of the content view repositories, they
are simply cloned from repos managed by katello.