### PR TITLE
Fixes #14484: use minification safe format to prevent JS error.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.routes.js
@@ -10,10 +10,10 @@
 angular.module('Bastion.capsule-content').config(['$stateProvider', '$urlRouterProvider', function ($stateProvider, $urlRouterProvider) {
 
     // Catch the url to prevent the router to perform redirect.
-    $urlRouterProvider.when('/smart_proxies/:proxyId', function ($match, $stateParams) {
+    $urlRouterProvider.when('/smart_proxies/:proxyId', ['$match', '$stateParams', function ($match, $stateParams) {
         $stateParams.pageName = 'smart_proxies/detail';
         return true;
-    });
+    }]);
 
     // Add rule to redirect links on the smart proxy detail page.
     // Changing state doesn't work there since there's no <ui-view> element there


### PR DESCRIPTION
The parameters to $urlRouterProvider.when() are injected when the
function form is used so we need to use the minification safe format.

http://projects.theforeman.org/issues/14484