### PR TITLE
[WIP] Fixes #15252 - Require dynflow before initialize

### DIFF
--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -96,6 +96,7 @@ module Katello
 
     initializer "katello.register_actions", :before => :finisher_hook do |_app|
       ForemanTasks.dynflow.require!
+      ForemanTasks.dynflow.initialize!
       action_paths = %W(#{Katello::Engine.root}/app/lib/actions
                         #{Katello::Engine.root}/app/lib/headpin/actions
                         #{Katello::Engine.root}/app/lib/katello/actions)


### PR DESCRIPTION
This is probably not the best way to fix this, but I wanted some
feedback from people, especially @iNecas, since this issue seems to have
started with [this commit](https://github.com/Katello/katello/commit/28c
b3ef503df6f53a14e68b0e80d4048d3a37b7a#diff-cf74e596d7887011413ee9d06b16b
753R97).