### PR TITLE
fixes #15239 - fix content host and system migration errors

### DIFF
--- a/db/migrate/20150930183738_migrate_content_hosts.rb
+++ b/db/migrate/20150930183738_migrate_content_hosts.rb
@@ -74,6 +74,7 @@ class MigrateContentHosts < ActiveRecord::Migration
     self.table_name = "katello_errata"
 
     has_many :systems_applicable, :through => :system_errata, :class_name => "MigrateContentHosts::System", :source => :system
+    has_many :content_facet_errata, :class_name => "MigrateContentHosts::ContentFacetErratum", :source => :erratum
   end
 
   class SystemErratum < ActiveRecord::Base
@@ -143,7 +144,7 @@ class MigrateContentHosts < ActiveRecord::Migration
     belongs_to :content_view, :inverse_of => :content_facets, :class_name => "MigrateContentHosts::ContentView"
     belongs_to :lifecycle_environment, :inverse_of => :content_facets, :class_name => "MigrateContentHosts::KTEnvironment"
 
-    has_many :content_facet_repositories, :class_name => "MigrateContentHosts::ContentFacetRepository", :dependent => :destroy, :inverse_of => :content_facets
+    has_many :content_facet_repositories, :class_name => "MigrateContentHosts::ContentFacetRepository", :dependent => :destroy, :inverse_of => :content_facet
     has_many :bound_repositories, :through => :content_facet_repositories, :class_name => "MigrateContentHosts::Repository", :source => :repository
     has_many :applicable_errata, :through => :content_facet_errata, :class_name => "MigrateContentHosts::Erratum", :source => :erratum
     has_many :content_facet_errata, :class_name => "MigrateContentHosts::ContentFacetErratum", :dependent => :destroy, :inverse_of => :content_facet

--- a/db/migrate/20160222143432_move_system_description_to_host.rb
+++ b/db/migrate/20160222143432_move_system_description_to_host.rb
@@ -11,8 +11,7 @@ class MoveSystemDescriptionToHost < ActiveRecord::Migration
     add_column :hosts, :description, :text
 
     System.find_each do |system|
-      system.foreman_host.description = system.description
-      system.foreman_host.save!
+      system.foreman_host.update_attribute(:description, system.description)
     end
 
     remove_column :katello_systems, :description
@@ -22,8 +21,7 @@ class MoveSystemDescriptionToHost < ActiveRecord::Migration
     add_column :katello_systems, :description, :text
 
     System.find_each do |system|
-      system.description = system.foreman_host.description
-      system.save!
+      system.update_attribute(:description, system.foreman_host.description)
     end
 
     remove_column :hosts, :description


### PR DESCRIPTION
During testing of PR 6066, additional errors were found with the
migrations after the PR was merged.  This commit is to address those
errors.

References:
https://github.com/Katello/katello/pull/6066#issuecomment-222348357
https://github.com/Katello/katello/pull/6066#issuecomment-222349268