### PR TITLE
Fixes #14724 - add proper redirection to be in sync with foreman behavior

### DIFF
--- a/app/controllers/katello/concerns/organizations_controller_extensions.rb
+++ b/app/controllers/katello/concerns/organizations_controller_extensions.rb
@@ -32,7 +32,7 @@ module Katello
             if @count_nil_hosts > 0
               redirect_to send("step2_#{taxonomy_single}_path",   @taxonomy)
             else
-              process_success(:object => @taxonomy)
+              process_success(:object => @taxonomy, :success_redirect => send("edit_#{taxonomy_single}_path", @taxonomy))
             end
           rescue ActiveRecord::RecordInvalid
             process_error(:render => "taxonomies/new", :object => @taxonomy)


### PR DESCRIPTION
Temporary fix, until https://github.com/theforeman/foreman/pull/3484 is merged in Foreman. After it's merged, there will be no need to duplicate foreman's behavior.