### PR TITLE
Fixes #14537 - fix `host.organization` references

### DIFF
--- a/app/lib/actions/katello/host/register.rb
+++ b/app/lib/actions/katello/host/register.rb
@@ -7,6 +7,7 @@ module Actions
         def plan(host, system, consumer_params, content_view_environment, activation_keys = [])
           sequence do
             unless host.new_record?
+              host.save!
               plan_action(Katello::Host::Unregister, host)
               host.reload
             end
@@ -67,8 +68,7 @@ module Actions
 
           if smart_proxy
             smart_proxy.content_host = system.content_host
-            org = system.content_facet.lifecycle_environment.organization
-            smart_proxy.organizations << org unless smart_proxy.organizations.include?(org)
+            smart_proxy.organizations << system.organization unless smart_proxy.organizations.include?(system.organization)
             smart_proxy.save!
           end
         end


### PR DESCRIPTION
The patch in #5951 fixed bats, but was not the most correct way of fixing the
issue.

This commit calls `host.save!` before unregistering, which allows use of
`host.organization` again. It also reverts changes to the
`connect_to_smart_proxy` method since we no longer need to use the
content_facet to get the org.