### PR TITLE
refs #15297: update puppet repo distributor during upgrade

### DIFF
--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -160,7 +160,7 @@ module Katello
         if capsule
           self.full_path(nil, true)
         else
-          self.url
+          self.url if self.respond_to?(:url)
         end
       end
 

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -262,6 +262,7 @@ module Katello
       load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/2.4/import_subscriptions.rake"
       load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/3.0/add_export_distributor.rake"
       load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/3.0/delete_docker_v1_content.rake"
+      load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/3.0/update_puppet_repository_distributors.rake"
       load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/3.0/update_subscription_facet_backend_data.rake"
     end
   end

--- a/lib/katello/tasks/upgrades/3.0/update_puppet_repository_distributors.rake
+++ b/lib/katello/tasks/upgrades/3.0/update_puppet_repository_distributors.rake
@@ -1,0 +1,20 @@
+namespace :katello do
+  namespace :upgrades do
+    namespace '3.0' do
+      task :update_puppet_repository_distributors => ["environment"] do
+        User.current = User.anonymous_api_admin
+        puts _("Updating Puppet Repository Distributors")
+        Katello::Repository.puppet_type.each do |repo|
+          ForemanTasks.sync_task(::Actions::Pulp::Repository::Refresh, repo)
+          ForemanTasks.sync_task(::Actions::Katello::Repository::MetadataGenerate, repo)
+        end
+
+        puts _("Updating Content View Puppet Environment Distributors")
+        Katello::ContentViewPuppetEnvironment.all.each do |repo|
+          ForemanTasks.sync_task(::Actions::Pulp::Repository::Refresh, repo)
+          ForemanTasks.sync_task(::Actions::Katello::Repository::MetadataGenerate, repo)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit contains a rake task to be executed as part of the
Katello 3.0 upgrade to ensure that all puppet repositories
(Repository & Content View Puppet Environment) are updated
to include the 'puppet distributor' that was added as part
of Katello 3.0.  In addition, it will publish those repositories
to ensure that the proper content is available on the
filesystem.