### PR TITLE
fixes #14349 - associate kexec template with operating system

### DIFF
--- a/app/helpers/katello/concerns/settings_helper_extensions.rb
+++ b/app/helpers/katello/concerns/settings_helper_extensions.rb
@@ -15,7 +15,9 @@ module Katello
           'katello_default_provision',
           'katello_default_ptable',
           'katello_default_PXELinux',
-          'katello_default_user_data'].include?(setting.name)
+          'katello_default_user_data',
+          'katello_default_kexec'
+        ].include?(setting.name)
 
         case setting.name
         when "default_download_policy"
@@ -32,6 +34,8 @@ module Katello
           edit_select(setting, :value, :select_values => katello_template_setting_values("PXELinux"))
         when "katello_default_user_data"
           edit_select(setting, :value, :select_values => katello_template_setting_values("user_data"))
+        when "katello_default_kexec"
+          edit_select(setting, :value, :select_values => katello_template_setting_values("kexec"))
         end
       end
 

--- a/app/models/setting/katello.rb
+++ b/app/models/setting/katello.rb
@@ -11,6 +11,7 @@ class Setting::Katello < Setting
         self.set('katello_default_PXELinux', N_("Default PXElinux template for new Operating Systems"), 'Kickstart default PXELinux'),
         self.set('katello_default_iPXE', N_("Default iPXE template for new Operating Systems"), 'Kickstart default iPXE'),
         self.set('katello_default_ptable', N_("Default partitioning table for new Operating Systems"), 'Kickstart default'),
+        self.set('katello_default_kexec', N_("Default kexec template for new Operating Systems"), 'Discovery Red Hat kexec'),
         self.set('content_action_accept_timeout', N_("Time in seconds to wait for a Host to pickup a remote action"), 20),
         self.set('content_action_finish_timeout', N_("Time in seconds to wait for a Host to finish a remote action"), 3600),
         self.set('restrict_composite_view', N_("If set to true, a composite content view may not be published or "\


### PR DESCRIPTION
In order for PXEless discovery to work, the target OS needs to be
associated with a kexec template.  We automatically associate the
other templates (provision, pxe, etc), so we should do kexec too to
avoid having the user do this manually.

Do note, there's no error caused if discovery is not installed, or the
template isn't available. The associations are done here:
     https://github.com/Katello/katello/blob/master/app/models/katello/concerns/operatingsystem_extensions.rb#L13

If you want to test it:

0. Have a Katello with discovery enabled
1. Sync OS with kickstart tree
2. Examine automatically created OS
3. Should have a kexec template associated
