### PR TITLE
Fixes #15192 - Revert strip out extraneous nil from `recognize` call

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -435,8 +435,8 @@ module Katello
     def authorize_proxy_routes
       deny_access unless (authenticate || authenticate_client)
 
-      route, params = Engine.routes.router.recognize(request) do |rte, parameters|
-        break rte, parameters if rte.name
+      route, _, params = Engine.routes.router.recognize(request) do |rte, match, parameters|
+        break rte, match, parameters if rte.name
       end
 
       # route names are defined in routes.rb (:as => :name)


### PR DESCRIPTION
This was cherrypicked to 3.0, but the issue was introduced
in rails 4.2.  3.0 is running on rails 4.1

This reverts commit f441c9c457dec02870ef541785489b6c8d750ff3.