### PR TITLE
Fixes #14989 - require_org will redirect to select_organization instead of 404.

### DIFF
--- a/app/controllers/katello/application_controller.rb
+++ b/app/controllers/katello/application_controller.rb
@@ -264,7 +264,7 @@ module Katello
     def require_org
       unless session && current_organization
         execute_after_filters
-        fail Errors::SecurityViolation, _("User does not belong to an organization.")
+        redirect_to '/select_organization?toState=' + request.path
       end
     end
 


### PR DESCRIPTION
To test choose Any Organization, then visit the sync status page. It will redirect you to select an organization.