### PR TITLE
Fixes #15334 - Sub status updates correctly in content host details page

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions.html
@@ -22,8 +22,8 @@
     <div class="detail">
       <span class="info-label" translate>Status</span>
         <span class="info-value">
-          <i class="fa fa-circle" ng-class="contentHostTable.getSubscriptionStatusColor(host.subscription_facet_attributes.subscription_status.color_code)"></i>
-          {{ host.subscription_facet_attributes.subscription_status.label }}
+          <i class="fa fa-circle" ng-class="contentHostTable.getSubscriptionStatusColor(host.subscription_status)"></i>
+          {{ host.subscription_status_label }}
         </span>
     </div>
 


### PR DESCRIPTION
To reproduce:

1) Import a manifest with valid subs
2) Register a RHEL content host
3) run subscription-manager attach --auto on the content host
4) check the content host details page > subscription tab for that content host

On this page, the subscription status should be yellow or green,
not red. The correct text should be next to the color.