### PR TITLE
fixes #14711 - ui: fix subscription -> associations -> content hosts

### DIFF
--- a/app/views/katello/api/v2/subscriptions/show.json.rabl
+++ b/app/views/katello/api/v2/subscriptions/show.json.rabl
@@ -27,6 +27,11 @@ node :systems do |subscription|
       service_level: sys.serviceLevel,
       autoheal: sys.autoheal,
       facts: {
+        dmi: {
+          memory: {
+            size: facts['dmi.memory.size']
+          }
+        },
         memory: {
           memtotal: facts['memory.memtotal']
         },

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/views/subscription-associations-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/views/subscription-associations-content-hosts.html
@@ -54,7 +54,7 @@
         <td bst-table-cell>{{ contentHost.service_level }}</td>
         <td bst-table-cell>{{ contentHost.facts.cpu['cpu_socket(s)'] }}</td>
         <td bst-table-cell>{{ contentHost.facts.cpu['core(s)_per_socket'] }}</td>
-        <td bst-table-cell>{{ host.facts["dmi::memory::size"]) }}</td>
+        <td bst-table-cell>{{ contentHost.facts.dmi.memory['size'] }}</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
This commit fixes an error that caused the following page not to render:
  Content -> Red Hat Subscriptions -> [subscription] -> Associations -> Content Hosts

The change will display memory using dmi::memory::size to be consistent with how the memory is shown for individual content hosts at:
  Hosts -> Content Hosts -> [host] -> Details