### PR TITLE
Fixes #14329 - allow 1024 char CDN urls

### DIFF
--- a/db/migrate/20160323065901_increase_cdn_length.rb
+++ b/db/migrate/20160323065901_increase_cdn_length.rb
@@ -1,0 +1,11 @@
+class IncreaseCdnLength < ActiveRecord::Migration
+  def up
+    change_column :katello_providers, :repository_url, :string, :limit => 1024
+    change_column :katello_repositories, :url, :string, :limit => 1024
+  end
+
+  def down
+    change_column :katello_providers, :repository_url, :string, :limit => 255
+    change_column :katello_repositories, :url, :string, :limit => 255
+  end
+end


### PR DESCRIPTION
Previously, the CDN url was limited to 255 char. This db migration updates it
to 1024 char.

How I tested:

* `migration:db:up` applied update, `migration:db:down` unapplied
* after updating URL to >255 char string, subsequent syncs attempted to use new URL