### PR TITLE
Fixes #14537 - unable to register with sub-man after puppet registration

### DIFF
--- a/app/lib/actions/katello/host/register.rb
+++ b/app/lib/actions/katello/host/register.rb
@@ -29,7 +29,6 @@ module Actions
             host.save!
 
             action_subject host
-            connect_to_smart_proxy(host)
 
             cp_create = plan_action(Candlepin::Consumer::Create, cp_environment_id: content_view_environment.cp_id,
                                     consumer_parameters: consumer_params, activation_keys: activation_keys.map(&:cp_name))
@@ -56,6 +55,7 @@ module Actions
           host.subscription_facet.update_from_consumer_attributes(host.subscription_facet.candlepin_consumer.consumer_attributes)
           host.subscription_facet.save!
           host.refresh_global_status!
+          connect_to_smart_proxy(host)
 
           system = ::Katello::System.find(input[:system_id])
           system.uuid = input[:uuid]


### PR DESCRIPTION
As part of the registration process, the host unregisters from any prior
registrations (https://git.io/vVPSi). However, this makes the host lose its
organization during the plan phase of the Register action.

The `connect_to_smart_proxy` method needs the host's org, but the org is
populated again by the time we hit the finalize phase. This commit moves the
method call from plan to finalize.