### PR TITLE
Fixes #15292 - fix capsule sync after upgrade

### DIFF
--- a/app/lib/actions/katello/capsule_content/sync.rb
+++ b/app/lib/actions/katello/capsule_content/sync.rb
@@ -82,8 +82,8 @@ module Actions
           repos.select do |repo|
             repo_details = capsule.pulp_repo_facts(repo.pulp_id)
             next unless repo_details
-            capsule_importer = repo_details["importers"][0]["config"]
-            !(repo.importer_matches?(capsule_importer))
+            capsule_importer = repo_details["importers"][0].try(:[], "config")
+            capsule_importer.nil? || !(repo.importer_matches?(capsule_importer))
           end
         end
 

--- a/app/lib/actions/pulp/repository/associate_importer.rb
+++ b/app/lib/actions/pulp/repository/associate_importer.rb
@@ -1,7 +1,7 @@
 module Actions
   module Pulp
     module Repository
-      class AssociateImporter < Pulp::Abstract
+      class AssociateImporter < Pulp::AbstractAsyncTask
         input_format do
           param :repo_id
           param :type_id
@@ -10,9 +10,8 @@ module Actions
           param :capsule_id
         end
 
-        def run
-          output[:response] = pulp_resources.repository.
-            associate_importer(*input.values_at(:repo_id, :type_id, :config))
+        def invoke_external_task
+          pulp_resources.repository.associate_importer(*input.values_at(:repo_id, :type_id, :config))
         end
       end
     end

--- a/app/lib/actions/pulp/repository/refresh.rb
+++ b/app/lib/actions/pulp/repository/refresh.rb
@@ -31,7 +31,7 @@ module Actions
                         :repo_id => repository.pulp_id,
                         :type_id => repository.importers.first['importer_type_id'],
                         :config => importer_config,
-                        :capsule_id => input[:capsule_id],
+                        :capsule_id => capsule_id,
                         :hash => { :importer_id => importer.id }
                        )
           end


### PR DESCRIPTION
This fixes a couple issues with capsule syncing when the capusle
has been upgraded from katello 2.4.  In this case these repos
have no importers and several issues were discovered in the code
that is adding the importer