### PR TITLE
Fixes #14512 - capsule sync with empty puppet repo errors

### DIFF
--- a/app/lib/actions/katello/repository/create.rb
+++ b/app/lib/actions/katello/repository/create.rb
@@ -46,7 +46,7 @@ module Actions
 
             concurrence do
               plan_action(::Actions::Pulp::Repos::Update, repository.product) if repository.product.sync_plan
-              plan_self(:repository_id => repository.id) unless repository.puppet?
+              plan_self(:repository_id => repository.id)
             end
           end
         end


### PR DESCRIPTION
To test:

1) Create an empty puppet repo, don't sync it
2) Sync capsule associated with the Library environment
3) Make sure the sync finishes fine and the empty puppet repo is on the capsule 