### PR TITLE
Fixes #14992 - Change content host status icons

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -104,6 +104,10 @@ module Katello
         @subscription_status_label ||= get_status(::Katello::SubscriptionStatus).to_label(options)
       end
 
+      def subscription_global_status
+        @subscription_global_status ||= get_status(::Katello::SubscriptionStatus).to_global
+      end
+
       def errata_status
         @errata_status ||= get_status(::Katello::ErrataStatus).status
       end

--- a/app/views/katello/api/v2/subscription_facet/base_with_root.json.rabl
+++ b/app/views/katello/api/v2/subscription_facet/base_with_root.json.rabl
@@ -6,4 +6,5 @@ node :content_host_id do |host|
   host.content_host.try(:id)
 end
 
-attributes :subscription_status, :subscription_status_label, :if => @object.get_status(Katello::SubscriptionStatus).relevant?
+attributes :subscription_status, :subscription_status_label, :subscription_global_status,
+           :if => @object.get_status(Katello::SubscriptionStatus).relevant?

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-associations.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-associations.controller.js
@@ -41,7 +41,7 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyAssociationsC
             contentHostsNutupane.load();
         });
 
-        $scope.getSubscriptionStatusColor = ContentHostsHelper.getSubscriptionStatusColor;
+        $scope.getHostStatusIcon = ContentHostsHelper.getHostStatusIcon;
 
         $scope.memory = ContentHostsHelper.memory;
     }]

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-associations-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-associations-content-hosts.html
@@ -34,7 +34,7 @@
             </a>
           </td>
           <td bst-table-cell>
-            <span class="fa fa-circle" ng-class="getSubscriptionStatusColor(contentHost.entitlementStatus)">
+            <span ng-class="getHostStatusIcon(contentHost.entitlementStatus)">
             </span>
           </td>
           <td bst-table-cell>{{ contentHost.environment.name }}</td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts-helper.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts-helper.service.js
@@ -7,28 +7,26 @@
  */
 angular.module('Bastion.content-hosts').service('ContentHostsHelper',
     function () {
-        this.getSubscriptionStatusColor = function (status) {
+        this.getHostStatusIcon = function (globalStatus) {
+            var icons;
             var colors = {
-                    'valid': 'green',
-                    'partial': 'yellow',
-                    'invalid': 'red',
-                    0: 'green',
-                    1: 'yellow',
-                    2: 'red',
-                    3: 'red'
-                };
+                // we can remove 'valid', 'partial', and 'invalid' when http://projects.theforeman.org/issues/15347 is fixed
+                'valid': 'green',
+                'partial': 'yellow',
+                'invalid': 'red',
+                0: 'green',
+                1: 'yellow',
+                2: 'red'
+            };
 
-            return colors[status] ? colors[status] : 'red';
-        };
+            globalStatus = colors[globalStatus] || "red";
+            icons = {
+                'green': globalStatus + ' host-status pficon pficon-ok status-ok',
+                'yellow': globalStatus + ' host-status pficon pficon-info status-warn',
+                'red': globalStatus + ' host-status pficon pficon-error-circle-o status-error'
+            };
 
-        this.getGlobalStatusColor = function (status) {
-            var colors = {
-                    0: 'green',
-                    1: 'yellow',
-                    2: 'red'
-                };
-
-            return colors[status] ? colors[status] : 'red';
+            return icons[globalStatus];
         };
     }
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
@@ -66,8 +66,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsController',
             nutupane.table.initialSelectAll = true;
         }
 
