### PR TITLE
fixes #14367 - content view update - fix for removing all repositories

### DIFF
--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -191,7 +191,10 @@ module Katello
     def view_params
       attrs = [:name, :description, {:repository_ids => []}, {:component_ids => []}]
       attrs.push(:label, :composite) if action_name == "create"
-      params.require(:content_view).permit(*attrs)
+      permitted_params = params.require(:content_view).permit(*attrs)
+      permitted_params[:repository_ids] ||= [] if params[:content_view].key?(:repository_ids)
+      permitted_params[:component_ids] ||= [] if params[:content_view].key?(:component_ids)
+      permitted_params
     end
 
     def find_environment


### PR DESCRIPTION
Without this change, if the user attempts to remove all repositories from a
content view (e.g. repository_ids=nil), no change is made to the content view.