### PR TITLE
Refs #14363 - adding missing input in Pulp::Repository::Refresh

### DIFF
--- a/app/lib/actions/pulp/abstract_async_task.rb
+++ b/app/lib/actions/pulp/abstract_async_task.rb
@@ -92,7 +92,7 @@ module Actions
       end
 
       def rescue_external_task(error)
-        if error.is_a?(Katello::Errors::PulpError)
+        if error.is_a?(::Katello::Errors::PulpError)
           fail error
         else
           super

--- a/app/lib/actions/pulp/repository/refresh.rb
+++ b/app/lib/actions/pulp/repository/refresh.rb
@@ -7,7 +7,7 @@ module Actions
         end
 
         def plan(repository, input = {})
-          repository_details = pulp_extensions(capsule_id).repository.retrieve_with_details(repository.pulp_id)
+          repository_details = pulp_extensions(input[:capsule_id]).repository.retrieve_with_details(repository.pulp_id)
           update_or_associate_importer(input[:capsule_id], repository, repository_details)
           update_or_associate_distributors(input[:capsule_id], repository, repository_details)
           remove_unnecessary_distributors(input[:capsule_id], repository, repository_details)


### PR DESCRIPTION
This was missed in the [original PR](https://github.com/Katello/katello/pull/5920) and is causing errors. 