### PR TITLE
Fixes #15035 - Adding rails script to katello

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+# This command will automatically be run when you run "rails" with Rails 4 gems installed from the root of your application.
+
+ENGINE_ROOT = File.expand_path('../..', __FILE__)
+ENGINE_PATH = File.expand_path('../../lib/katello/engine', __FILE__)
+
+# Set up gems listed in the Gemfile.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+
+require 'rails/all'
+require 'rails/engine/commands'


### PR DESCRIPTION
More info: http://guides.rubyonrails.org/engines.html#bin-directory

This will let us do things like generate models, migrations, etc from within katello:

```
$ bin/rails g model foobar foo:integer bar:string baz:references
$ bin/rails g migration add_user_id_to_content_views user_id:references
```