### PR TITLE
Fixes #15204- Reformat Sync Plan start date to work with hammer.

### DIFF
--- a/app/models/katello/sync_plan.rb
+++ b/app/models/katello/sync_plan.rb
@@ -55,7 +55,7 @@ module Katello
 
     def plan_date_time(localtime = true)
       date_obj = localtime ? self.zone_converted : self.sync_date
-      date_obj.strftime('%m/%d/%Y %I:%M:%p')
+      date_obj.strftime('%Y/%m/%d %H:%M:%S %z')
     end
 
     def schedule_format


### PR DESCRIPTION
I made the format this way because Firefox cannot parse the date as is, `%Y-%m-%d %H:%M:%S %z` My original crack at it, broke the ability to view it in Hammer. So this rewrite is more in-line with the original format and works with Hammer. 