### PR TITLE
fixes #14900 - handle remote_execution_ssh_keys correctly

### DIFF
--- a/app/views/foreman/unattended/finish-katello.erb
+++ b/app/views/foreman/unattended/finish-katello.erb
@@ -42,6 +42,8 @@ echo "updating system time"
 # update all the base packages from the updates repository
 yum -t -y -e 0 update
 
+<%= snippet('remote_execution_ssh_keys') %>
+
 <% if salt_enabled %>
 yum -t -y -e 0 install salt-minion
 cat > /etc/salt/minion << EOF
@@ -59,8 +61,6 @@ echo "Configuring puppet"
 cat > /etc/puppet/puppet.conf << EOF
 <%= snippet 'puppet.conf' %>
 EOF
-
-<%= snippet('remote_execution_ssh_keys') %>
 
 # Setup puppet to run on system reboot
 /sbin/chkconfig --level 345 puppet on

--- a/app/views/foreman/unattended/kickstart-katello.erb
+++ b/app/views/foreman/unattended/kickstart-katello.erb
@@ -111,6 +111,8 @@ echo "updating system time"
 # update all the base packages from the updates repository
 yum -t -y -e 0 update
 
+<%= snippet('remote_execution_ssh_keys') %>
+
 <% if salt_enabled %>
 yum -t -y -e 0 install salt-minion
 cat > /etc/salt/minion << EOF
@@ -130,8 +132,6 @@ echo "Configuring puppet"
 cat > /etc/puppet/puppet.conf << EOF
 <%= snippet 'puppet.conf' %>
 EOF
-
-<%= snippet('remote_execution_ssh_keys') %>
 
 # Setup puppet to run on system reboot
 /sbin/chkconfig --level 345 puppet on

--- a/app/views/foreman/unattended/userdata-katello.erb
+++ b/app/views/foreman/unattended/userdata-katello.erb
@@ -17,8 +17,10 @@ ssh_authorized_keys:
 <% if @host.params['sshkey'].present? -%>
   - <%= @host.params['sshkey'] %>
 <% end -%>
+<% if @host.params['remote_execution_ssh_keys'].present? -%>
 <% @host.params['remote_execution_ssh_keys'].each do |key| -%>
   - <%= key %>
+<% end -%>
 <% end -%>
 <% end -%>
 write_files:


### PR DESCRIPTION
It is currently in the puppet block in two of the templates, but should
not be. Also the user data template could raise an error if the plugin
is not enabled in Katello.  We should check if the key is present first.