### PR TITLE
Fixes #15183 - delay cp content sync till end

### DIFF
--- a/app/lib/actions/katello/content_view/promote.rb
+++ b/app/lib/actions/katello/content_view/promote.rb
@@ -27,7 +27,7 @@ module Actions
                           :puppet_modules_present => version.puppet_module_count > 0)
 
               repos_to_delete(version, environment).each do |repo|
-                plan_action(Repository::Destroy, repo, :planned_destroy => true)
+                plan_action(Repository::Destroy, repo, :skip_environment_update => true, :planned_destroy => true)
               end
             end
 

--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -33,7 +33,7 @@ module Actions
               end
 
               repos_to_delete(content_view).each do |repo|
-                plan_action(Repository::Destroy, repo, :planned_destroy => true)
+                plan_action(Repository::Destroy, repo, :skip_environment_update => true, :planned_destroy => true)
               end
             end
 


### PR DESCRIPTION
of publish and promote tasks.  Prior to this change
when deleting multiple repos during publish & promote (because
the repo is no longer in the Content View), multiple set_content
calls occuring can result in an error.  Since we are syncing
the content ids at the end of this process anyways, they are not
needed.