### PR TITLE
Fixes #15295 - Puppet env populated in New Hosts

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -83,7 +83,7 @@ module Katello
           if content_facet.present?
             self.content_facet.kickstart_repository_id = hostgroup.inherited_kickstart_repository_id
           end
-          assign_hostgroup_attributes(%w(content_source_id content_view_id lifecycle_environment_id))
+          assign_hostgroup_attributes(%w(content_source_id content_view_id lifecycle_environment_id environment_id))
         end
         set_hostgroup_defaults_without_katello_attributes
       end


### PR DESCRIPTION
Prior to this commit on a new hosts page if you selected a Hostgroup,
the Puppet Environment property will not get inherited automatically.

This commit addresses that issue.