### PR TITLE
Fixes #14309 - Copy content view no longer raises NoMethodError

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -83,9 +83,9 @@ module Katello
       new_view = ContentView.new
       new_view.name = new_name
       new_view.attributes = self.attributes.slice("description", "organization_id", "default", "composite")
+      new_view.save!
       new_view.repositories = self.repositories
       new_view.components = self.components
-      new_view.save!
 
       self.content_view_puppet_modules.each do |puppet_module|
         new_view.content_view_puppet_modules << puppet_module.dup


### PR DESCRIPTION
This was a weird one. Current code in master works in development, but not in production. Additional save seems to take care of the issue.