### PR TITLE
Fixes #14933 - Content Host Counts column on the Errata page should o…

### DIFF
--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -61,12 +61,16 @@ module Katello
       where("#{self.table_name}.id in (?) or #{self.table_name}.uuid in (?) or #{self.table_name}.errata_id in (?)", id_integers, ids, ids)
     end
 
-    def hosts_applicable
-      self.content_facets_applicable.joins(:host)
+    def hosts_applicable(org_id = nil)
+      if org_id.present?
+        self.content_facets_applicable.joins(:host).where("#{::Host.table_name}.organization_id" => org_id)
+      else
+        self.content_facets_applicable.joins(:host)
+      end
     end
 
-    def hosts_available
-      self.hosts_applicable.joins("INNER JOIN #{Katello::RepositoryErratum.table_name} on \
+    def hosts_available(org_id = nil)
+      self.hosts_applicable(org_id).joins("INNER JOIN #{Katello::RepositoryErratum.table_name} on \
         #{Katello::RepositoryErratum.table_name}.erratum_id = #{self.id}").joins(:content_facet_repositories).
         where("#{Katello::ContentFacetRepository.table_name}.repository_id = #{Katello::RepositoryErratum.table_name}.repository_id").uniq
     end

--- a/app/views/katello/api/v2/errata/show.json.rabl
+++ b/app/views/katello/api/v2/errata/show.json.rabl
@@ -12,8 +12,8 @@ end
 
 attributes :errata_type => :type
 
-node(:hosts_available_count) { |m| m.hosts_available.count }
-node(:hosts_applicable_count) { |m| m.hosts_applicable.count }
+node(:hosts_available_count) { |m| m.hosts_available(params[:organization_id]).count }
+node(:hosts_applicable_count) { |m| m.hosts_applicable(params[:organization_id]).count }
 
 node :packages do |e|
   e.packages.pluck(:nvrea)

--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -196,7 +196,7 @@ class ActiveSupport::TestCase
 
   def render_rabl(filepath, resource)
     Rabl::Renderer.new(filepath, resource, :view_path => "#{Katello::Engine.root}/app/views/",
-                       :format => 'hash', :locals => {:resource => resource}).render
+                       :format => 'hash', :locals => {:resource => resource}, :scope => OpenStruct.new(:params => {})).render
   end
 
   def assert_service_not_used(service_class)

--- a/test/models/erratum_test.rb
+++ b/test/models/erratum_test.rb
@@ -132,8 +132,9 @@ module Katello
 
     def test_hosts_available
       assert_includes @security.hosts_available, @host.content_facet
+      assert_includes @security.hosts_available(@host.organization), @host.content_facet
       refute_includes @security.hosts_available, @host_without_errata
-      refute_includes @bugfix.hosts_available, @host_without_errata
+      refute_includes @bugfix.hosts_available(@host.organization), @host_without_errata
     end
 
     def test_installable_for_hosts


### PR DESCRIPTION
…nly count hosts in the current org

If organization_id is supplied we only return applicable & available hosts in that org, if it isn't supplied we keep the current behavior and count all hosts across every org.

I#m not sure if we should be requiring organization_id to be supplied with this API GET /katello/api/errata ?