### PR TITLE
Fixes #14824 - strip out extraneous nil from `recognize` call

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -435,8 +435,8 @@ module Katello
     def authorize_proxy_routes
       deny_access unless (authenticate || authenticate_client)
 
-      route, _, params = Engine.routes.router.recognize(request) do |rte, match, parameters|
-        break rte, match, parameters if rte.name
+      route, params = Engine.routes.router.recognize(request) do |rte, parameters|
+        break rte, parameters if rte.name
       end
 
       # route names are defined in routes.rb (:as => :name)


### PR DESCRIPTION
We had a `_` that was used to eat a `nil` which is no longer needed, see
https://github.com/rails/rails/commit/dd1f23df7b59a6d0c4cba9c22292032414a7adfe.