### PR TITLE
Fixes #14804 - Activation keys filter by content view

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -5,6 +5,7 @@ module Katello
     before_filter :verify_presence_of_organization_or_environment, :only => [:index]
     before_filter :find_environment, :only => [:index, :create, :update]
     before_filter :find_optional_organization, :only => [:index, :create, :show]
+    before_filter :find_content_view, :only => [:index]
     before_filter :find_activation_key, :only => [:show, :update, :destroy, :available_releases, :copy, :product_content,
                                                   :available_host_collections, :add_host_collections, :remove_host_collections,
                                                   :content_override, :add_subscriptions, :remove_subscriptions,
@@ -291,6 +292,14 @@ module Katello
     def verify_presence_of_organization_or_environment
       return if params.key?(:organization_id) || params.key?(:environment_id)
       fail HttpErrors::BadRequest, _("Either organization ID or environment ID needs to be specified")
+    end
+
+    def find_content_view
+      if params.include?(:content_view_id)
+        cv_id = params[:content_view_id]
+        @content_view = ContentView.find_by(:id => cv_id)
+        fail HttpErrors::NotFound, _("Couldn't find content view '%s'") % cv_id if @content_view.nil?
+      end
     end
 
     def activation_key_params

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -14,6 +14,7 @@ module Katello
       @organization = get_organization
       @activation_key = ActivationKey.find(katello_activation_keys(:simple_key).id)
       @view = katello_content_views(:library_view)
+      @acme_view = katello_content_views(:acme_default)
       @library = @organization.library
     end
 
@@ -48,6 +49,13 @@ module Katello
       assert_protected_action(:index, allowed_perms, denied_perms) do
         get :index, :organization_id => @organization.id
       end
+    end
+
+    def test_index_filter_by_content_view
+      results = JSON.parse(get(:index, :organization_id => @organization.id, :content_view_id => @acme_view.id).body)
+
+      assert_response :success
+      assert_equal results["results"].size, 4
     end
 
     def test_show


### PR DESCRIPTION
It looks like we weren't finding the content view before, but still using a @content_view global variable. I added a function to find the content view on the index call for activation keys. I added a test this functionality as well (it is failing on master)