### PR TITLE
Fixes #14698 - use `/var/lib/pulp/katello-export` as default export location

### DIFF
--- a/app/models/setting/katello.rb
+++ b/app/models/setting/katello.rb
@@ -22,7 +22,7 @@ class Setting::Katello < Setting
         self.set('check_services_before_actions', N_("Whether or not to check the status of backend services such as pulp and candlepin prior to performing some actions."), true),
         self.set('force_post_sync_actions', N_("Force post sync actions such as indexing and email even if no content was available."), false),
         self.set('default_download_policy', N_("Default download policy for repositories (either 'immediate', 'on_demand', or 'background')"), "immediate"),
-        self.set('pulp_export_destination', N_("On-disk location for exported repositories"), N_("Please fill path in.")),
+        self.set('pulp_export_destination', N_("On-disk location for exported repositories"), N_("/var/lib/pulp/katello-export")),
         self.set('pulp_client_key', N_("Path for ssl key used for pulp server auth"), "/etc/pki/katello/private/pulp-client.key"),
         self.set('pulp_client_cert', N_("Path for ssl cert used for pulp server auth"), "/etc/pki/katello/certs/pulp-client.crt"),
         self.set('remote_execution_by_default', N_("If set to true, use the remote execution over katello-agent for remote actions"), false),


### PR DESCRIPTION
The patch in https://github.com/Katello/puppet-katello/pull/123 creates a
default directory in `/var/lib/pulp/katello-export`.

This Katello patch sets the default to match, which allows users to perform an
export "out of the box" without having to hop to the command line to create
directories.

A new directory under `/var/lib/pulp/` was chosen for the default since users
are already aware that this path may use considerable disk space.  This setting
is still settable via web UI and hammer in case someone wants to do a one-off
export to a different location.