### PR TITLE
Fixes #14807 - don't generate repo metadata when nothing was synced

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -27,10 +27,10 @@ Metrics/AbcSize:
 Metrics/BlockNesting:
   Max: 4
 
-# Offense count: 54
+# Offense count: 55
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 504
+  Max: 507
 
 # Offense count: 90
 Metrics/CyclomaticComplexity:

--- a/app/lib/actions/katello/repository/sync.rb
+++ b/app/lib/actions/katello/repository/sync.rb
@@ -36,6 +36,9 @@ module Actions
             end
 
             contents_changed = output[:contents_changed]
+            plan_action(Pulp::Repository::Publish, :pulp_id => repo.pulp_id,
+                                                   :distributor_type_filter => ::Katello::Repository::PUBLISH_DISTRIBUTOR_TYPES,
+                                                   :contents_changed => contents_changed)
             plan_action(Katello::Repository::IndexContent, :id => repo.id, :contents_changed => contents_changed)
             plan_action(Katello::Foreman::ContentUpdate, repo.environment, repo.content_view, repo)
             plan_action(Katello::Repository::CorrectChecksum, repo)

--- a/app/lib/actions/pulp/abstract_content_task.rb
+++ b/app/lib/actions/pulp/abstract_content_task.rb
@@ -1,0 +1,25 @@
+module Actions
+  module Pulp
+    class AbstractContentTask < Pulp::AbstractAsyncTask
+      def contents_changed?(tasks)
+        if tasks.is_a?(Hash)
+          # note: for syncs initiated by a sync plan, tasks is a hash input
+          sync_task = tasks
+        else
+          sync_task = tasks.find { |task| (task['tags'] || []).include?('pulp:action:sync') }
+        end
+
+        if sync_task && sync_task['state'] == 'finished' && sync_task[:result]
+          sync_task['result']['added_count'] > 0 || sync_task['result']['removed_count'] > 0 || sync_task['result']['updated_count'] > 0
+        else
+          true #if we can't figure it out, assume something changed
+        end
+      end
+
+      def external_task=(tasks)
+        output[:contents_changed] = contents_changed?(tasks)
+        super
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp/consumer/sync_capsule.rb
+++ b/app/lib/actions/pulp/consumer/sync_capsule.rb
@@ -1,7 +1,7 @@
 module Actions
   module Pulp
     module Consumer
-      class SyncCapsule < ::Actions::Pulp::AbstractAsyncTask
+      class SyncCapsule < ::Actions::Pulp::AbstractContentTask
         input_format do
           param :capsule_id, Integer
           param :repo_pulp_id, String

