### PR TITLE
Fixes #14647 - Corrects docker feed url when creating repos on capsule

### DIFF
--- a/app/lib/actions/katello/capsule_content/create_repos.rb
+++ b/app/lib/actions/katello/capsule_content/create_repos.rb
@@ -24,7 +24,7 @@ module Actions
                       content_type: repository.content_type,
                       pulp_id: repository.pulp_id,
                       name: repository.name,
-                      feed: repository.full_path,
+                      feed: repository.docker? ? repository.docker_feed_url(true) : repository.full_path,
                       ssl_ca_cert: ::Cert::Certs.ca_cert,
                       ssl_client_cert: ueber_cert[:cert],
                       ssl_client_key: ueber_cert[:key],

--- a/app/lib/actions/katello/capsule_content/sync.rb
+++ b/app/lib/actions/katello/capsule_content/sync.rb
@@ -20,13 +20,13 @@ module Actions
           fail _("Action not allowed for the default capsule.") if capsule_content.default_capsule?
 
           need_updates = repos_needing_updates(capsule_content, environment, content_view)
-          need_updates.each do |repo|
-            plan_action(Pulp::Repository::Refresh, repo, capsule_id: capsule_content.capsule.id)
-          end
-
           repository_ids = get_repository_ids(capsule_content, environment, content_view, repository)
           unless repository_ids.blank?
             sequence do
+              need_updates.each do |repo|
+                plan_action(Pulp::Repository::Refresh, repo, capsule_id: capsule_content.capsule.id)
+              end
+
               plan_action(ConfigureCapsule, capsule_content, environment, content_view)
 
               smart_proxy = SmartProxy.where(:content_host_id => capsule_content.consumer.id).first


### PR DESCRIPTION
To test:

1) Set up a capsule
2) Create a docker repo and sync
3) Sync the capsule (associated with Library)
4) Make sure docker repo syncs correctly to capsule
5) Try at least two more syncs (no need to change anything) and make sure they run correctly

Also, it would be a good idea to make sure other types of repos are still syncing fine