### PR TITLE
Fixes #14723 - dash widget optimization

### DIFF
--- a/app/models/katello/concerns/organization_extensions.rb
+++ b/app/models/katello/concerns/organization_extensions.rb
@@ -60,6 +60,10 @@ module Katello
           self.providers.redhat.first
         end
 
+        def active_pools_count
+          self.pools.count { |p| p[:activeSubscription] == true }
+        end
+
         def anonymous_provider
           self.providers.anonymous.first
         end

--- a/app/views/dashboard/_subscription_status_widget.html.erb
+++ b/app/views/dashboard/_subscription_status_widget.html.erb
@@ -4,7 +4,7 @@
 
 <% organizations = Organization.current.present? ? [Organization.current] : User.current.allowed_organizations %>
 <% subscriptions = Katello::Subscription.in_organization(organizations).includes(:pools) %>
-<% total_active_subscriptions = subscriptions.select(&:active?).count %>
+<% total_active_subscriptions = organizations.map {|org| org.active_pools_count}.reduce(:+) %>
 <% total_expiring_subscriptions = subscriptions.select(&:expiring_soon?).count %>
 <% total_recently_expired_subscriptions = subscriptions.select(&:recently_expired?).count %>
 


### PR DESCRIPTION
Previously, a call was made to candlepin for each pool, to determine if
the pool was active or not. This caused the dashboard to slow down as
subs were added.

Instead, call candlepin once for each org to obtain the total active
pool count.

How I tested:

 * load a manifest with five subs into Org A
 * load a manifest with one sub into Org B
 * tail `/var/log/candlepin/candlepin.log`, note that only one call is
   being made when viewing Org A's dashboard
 * note that two calls are made when viewing "Any Organization"'s board
 * confirmed that org count was right for A, B, and Any.