### PR TITLE
Fixes #15024: only return installable errata for hosts provided.

### DIFF
--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -82,7 +82,8 @@ module Katello
         joins("INNER JOIN #{Katello::RepositoryErratum.table_name} AS host_repo_errata ON \
           host_repo_errata.erratum_id = #{Katello::Erratum.table_name}.id").
         where("#{Katello::ContentFacetRepository.table_name}.repository_id = host_repo_errata.repository_id")
-      query.where("#{Katello::Host::ContentFacet.table_name}.host_id" => [hosts.map(&:id)]) if hosts
+
+      query = query.joins(:content_facets).where("#{Katello::Host::ContentFacet.table_name}.host_id" => [hosts.map(&:id)]) if hosts
       query.uniq
     end
 

--- a/test/models/erratum_test.rb
+++ b/test/models/erratum_test.rb
@@ -157,5 +157,13 @@ module Katello
       assert_includes errata, @bugfix
       refute_includes errata, @enhancement
     end
+
+    def test_installable_for_hosts_without_errata
+      #Tests issue #15024
+      errata = Erratum.installable_for_hosts([@host_without_errata])
+      refute_includes errata, @security
+      refute_includes errata, @bugfix
+      refute_includes errata, @enhancement
+    end
   end
 end


### PR DESCRIPTION
The query for installable errata for hosts was not using the hosts
argument if provided.  This commit fixes the query to return only
installable errata for the hosts provided.

http://projects.theforeman.org/issues/15024