### PR TITLE
Fixes #15357 - ensure valid interfaces after upgrade

### DIFF
--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -16,17 +16,22 @@ module Katello
       attr_accessor :installed_products, :facts, :hypervisor_guest_uuids
 
       def update_from_consumer_attributes(consumer_params)
+        import_database_attributes(consumer_params)
+        self.installed_products = consumer_params['installedProducts'] unless consumer_params['installedProducts'].blank?
+        self.hypervisor_guest_uuids = consumer_params['guestIds'] unless consumer_params['hypervisor_guest_uuids'].blank?
+        self.facts = consumer_params['facts'] unless consumer_params['facts'].blank?
+      end
+
+      def import_database_attributes(consumer_params)
         self.autoheal = consumer_params['autoheal'] unless consumer_params['autoheal'].blank?
         self.service_level = consumer_params['serviceLevel'] unless consumer_params['serviceLevel'].blank?
         self.registered_at = consumer_params['created'] unless consumer_params['created'].blank?
         self.last_checkin = consumer_params['lastCheckin'] unless consumer_params['lastCheckin'].blank?
-        self.release_version = consumer_params['releaseVer'] unless consumer_params['releaseVer'].blank?
-        self.installed_products = consumer_params['installedProducts'] unless consumer_params['installedProducts'].blank?
-        self.hypervisor_guest_uuids = consumer_params['guestIds'] unless consumer_params['hypervisor_guest_uuids'].blank?
-        self.facts = consumer_params['facts'] unless consumer_params['facts'].blank?
 
-        if self.release_version.is_a?(Hash)
-          self.release_version = self.release_version['releaseVer']
+        unless consumer_params['releaseVer'].blank?
+          release = consumer_params['releaseVer']
+          release = release['releaseVer'] if release.is_a?(Hash)
+          self.release_version = release
         end
       end
 

--- a/test/models/host/subscription_facet_test.rb
+++ b/test/models/host/subscription_facet_test.rb
@@ -62,6 +62,13 @@ module Katello
       assert_equal subscription_facet.release_version, params[:releaseVer]
     end
 
+    def test_update_from_consumer_attributes_release_version
+      params = { :lastCheckin => DateTime.now, :autoheal => true, :serviceLevel => "Premium", :releaseVer => {'releaseVer' => "7Server" }}
+      subscription_facet.update_from_consumer_attributes(params.with_indifferent_access)
+
+      assert_equal '7Server', subscription_facet.release_version
+    end
+
     def test_candlepin_environment_id
       assert_equal subscription_facet.candlepin_environment_id, ContentViewEnvironment.where(:content_view_id => view, :environment_id => library).first.cp_id
     end


### PR DESCRIPTION
prior to upgrading a couple of situtations can occur taht prevent
re-registration of hosts via sub-man

1) a system was already registered, and a host was create during the
   migration, but since facts were not imported there are no valid interfaces
2) a host exists without any interfaces, and has no facts.  This may not actually
   happen in the wild but there is nothing stopping it from happening, so its handled here