### PR TITLE
Fixes #15191 - CV version page slows as versions are added

### DIFF
--- a/app/views/katello/api/v2/content_view_histories/base.json.rabl
+++ b/app/views/katello/api/v2/content_view_histories/base.json.rabl
@@ -1,0 +1,25 @@
+object @resource
+
+attributes :user, :status
+
+child :environment => :environment do |_h|
+  attributes :id, :name
+end
+
+node :version do |h|
+  h.content_view_version.version
+end
+
+node :description do |h|
+  h.content_view_version.description
+end
+
+node :publish do |h|
+  h.environment.nil?
+end
+
+node :version_id do |h|
+  h.content_view_version.id
+end
+
+extends 'katello/api/v2/common/timestamps'

--- a/app/views/katello/api/v2/content_view_histories/show.json.rabl
+++ b/app/views/katello/api/v2/content_view_histories/show.json.rabl
@@ -1,26 +1,6 @@
 object @resource
 
-attributes :user, :status
-
-child :environment => :environment do |_h|
-  attributes :id, :name
-end
-
-node :version do |h|
-  h.content_view_version.version
-end
-
-node :description do |h|
-  h.content_view_version.description
-end
-
-node :publish do |h|
-  h.environment.nil?
-end
-
-node :version_id do |h|
-  h.content_view_version.id
-end
+extends 'katello/api/v2/content_view_histories/base'
 
 child :task => :task do
   extends 'foreman_tasks/api/tasks/show'

--- a/app/views/katello/api/v2/content_view_versions/base.json.rabl
+++ b/app/views/katello/api/v2/content_view_versions/base.json.rabl
@@ -66,7 +66,11 @@ child :archived_repos => :repositories do
 end
 
 child :last_event => :last_event do
-  extends 'katello/api/v2/content_view_histories/show'
+  extends 'katello/api/v2/content_view_histories/base'
+  child :task => :task do
+    attributes :id, :label, :pending
+    attributes :username, :started_at, :ended_at, :state, :result
+  end
 end
 
 child :active_history => :active_history do


### PR DESCRIPTION
Rendering certain attributes of tasks were causing significant
slowdowns. Specifically, `:progress`, `:input`, `:output`,
`:humanized`, and `:cli_example` were causing about 120msec of time per
task to render. Only the first of these would incur the time hit, and
subsequent calls to other attributes would be fast.

The CVV JS does not appear to require any of the removed task fields. I have
some guesses but I am not 100% sure why these attributes cause the delay.

I used the following to determine which attributes were slow to load:

```
      # Indicates an attribute or method should be included in the json output
      # attribute :foo, :as => "bar"
      # attribute :foo, :as => "bar", :if => lambda { |m| m.foo }
      def attribute(name, options = {})
        a = Time.now
        return unless @_object && attribute_present?(name) && resolve_condition(options)
        attribute = data_object_attribute(name)
        name = (options[:as] || name).to_sym
        b = Time.now
        took = (b-a)*1000
        puts "Took #{(b-a)*1000} msec for #{name}" if took > 10
        @_result[name] = attribute
      end
      alias_method :attributes, :attribute
```

After applying this to
https://github.com/nesquena/rabl/blob/master/lib/rabl/builder.rb#L134-144, it
showed which attributes took more than 10 msec to load.