### PR TITLE
Fixes #14386 - Provides list for download policy error message.

### DIFF
--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -90,7 +90,10 @@ module Katello
       :allow_blank => false,
       :message => ->(_, _) { _("must be one of the following: %s") % Katello::RepositoryTypeManager.repository_types.keys.join(', ') }
     }
-    validates :download_policy, inclusion: { in: ::Runcible::Models::YumImporter::DOWNLOAD_POLICIES }, if: :yum?
+    validates :download_policy, inclusion: {
+      :in => ::Runcible::Models::YumImporter::DOWNLOAD_POLICIES,
+      :message => _("must be one of the following: %s") % ::Runcible::Models::YumImporter::DOWNLOAD_POLICIES.join(', ')
+    }, if: :yum?
     validate :ensure_no_download_policy, if: ->(repo) { !repo.yum? }
     validate :ensure_valid_docker_attributes, :if => :docker?
     validate :ensure_docker_repo_unprotected, :if => :docker?

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -563,6 +563,15 @@ module Katello
       put :update, :id => repo.id, :docker_upstream_name => "helloworld"
     end
 
+    def test_update_false_download_policy
+      expected_message = "must be one of the following: %s" % ::Runcible::Models::YumImporter::DOWNLOAD_POLICIES.join(', ')
+      response = put :update, :id => @repository.id, :download_policy => 'false'
+      body = JSON.parse(response.body)
+
+      assert_response 422
+      assert_equal(expected_message, body['errors']['download_policy'][0])
+    end
+
     def test_remove_content
       @repository.rpms << @rpm
       @controller.expects(:sync_task).with(::Actions::Katello::Repository::RemoveContent,


### PR DESCRIPTION
To test: do a put request on katello/api/repositories/<repository id> but try to update it with an incompatible download policy. 