--- a/app/lib/actions/pulp/repository/create.rb
+++ b/app/lib/actions/pulp/repository/create.rb
@@ -112,7 +112,7 @@ module Actions
         def yum_distributor
           yum_dist_options = { protected: true,
                                id: input[:pulp_id],
-                               auto_publish: true }
+                               auto_publish: false }
           yum_dist_options[:checksum_type] = input[:checksum_type] if input[:checksum_type]
           Runcible::Models::YumDistributor.new(input[:path],
                                                input[:unprotected] || false,

--- a/app/lib/actions/pulp/repository/distributor_publish.rb
+++ b/app/lib/actions/pulp/repository/distributor_publish.rb
@@ -4,6 +4,7 @@ module Actions
       class DistributorPublish < Pulp::AbstractAsyncTask
         input_format do
           param :pulp_id
+          param :distributor_id
           param :distributor_type_id
           param :source_pulp_id
           param :dependency
@@ -13,7 +14,7 @@ module Actions
         def invoke_external_task
           pulp_extensions.repository.
               publish(input[:pulp_id],
-                      distributor_id(input[:pulp_id], input[:distributor_type_id]),
+                      input[:distributor_id] || distributor_id(input[:pulp_id], input[:distributor_type_id]),
                       distributor_config)
         end
 

--- a/app/lib/actions/pulp/repository/distributor_publish_changes.rb
+++ b/app/lib/actions/pulp/repository/distributor_publish_changes.rb
@@ -1,0 +1,19 @@
+module Actions
+  module Pulp
+    module Repository
+      class DistributorPublishChanges < DistributorPublish
+        middleware.use Actions::Middleware::ExecuteIfContentsChanged
+
+        input_format do
+          param :pulp_id
+          param :distributor_id
+          param :distributor_type_id
+          param :source_pulp_id
+          param :dependency
+          param :override_config
+          param :contents_changed
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp/repository/publish.rb
+++ b/app/lib/actions/pulp/repository/publish.rb
@@ -1,0 +1,34 @@
+module Actions
+  module Pulp
+    module Repository
+      class Publish < Pulp::Abstract
+        input_format do
+          param :pulp_id
+          param :capsule_id
+          param :distributor_type_filter
+          param :contents_changed
+        end
+
+        def plan(input)
+          input[:distributor_type_filter] ||= []
+
+          distributors(input[:pulp_id]).each do |dist|
+            # filter only allowed distributors and skip distributors that are published automatically in Pulp
+            if input[:distributor_type_filter].include?(dist['distributor_type_id']) && (dist['auto_publish'] == false)
+              plan_action(Pulp::Repository::DistributorPublishChanges,
+                :pulp_id => input[:pulp_id],
+                :capsule_id => input[:capsule_id],
+                :distributor_id => dist["id"],
+                :contents_changed => input[:contents_changed])
+            end
+          end
+        end
+
+        def distributors(pulp_repo_id)
+          repository_details = pulp_extensions.repository.retrieve_with_details(pulp_repo_id)
+          repository_details["distributors"]
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp/repository/sync.rb
+++ b/app/lib/actions/pulp/repository/sync.rb
@@ -1,7 +1,7 @@
 module Actions
   module Pulp
     module Repository
-      class Sync < Pulp::AbstractAsyncTask
+      class Sync < Pulp::AbstractContentTask
         include Helpers::Presenter
 
         input_format do
@@ -41,32 +41,12 @@ module Actions
           check_error_details
         end
 
-        def external_task=(tasks)
-          output[:contents_changed] = contents_changed?(tasks)
-          super
-        end
-
         def check_error_details
           output[:pulp_tasks].each do |pulp_task|
             error_details = pulp_task.try(:[], "progress_report").try(:[], "yum_importer").try(:[], "content").try(:[], "error_details")
             if error_details && error_details[0]
               fail _("An error occurred during the sync \n%{error_message}") % {:error_message => error_details[0]}
             end
-          end
-        end
-
-        def contents_changed?(tasks)
-          if tasks.is_a?(Hash)
-            # note: for syncs initiated by a sync plan, tasks is a hash input
-            sync_task = tasks
-          else
-            sync_task = tasks.find { |task| (task['tags'] || []).include?('pulp:action:sync') }
-          end
-
-          if sync_task && sync_task['state'] == 'finished' && sync_task[:result]
-            sync_task['result']['added_count'] > 0 || sync_task['result']['removed_count'] > 0 || sync_task['result']['updated_count'] > 0
-          else
-            true #if we can't figure it out, assume something changed
           end
         end
 

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -23,6 +23,10 @@ module Katello
     DOCKER_TYPE = 'docker'
     OSTREE_TYPE = 'ostree'
 
+    PUBLISH_DISTRIBUTOR_TYPES = [
+      Runcible::Models::YumDistributor.type_id
+    ]
+
     CHECKSUM_TYPES = %w(sha1 sha256)
 
     belongs_to :environment, :inverse_of => :repositories, :class_name => "Katello::KTEnvironment"


### PR DESCRIPTION
Turns off auto-publishing for yum repos in Pulp. Auto-publish always triggers metadata regenerate regardless of whether any updates are synced.

This PR adds action `Pulp::Repository::Publish` which conditionally publishes repos only if new content was downloaded.

DO NOT MERGE YET - tests are still missing

