### PR TITLE
Fixes #14043 - Fixes how product associations are made, to work with multiple organizations correctly.

### DIFF
--- a/app/models/katello/glue/candlepin/subscription.rb
+++ b/app/models/katello/glue/candlepin/subscription.rb
@@ -47,7 +47,7 @@ module Katello
         cp_product_ids = products.map { |product| product["id"] }
         cp_product_ids << self.product_id if self.product_id
         cp_product_ids.each do |cp_id|
-          product = ::Katello::Product.where(:cp_id => cp_id)
+          product = ::Katello::Product.where(:cp_id => cp_id, :organization_id => self.organization_id)
           if product.any?
             ::Katello::SubscriptionProduct.where(:subscription_id => self.id, :product_id => product.first.id).first_or_create
           end


### PR DESCRIPTION
To reproduce:

1. Create two organizations and give them both manifests with overlapping products.

2. On one organization give it a product that has a subscription with many products (EG: I used Red Hat enterprise Linux 7 Server (Kickstart)).

3. In the other organization add products that are in the subscriptions products of the first organizations product. (EG: I enabled Linux Atomic Host RPMs and Oracle java RHEL server).

4. If the change has been applied then when you run hammer activation-key product-content --id [id of first organization's activation key] you should only see products enabled for the first organization. If it's not been applied you should see those and the products enabled in the second organization.