### PR TITLE
Fixes #15340 - Org destroy unassociates hostgroups

### DIFF
--- a/app/lib/actions/katello/content_view/remove.rb
+++ b/app/lib/actions/katello/content_view/remove.rb
@@ -64,6 +64,11 @@ module Actions
                       environment_names: cv_envs.map { |cve| cve.environment.name },
                       version_ids: versions.map(&:id),
                       content_view_history_ids: cv_histories.map { |history| history.id })
+
+            if organization_destroy
+              content_view.hostgroups.clear
+              content_view.hosts.clear
+            end
           end
         end
 

--- a/app/lib/actions/katello/environment/destroy.rb
+++ b/app/lib/actions/katello/environment/destroy.rb
@@ -24,6 +24,11 @@ module Actions
               end
             end
 
+            if organization_destroy
+              env.hostgroups.clear
+              env.hosts.clear
+            end
+
             plan_self
           end
         end

--- a/app/lib/actions/katello/host/destroy.rb
+++ b/app/lib/actions/katello/host/destroy.rb
@@ -5,13 +5,13 @@ module Actions
         middleware.use ::Actions::Middleware::RemoteAction
 
         def plan(host, options = {})
-          skip_candlepin = options.fetch(:skip_candlepin, false)
+          organization_destroy = options.fetch(:organization_destroy, false)
           unregistering = options.fetch(:unregistering, false)
 
           action_subject(host)
 
           concurrence do
-            if !skip_candlepin && host.subscription_facet.try(:uuid)
+            if !organization_destroy && host.subscription_facet.try(:uuid)
               plan_action(Candlepin::Consumer::Destroy, uuid: host.subscription_facet.uuid)
             end
             plan_action(Pulp::Consumer::Destroy, uuid: host.content_facet.uuid) if host.content_facet.try(:uuid)
@@ -20,20 +20,30 @@ module Actions
           host.subscription_facet.try(:destroy!)
 
           if unregistering
-            if host.content_facet
-              host.content_facet.uuid = nil
-              host.content_facet.save!
-            end
-
-            host.get_status(::Katello::ErrataStatus).destroy
-            host.get_status(::Katello::SubscriptionStatus).destroy
-            host.installed_packages.destroy_all
+            unregister(host)
+          elsif organization_destroy
+            host.content_facet.try(:destroy!)
+            destroy_host_artifacts(host)
           else
             host.content_facet.try(:destroy!)
             unless host.destroy
               fail host.errors.full_messages.join('; ')
             end
           end
+        end
+
+        def unregister(host)
+          if host.content_facet
+            host.content_facet.uuid = nil
+            host.content_facet.save!
+          end
+          destroy_host_artifacts(host)
+        end
+
+        def destroy_host_artifacts(host)
+          host.get_status(::Katello::ErrataStatus).destroy
+          host.get_status(::Katello::SubscriptionStatus).destroy
+          host.installed_packages.destroy_all
         end
 
         def humanized_name

--- a/app/lib/actions/katello/organization/destroy.rb
+++ b/app/lib/actions/katello/organization/destroy.rb
@@ -46,8 +46,8 @@ module Actions
 
         def remove_consumers(organization)
           concurrence do
-            organization.hosts.each do |host|
-              plan_action(Katello::Host::Destroy, host, skip_candlepin: true)
+            ::Host.unscoped.where(:organization => organization).each do |host|
+              plan_action(Katello::Host::Destroy, host, organization_destroy: true)
             end
 
             organization.activation_keys.each do |key|