-        $scope.contentHostTable.getSubscriptionStatusColor = ContentHostsHelper.getSubscriptionStatusColor;
-        $scope.contentHostTable.getGlobalStatusColor = ContentHostsHelper.getGlobalStatusColor;
+        $scope.contentHostTable.getHostStatusIcon = ContentHostsHelper.getHostStatusIcon;
 
         $scope.contentHostTable.closeItem = function () {
             $scope.transitionTo('content-hosts.index');

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -41,11 +41,11 @@
            bst-feature-flag="remote_actions">
         <span class="info-label" translate>Katello Agent</span>
         <span class="info-value" ng-show="host.content_facet_attributes.katello_agent_installed">
-          <span class="fa fa-circle green"></span>
+          <span class="{{ contentHostTable.getHostStatusIcon(0) }}"></span>
           <span translate>Installed</span>
         </span>
         <span class="info-value" ng-hide="host.content_facet_attributes.katello_agent_installed">
-          <span class="fa fa-circle yellow"></span>
+          <span class="{{ contentHostTable.getHostStatusIcon(1) }}"></span>
           <span translate>Not installed</span>
         </span>
       </div>
@@ -77,7 +77,7 @@
       <div class="detail">
         <span class="info-label" translate>Subscription Status</span>
         <span class="info-value">
-          <i class="fa fa-circle" ng-class="contentHostTable.getSubscriptionStatusColor(host.subscription_status)"></i>
+          <i ng-class="contentHostTable.getHostStatusIcon(host.subscription_global_status)"></i>
           {{ host.subscription_status_label }}
         </span>
       </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-provisioning-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-provisioning-info.html
@@ -18,7 +18,7 @@
       <div class="detail">
         <span class="info-label" translate>Status</span>
         <span class="info-value">
-          <i class="fa fa-circle provisioning-status" ng-class="contentHostTable.getGlobalStatusColor(host.global_status)"></i>
+          <i ng-class="contentHostTable.getHostStatusIcon(host.global_status)"></i>
           {{ host.global_status_label | translate }}
         </span>
       </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions.html
@@ -22,8 +22,8 @@
     <div class="detail">
       <span class="info-label" translate>Status</span>
         <span class="info-value">
-          <i class="fa fa-circle" ng-class="contentHostTable.getSubscriptionStatusColor(host.subscription_status)"></i>
-          {{ host.subscription_status_label }}
+          <i ng-class="contentHostTable.getHostStatusIcon(host.subscription_global_status)"></i>
+          {{ host.subscription_status_label | translate }}
         </span>
     </div>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts-table-collapsed.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts-table-collapsed.html
@@ -14,7 +14,7 @@
         active-row="stateIncludes('content-hosts.details', {hostId: host.id})"
         ng-controller="ContentHostStatusController">
       <td bst-table-cell>
-        <span class="fa fa-circle" ng-class="contentHostTable.getSubscriptionStatusColor(host.subscription_status)">
+        <span ng-class="contentHostTable.getHostStatusIcon(host.subscription_global_status)">
         </span>
         <a ui-sref="content-hosts.details.info({hostId: host.id})">
           {{ host.name }}

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts-table-full.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts-table-full.html
@@ -29,7 +29,7 @@
         </a>
       </td>
       <td bst-table-cell>
-        <span class="fa fa-circle" ng-class="contentHostTable.getSubscriptionStatusColor(host.subscription_status)">
+        <span ng-class="contentHostTable.getHostStatusIcon(host.subscription_global_status)">
         </span>
       </td>
       <td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/subscription-associations-content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/subscription-associations-content-hosts.controller.js
@@ -25,7 +25,7 @@ angular.module('Bastion.subscriptions').controller('SubscriptionAssociationsCont
             $scope.working = false;
         });
 
-        $scope.getSubscriptionStatusColor = ContentHostsHelper.getSubscriptionStatusColor;
+        $scope.getHostStatusIcon = ContentHostsHelper.getHostStatusIcon;
 
         $scope.memory = ContentHostsHelper.memory;
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/views/subscription-associations-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/views/subscription-associations-content-hosts.html
@@ -45,7 +45,7 @@
           </a>
         </td>
         <td bst-table-cell>
-          <span class="fa fa-circle" ng-class="getSubscriptionStatusColor(contentHost['entitlement_status'])">
+          <span ng-class="getHostStatusIcon(contentHost['entitlement_status'])">
           </span>
         </td>
         <td bst-table-cell>{{ virtual(contentHost.facts) | booleanToYesNo }}</td>

--- a/engines/bastion_katello/test/content-hosts/content-hosts-helper.service.test.js
+++ b/engines/bastion_katello/test/content-hosts/content-hosts-helper.service.test.js
@@ -1,5 +1,8 @@
 describe('Controller: ContentHostsController', function() {
     var ContentHostsHelper;
+    var greenStatus = 'green host-status pficon pficon-ok status-ok';
+    var yellowStatus = 'yellow host-status pficon pficon-info status-warn';
+    var redStatus = 'red host-status pficon pficon-error-circle-o status-error';
 
     beforeEach(module('Bastion.content-hosts'));
 
@@ -8,15 +11,15 @@ describe('Controller: ContentHostsController', function() {
     }));
 
     it("provides a way to get the status color for the content host.", function() {
-        expect(ContentHostsHelper.getSubscriptionStatusColor("valid")).toBe("green");
-        expect(ContentHostsHelper.getSubscriptionStatusColor("partial")).toBe("yellow");
-        expect(ContentHostsHelper.getSubscriptionStatusColor("error")).toBe("red");
+        expect(ContentHostsHelper.getHostStatusIcon("valid")).toBe(greenStatus);
+        expect(ContentHostsHelper.getHostStatusIcon("partial")).toBe(yellowStatus);
+        expect(ContentHostsHelper.getHostStatusIcon("error")).toBe(redStatus);
     });
 
     it("provides a way to get the global status color.", function() {
-        expect(ContentHostsHelper.getGlobalStatusColor(0)).toBe("green");
-        expect(ContentHostsHelper.getGlobalStatusColor(1)).toBe("yellow");
-        expect(ContentHostsHelper.getGlobalStatusColor(2)).toBe("red");
+        expect(ContentHostsHelper.getHostStatusIcon(0)).toBe(greenStatus);
+        expect(ContentHostsHelper.getHostStatusIcon(1)).toBe(yellowStatus);
+        expect(ContentHostsHelper.getHostStatusIcon(2)).toBe(redStatus);
     });
 
 });


### PR DESCRIPTION
This changes the content host status and other status icons to have symbols as well as a color. There are two reasons to do this:
1) unify the symbols with Foreman's
2) make the icons color-blind friendly