### PR TITLE
fixes #14532 - activation key - fix for product content when there are no subscriptions

### DIFF
--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -107,7 +107,7 @@ module Katello
     end
 
     def available_content
-      self.products.map(&:available_content).flatten.uniq { |product| product.content.id }
+      self.products ? self.products.map(&:available_content).flatten.uniq { |product| product.content.id } : []
     end
 
     def valid_content_label?(content_label)


### PR DESCRIPTION
This commit is to address the following error below where an activation
key does not have any subscriptions assigned.

E.g. using hammer:

Before:
```
hammer> activation-key product-content --id 3
undefined method `map' for nil:NilClass
```
After:
```
hammer> activation-key product-content --id 3
---|------|------|-----|---------|-------|---------
ID | NAME | TYPE | URL | GPG KEY | LABEL | ENABLED?
---|------|------|-----|---------|-------|---------
```
After (with subscriptions):
```
hammer> activation-key product-content --id 3
--------------|------|------|-----|---------|------------------------------|---------
ID            | NAME | TYPE | URL | GPG KEY | LABEL                        | ENABLED?
--------------|------|------|-----|---------|------------------------------|---------
1459799241671 | zoo  |      |     |         | Default_Organization_zoo_zoo | default
--------------|------|------|-----|---------|------------------------------|---------
```