### PR TITLE
Fixes #13756 - improve package install experience on unregistered host

### DIFF
--- a/app/controllers/katello/api/v2/host_packages_controller.rb
+++ b/app/controllers/katello/api/v2/host_packages_controller.rb
@@ -91,8 +91,9 @@ module Katello
     def find_editable_host_with_facet
       @host = resource_finder(::Host::Managed.authorized("edit_hosts"), params[:host_id])
       fail HttpErrors::NotFound, _("Couldn't find host with host id '%s'") % params[:host_id] if @host.nil?
-      fail HttpErrors::NotFound, _("Host id '%s' does not have a content facet") % params[:host_id] if @host.content_facet.nil?
-      fail HttpErrors::NotFound, _("Host id '%s' content facet is missing a uuid") % params[:host_id] if @host.content_facet.uuid.nil?
+      if @host.content_facet.try(:uuid).nil?
+        fail HttpErrors::NotFound, _("Host has not been registered with subscription-manager.") % params[:host_id]
+      end
       @host
     end
 

--- a/app/lib/actions/katello/host/destroy.rb
+++ b/app/lib/actions/katello/host/destroy.rb
@@ -33,6 +33,7 @@ module Actions
 
             host.get_status(::Katello::ErrataStatus).destroy
             host.get_status(::Katello::SubscriptionStatus).destroy
+            host.installed_packages.destroy_all
           else
             host.content_facet.try(:destroy!)
             unless host.destroy

--- a/app/lib/katello/bulk_actions.rb
+++ b/app/lib/katello/bulk_actions.rb
@@ -7,14 +7,14 @@ module Katello
     end
 
     def install_packages(packages)
-      fail Errors::HostCollectionEmptyException if self.consumer_ids.empty?
+      fail Errors::EmptyBulkActionException if self.consumer_ids.empty?
       perform_bulk_action do |consumer_group|
         consumer_group.install_package(packages)
       end
     end
 
     def uninstall_packages(packages)
-      fail Errors::HostCollectionEmptyException if self.consumer_ids.empty?
+      fail Errors::EmptyBulkActionException if self.consumer_ids.empty?
       perform_bulk_action do |consumer_group|
         consumer_group.uninstall_package(packages)
       end
@@ -22,28 +22,28 @@ module Katello
 
     def update_packages(packages = nil)
       # if no packages are provided, a full system update will be performed (e.g ''yum update' equivalent)
-      fail Errors::HostCollectionEmptyException if self.consumer_ids.empty?
+      fail Errors::EmptyBulkActionException if self.consumer_ids.empty?
       perform_bulk_action do |consumer_group|
         consumer_group.update_package(packages)
       end
     end
 
     def install_package_groups(groups)
-      fail Errors::HostCollectionEmptyException if self.consumer_ids.empty?
+      fail Errors::EmptyBulkActionException if self.consumer_ids.empty?
       perform_bulk_action do |consumer_group|
         consumer_group.install_package_group(groups)
       end
     end
 
     def update_package_groups(groups)
-      fail Errors::HostCollectionEmptyException if self.consumer_ids.empty?
+      fail Errors::EmptyBulkActionException if self.consumer_ids.empty?
       perform_bulk_action do |consumer_group|
         consumer_group.install_package_group(groups)
       end
     end
 
     def uninstall_package_groups(groups)
-      fail Errors::HostCollectionEmptyException if self.consumer_ids.empty?
+      fail Errors::EmptyBulkActionException if self.consumer_ids.empty?
       perform_bulk_action do |consumer_group|
         consumer_group.uninstall_package_group(groups)
       end

--- a/app/lib/katello/errors.rb
+++ b/app/lib/katello/errors.rb
@@ -35,6 +35,12 @@ module Katello
       end
     end
 
+    class EmptyBulkActionException < StandardError
+      def message
+        _("No hosts registered with subscription-manager found in selection.")
+      end
+    end
+
     class ConnectionRefusedException < StandardError; end
 
     class MaxHostsReachedException < StandardError; end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages.html
@@ -1,7 +1,6 @@
 <span page-title ng-model="host">{{ 'Packages for: ' | translate }} {{ host.name }}</span>
 
 <section ng-hide="denied('edit_hosts', host)" bst-feature-flag="remote_actions">
-  <div bst-alerts success-messages="successMessages" error-messages="errorMessages"></div>
   <h4 translate>Package Actions</h4>
   <p bst-alert="info" ng-hide="contentHost.katello_agent_installed">
     <span translate>


### PR DESCRIPTION
this commit does a few things:
  * At unregister time, delete installed_packages list as they may not be accurate
  * If attempting to install a package, throw a nicer warning
  * UI to attempt to install a package is still there for REX
  * Remove duplicate error/success messages block