### PR TITLE
Fixes #14917: fix select all when adding erratum to an errata filter.

### DIFF
--- a/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
@@ -113,8 +113,11 @@ module Katello
 
     def process_errata_ids(select_all_params)
       if select_all_params[:included][:ids].blank?
+        select_all_params[:excluded][:ids] ||= [] if select_all_params[:excluded][:ids].nil?
         current_errata_ids = @filter.erratum_rules.map(&:errata_id) + select_all_params[:excluded][:ids]
-        Erratum.where('errata_id not in (?)', current_errata_ids).in_repositories(@filter.applicable_repos).pluck(:errata_id)
+        query = Erratum
+        query = query.where('errata_id not in (?)', current_errata_ids) unless current_errata_ids.empty?
+        query.in_repositories(@filter.applicable_repos).pluck(:errata_id)
       else
         []
       end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/date-type-errata-filter.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/date-type-errata-filter.html
@@ -1,5 +1,6 @@
 <form name="errataForm" class="form-horizontal">
 
+  <div data-block="messages" bst-alerts success-messages="successMessages" error-messages="errorMessages"></div>
   <div ng-include="'content-views/details/filters/views/date-type-errata.html'"></div>
 
   <div bst-form-buttons

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/date-type-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/date-type-errata.html
@@ -1,5 +1,3 @@
-<div data-block="messages" bst-alerts success-messages="successMessages" error-messages="errorMessages"></div>
-
 <div bst-form-group label="{{ 'Errata Type' | translate }}">
 
   <label class="checkbox-inline">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/errata-filter-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/errata-filter-details.html
@@ -7,6 +7,7 @@
 <div data-extend-template="layouts/details-nutupane.html">
 
   <div data-block="header"></div>
+  <span data-block="no-rows-message" translate>No Errata to display</span>
 
   <div data-block="actions">
     <button class="btn btn-primary fr"


### PR DESCRIPTION
The select all functionality of the errata filter by erratum ID was
completely broken after the rails 4 conversion.  This commit fixes
a couple of issues when adding erratum to a filter using the select
all functionality.

Also, fixes a couple of minor UI issues on the errata filter pages.

http://projects.theforeman.org/issues/14917