### PR TITLE
fixes #15255 - fix additional migrate_content_hosts migration errors

### DIFF
--- a/db/migrate/20150930183738_migrate_content_hosts.rb
+++ b/db/migrate/20150930183738_migrate_content_hosts.rb
@@ -18,7 +18,7 @@ class MigrateContentHosts < ActiveRecord::Migration
   class SmartProxy < ActiveRecord::Base
     self.table_name = "smart_proxies"
 
-    belongs_to :content_host, :class_name => "MigrateContentHosts::ContentHost", :inverse_of => :capsule
+    belongs_to :content_host, :class_name => "MigrateContentHosts::System", :inverse_of => :capsule
   end
 
   class KTEnvironment < ActiveRecord::Base
@@ -354,8 +354,10 @@ class MigrateContentHosts < ActiveRecord::Migration
         create_subscription_facet(host, system) unless host.subscription_facet
       end
 
-      system.host_id = host.id
-      system.save!
+      unless system.destroyed? # if the system was unregistered, it will no longer exist
+        system.host_id = host.id
+        system.save!
+      end
     end
   end
 end


### PR DESCRIPTION
This commit fixes 2 errors observed while executing the migration:

Error 1:
...
uninitialized constant MigrateContentHosts::SmartProxy::MigrateContentHosts::ContentHost
/opt/rh/rh-ror41/root/usr/share/gems/gems/activerecord-4.1.5/lib/active_record/inheritance.rb:133:in `compute_type'
...
/opt/theforeman/tfm/root/usr/share/gems/gems/katello-3.0.0.38/db/migrate/20150930183738_migrate_content_hosts.rb:282:in `unregister_system'
/opt/theforeman/tfm/root/usr/share/gems/gems/katello-3.0.0.38/db/migrate/20150930183738_migrate_content_hosts.rb:347:in `block in up'
/opt/theforeman/tfm/root/usr/share/gems/gems/katello-3.0.0.38/db/migrate/20150930183738_migrate_content_hosts.rb:315:in `each'
/opt/theforeman/tfm/root/usr/share/gems/gems/katello-3.0.0.38/db/migrate/20150930183738_migrate_content_hosts.rb:315:in `up'

Error 2:
...
can't modify frozen Hash/opt/rh/rh-ror41/root/usr/share/gems/gems/activerecord-4.1.5/lib/active_record/attribute_methods/write.rb:91:in `write_attribute_with_type_cast'
...
/opt/theforeman/tfm/root/usr/share/gems/gems/katello-3.0.0.38/db/migrate/20150930183738_migrate_content_hosts.rb:357:in `block in up'