### PR TITLE
Fixes #15177 - Add validation to content view...

### DIFF
--- a/app/lib/katello/validators/content_view_puppet_module_validator.rb
+++ b/app/lib/katello/validators/content_view_puppet_module_validator.rb
@@ -3,21 +3,27 @@ module Katello
     class ContentViewPuppetModuleValidator < ActiveModel::Validator
       def validate(record)
         if record.uuid.blank? && (record.name.blank? || record.author.blank?)
-          invalid_parameters = _("Invalid puppet module parameters specified.  Either 'uuid' or 'name' and 'author' must be specified.")
-          record.errors[:base] << invalid_parameters
-          return
-        end
+          record.errors[:base] << _("Invalid puppet module parameters specified. \
+                                    Either 'uuid' or 'name' and 'author' must be specified.")
+        elsif record.name && record.author &&
+          !PuppetModule.exists?(name: record.name, author: record.author)
+          record.errors[:base] << _("Puppet Module with name='%{name}' and author='%{author}' does\
+                                    not exist") % { name: record.name, author: record.author }
+        elsif record.uuid && !PuppetModule.exists?(uuid: record.uuid)
+          record.errors[:base] << _("Puppet Module with uuid='%{uuid}' does not\
+                                    exist") % { uuid: record.uuid }
+        else
+          puppet_modules = if record.uuid.blank?
+                             PuppetModule.where(name: record.name, author: record.author)
+                           else
+                             PuppetModule.where(uuid: record.uuid)
+                           end
+          repositories = puppet_modules.flat_map(&:repositories)
 
-        if record.name && record.author
-          # validate that a puppet module exists with this name+author
-          unless PuppetModule
-                  .in_repositories(record.content_view.puppet_repos)
-                  .where(:name => record.name, :author => record.author).present?
-
-            invalid_parameters = _("Puppet Module with name='%{name}' and author='%{author}' does not exist") %
-                { :name => record.name, :author => record.author }
-
-            record.errors[:base] << invalid_parameters
+          if repositories.present? && record.content_view.present? &&
+              !repositories.map(&:organization).include?(record.content_view.organization)
+            record.errors[:base] << _("Puppet Module does not belong to content view organization\
+                                      '%{name}'" % { name: record.content_view.organization.name })
           end
         end
       end

--- a/test/controllers/api/v2/content_view_puppet_modules_controller_test.rb
+++ b/test/controllers/api/v2/content_view_puppet_modules_controller_test.rb
@@ -54,6 +54,21 @@ module Katello
       assert_includes @content_view.reload.puppet_modules.map(&:name), "abrt"
     end
 
+    def test_create_with_id
+      @puppet_module = katello_puppet_modules(:dhcp)
+      @content_view = katello_content_views(:library_dev_view)
+      assert_empty @content_view.puppet_modules
+
+      post :create, content_view_id: @content_view.id, id: @puppet_module.id
+
+      assert_response :success
+
+      assert_template layout: "katello/api/v2/layouts/resource"
+      assert_template "katello/api/v2/content_view_puppet_modules/create"
+
+      assert_includes @content_view.reload.puppet_modules.map(&:uuid), @puppet_module.uuid
+    end
+
     def test_create_protected
       allowed_perms = [@update_permission]
       denied_perms = [@view_permission, @create_permission, @destroy_permission]

--- a/test/lib/validators/content_view_puppet_module_validator_test.rb
+++ b/test/lib/validators/content_view_puppet_module_validator_test.rb
@@ -5,55 +5,100 @@ require 'katello_test_helper'
 module Katello
   class ContentViewPuppetModuleValidatorTest < ActiveSupport::TestCase
     def setup
+      @rhel_repository = katello_repositories(:rhel_6_x86_64)
       @repository = katello_repositories(:p_forge)
-      @base_record = { :errors => { :base => [] }, :content_view => OpenStruct.new(:puppet_repos => [@repository]) }
-      @validator = Validators::ContentViewPuppetModuleValidator.new(:attributes => [:name])
+      @base_record = { errors: { base: [] }, content_view: OpenStruct.new(puppet_repos: [@repository], organization: @repository.organization) }
+      @validator = Validators::ContentViewPuppetModuleValidator.new(attributes: [:name])
     end
 
-    test "fails if both name and uuid blank" do
-      @model = OpenStruct.new(:errors => {:base => []})
+    test "passes if name and author match a puppet module" do
+      pm = katello_puppet_modules(:abrt)
+      @model = OpenStruct.new(@base_record.merge(name: pm.name, author: pm.author))
       @validator.validate(@model)
-
-      refute_empty @model.errors[:base]
+      assert_empty @model.errors[:base]
     end
 
     test "fails if only name provided" do
