### PR TITLE
Fixes #14430 - fix JS unit test breakage

### DIFF
--- a/engines/bastion_katello/test/errata/apply-errata.controller.test.js
+++ b/engines/bastion_katello/test/errata/apply-errata.controller.test.js
@@ -203,8 +203,12 @@ describe('Controller: ApplyErrataController', function() {
             });
 
             afterEach(function () {
-                expect(ContentViewVersion.incrementalUpdate).toHaveBeenCalledWith(expectedParams, jasmine.any(Function),
+                expect(ContentViewVersion.incrementalUpdate).toHaveBeenCalledWith(jasmine.any(Object), jasmine.any(Function),
                     jasmine.any(Function));
+                expect(ContentViewVersion.incrementalUpdate.mostRecentCall.args[0]['add_content']).toEqual(expectedParams['add_content'])
+                expect(ContentViewVersion.incrementalUpdate.mostRecentCall.args[0]['content_view_version_environments']).toContain(expectedParams['content_view_version_environments'][0])
+                expect(ContentViewVersion.incrementalUpdate.mostRecentCall.args[0]['content_view_version_environments']).toContain(expectedParams['content_view_version_environments'][1])
+                expect(ContentViewVersion.incrementalUpdate.mostRecentCall.args[0]['resolve_dependencies']).toEqual(expectedParams['resolve_dependencies'])
             });
 
             it("and succeed", function () {
@@ -248,8 +252,12 @@ describe('Controller: ApplyErrataController', function() {
             });
 
             afterEach(function () {
-                expect(ContentViewVersion.incrementalUpdate).toHaveBeenCalledWith(expectedParams, jasmine.any(Function),
+                expect(ContentViewVersion.incrementalUpdate).toHaveBeenCalledWith(jasmine.any(Object), jasmine.any(Function),
                     jasmine.any(Function));
+                expect(ContentViewVersion.incrementalUpdate.mostRecentCall.args[0]['add_content']).toEqual(expectedParams['add_content'])
+                expect(ContentViewVersion.incrementalUpdate.mostRecentCall.args[0]['content_view_version_environments']).toContain(expectedParams['content_view_version_environments'][0])
+                expect(ContentViewVersion.incrementalUpdate.mostRecentCall.args[0]['content_view_version_environments']).toContain(expectedParams['content_view_version_environments'][1])
+                expect(ContentViewVersion.incrementalUpdate.mostRecentCall.args[0]['resolve_dependencies']).toEqual(expectedParams['resolve_dependencies'])
             });
 
             it("and succeed", function () {


### PR DESCRIPTION
The array ordering got swapped during execution recently, causing
intermittent Jenkins failures.

This commit removes the checks for expectedParameters for two tests,
since the tests were relying on specific array ordering.