### PR TITLE
Fixes #14441 - Removes incorrect upload endpoint from documentation.

### DIFF
--- a/app/controllers/katello/api/v2/subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/subscriptions_controller.rb
@@ -81,7 +81,6 @@ module Katello
     end
 
     api :POST, "/organizations/:organization_id/subscriptions/upload", N_("Upload a subscription manifest")
-    api :POST, "/subscriptions/upload", N_("Upload a subscription manifest")
     param :organization_id, :number, :desc => N_("Organization id"), :required => true
     param :content, File, :desc => N_("Subscription manifest file"), :required => true
     param :repository_url, String, :desc => N_("repository url"), :required => false


### PR DESCRIPTION
After testing this endpoint it doesn't seem to have any actual routing associated with it.

To test:

Be on the new branch and then run rake apipie:cache FOREMAN_APIPIE_LANGS=en.

Go to: /apidoc/v2/subscriptions/upload.html and you should only see one end point and its parameters.