### PR TITLE
Fixes #14819 - Fix single content repo uploads

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -263,7 +263,7 @@ module Katello
     def upload_content
       fail Katello::Errors::InvalidRepositoryContent, _("Cannot upload Docker content.") if @repository.docker?
 
-      filepaths = params[:content].collect do |content|
+      filepaths = Array.wrap(params[:content]).compact.collect do |content|
         {path: content.path, filename: content.original_filename}
       end
 

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -676,7 +676,17 @@ module Katello
             files.size == 1 && files.first[:filename].include?("puppet_module.tar.gz")
       end
 
+      # array
       post :upload_content, :id => @repository.id, :content => [puppet_module]
+      assert_response :success
+
+      assert_sync_task ::Actions::Katello::Repository::UploadFiles do |repo, files|
+        repo.id == @repository.id &&
+            files.size == 1 && files.first[:filename].include?("puppet_module.tar.gz")
+      end
+
+      # single file
+      post :upload_content, :id => @repository.id, :content => puppet_module
       assert_response :success
     end
 


### PR DESCRIPTION
It looks like in 6300c23eae49a5c8d612b84c70f75993fb65443e we accidentally removed the Array.wrap call which was needed if api users upload single files (instead of arrays).