### PR TITLE
Fixes #14972 - Update docs links in the contributing markdown file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,12 +3,11 @@ Contributing to Katello
 
 As an open-source project, we enjoy working with the community. We've developed
 some guidelines though for contributing to Katello. Please see our
-[development guidelines](https://fedorahosted.org/katello/wiki/DevProcess).
+[development guidelines](http://www.katello.org/developers/).
 Also, make sure your code conforms to our style guidelines:
 
-* [Ruby guidelines](https://fedorahosted.org/katello/wiki/RubyCodeConventions)
-* [Javascript guidelines](https://github.com/Katello/katello.org/blob/master/docs/developer_guide/style/javascript.md)
-* [Python guidelines](https://fedorahosted.org/katello/wiki/PythonCodeConventions)
+* [Ruby guidelines](http://www.katello.org/developers/style/ruby.html)
+* [Javascript guidelines](http://www.katello.org/developers/style/javascript.html)
 
 Be sure to check out our README and let us know on our mailing list or IRC
 if you have any questions.


### PR DESCRIPTION
All the links are broken currently. These new URLs link to the katello.org docs. There is no Python in the project that I can find, and there is no style guide for Python at katello.org, so I removed that line.