-      @model = OpenStruct.new(@base_record.merge(:name => "module name"))
+      @model = OpenStruct.new(@base_record.merge(name: "abrt"))
       @validator.validate(@model)
 
       refute_empty @model.errors[:base]
     end
 
-    test "passes if name and author provided" do
-      puppet = PuppetModule.create!(:name => "module name", :author => "module author", :uuid => '9932943299423')
-      puppet.repositories << @repository
-      @model = OpenStruct.new(@base_record.merge(:name => "module name", :author => "module author"))
+    test "fails if only author provided" do
+      @model = OpenStruct.new(@base_record.merge(author: "johndoe"))
       @validator.validate(@model)
+
+      refute_empty @model.errors[:base]
+    end
+
+    test "fails if name and author do not match a puppet module" do
+      @model = OpenStruct.new(@base_record.merge(name: "abrt", author: "Nyota Uhura"))
+      @validator.validate(@model)
+      refute_empty @model.errors[:base]
+    end
+
+    test "fails if both name and uuid blank" do
+      @model = OpenStruct.new(errors: {base: []})
+      @validator.validate(@model)
+
+      refute_empty @model.errors[:base]
+    end
+
+    test "passes if uuid matches a puppet module" do
+      @model = OpenStruct.new(@base_record.merge(uuid: katello_puppet_modules(:abrt).uuid))
+      @validator.validate(@model)
+
       assert_empty @model.errors[:base]
     end
 
-    test "passes if uuid provided" do
-      @model = OpenStruct.new(@base_record.merge(:uuid => "3bd47a52-0847-42b5-90ff-206307b48b22"))
-      @validator.validate(@model)
-
-      assert_empty @model.errors[:base]
-    end
-
-    test "fails if module does not exists" do
-      @model = OpenStruct.new(@base_record.merge(:name => "module name", :author => "module author"))
+    test "fails if uuid does not match a puppet module" do
+      @model = OpenStruct.new(@base_record.merge(uuid: "3bd47a52-90ff-20630asddfat"))
       Katello::PuppetModule.stubs(:exists?).returns(false)
       @validator.validate(@model)
 
       refute_empty @model.errors[:base]
     end
 
-    test "passes if the module does exist" do
-      puppet = PuppetModule.create!(:name => "module name", :author => "module author", :uuid => '9932943299423')
-      puppet.repositories << @repository
-      @model = OpenStruct.new(@base_record.merge(:name => "module name", :author => "module author"))
+    test "fails if puppet module does not belong to a repository in the content view organization" do
+      @model = OpenStruct.new(@base_record.merge(
+        uuid: katello_puppet_modules(:abrt).uuid, content_view: OpenStruct.new(
+          organization: OpenStruct.new(name: :dev))))
+      @validator.validate(@model)
+
+      refute_empty @model.errors[:base]
+    end
+
+    test "passes if identical puppet modules belong to repositories of different organizations including the content view organization" do
+      puppet_module = mock('Katello::PuppetModule')
+      repo = mock('Katello::Repository')
+
+      puppet_module.stubs(:repositories).returns([repo])
+      Katello::PuppetModule.stubs(:where).returns([katello_puppet_modules(:abrt), puppet_module])
+      repo.stubs(:organization).returns(:dev)
+
+      @model = OpenStruct.new(@base_record.merge(
+        name: "abrt", author: "johndoe",
+        content_view: OpenStruct.new(organization: :dev)))
       @validator.validate(@model)
 
       assert_empty @model.errors[:base]
+    end
+
+    test "fails if identical puppet modules belong to repositories of different organizations excluding the content view organization" do
+      puppet_module = mock('Katello::PuppetModule')
+      repo = mock('Katello::Repository')
+
+      puppet_module.stubs(:repositories).returns([repo])
+      Katello::PuppetModule.stubs(:where).returns([katello_puppet_modules(:abrt), puppet_module])
+      repo.stubs(:organization).returns(:dev)
+
+      @model = OpenStruct.new(@base_record.merge(
+        name: "abrt", author: "johndoe",
+        content_view: OpenStruct.new(organization: OpenStruct.new(name: :not_dev))))
+      @validator.validate(@model)
+
+      refute_empty @model.errors[:base]
     end
   end
 end


### PR DESCRIPTION
Add validation to content view puppet module to make sure a valid content view with that same uuid
or name/author combination exists. In addition, the user may use the
puppet_module id, which will set the uuid of the
content_view_puppet_module to the same as the puppet_module.

If a content view is specified, the puppet module must belong to a
repository that belongs to the same organization as the content view.

An edge case: If two puppet modules with identical names and authors but
two different organizations are used to validate a content view puppet
module whose content view organization is one of the two organizations,
validation should pass.