### PR TITLE
fixes #14268 - optimize scoped_search queries when sub_total == 0

### DIFF
--- a/test/controllers/api/v2/api_controller_test.rb
+++ b/test/controllers/api/v2/api_controller_test.rb
@@ -1,0 +1,55 @@
+require 'katello_test_helper'
+
+module Katello
+  class Api::V2::ApiControllerTest < ActionController::TestCase
+    def setup
+      katello_errata
+      @controller = Katello::Api::V2::ApiController.new
+      @query = Erratum.all
+      @default_sort = %w(updated desc)
+      @options = { :resource_class => Katello::Erratum }
+    end
+
+    def teardown
+      @controller = nil
+      @query = nil
+      @default_sort = nil
+      @options = nil
+    end
+
+    def test_scoped_search
+      params = {}
+      @controller.stubs(:params).returns(params)
+
+      response = @controller.scoped_search(@query, @default_sort[0], @default_sort[1], @options)
+      refute_empty response[:results], "results"
+      assert_equal 3, response[:subtotal], "subtotal"
+      assert_equal 3, response[:total], "total"
+      assert_equal 1, response[:page], "page"
+      assert_equal ::Setting::General.entries_per_page, response[:per_page], "per page"
+      assert_nil response[:error], "error"
+    end
+
+    def test_scoped_search_no_results
+      params = { :search => "asdfasdf" }
+      @controller.stubs(:params).returns(params)
+
+      response = @controller.scoped_search(@query, @default_sort[0], @default_sort[1], @options)
+      assert_empty response[:results], "results"
+      assert_equal 0, response[:subtotal], "subtotal"
+      assert_nil response[:error], "error"
+    end
+
+    def test_scoped_search_zero_total
+      @query = []
+      params = {}
+      @controller.stubs(:params).returns(params)
+
+      response = @controller.scoped_search(@query, @default_sort[0], @default_sort[1], @options)
+      assert_empty response[:results], "results"
+      assert_equal 0, response[:subtotal], "subtotal"
+      assert_equal 0, response[:total], "total"
+      assert_nil response[:error], "error"
+    end
+  end
+end


### PR DESCRIPTION
There are three queries to the database (more or less) when a request is
passed through ``Katello::Api::ApiController#scoped_search`` in the
following order.

Query 1 - Get the total number of rows for a given object type ("total")
Query 2 - Get the total number of rows using a given search string
          ("sub_total")
Query 3 - Get the actual rows on the object type using a given search
          string. ("results")

Query 1 is trivial and essentially instantaneous. Queries 2 and 3 can
take some time though. In the case of an errata index with RHEL7 sync'd,
queries 2 and 3 both take roughly a second bringing the average total
request time over 4 seconds.

This commit adds a small change to #scoped_search to reduce the number
of database queries, namely 2 and 3, where possible. If the total
number of rows for a given object are zero, then we can assume that
sub_total will also be zero and that the result set is going to be an
empty array. It can also be assumed that if sub_total is zero then the
result set will be ``[]``. Knowing these assumptions, we can skip queries
2 and 3 when we know results are going to be empty.