### PR TITLE
Fixes #15083: add puppet modules to the list of fenced pages.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/fenced-pages.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/fenced-pages.service.js
@@ -18,7 +18,8 @@ angular.module('Bastion.organizations').service('FencedPages',
             'content-views',
             'errata',
             'content-hosts',
-            'host-collections'
+            'host-collections',
+            'puppet-modules'
         ];
 
         this.addPages = function (pages) {

--- a/engines/bastion_katello/test/organizations/fenced-pages.service.test.js
+++ b/engines/bastion_katello/test/organizations/fenced-pages.service.test.js
@@ -5,13 +5,10 @@ describe('Factory: FencedPages', function() {
         FencedPages = _FencedPages_;
     }));
 
-    it("should list all the fenced pages", function () {
-        expect(FencedPages.list().length).toBe(10);
-    });
-
     it("should add page to the list", function () {
+        var expectedLength = FencedPages.list().length + 2;
         FencedPages.addPages(["testpage", "testpage2"]);
-        expect(FencedPages.list().length).toBe(12);
+        expect(FencedPages.list().length).toBe(expectedLength);
     });
 
     it("should find if page is in the list", function () {


### PR DESCRIPTION
Puppet Modules require an organization so add it to the list of fenced
pages that require organizations.

http://projects.theforeman.org/issues/15083