### PR TITLE
Fixes #14388 - Creates RH Atomic OS in seed

### DIFF
--- a/app/models/katello/concerns/operatingsystem_extensions.rb
+++ b/app/models/katello/concerns/operatingsystem_extensions.rb
@@ -3,15 +3,25 @@ module Katello
     module OperatingsystemExtensions
       extend ActiveSupport::Concern
 
+      REDHAT_ATOMIC_HOST_DISTRO_NAME = "Red Hat Enterprise Linux Atomic Host"
+      REDHAT_ATOMIC_HOST_OS = "RedHat_Enterprise_Linux_Atomic_Host"
+
       included do
         after_create :assign_templates!
+        before_create :set_atomic_attributes, :if => proc { |os| os.name == ::Operatingsystem::REDHAT_ATOMIC_HOST_OS }
       end
 
       def assign_templates!
         # Automatically assign default templates
         if self.family == 'Redhat'
           TemplateKind.all.each do |kind|
-            if (template = ProvisioningTemplate.find_by_name(Setting["katello_default_#{kind.name}"]))
+            if name == ::Operatingsystem::REDHAT_ATOMIC_HOST_OS && kind.name == "provision"
+              provisioning_template_name = Setting["katello_default_atomic_provision"]
+            else
+              provisioning_template_name = Setting["katello_default_#{kind.name}"]
+            end
+
+            if (template = ProvisioningTemplate.find_by_name(provisioning_template_name))
               provisioning_templates << template unless provisioning_templates.include?(template)
               if OsDefaultTemplate.where(:template_kind_id => kind.id, :operatingsystem_id => id).empty?
                 OsDefaultTemplate.create(:template_kind_id => kind.id, :provisioning_template_id => template.id, :operatingsystem_id => id)
@@ -23,6 +33,12 @@ module Katello
             ptables << ptable unless ptables.include?(ptable)
           end
         end
+      end
+
+      def set_atomic_attributes
+        self.description = "#{::Operatingsystem::REDHAT_ATOMIC_HOST_DISTRO_NAME} #{release}"
+        self.architectures << Architecture.where(:name => "x86_64").first_or_create
+        self.family = "Redhat"
       end
     end
   end

