### PR TITLE
Fixes #14861 - disable remove product button for red hat repositories

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/product-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/product-details.controller.js
@@ -48,12 +48,12 @@ angular.module('Bastion.products').controller('ProductDetailsController',
             var readOnlyReason = null;
 
             if (product.$resolved) {
-                if ($scope.denied('destroy_products', product)) {
+                if (product.redhat) {
+                    readOnlyReason = 'redhat';
+                } else if ($scope.denied('destroy_products', product)) {
                     readOnlyReason = 'permissions';
                 } else if (product['published_content_view_ids'].length > 0) {
                     readOnlyReason = 'published';
-                } else if (product.redhat) {
-                    readOnlyReason = 'redhat';
                 }
             }
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-details.html
@@ -20,17 +20,17 @@
         </div>
 
         <span ng-switch="getReadOnlyReason(product)" bst-feature-flag="custom_products">
-          <i class="fa fa-question-sign" ng-switch-when="permissions"
+          <i class="fa fa-question-circle" ng-switch-when="permissions"
              tooltip="{{ 'You cannot remove this product because you do not have permission.' | translate }}"
              tooltip-animation="false"
              tooltip-append-to-body="true">
           </i>
-          <i class="fa fa-question-sign" ng-switch-when="published"
+          <i class="fa fa-question-circle" ng-switch-when="published"
              tooltip="{{ 'You cannot remove this product because it was published to a content view.' | translate }}"
              tooltip-animation="false"
              tooltip-append-to-body="true">
           </i>
-          <i class="fa fa-question-sign" ng-switch-when="redhat"
+          <i class="fa fa-question-circle" ng-switch-when="redhat"
              tooltip="{{ 'You cannot remove this product because it is a Red Hat product.' | translate }}"
              tooltip-animation="false"
              tooltip-append-to-body="true">
@@ -38,7 +38,7 @@
         </span>
 
         <button class="btn btn-default" bst-feature-flag="custom_products"
-                ng-hide="productDeletable(product)"
+                ng-disabled="!productDeletable(product)"
                 ng-click="openModal()">
           <i class="fa fa-trash-o"></i>
           {{ "Remove Product" | translate }}


### PR DESCRIPTION
The Remove Product button is disabled if the user doesn't have the permissions to delete a product, the product is published in a content view, or if it is in a red hat product. There should be a tooltip showing next to the disabled 'remove product' button explaining why it is disabled.