--- a/app/views/overrides/taxonomies/_action_buttons.html.erb
+++ b/app/views/overrides/taxonomies/_action_buttons.html.erb
@@ -1,7 +1,7 @@
 <% if taxonomy.is_a?(Organization) %>
   <%= action_buttons(
     display_link_if_authorized(_("Edit"), hash_for_edit_taxonomy_path(taxonomy) ),
-    display_delete_if_authorized(hash_for_taxonomy_path(taxonomy), :confirm => _("Delete %s?") % taxonomy.name, :action => :destroy),
+    display_delete_if_authorized(hash_for_taxonomy_path(taxonomy), :data => { :confirm => _("%s %s has %s Hosts and %s Hostgroups that will need to be reassociated post deletion. Delete %s?") % [taxonomy_title, taxonomy.name, taxonomy.hosts.count, taxonomy.hostgroups.count, taxonomy.name]}, :action => :destroy),
     (link_to((_("Select hosts to assign to %s") % taxonomy.name), assign_hosts_taxonomy_path(taxonomy)) if @count_nil_hosts > 0),
     (link_to(n_("Assign the %{count} host with no %{taxonomy_single} to %{taxonomy_name}", "Assign all %{count} hosts with no %{taxonomy_single} to %{taxonomy_name}", @count_nil_hosts) % {:count => @count_nil_hosts, :taxonomy_single => taxonomy_single, :taxonomy_name => taxonomy.name}  ,
              assign_all_hosts_taxonomy_path(taxonomy),
@@ -12,7 +12,7 @@
     display_link_if_authorized(_("Edit"), hash_for_edit_taxonomy_path(taxonomy) ),
     display_link_if_authorized(_("Nest"), hash_for_nest_taxonomy_path(taxonomy) ),
     display_link_if_authorized(_("Clone"), hash_for_clone_taxonomy_path(taxonomy) ),
-    display_delete_if_authorized(hash_for_taxonomy_path(taxonomy), :confirm => _("Delete %s?") % taxonomy.name, :action => :destroy),
+    display_delete_if_authorized(hash_for_taxonomy_path(taxonomy), :data => { :confirm => _("%s %s has %s Hosts and %s Hostgroups that will need to be reassociated post deletion. Delete %s?") % [taxonomy_title, taxonomy.name, taxonomy.hosts.count, taxonomy.hostgroups.count, taxonomy.name]}, :action => :destroy),
     (link_to((_("Select hosts to assign to %s") % taxonomy.name), assign_hosts_taxonomy_path(taxonomy)) if @count_nil_hosts > 0),
     (link_to(n_("Assign the %{count} host with no %{taxonomy_single} to %{taxonomy_name}", "Assign all %{count} hosts with no %{taxonomy_single} to %{taxonomy_name}", @count_nil_hosts) % {:count => @count_nil_hosts, :taxonomy_single => taxonomy_single, :taxonomy_name => taxonomy.name}  ,
              assign_all_hosts_taxonomy_path(taxonomy),

--- a/test/actions/katello/host/destroy_test.rb
+++ b/test/actions/katello/host/destroy_test.rb
@@ -59,12 +59,13 @@ module Katello::Host
         assert_nil @host.content_facet.uuid
       end
 
-      it 'plans with skip_candlepin true' do
+      it 'plans with organization_destroy true' do
         uuid = @host.content_facet.uuid
+        @host.content_facet.expects(:destroy!)
         action = create_action action_class
         action.stubs(:action_subject).with(@host)
 
-        plan_action action, @host, :unregistering => true, :skip_candlepin => true
+        plan_action action, @host, :organization_destroy => true
 
         refute_action_planned action, candlepin_destroy_class
         assert_action_planed_with action, pulp_destroy_class, :uuid => uuid

--- a/test/actions/katello/organization_test.rb
+++ b/test/actions/katello/organization_test.rb
@@ -56,7 +56,9 @@ module ::Actions::Katello::Organization
       organization.expects(:label).returns("ACME_Corporation")
       organization.expects(:validate_destroy).returns([])
       organization.expects(:products).twice.returns([])
-      organization.expects(:hosts).returns([])
+      where_clause = mock
+      where_clause.expects(:where).returns([])
+      ::Host.expects(:unscoped).returns(where_clause)
       organization.expects(:activation_keys).returns([])
       organization.expects(:content_views).returns(stub(:non_default => []))
       organization.expects(:default_content_view).twice.returns(default_view)


### PR DESCRIPTION
Org destroy was not properly unassociating environments and content
views from hosts + hostgroups.

Updated the plan to handle that
