### PR TITLE
Fixes #14902: refresh nutupane when adding or removing sync plans.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/new/new-sync-plan.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/new/new-sync-plan.controller.js
@@ -25,6 +25,7 @@ angular.module('Bastion.sync-plans').controller('NewSyncPlanController',
             function success(syncPlan) {
                 $scope.working = false;
                 GlobalNotification.setSuccessMessage(translate('New sync plan successfully created.'));
+                $scope.nutupane.refresh();
                 if ($scope.product) {
                     $scope.product['sync_plan_id'] = syncPlan.id;
                     $scope.$state.go('products.details.info', {productId: $scope.product.id});

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/sync-plans.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/sync-plans.controller.js
@@ -48,6 +48,7 @@ angular.module('Bastion.sync-plans').controller('SyncPlansController',
                 syncPlan.$remove(function () {
                     GlobalNotification.setSuccessMessage(translate('Sync Plan %s has been deleted.').replace('%s', syncPlan.name));
                     $scope.removeRow(syncPlan.id);
+                    $scope.nutupane.refresh();
                     $scope.transitionTo('sync-plans.index');
                 });
             };

--- a/engines/bastion_katello/test/sync-plans/new-sync-plan.controller.test.js
+++ b/engines/bastion_katello/test/sync-plans/new-sync-plan.controller.test.js
@@ -13,6 +13,7 @@ describe('Controller: NewSyncPlanController', function() {
         GlobalNotification = $injector.get('GlobalNotification');
         $scope = $injector.get('$rootScope').$new();
         $scope.$state = {go: function () {}};
+        $scope.nutupane = {refresh: function () {}};
 
         translate = function (string) { return string; };
 

--- a/engines/bastion_katello/test/sync-plans/sync-plans.controller.test.js
+++ b/engines/bastion_katello/test/sync-plans/sync-plans.controller.test.js
@@ -14,6 +14,7 @@ describe('Controller: SyncPlansController', function() {
             this.get = function() {};
             this.enableSelectAllResults = function () {};
             this.removeRow = function () {};
+            this.refresh = function () {};
         };
 
         translate = function (string) {


### PR DESCRIPTION
The nutupane table wasn't being refreshed when adding or removing
sync plans and thus the count was off.  This commit refreshes the
nutupane after altering the total number of sync plans.

http://projects.theforeman.org/issues/14902