### PR TITLE
Fixes #14722 - wait on subs refresh task on product create

### DIFF
--- a/app/lib/actions/candlepin/owner/refresh_subscriptions.rb
+++ b/app/lib/actions/candlepin/owner/refresh_subscriptions.rb
@@ -1,0 +1,15 @@
+module Actions
+  module Candlepin
+    module Owner
+      class RefreshSubscriptions < Candlepin::AbstractAsyncTask
+        input_format do
+          param :label
+        end
+
+        def invoke_external_task
+          ::Katello::Resources::Candlepin::Subscription.refresh_for_owner(input[:label])
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/product/create.rb
+++ b/app/lib/actions/katello/product/create.rb
@@ -3,26 +3,31 @@ module Actions
     module Product
       class Create < Actions::EntryAction
         def plan(product, organization)
-          product.provider = organization.anonymous_provider
-          product.organization = organization
+          sequence do
+            product.provider = organization.anonymous_provider
+            product.organization = organization
 
-          cp_create = plan_action(::Actions::Candlepin::Product::Create,
-                                  :name => product.name,
-                                  :multiplier => 1,
-                                  :attributes => [{:name => "arch", :value => "ALL"}])
+            cp_create = plan_action(::Actions::Candlepin::Product::Create,
+                                    :name => product.name,
+                                    :multiplier => 1,
+                                    :attributes => [{:name => "arch", :value => "ALL"}])
 
-          cp_id = cp_create.output[:response][:id]
+            cp_id = cp_create.output[:response][:id]
 
-          sub_create = plan_action(::Actions::Candlepin::Product::CreateUnlimitedSubscription,
-                      :owner_key => organization.label,
-                      :product_id => cp_id)
-          subscription_id = sub_create.output[:response][:id]
+            sub_create = plan_action(::Actions::Candlepin::Product::CreateUnlimitedSubscription,
+                        :owner_key => organization.label,
+                        :product_id => cp_id)
 
-          product.save!
-          action_subject product, :cp_id => cp_id
+            subscription_id = sub_create.output[:response][:id]
 
-          plan_self
-          plan_action Katello::Product::ReindexSubscriptions, product, subscription_id
+            plan_action(::Actions::Candlepin::Owner::RefreshSubscriptions,
+                                  :label => organization.label)
+            product.save!
+            action_subject product, :cp_id => cp_id
+
+            plan_self
+            plan_action Katello::Product::ReindexSubscriptions, product, subscription_id
+          end
         end
 
         def finalize

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -569,7 +569,6 @@ module Katello
 
           def create_for_owner(owner_key, attrs)
             subscription = self.post("/candlepin/owners/#{owner_key}/subscriptions", attrs.to_json, self.default_headers).body
-            self.put("/candlepin/owners/#{owner_key}/subscriptions", {}.to_json, self.default_headers).body
             subscription
           end
 


### PR DESCRIPTION
as that is when the unlimited pool gets created
and if we do not wait the pool may not exist
at indexing time