### PR TITLE
Fixes #14873 - Repo syncs are successful when capsule is unresponsive

### DIFF
--- a/app/lib/actions/katello/capsule_content/sync.rb
+++ b/app/lib/actions/katello/capsule_content/sync.rb
@@ -11,6 +11,7 @@ module Actions
         end
 
         def plan(capsule_content, options = {})
+          capsule_content.ping_pulp
           action_subject(capsule_content.capsule)
 
           environment = options.fetch(:environment, nil)

--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -1,3 +1,4 @@
+# rubocop:disable HandleExceptions
 module Actions
   module Katello
     module ContentView
@@ -49,9 +50,13 @@ module Actions
         end
 
         def run
-          ForemanTasks.async_task(ContentView::CapsuleGenerateAndSync,
-                                  ::Katello::ContentView.find(input[:content_view_id]),
-                                  ::Katello::KTEnvironment.find(input[:environment_id]))
+          environment = ::Katello::KTEnvironment.find(input[:environment_id])
+          if ::Katello::CapsuleContent.sync_needed?(environment)
+            ForemanTasks.async_task(ContentView::CapsuleGenerateAndSync,
+                                    ::Katello::ContentView.find(input[:content_view_id]),
+                                    environment)
+          end
+        rescue ::Katello::Errors::CapsuleCannotBeReached # skip any capsules that cannot be connected to
         end
 
         def rescue_strategy_for_self

--- a/app/lib/actions/katello/repository/sync.rb
+++ b/app/lib/actions/katello/repository/sync.rb
@@ -1,3 +1,4 @@
+# rubocop:disable HandleExceptions
 module Actions
   module Katello
     module Repository
@@ -51,6 +52,7 @@ module Actions
 
         def run
           ForemanTasks.async_task(Repository::CapsuleGenerateAndSync, ::Katello::Repository.find(input[:id]))
+        rescue ::Katello::Errors::CapsuleCannotBeReached # skip any capsules that cannot be connected to
         end
 
         def humanized_name

--- a/app/lib/katello/errors.rb
+++ b/app/lib/katello/errors.rb
@@ -41,6 +41,8 @@ module Katello
 
     class OrganizationDestroyException < StandardError; end
 
+    class CapsuleCannotBeReached < StandardError; end
+
     class UnsupportedActionException < StandardError
       attr_reader :action, :receiver
 

--- a/test/actions/katello/capsule_content_test.rb
+++ b/test/actions/katello/capsule_content_test.rb
@@ -22,6 +22,7 @@ module ::Actions::Katello::CapsuleContent
 
     before do
       set_user
+      ::Katello::CapsuleContent.any_instance.stubs(:ping_pulp).returns({})
       @capsule_system = create(:katello_system,
                                :capsule,
                                name: proxy_with_pulp.name,


### PR DESCRIPTION
When a capsule is down, repository syncs should still be successful on the main Katello server. A separate capsule sync will run if there are capsules to sync to and that task will fail if the capsule is unreachable.

To test:
set up a capsule, sync repositories to it, associate it with library env. Then shut off the capsule and sync a new repository. That task should be successful. Also promote and publish content views. These tasks should be succesful, and if there is a CapsuleGenerateAndSync task, it should fail since the capsule is unreachable. Testing a promote when the capsule is in a dev env would be helpful as well