### PR TITLE
Fixes #14428 - improves performance with purge empty errata and groups

### DIFF
--- a/app/lib/actions/katello/repository/clone_yum_content.rb
+++ b/app/lib/actions/katello/repository/clone_yum_content.rb
@@ -38,15 +38,16 @@ module Actions
             plan_copy(Pulp::Repository::CopyYumMetadataFile, source_repo, target_repo)
             plan_copy(Pulp::Repository::CopyDistribution, source_repo, target_repo)
 
+            plan_action(Katello::Repository::IndexContent, id: target_repo.id) if index_content
+
             if purge_empty_units
-              plan_action(Katello::Repository::IndexErrata, target_repo)
               plan_action(Pulp::Repository::PurgeEmptyErrata, :pulp_id => target_repo.pulp_id)
-              plan_action(Katello::Repository::IndexPackageGroups, target_repo)
               plan_action(Pulp::Repository::PurgeEmptyPackageGroups, :pulp_id => target_repo.pulp_id)
+              plan_action(Katello::Repository::IndexErrata, target_repo)
+              plan_action(Katello::Repository::IndexPackageGroups, target_repo)
             end
 
             plan_action(Katello::Repository::MetadataGenerate, target_repo, filters.empty? ? source_repo : nil) if generate_metadata
-            plan_action(Katello::Repository::IndexContent, id: target_repo.id) if index_content
           end
         end
 

--- a/app/lib/actions/katello/repository/index_errata.rb
+++ b/app/lib/actions/katello/repository/index_errata.rb
@@ -7,11 +7,8 @@ module Actions
         end
 
         def run
-          ::User.current = ::User.find(input[:user_id])
           repo = ::Katello::Repository.find(input[:id])
           repo.index_db_errata
-        ensure
-          ::User.current = nil
         end
       end
     end

--- a/app/lib/actions/pulp/repository/purge_empty_errata.rb
+++ b/app/lib/actions/pulp/repository/purge_empty_errata.rb
@@ -8,16 +8,10 @@ module Actions
 
         def invoke_external_task
           repo = ::Katello::Repository.where(:pulp_id => input[:pulp_id]).first
+          errata_to_delete = repo.empty_errata
 
-          package_lists = repo.package_lists_for_publish
-          filenames = package_lists[:filenames]
-
-          errata_to_delete = repo.errata.collect do |erratum|
-            erratum.errata_id if filenames.intersection(erratum.packages.pluck(:filename)).empty?
-          end
-          errata_to_delete.compact!
           repo.unassociate_by_filter(::Katello::ContentViewErratumFilter::CONTENT_TYPE,
-                                 "id" => { "$in" => errata_to_delete })
+                                 "id" => { "$in" => errata_to_delete.map(&:errata_id) })
         end
       end
     end

--- a/app/lib/actions/pulp/repository/purge_empty_package_groups.rb
+++ b/app/lib/actions/pulp/repository/purge_empty_package_groups.rb
@@ -8,13 +8,11 @@ module Actions
 
         def invoke_external_task
           repo = ::Katello::Repository.where(:pulp_id => input[:pulp_id]).first
-
-          package_lists = repo.package_lists_for_publish
-          rpm_names = package_lists[:names]
+          rpm_names = repo.rpms.pluck(:name).uniq
 
           # Remove all  package groups with no packages
-          package_groups_to_delete = repo.package_groups.collect do |group|
-            group.uuid if rpm_names.intersection(group.package_names).empty?
+          package_groups_to_delete = repo.package_groups.select do |group|
+            (rpm_names & group.package_names).empty?
           end
           criteria = {:association => {"unit_id" => {"$in" => package_groups_to_delete.compact}}}
 

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -1,4 +1,5 @@
 module Katello
+  # rubocop:disable Metrics/ClassLength
   class Repository < Katello::Model
     self.include_root_in_json = false
 
@@ -187,6 +188,28 @@ module Katello
 
     def custom?
       !(redhat?)
+    end
+
+    def empty_errata
+      repository_rpm = Katello::RepositoryRpm.table_name
+      repository_errata = Katello::RepositoryErratum.table_name
+      rpm = Katello::Rpm.table_name
+      errata = Katello::Erratum.table_name
+      erratum_package = Katello::ErratumPackage.table_name
+
+      errata_with_packages = Erratum.joins(
+        "INNER JOIN #{erratum_package} on #{erratum_package}.erratum_id = #{errata}.id",
+        "INNER JOIN #{repository_errata} on #{repository_errata}.erratum_id = #{errata}.id",
+        "INNER JOIN #{rpm} on #{rpm}.filename = #{erratum_package}.filename",
+        "INNER JOIN #{repository_rpm} on #{repository_rpm}.rpm_id = #{rpm}.id").
+        where("#{repository_rpm}.repository_id" => self.id).
+        where("#{repository_errata}.repository_id" => self.id)
+
+      if errata_with_packages.any?
+        self.errata.where("#{Katello::Erratum.table_name}.id NOT IN (?)", errata_with_packages.pluck("#{errata}.id"))
+      else
+        self.errata
+      end
     end
 
     def library_instance?

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -141,6 +141,25 @@ module Katello
       refute @repo2.valid?
     end
 
+    def test_empty_errata
+      @fedora_17_x86_64.errata.destroy_all
+      filename = 'much-rpm.much-wow'
+
+      erratum = @fedora_17_x86_64.errata.create! do |new_erratum|
+        new_erratum.uuid = "foo"
+        new_erratum.packages = [ErratumPackage.new(:filename => filename, :nvrea => 'foo', :name => 'foo')]
+      end
+
+      assert_includes @fedora_17_x86_64.empty_errata, erratum
+
+      @fedora_17_x86_64.rpms.create! do |rpm|
+        rpm.uuid = 'its the uuid that never ends oh wait it does'
+        rpm.filename = filename
+      end
+
+      refute_includes @fedora_17_x86_64.empty_errata, erratum
+    end
+
     def test_create_with_no_type
       @repo.content_type = ''
       assert_raises ActiveRecord::RecordInvalid do


### PR DESCRIPTION
This improves and streamlines the purge empty errata and purge empty group tasks.
Previously we did not index all of the data until after these steps ran, causing us to
go to pulp for lots of data that could be really slow on heavily loaded systems.

With this change we index prior to these steps and use our database whenever possible.

On a lightly loaded satellite this only saved about 14 seconds for PurgeEmptyErrata
(17s vs 3s) and 10 seconds for PurgeEmptyPackageGroups (11s vs  8s). However for
heavily loaded systems the slowest part of each of the steps no longer exists
(pulling all the package filenames and names for all rpms in the repo).  Some servers
have seen these steps take ~30 mintues or longer due to these calls.