### PR TITLE
fixes #14465 - fix deletion of composite content view versions

### DIFF
--- a/app/lib/actions/katello/repository/destroy.rb
+++ b/app/lib/actions/katello/repository/destroy.rb
@@ -10,7 +10,8 @@ module Actions
         def plan(repository, options = {})
           planned_destroy = options.fetch(:planned_destroy, false)
 
-          skip_environment_update = options.fetch(:organization_destroy, false)
+          skip_environment_update = options.fetch(:skip_environment_update, false) ||
+              options.fetch(:organization_destroy, false)
           action_subject(repository)
 
           if !planned_destroy && !repository.assert_deletable


### PR DESCRIPTION
Prior to this commit, if a composite content view consisted of multiple
component views, attempting to delete a version would generate an error
similar to:

Katello::Resources::Candlepin::Environment: 400 Bad Request (DELETE /candlepin/environments/1-7/content?content=1459785851927)