--- a/app/models/setting/katello.rb
+++ b/app/models/setting/katello.rb
@@ -4,7 +4,6 @@ class Setting::Katello < Setting
 
     self.transaction do
       [
-        self.set('default_cdn_ostree_branch_name', N_("Name of the default OSTree branch when enabling a Red Hat OSTree repo"), 'rhel-atomic-host/7/x86_64/standard'),
         self.set('katello_default_provision', N_("Default provisioning template for new Operating Systems"), 'Katello Kickstart Default'),
         self.set('katello_default_finish', N_("Default finish template for new Operating Systems"), 'Katello Kickstart Default Finish'),
         self.set('katello_default_user_data', N_("Default user data for new Operating Systems"), 'Katello Kickstart Default User Data'),
@@ -12,6 +11,7 @@ class Setting::Katello < Setting
         self.set('katello_default_iPXE', N_("Default iPXE template for new Operating Systems"), 'Kickstart default iPXE'),
         self.set('katello_default_ptable', N_("Default partitioning table for new Operating Systems"), 'Kickstart default'),
         self.set('katello_default_kexec', N_("Default kexec template for new Operating Systems"), 'Discovery Red Hat kexec'),
+        self.set('katello_default_atomic_provision', N_("Default provisioning template for new Atomic Operating Systems"), 'Katello Atomic Kickstart Default'),
         self.set('content_action_accept_timeout', N_("Time in seconds to wait for a Host to pickup a remote action"), 20),
         self.set('content_action_finish_timeout', N_("Time in seconds to wait for a Host to finish a remote action"), 3600),
         self.set('restrict_composite_view', N_("If set to true, a composite content view may not be published or "\

--- a/app/services/katello/candlepin/consumer.rb
+++ b/app/services/katello/candlepin/consumer.rb
@@ -121,6 +121,8 @@ module Katello
       end
 
       def self.distribution_to_puppet_os(name)
+        return ::Operatingsystem::REDHAT_ATOMIC_HOST_OS if name == ::Operatingsystem::REDHAT_ATOMIC_HOST_DISTRO_NAME
+
         name = name.downcase
         if name =~ /red\s*hat/
           'RedHat'

--- a/db/seeds.d/109-atomic_os.rb
+++ b/db/seeds.d/109-atomic_os.rb
@@ -1,0 +1,11 @@
+# This file should contain all the record creation needed to seed the database with its default values.
+# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
+#
+# !!! PLEASE KEEP THIS SCRIPT IDEMPOTENT !!!
+#
+
+::User.current = ::User.anonymous_api_admin
+os_attributes = {:major => "7", :minor => "2", :name => ::Operatingsystem::REDHAT_ATOMIC_HOST_OS}
+Operatingsystem.where(os_attributes).first_or_create!
+
+::User.current = nil

--- a/test/lib/tasks/seeds_test.rb
+++ b/test/lib/tasks/seeds_test.rb
@@ -5,6 +5,7 @@ module Katello
     setup do
       Setting.stubs(:[]).with(:administrator).returns("root@localhost")
       Setting.stubs(:[]).with(:send_welcome_email).returns(false)
+      Setting.stubs(:[]).with(regexp_matches(/katello_default_/)).returns("Crazy Template")
       Katello::Repository.stubs(:ensure_sync_notification)
     end
 
@@ -87,6 +88,13 @@ module Katello
     test "Make sure sync notifications  notiffication got setup" do
       Katello::Repository.expects(:ensure_sync_notification). returns(true)
       seed
+    end
+  end
+
+  class AtomicOsTest < SeedsTest
+    test "Make sure atomic OS got setup" do
+      seed
+      assert Operatingsystem.find_by(:name => Operatingsystem::REDHAT_ATOMIC_HOST_OS).present?
     end
   end
 end

--- a/test/models/concerns/operatingsystem_extensions_test.rb
+++ b/test/models/concerns/operatingsystem_extensions_test.rb
@@ -28,5 +28,29 @@ module Katello
 
       assert os.ptables.include? ptable
     end
+
+    def test_assign_template_for_atomic
+      template = templates(:mystring2)
+      ptable = FactoryGirl.create(:ptable)
+      Setting.create(:name => 'katello_default_atomic_provision', :description => 'atomic default template',
+                     :category => 'Setting::Katello', :settings_type => 'string',
+                     :default => template.name)
+
+      Setting.create(:name => 'katello_default_ptable', :description => 'default template',
+                     :category => 'Setting::Katello', :settings_type => 'string',
+                     :default => ptable.name)
+
+      os_attributes = {:major => "7", :minor => "3", :name => ::Operatingsystem::REDHAT_ATOMIC_HOST_OS}
+      os = Operatingsystem.create!(os_attributes)
+
+      assert ::OsDefaultTemplate.where(:template_kind_id    => ::TemplateKind.find_by_name('provision').id,
+                                       :provisioning_template_id  => template.id,
+                                       :operatingsystem_id  => os.id).any?
+
+      assert os.ptables.include? ptable
+      assert_equal "Redhat", os.family
+      assert_equal "x86_64", os.architectures.first.name
+      assert_equal "#{::Operatingsystem::REDHAT_ATOMIC_HOST_DISTRO_NAME} 7.3", os.description
+    end
   end
 end


### PR DESCRIPTION
When subscription manager sends facts about a content host then the
Operating system of the host is inferred from its distribution name
and version. That inferred OS is attached to the host
However the host validation requires install media/partition tables to
be of the same OS
The facts parser however does not understand what an Atomic OS is.
Thus it ties Atomic host to Redhat 7.2 even for atomic.
This causes host.save! to fail because the right media is NOT attached
to OS.

This commit creates a dedicated  "Redhat Atomic 7.2"  OS in the seed
script  and tell the user if you want to use Atomic use this exact OS.

The facts parser then checks if "distro name has atomic" tie it to this OS