### PR TITLE
Fixes #15233 - add index to `katello_repository_rpms`

### DIFF
--- a/app/controllers/katello/api/v2/host_contents_controller.rb
+++ b/app/controllers/katello/api/v2/host_contents_controller.rb
@@ -1,6 +1,6 @@
 module Katello
   class Api::V2::HostContentsController < Katello::Api::V2::ApiController
-    def_param_group :content_facet_attributes  do
+    def_param_group :content_facet_attributes do
       param :content_view_id, Integer
       param :lifecycle_environment_id, Integer
       param :kickstart_repository_id, Integer, :desc => N_("Repository Id associated with the kickstart repo used for provisioning")

--- a/db/migrate/20160530184400_add_repo_id_indexes.rb
+++ b/db/migrate/20160530184400_add_repo_id_indexes.rb
@@ -1,0 +1,10 @@
+class AddRepoIdIndexes < ActiveRecord::Migration
+  def change
+    add_index :katello_repository_docker_manifests, :repository_id
+    add_index :katello_repository_errata, :repository_id
+    add_index :katello_repository_ostree_branches, :repository_id
+    add_index :katello_repository_package_groups, :repository_id
+    add_index :katello_repository_puppet_modules, :repository_id
+    add_index :katello_repository_rpms, :repository_id
+  end
+end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -102,7 +102,7 @@ module Katello
       ForemanTasks.dynflow.config.eager_load_paths.concat(action_paths)
     end
 
-    initializer "katello.set_dynflow_middlewares",  :before => :finisher_hook do |_app|
+    initializer "katello.set_dynflow_middlewares", :before => :finisher_hook do |_app|
       # We don't enable this in test env, as it adds the new field into the actions input
       # that we are not interested in tests
       unless Rails.env.test?
@@ -226,12 +226,12 @@ module Katello
       #facet extensions
       Facets.register(Katello::Host::ContentFacet, :content_facet) do
         api_view :list => 'katello/api/v2/content_facet/base_with_root', :single => 'katello/api/v2/content_facet/show'
-        api_docs :content_facet_attributes,  ::Katello::Api::V2::HostContentsController
+        api_docs :content_facet_attributes, ::Katello::Api::V2::HostContentsController
       end
 
       Facets.register(Katello::Host::SubscriptionFacet, :subscription_facet) do
         api_view :list => 'katello/api/v2/subscription_facet/base_with_root', :single => 'katello/api/v2/subscription_facet/show'
-        api_docs :subscription_facet_attributes,  ::Katello::Api::V2::HostSubscriptionsController
+        api_docs :subscription_facet_attributes, ::Katello::Api::V2::HostSubscriptionsController
       end
 
       #Api controller extensions


### PR DESCRIPTION
The CVV page was calling
`/katello/api/v2/content_view_versions?content_view_id=<id>`, which includes,
among other things, a package count for all repos in each CVV.

This is found via the following query:

```sql
SELECT Count(*)
FROM   "katello_rpms"
       INNER JOIN "katello_repository_rpms"
               ON "katello_repository_rpms"."rpm_id" = "katello_rpms"."id"
WHERE  "katello_repository_rpms"."repository_id" IN (SELECT
       "katello_repositories"."id"
                                                     FROM
       "katello_repositories"
                                                     WHERE
              "katello_repositories"."content_view_version_id" = $1
              AND ( environment_id IS NULL ))
```

This query induced a sequential scan on `katello_repository_rpms` (see
https://explain.depesz.com/s/sMy).

There was an index for `repository_id, rpm_id` for the table, but not just
`repository_id`. This patch adds a migration to create the index.

Times per-query should be reduced from 300+ msec to 20-30 msec. The explain
plan with the index is available at https://explain.depesz.com/s/epd9.

_NOTE_: when testing, you will need to ensure `katello_repository_rpms` has
enough rows for the profiler to prefer the index over a seq scan. I used an
existing DB that was a shade under 4 million rows for the table. If the table
is too small, both explain plans (with and without the index) will look the
same.