### PR TITLE
Revert "Fixes #14372 - Content host status is green, but shows warning"

### DIFF
--- a/app/lib/actions/katello/host/generate_applicability.rb
+++ b/app/lib/actions/katello/host/generate_applicability.rb
@@ -15,7 +15,7 @@ module Actions
         def finalize
           ::Host.where(:id => input[:host_ids]).each do |host|
             host.content_facet.try(:import_applicability)
-            host.content_facet.update_errata_status
+            host.get_status(::Katello::ErrataStatus).refresh!
           end
         end
       end

--- a/app/lib/actions/katello/host/register.rb
+++ b/app/lib/actions/katello/host/register.rb
@@ -54,7 +54,6 @@ module Actions
           host.content_facet.save!
           host.subscription_facet.update_from_consumer_attributes(host.subscription_facet.candlepin_consumer.consumer_attributes)
           host.subscription_facet.save!
-          host.refresh_global_status!
           connect_to_smart_proxy(host)
 
           system = ::Katello::System.find(input[:system_id])

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -69,7 +69,7 @@ module Katello
             remove_errata_applicability(to_remove) unless to_remove.blank?
           end
         end
-        self.update_errata_status
+        host.get_status(::Katello::ErrataStatus).refresh!
       end
 
       def self.in_content_view_version_environments(version_environments)
@@ -118,11 +118,6 @@ module Katello
 
       def katello_agent_installed?
         self.host.installed_packages.where("#{Katello::InstalledPackage.table_name}.name" => 'katello-agent').any?
-      end
-
-      def update_errata_status
-        host.get_status(::Katello::ErrataStatus).refresh!
-        host.refresh_global_status!
       end
 
       private

--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -44,7 +44,6 @@ module Katello
 
       def update_subscription_status
         host.get_status(::Katello::SubscriptionStatus).refresh!
-        host.refresh_global_status!
       end
 
       def self.new_host_from_facts(facts, org, location)


### PR DESCRIPTION
This reverts commit 1442cbd0ce9fab4958eecb1deffcef7548047531.

Conflicts:
	app/lib/actions/katello/host/register.rb