### PR TITLE
fixes #15260 - migrate_content_host: support env/view only on content facet

### DIFF
--- a/db/migrate/20150930183738_migrate_content_hosts.rb
+++ b/db/migrate/20150930183738_migrate_content_hosts.rb
@@ -183,13 +183,15 @@ class MigrateContentHosts < ActiveRecord::Migration
     Rails.logger
   end
 
-  def create_content_facet(host, system)
+  def create_content_facet(host, system, include_env_and_view_only = false)
     logger.info("Creating content facet for host #{host.name}.")
     content_facet = host.content_facet = MigrateContentHosts::ContentFacet.new(:content_view => system.content_view,
                                                          :lifecycle_environment => system.environment)
-    content_facet.uuid = system.uuid
-    content_facet.bound_repositories = system.bound_repositories
-    content_facet.applicable_errata = system.applicable_errata
+    unless include_env_and_view_only
+      content_facet.uuid = system.uuid
+      content_facet.bound_repositories = system.bound_repositories
+      content_facet.applicable_errata = system.applicable_errata
+    end
     content_facet.save!
   end
 
@@ -343,7 +345,7 @@ class MigrateContentHosts < ActiveRecord::Migration
         end
         host = hosts.first
 
-        create_content_facet(host, system) unless host.content_facet
+        create_content_facet(host, system, true) unless host.content_facet
         unregister_system(system)
 
       else #host exists in the correct org


### PR DESCRIPTION
This commit updates the 'create_content_facet' so that the caller
can include an argument which will cause it to only associate
lifecycle environment and content view with the facet created.

This is needed to handle the case where the content facet is created
for a host; however, the legacy system will be immediately unregistered/
destroyed.  With this change, when the host re-registers after
the migration is completed, no errors will be generated
(e.g. 404 on delete of pulp consumer).