### PR TITLE
Fixes #14644 - Progress bar will no longer show so many decimal places.

### DIFF
--- a/app/views/foreman/smart_proxies/_content_sync.html.erb
+++ b/app/views/foreman/smart_proxies/_content_sync.html.erb
@@ -5,7 +5,7 @@
 
   {{ syncStatusText(syncState, syncStatus) }}
   <div ng-show="syncState.is(syncState.SYNCING, syncState.SYNC_TRIGGERED, syncState.CANCEL_TRIGGERED, syncState.FAILURE)">
-    {{syncTask.progressbar.value || 0}}%
+    {{ syncTask.progressbar.value || 0 | number: 0 }}%
     <a href="<%= @task_search_url %>" target="_self">
       <div ng-class="{ active: isTaskInProgress(syncTask) }" class="progress progress-striped">
         <span progressbar


### PR DESCRIPTION
![download](https://cloud.githubusercontent.com/assets/8502976/14531637/1e0a7876-022c-11e6-9870-3c5d0b3225c9.png)

To test sync a capsule and watch the percentage complete.
