### PR TITLE
Fixes #14822: use host.comment rather than content_host.description.

### DIFF
--- a/app/controllers/katello/api/v2/systems_controller.rb
+++ b/app/controllers/katello/api/v2/systems_controller.rb
@@ -174,7 +174,7 @@ module Katello
     end
 
     def system_params(param_hash)
-      system_params = param_hash.require(:system).permit(:name, :description, :location, :owner, :type,
+      system_params = param_hash.require(:system).permit(:name, :location, :owner, :type,
                                                      :service_level, :autoheal,
                                                      :guest_ids, :host_collection_ids => [])
 

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -28,7 +28,7 @@ module Katello
         scoped_search :in => :installed_packages, :on => :nvra, :complete_value => true, :rename => :installed_package
         scoped_search :in => :installed_packages, :on => :name, :complete_value => true, :rename => :installed_package_name
 
-        attr_accessible :content_source_id, :host_collection_ids, :description
+        attr_accessible :content_source_id, :host_collection_ids
       end
 
       def validate_media_with_capsule?

--- a/db/migrate/20160426145517_move_host_description_to_host_comment.rb
+++ b/db/migrate/20160426145517_move_host_description_to_host_comment.rb
@@ -1,0 +1,28 @@
+class MoveHostDescriptionToHostComment < ActiveRecord::Migration
+  class Host < ActiveRecord::Base
+    self.table_name = "hosts"
+  end
+
+  def up
+    Host.find_each do |host|
+      if host.comment.empty?
+        host.comment = host.description
+      else
+        host.comment = [host.comment, host.description].join("\n") unless host.description.empty?
+      end
+      host.save!
+    end
+
+    remove_column :hosts, :description
+  end
+
+  def down
+    add_column :hosts, :description, :text
+
+    Host.find_each do |host|
+      host.description = host.comment
+      host.comment = nil
+      host.save!
+    end
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
@@ -70,7 +70,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsController
             var whitelistedHostObject = {},
                 whitelist = [
                     "name",
-                    "description"
+                    "comment"
                 ];
 
             if (saveFacets) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -26,7 +26,7 @@
       <div class="detail">
         <span class="info-label" translate>Description</span>
         <span class="info-value"
-              bst-edit-textarea="host.description"
+              bst-edit-textarea="host.comment"
               readonly="denied('edit_hosts', host)"
               on-save="save(host)">
         </span>


### PR DESCRIPTION
As part of host unification we need to migrate the description field
on content host to use the host comment field.  This commit fixes the
UI to use host.comment as well as migrates existing content host
descriptions to the host.comment field.

http://projects.theforeman.org/issues/14822