### PR TITLE
Fixes #14949 - Fail on import upload failures

### DIFF
--- a/app/lib/actions/pulp/repository/import_upload.rb
+++ b/app/lib/actions/pulp/repository/import_upload.rb
@@ -16,10 +16,6 @@ module Actions
                                                    input[:unit_key],
                                                     unit_metadata: {})
         end
-
-        def rescue_strategy
-          Dynflow::Action::Rescue::Skip
-        end
       end
     end
   end


### PR DESCRIPTION
Calling import_upload in the API was returning 200 which caused the CLI to report that the upload was successful.