### PR TITLE
Fixes #13718: call foreman setTab() on non-content pages.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.controller.js
@@ -20,7 +20,6 @@ angular.module('Bastion.capsule-content').controller('CapsuleContentController',
         var urlMatcher = $urlMatcherFactory.compile("/smart_proxies/:capsuleId");
         var capsuleId = urlMatcher.exec($location.path()).capsuleId;
 
-
         function processError(response) {
             if (response.data && response.data.displayMessage) {
                 $scope.syncErrorMessages = [response.data.displayMessage];

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.routes.js
@@ -1,15 +1,15 @@
 /**
- * @ngdoc object
- * @name Bastion.capsule-content.config
- *
- * @requires $stateProvider
- *
- * @description
- *   Used for systems level configuration such as setting up the ui state machine.
- */
+* @ngdoc object
+* @name Bastion.capsule-content.config
+*
+* @requires $stateProvider
+* @requires $urlRouterProvider
+*
+* @description
+*   Used for systems level configuration such as setting up the ui state machine.
+*/
 angular.module('Bastion.capsule-content').config(['$stateProvider', '$urlRouterProvider', function ($stateProvider, $urlRouterProvider) {
-
-    // Catch the url to prevent the router to perform redirect.
+    //Catch the url to prevent the router to perform redirect.
     $urlRouterProvider.when('/smart_proxies/:proxyId', ['$match', '$stateParams', function ($match, $stateParams) {
         $stateParams.pageName = 'smart_proxies/detail';
         return true;
@@ -25,5 +25,26 @@ angular.module('Bastion.capsule-content').config(['$stateProvider', '$urlRouterP
             $window.location.href = $location.path();
         }
     });
+}]);
 
+/**
+ * @ngdoc run
+ * @name Bastion.capsule-content.run
+ *
+ * @requires $rootScope
+ * @requires $window
+ * @requires $timeout
+ *
+ * @description
+ *   Ensure foreman's setTab() function is called on capsule content pages.
+ */
+angular.module('Bastion.capsule-content').run(['$rootScope', '$window', '$timeout', function ($rootScope, $window, $timeout) {
+    var smartProxiesRegex = new RegExp("/smart_proxies/.+#.+");
+    $rootScope.$on('$locationChangeStart', function (event, newUrl) {
+        if (newUrl.match(smartProxiesRegex)) {
+            $timeout(function () {
+                $window.setTab();
+            });
+        }
+    });
 }]);


### PR DESCRIPTION
Fix the dropdown menu not working by calling the foreman setTab()
function when a route does not match the content routes.

http://projects.theforeman.org/issues/13718