### PR TITLE
Fixes #14940 - update all packages on a content host

### DIFF
--- a/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
@@ -109,6 +109,7 @@ module Katello
           :desc => N_("The type of content.  The following types are supported: 'package' and 'package_group."),
           :required => true
     param :content, Array, :desc => N_("List of content (e.g. package or package group names)"), :required => true
+    param :update_all, :bool, :desc => N_("Updates all packages on the host(s)")
     def update_content
       content_action
     end
@@ -217,14 +218,14 @@ module Katello
         respond_for_async :resource => task
       else
         action = Katello::BulkActions.new(@hosts)
-        job = action.send(PARAM_ACTIONS[params[:action]][params[:content_type]],  params[:content])
+        job = action.send(PARAM_ACTIONS[params[:action]][params[:content_type]],  params[:content], :update_all => params[:update_all])
         respond_for_show :template => 'job', :resource => job
       end
     end
 
     def validate_content_action
       fail HttpErrors::BadRequest, _("A content_type must be provided.") if params[:content_type].blank?
-      fail HttpErrors::BadRequest, _("No content has been provided.") if params[:content].blank?
+      fail HttpErrors::BadRequest, _("No content has been provided.") if params[:content].blank? && !params[:update_all]
 
       if PARAM_ACTIONS[params[:action]][params[:content_type]].nil?
         fail HttpErrors::BadRequest, _("Invalid content type %s") % params[:content_type]

--- a/app/lib/katello/bulk_actions.rb
+++ b/app/lib/katello/bulk_actions.rb
@@ -6,43 +6,42 @@ module Katello
       @consumer_ids = hosts.map { |host| host.content_facet.try(:uuid) }.compact
     end
 
-    def install_packages(packages)
+    def install_packages(packages, _options = {})
       fail Errors::EmptyBulkActionException if self.consumer_ids.empty?
       perform_bulk_action do |consumer_group|
         consumer_group.install_package(packages)
       end
     end
 
-    def uninstall_packages(packages)
+    def uninstall_packages(packages, _options = {})
       fail Errors::EmptyBulkActionException if self.consumer_ids.empty?
       perform_bulk_action do |consumer_group|
         consumer_group.uninstall_package(packages)
       end
     end
 
-    def update_packages(packages = nil)
-      # if no packages are provided, a full system update will be performed (e.g ''yum update' equivalent)
+    def update_packages(packages = nil, options = {})
       fail Errors::EmptyBulkActionException if self.consumer_ids.empty?
       perform_bulk_action do |consumer_group|
-        consumer_group.update_package(packages)
+        consumer_group.update_package(packages, options)
       end
     end
 
-    def install_package_groups(groups)
-      fail Errors::EmptyBulkActionException if self.consumer_ids.empty?
-      perform_bulk_action do |consumer_group|
-        consumer_group.install_package_group(groups)
-      end
-    end
-
-    def update_package_groups(groups)
+    def install_package_groups(groups, _options = {})
       fail Errors::EmptyBulkActionException if self.consumer_ids.empty?
       perform_bulk_action do |consumer_group|
         consumer_group.install_package_group(groups)
       end
     end
 
-    def uninstall_package_groups(groups)
+    def update_package_groups(groups, _options = {})
+      fail Errors::EmptyBulkActionException if self.consumer_ids.empty?
+      perform_bulk_action do |consumer_group|
+        consumer_group.install_package_group(groups)
+      end
+    end
+
+    def uninstall_package_groups(groups, _options = {})
       fail Errors::EmptyBulkActionException if self.consumer_ids.empty?
       perform_bulk_action do |consumer_group|
         consumer_group.uninstall_package_group(groups)

--- a/app/services/katello/pulp/consumer_group.rb
+++ b/app/services/katello/pulp/consumer_group.rb
@@ -42,11 +42,11 @@ module Katello
         raise e
       end
 
-      def update_package(packages)
+      def update_package(packages, options = {})
         Rails.logger.debug "Scheduling package update for consumer group #{self.pulp_id}"
 
-        options = {"importkeys" => true}
-        options[:all] = true if packages.blank?
+        options.merge!(:importkeys => true)
+        options[:all] = true if options[:update_all]
         Katello.pulp_server.extensions.consumer_group.update_content(self.pulp_id,
                                                                        'rpm',
                                                                        packages,

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-action-packages.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-action-packages.controller.js
@@ -21,9 +21,10 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkActionPackag
 
         function successMessage(type) {
             var messages = {
-                install: translate("Succesfully scheduled package installation"),
-                update: translate("Succesfully scheduled package update"),
-                remove: translate("Succesfully scheduled package removal")
+                install: translate("Successfully scheduled package installation"),
+                update: translate("Successfully scheduled package update"),
+                remove: translate("Successfully scheduled package removal"),
+                "update all": translate("Successfully scheduled an update of all packages")
             };
             return messages[type];
         }
@@ -31,7 +32,12 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkActionPackag
         function installParams() {
             var params = $scope.nutupane.getAllSelectedResults();
             params['content_type'] = $scope.content.contentType;
-            params.content = $scope.content.content.split(/ *, */);
+            if ($scope.content.action === "update all") {
+                params['update_all'] = true;
+                params.content = null;
+            } else {
+                params.content = $scope.content.content.split(/ *, */);
+            }
             params['organization_id'] = CurrentOrganization;
             return params;
         }
@@ -102,6 +108,8 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkActionPackag
                 HostBulkAction.updateContent(params, success, error);
             } else if ($scope.content.action === "remove") {
                 HostBulkAction.removeContent(params, success, error);
+            } else if ($scope.content.action === "update all") {
+                HostBulkAction.updateContent(params, success, error);
             }
 
             return deferred.promise;
