### PR TITLE
Fixes #14944 - disable changing CVs and lifecycle envs for registered managed hosts

### DIFF
--- a/app/controllers/katello/concerns/api/v2/hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/hosts_controller_extensions.rb
@@ -5,6 +5,8 @@ module Katello
       include ForemanTasks::Triggers
 
       included do
+        before_filter :check_env_and_cv, :only => [:update]
+
         def destroy
           sync_task(::Actions::Katello::Host::Destroy, @host)
           process_response(:object => @host)
@@ -25,6 +27,12 @@ module Katello
             'edit'
           else
             super
+          end
+        end
+
+        def check_env_and_cv
+          if !@host.content_facet.nil? && (params[:lifecycle_environment_id] || params[:content_view_id])
+            raise ::Foreman::Exception.new(N_("Can't update content view and lifecycle environment for existing content host."))
           end
         end
       end

--- a/app/views/overrides/activation_keys/_host_environment_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_environment_select.html.erb
@@ -14,7 +14,7 @@
     select_tag env_select_id, lifecycle_environment_options(@hostgroup, :include_blank => blank_or_inherit_with_id(f, :lifecycle_environment)),
                :class => 'form-control',  :name => env_select_name
   else
-    select_tag env_select_id, lifecycle_environment_options(@host, :selected_host_group => @hostgroup, :include_blank => blank_or_inherit_with_id(f, :lifecycle_environment)), :class => 'form-control',  :name => env_select_name
+    select_tag env_select_id, lifecycle_environment_options(@host, :selected_host_group => @hostgroup, :include_blank => blank_or_inherit_with_id(f, :lifecycle_environment)), :class => 'form-control',  :name => env_select_name, :disabled => !@host.content_facet.nil?
   end
 end %>
 
@@ -26,7 +26,7 @@ end %>
     select_tag cv_select_id,  content_views_for_host(@hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_view)), :data => {"spinner_path" => spinner_path},
                :class => 'form-control',  :name => cv_select_name
   else
-    select_tag cv_select_id,  content_views_for_host(@host, :selected_host_group => @hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_view)), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cv_select_name
+    select_tag cv_select_id,  content_views_for_host(@host, :selected_host_group => @hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_view)), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cv_select_name, :disabled => !@host.content_facet.nil?
   end
 end %>
 


### PR DESCRIPTION
There's no katello orchestration hooked on foreman host form. Therefore change of lifecycle environment or CV isn't propagated to Candlepin. This PR disables the fields for hosts that have existing content_facet (= were registered in katello).