### PR TITLE
Fixes #14354 - fix "frozen hash" error on sub-man register

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -243,7 +243,7 @@ module Katello
     def facts
       User.as_anonymous_admin do
         sync_task(::Actions::Katello::Host::Update, @host, rhsm_params)
-        Katello::Host::SubscriptionFacet.update_facts(@host, rhsm_params[:facts])
+        Katello::Host::SubscriptionFacet.update_facts(@host, rhsm_params[:facts]) unless rhsm_params[:facts].blank?
       end
       render :json => {:content => _("Facts successfully updated.")}, :status => 200
     end

--- a/app/lib/actions/katello/host/destroy.rb
+++ b/app/lib/actions/katello/host/destroy.rb
@@ -33,6 +33,7 @@ module Actions
 
             host.get_status(::Katello::ErrataStatus).destroy
             host.get_status(::Katello::SubscriptionStatus).destroy
+            host.reload
           else
             host.content_facet.try(:destroy!)
             unless host.destroy

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -114,6 +114,14 @@ module Katello
         put :facts, :id => @host.subscription_facet.uuid, :facts => facts
         assert_equal 200, response.status
       end
+
+      it "should update other attributes without facts" do
+        Host::SubscriptionFacet.expects(:update_facts).never
+        assert_sync_task(::Actions::Katello::Host::Update)
+
+        put :facts, :id => @host.subscription_facet.uuid, :serviceLevel => 'synthetic'
+        assert_equal 200, response.status
+      end
     end
 
     describe "list owners" do


### PR DESCRIPTION
after a sub-man clean.

Also discovered an error immediately after registration when uploading facts.