### PR TITLE
Fixes #15162 - Host collections can be removed

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -313,6 +313,8 @@ module Katello
                                                           :auto_attach,
                                                           :max_hosts,
                                                           :unlimited_hosts,
+                                                          # For deep_munge; Remove for Rails 5
+                                                          :host_collection_ids,
                                                           :content_overrides => [],
                                                           :host_collection_ids => [])
 

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -246,5 +246,11 @@ module Katello
         post(:remove_subscriptions, :organization_id => @organization.id, :id => @activation_key.id, :subscription_id => 123)
       end
     end
+
+    def test_remove_host_collections
+      ActivationKey.any_instance.stubs(:save!)
+      ActivationKey.any_instance.expects(:host_collection_ids=).with([])
+      put(:remove_host_collections, organization_id: @organization.id, id: @activation_key.id, host_collection_ids: [])
+    end
   end
 end


### PR DESCRIPTION
This issue is caused by the deep_munge method in Rails 4. We use our API
to GET a record, update a collection of children, then PUT the updated
record to the API in order to update the DB. If the collection of
children is empty, deep munge in conjunction with strong parameters,
translates the empty array into nil, and the collection of children
remains unchanged.

This fix is a workaround and should be removed when upgrading Foretello
to Rails 5. I made a comment containing "Rails 5" so it can be addressed
during the upgrade with a global find.