@@ -115,6 +123,10 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkActionPackag
 
             if (!action) {
                 action = $scope.content.action;
+            }
+
+            if (action === "update all") {
+                action = "update";
             }
 
             if ($scope.content.contentType === 'package_group') {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/bulk-actions-packages.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/bulk-actions-packages.html
@@ -4,6 +4,28 @@
   <section>
     <h4 translate>Content Host Package Management</h4>
 
+    <span class="input-group-btn">
+      <button class="btn btn-default"
+              type="button"
+              translate
+              ng-hide="denied('edit_hosts')"
+              ng-click="confirmContentAction('update all', content)"
+              ng-disabled="(table.numSelected === 0)">
+        Update All Packages
+      </button>
+      <button class="btn btn-default dropdown-toggle"
+              ng-hide="!remoteExecutionPresent"
+              ng-disabled="(table.numSelected === 0) || !packageActionForm.$valid || content.confirm"
+              type="button" id="update-all-use-remote-execution" data-toggle="dropdown">
+        <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu" role="menu" aria-labelledby="install-use-remote-execution">
+        <li role="presentation"><a ng-click="performViaKatelloAgent('update all', content)" role="menuitem" tabindex="-1" href="#" translate>via Katello Agent</a></li>
+        <li role="presentation"><a ng-click="performViaRemoteExecution('update all', false)" role="menuitem" tabindex="-1" href="#" translate>via remote execution</a></li>
+        <li role="presentation"><a ng-click="performViaRemoteExecution('update all', true)" role="menuitem" tabindex="-1" href="#" translate>via remote execution - customize first</a></li>
+      </ul>
+    </span>
+
     <form id="packageActionForm" name="packageActionForm" class="form" method="post" action="/katello/remote_execution">
       <input type="hidden" name="name" ng-value="content.content"/>
       <input type="hidden" name="remote_action" ng-value="packageActionFormValues.remoteAction"/>
@@ -13,7 +35,7 @@
       <input type="hidden" name="customize" ng-value="packageActionFormValues.customize"/>
     </form>
 
-    <form name="systemContentForm" class="form" ng-hide="content.workingMode || denied('edit_hosts')">
+    <form name="systemContentForm" class="form" ng-hide="content.workingMode || denied('edit_hosts')" novalidate>
 
       <div>
         <input id="package" type="radio"
@@ -117,9 +139,12 @@
         <div class="confirmation_text" ng-show="content.action == 'remove'" translate>
           Are you sure you want to remove {{ content.content }} from the {{ getSelectedSystemIds().length }} system(s) selected?
         </div>
+        <div class="confirmation_text" ng-show="content.action == 'update all'" translate>
+          Are you sure you want to update all packages on the {{ getSelectedSystemIds().length }} system(s) selected?
+        </div>
 
         <button class="btn btn-default" ng-click="performContentAction()" translate>Yes</button>
-        <button class="btn btn-default" ng-click="content.confirm = false" translate>No</button>
+        <button type="button" class="btn btn-default" ng-click="content.confirm = false" translate>No</button>
       </div>
 
     </form>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages.controller.js
@@ -109,6 +109,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostPackagesControlle
         $scope.detailsTable = packagesNutupane.table;
         $scope.detailsTable.openEventInfo = openEventInfo;
         $scope.detailsTable.contentHost = $scope.contentHost;
+        $scope.detailsTable.selectAllResultsEnabled = true;
 
         $scope.detailsTable.taskFailed = function (task) {
             return angular.isUndefined(task) || task.failed || task['affected_units'] === 0;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages.html
@@ -85,6 +85,8 @@
     </div>
   </div>
 
+  <div data-extend-template="layouts/select-all-results.html"></div>
+
   <div data-block="table">
     <table ng-class="{'table-mask': detailsTable.working}" class="table table-full table-striped">
       <thead>


### PR DESCRIPTION
This adds a way to update all packages on a content host in two places

Hosts > Content Hosts > (select content host name) > Packages tab:
select all viewable checkboxes, a message should appear asking if you 
want to select all the checkboxes, click that and click "update all"

Hosts > Content Hosts > (select content host checkboxes) > Bulk Actions > Packages tab:
click update all packages button