### PR TITLE
Fixes #14895 - Check services on backend objects

### DIFF
--- a/lib/katello/tasks/clean_backend_objects.rake
+++ b/lib/katello/tasks/clean_backend_objects.rake
@@ -58,6 +58,12 @@ namespace :katello do
       end
     end
 
+    # check services first
+    result = ::Katello::Ping.ping
+    if result[:status] != ::Katello::Ping::OK_RETURN_CODE
+      fail "Could not connect to service: #{result[:message]}"
+    end
+
     User.current = User.anonymous_admin
     cleanup_systems
     cleanup_host_delete_artifacts


### PR DESCRIPTION
Having .rake file check candlepin to make sure its running before it
starts the cleanup process.