### PR TITLE
fixes #14351 - split host id parameter to remote execution controller

### DIFF
--- a/app/controllers/katello/remote_execution_controller.rb
+++ b/app/controllers/katello/remote_execution_controller.rb
@@ -25,7 +25,7 @@ module Katello
         if params[:scoped_search].present?
           params[:scoped_search]
         else
-          ::Host.where(:id => params[:host_ids])
+          ::Host.where(:id => params[:host_ids].try(:split, ','))
         end
       end
 


### PR DESCRIPTION
The bulk action tool delivers a comma-separated list of host ID's, so we need
to turn it into an array.  Otherwise, the .where query will still work but it
only finds the first host in the list of ID's.