### PR TITLE
Fixes #13762: Don't save organization during environment create

### DIFF
--- a/app/controllers/katello/api/v2/environments_controller.rb
+++ b/app/controllers/katello/api/v2/environments_controller.rb
@@ -82,8 +82,6 @@ module Katello
       create_params[:organization] = @organization
       create_params[:prior] = @prior
       @environment = KTEnvironment.create!(create_params)
-      @organization.kt_environments << @environment
-      @organization.save!
       respond
     end
 


### PR DESCRIPTION
Organization save when creating environment could lead to mismatches
that report validation errors to the user on the organization but
not the environment itself. This code previously ensured the organization
was associated to the environment but testing indicated this was
not needed.