### PR TITLE
Fixes #14786 - Unset download_policy if not yum

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/new-repository.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/new-repository.controller.js
@@ -76,6 +76,9 @@ angular.module('Bastion.repositories').controller('NewRepositoryController',
             if (repository.content_type === 'ostree') {
                 repository.unprotected = false;
             }
+            if (repository.content_type !== 'yum') {
+                repository['download_policy'] = '';
+            }
             repository.$save(success, error);
         };
 


### PR DESCRIPTION
In order to default the download_policy in 277c6d7fa43458096673fb9518eb13b18e18bc6f, we set the download_policy on the repo. We need to unset it though if it's not a yum repo before we save.