### PR TITLE
Fixes #15180: display sync plan times in local time zone.

### DIFF
--- a/app/controllers/katello/api/v2/sync_plans_controller.rb
+++ b/app/controllers/katello/api/v2/sync_plans_controller.rb
@@ -45,13 +45,14 @@ module Katello
     param :organization_id, :number, :desc => N_("Filter sync plans by organization name or label"), :required => true
     param_group :sync_plan
     def create
-      sync_date = sync_plan_params[:sync_date].to_time
+      sync_date = sync_plan_params[:sync_date].to_time(:utc)
 
       unless sync_date.is_a?(Time)
         fail _("Date format is incorrect.")
       end
 
       @sync_plan = SyncPlan.new(sync_plan_params)
+      @sync_plan.sync_date = sync_date
       @sync_plan.organization = @organization
       @sync_plan.save!
 

--- a/app/models/katello/sync_plan.rb
+++ b/app/models/katello/sync_plan.rb
@@ -34,28 +34,20 @@ module Katello
       errors.add :base, _("Start Date and Time can't be blank") if self.sync_date.nil?
     end
 
-    def zone_converted
-      #convert time to local timezone
-      self.sync_date.localtime.to_datetime
-    end
-
     def plan_day
       WEEK_DAYS[self.sync_date.strftime('%A').to_i]
     end
 
-    def plan_date(localtime = true)
-      date_obj = localtime ? self.zone_converted : self.sync_date
-      date_obj.strftime('%m/%d/%Y')
+    def plan_date
+      self.sync_date.strftime('%m/%d/%Y')
     end
 
-    def plan_time(localtime = true)
-      date_obj = localtime ? self.zone_converted : self.sync_date
-      date_obj.strftime('%I:%M %p')
+    def plan_time
+      self.sync_date.strftime('%I:%M %p')
     end
 
-    def plan_date_time(localtime = true)
-      date_obj = localtime ? self.zone_converted : self.sync_date
-      date_obj.strftime('%Y/%m/%d %H:%M:%S %z')
+    def plan_date_time
+      self.sync_date.strftime('%Y/%m/%d %H:%M:%S %Z')
     end
 
     def schedule_format
@@ -77,8 +69,7 @@ module Katello
 
     def next_sync
       return nil unless self.enabled
-
-      now = Time.now.utc
+      now = Time.current
       next_sync = self.sync_date
 
       if self.sync_date < now
@@ -107,6 +98,8 @@ module Katello
                                  :sec => self.sync_date.sec).advance(:days => days)
         end
       end
+
+      next_sync = next_sync.strftime('%Y/%m/%d %H:%M:%S %Z') if next_sync
       next_sync
     end
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/new/views/new-sync-plan-form.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/new/views/new-sync-plan-form.html
@@ -45,6 +45,7 @@
           ng-model="syncPlan.startTime"
           tabindex="5">
    </timepicker>
+   <p class="help-block" translate>The time the sync should happen in your current time zone.</p>
  </div>
 
  <div bst-form-buttons

--- a/spec/models/sync_plan_spec.rb
+++ b/spec/models/sync_plan_spec.rb
@@ -27,7 +27,7 @@ module Katello
 
       describe "provide the next sync date as" do
         it "the sync date if in the future" do
-          sync_date = '5000-11-17 18:26:48 UTC'
+          sync_date = '5000/11/17 18:26:48 UTC'
           @plan.sync_date = sync_date
           @plan.next_sync.to_s.must_equal(sync_date)
         end


### PR DESCRIPTION
Fix sync plans so that times are shown in local time zones instead of
server time.

http://projects.theforeman.org/issues/15180