### PR TITLE
Fixes #12650 - make sure we sync on QPID acknowledge

### DIFF
--- a/app/lib/actions/candlepin/candlepin_listening_service.rb
+++ b/app/lib/actions/candlepin/candlepin_listening_service.rb
@@ -77,7 +77,7 @@ module Actions
               message = fetch_message
               if message[:result]
                 result = message[:result]
-                @session.acknowledge(:message => result)
+                @session.acknowledge(:message => result, :sync => true)
                 suspended_action.notify_message_received(result.message_id, result.subject, result.content)
               elsif message[:error]
                 suspended_action.notify_not_connected(message[:error])


### PR DESCRIPTION
It seems the way we use the QPID client library causes the memory leaks 
described in https://issues.apache.org/jira/browse/QPID-3321

Steps to test:

```
I=0; while subscription-manager register --username admin --password changeme\
   --org 'Default Organization' --environment Library --force; do
  I=$((I+1));
  echo $I
done
```

In other shell:

```
PID=`/usr/sbin/pidof dynflow_executor`
watch "cat /proc/$PID/status | grep ^VmData"
```
and watch the number grow without the fix and stay still with the fix