### PR TITLE
Fixes #15186 - API end points involving products/:id/repositories route properly.

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -37,6 +37,8 @@ module Katello
     api :GET, "/repositories", N_("List of enabled repositories")
     api :GET, "/content_views/:id/repositories", N_("List of repositories for a content view")
     api :GET, "/organizations/:organization_id/environments/:environment_id/repositories", _("List repositories in the environment")
+    api :GET, "/products/:product_id/repositories", N_("List of repositories for a product")
+    api :GET, "/environments/:environment_id/products/:product_id/repositories", N_("List of repositories belonging to a product in an environment")
     param :organization_id, :number, :desc => N_("ID of an organization to show repositories in")
     param :product_id, :number, :desc => N_("ID of a product to show repositories of")
     param :environment_id, :number, :desc => N_("ID of an environment to show repositories in")

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -345,7 +345,9 @@ Katello::Engine.routes.draw do
 
         api_resources :environments, :only => [] do
           api_resources :products, :only => [:index] do
-            get :repositories, :on => :member
+            api_resources :repositories, :only => [:index] do
+              get :index, :on => :member
+            end
           end
 
           api_resources :content_views, :only => [:index]
@@ -357,6 +359,9 @@ Katello::Engine.routes.draw do
         end
 
         api_resources :products, :only => [] do
+          api_resources :repositories, :only => [:index] do
+            get :index, :on => :member
+          end
           get :repositories, :on => :member
           api_resources :sync, :only => [:index] do
             delete :index, :on => :collection, :action => :cancel


### PR DESCRIPTION
Added documentation for new routes to apipie docs.

To test send a get request to: 

api/v2/products/:product_id/repositories

api/v2/environments/:environment_id/products/:product_id/repositories

You can also reload the Apidoc and make sure that the documentation is properly loaded.