### PR TITLE
Fixes #15039 - already initialized constant error on upgrade

### DIFF
--- a/config/routes/overrides.rb
+++ b/config/routes/overrides.rb
@@ -1,6 +1,6 @@
 module Katello
   class WhitelistConstraint
-    PATHS = [%r{\A/api/v2/organizations/\S+/parameters}]
+    PATHS ||= [%r{\A/api/v2/organizations/\S+/parameters}]
 
     def matches?(request)
       PATHS.map { |path| request.env["REQUEST_PATH"].match(path) }.any? ? false : true


### PR DESCRIPTION
This commit is to address the following error observed during upgrade:

[ERROR 2016-05-12 21:39:04 main] /opt/theforeman/tfm/root/usr/share/gems/gems/katello-3.0.0.28/config/routes/overrides.rb:3: warning: already initialized constant Katello::WhitelistConstraint::PATHS