### PR TITLE
Fixes #14582: specify correct path for expander icons.

### DIFF
--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -44,7 +44,13 @@ module Katello
     initializer 'katello.configure_assets', :group => :all do
       def find_assets(args = {})
         type = args.fetch(:type, nil)
-        asset_dir = "#{Katello::Engine.root}/app/assets/#{type}/"
+        vendor = args.fetch(:vendor, false)
+
+        if vendor
+          asset_dir = "#{Katello::Engine.root}/vendor/assets/#{type}/"
+        else
+          asset_dir = "#{Katello::Engine.root}/app/assets/#{type}/"
+        end
 
         asset_paths = Dir[File.join(asset_dir, '**', '*')].reject { |file| File.directory?(file) }
         asset_paths.each { |file| file.slice!(asset_dir) }
@@ -54,6 +60,7 @@ module Katello
 
       javascripts = find_assets(:type => 'javascripts')
       images = find_assets(:type => 'images')
+      vendor_images = find_assets(:type => 'images', :vendor => true)
 
       precompile = [
         'katello/katello.css',
@@ -62,8 +69,10 @@ module Katello
         'bastion_katello/bastion_katello.js',
         /bastion_katello\S+.(?:svg|eot|woff|ttf)$/
       ]
+
       precompile.concat(javascripts)
       precompile.concat(images)
+      precompile.concat(vendor_images)
 
       SETTINGS[:katello] = {} unless SETTINGS.key?(:katello)
       SETTINGS[:katello][:assets] = {:precompile => precompile}

--- a/vendor/assets/stylesheets/katello/jquery.treeTable.scss
+++ b/vendor/assets/stylesheets/katello/jquery.treeTable.scss
@@ -15,11 +15,11 @@
 }
 
 .treeTable tr.collapsed td .expander {
-  background-image: url(icons/expander-collapsed.png);
+  background-image: image-url("katello/icons/expander-collapsed.png");
 }
 
 .treeTable tr.expanded td .expander {
-  background-image: url(icons/expander-expanded.png);
+  background-image: image-url("katello/icons/expander-expanded.png");
 }
 
 /* jquery.treeTable.sortable


### PR DESCRIPTION
The expander icons were not being replaced with the versioned files
in production, this commit fixes the issue by referencing the correct
path for the icons.

http://projects.theforeman.org/issues/14582