### PR TITLE
Fixes #15253 - do not do `DISTINCT` on katello_errata.*

### DIFF
--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -47,7 +47,9 @@ module Katello
 
     def self.applicable_to_hosts(hosts)
       self.joins(:content_facet_errata).joins(:content_facets).
-          where("#{Katello::Host::ContentFacet.table_name}.host_id" => hosts).uniq
+         where("#{Katello::Host::ContentFacet.table_name}.host_id" => hosts).
+         select("DISTINCT ON (#{self.table_name}.updated, #{self.table_name}.id) #{self.table_name}.*").
+         order("#{self.table_name}.updated desc, #{self.table_name}.id")
     end
 
     def <=>(other)

--- a/app/views/dashboard/_errata_widget.html.erb
+++ b/app/views/dashboard/_errata_widget.html.erb
@@ -4,7 +4,7 @@
 
 <% organizations = Organization.current.present? ? [Organization.current] : User.current.allowed_organizations %>
 <% hosts = ::Host::Managed.authorized("view_hosts") %>
-<% errata = Katello::Erratum.applicable_to_hosts(hosts).order('updated desc').limit(6) %>
+<% errata = Katello::Erratum.applicable_to_hosts(hosts).limit(6) %>
 
 <% if errata.empty? %>
   <p class="ca"><%= _("There are no errata that need to be applied to registered content hosts.") %></p>


### PR DESCRIPTION
The erratum model obj has a query to find all errata that are applicable to hosts. At the end of the query, it does a `DISTINCT` to make sure there aren't duplicate errata that may have been listed from the join. For example:

```sql
 SELECT DISTINCT "katello_errata".*
 FROM "katello_errata"
   INNER JOIN "katello_content_facet_errata" ON "katello_content_facet_errata"."erratum_id" = "katello_errata"."id"
   INNER JOIN "katello_content_facet_errata" "content_facet_errata_katello_errata_join" ON "content_facet_errata_katello_errata_join"."erratum_id" = "katello_errata"."id"
   INNER JOIN "katello_content_facets" ON "katello_content_facets"."id" = "content_facet_errata_katello_errata_join"."content_facet_id"
 WHERE "katello_content_facets"."host_id" IN
 (
        SELECT "hosts"."id"
        FROM   "hosts"
        WHERE  "hosts"."type"            IN ('Host::Managed')
        AND    "hosts"."organization_id" IN (1))
 ORDER BY updated DESC
 limit 6;
```

The `DISTINCT "katello_errata".*` causes issues when the number of hosts * the
number of errata is over about 100K, since it attempts to sort by every col, as
seen in this explain plan:

```
         ->  Sort  (cost=50522.02..50628.22 rows=42483 width=1269) (actual time=63211.686..79656.391 rows=42483 loops=1)
               Sort Key: katello_errata.updated, katello_errata.id, katello_errata.uuid, katello_errata.errata_id,
                         katello_errata.created_at, katello_errata.updated_at, katello_errata.issued,
                         katello_errata.errata_type, katello_errata.severity, katello_errata.title,
                         katello_errata.solution, katello_errata.description, katello_errata.summary,
                         katello_errata.reboot_suggested
               Sort Method: external merge  Disk: 36304kB

```

This can take upwards of 80 seconds on a strong system, and can take multiple
minutes on a development VM.

We do not need to check for uniqueness on every column, since katello_errata
already has a surrogate PK. However, we can't do `DISTINCT` on the ID, and then
an `ORDER BY` on the updated time, since that's two different sorts. Instead,
we can sort by the updated time, and then sort by ID. That way, the cols on
`DISTINCT` and `ORDER BY` match.