### PR TITLE
Fixes #15274 - Adjust full_results param

### DIFF
--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -20,7 +20,7 @@ module Katello
       param :page, :number, :desc => N_("Page number, starting at 1")
       param :per_page, :number, :desc => N_("Number of results per page to return")
       param :order, String, :desc => N_("Sort field and order, eg. 'name DESC'")
-      param :full_results, :bool, :desc => N_("Whether or not to show all results")
+      param :full_result, :bool, :desc => N_("Whether or not to show all results")
       param :sort, Hash, :desc => N_("Hash version of 'order' param") do
         param :by, String, :desc => N_("Field to sort the results on")
         param :order, String, :desc => N_("How to order the sorted results (e.g. ASC for ascending)")
@@ -66,7 +66,7 @@ module Katello
       query = query.order("#{query.table_name}.id DESC") unless group #secondary order to ensure sort is deterministic
       query = query.includes(includes) if includes.length > 0
 
-      if params[:full_result]
+      if Foreman::Cast.to_bool(params[:full_result])
         params[:per_page] = total
       else
         query = query.paginate(paginate_options)

--- a/test/controllers/api/v2/api_controller_test.rb
+++ b/test/controllers/api/v2/api_controller_test.rb
@@ -32,6 +32,26 @@ module Katello
       assert_nil response[:error], "error"
     end
 
+    def test_scoped_search_full_results_true
+      params = { full_result: 'true', per_page: 2 }
+      @controller.stubs(:params).returns(params)
+
+      response = @controller.scoped_search(@query, @default_sort[0], @default_sort[1], @options)
+      refute_empty response[:results], "results"
+      assert_nil response[:error], "error"
+      refute_equal(2, response[:results].length)
+    end
+
+    def test_scoped_search_full_results_false
+      params = { full_result: 'false', per_page: 2 }
+      @controller.stubs(:params).returns(params)
+
+      response = @controller.scoped_search(@query, @default_sort[0], @default_sort[1], @options)
+      refute_empty response[:results], "results"
+      assert_nil response[:error], "error"
+      assert_equal(2, response[:results].length)
+    end
+
     def test_scoped_search_no_results
       params = { :search => "asdfasdf" }
       @controller.stubs(:params).returns(params)


### PR DESCRIPTION
While the API advertised a parameter named :full_results, our code was
expecting the param to be named :full_result. This change adds tests to
ensure the :full_results parameter can be used and is actually effective
in our system.

In addition, this changes the API parameter documented from
:full_results to :full_result

Furthermore, this parameter was failing to cast from a JSON string to a
boolean such that 'false', 'true', 0, or 1 would return a true value.
This introduces a proper cast using `Foreman::Cast.to_bool`.