### PR TITLE
Fixes #15367 - Fixing nonexistent host param value

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -151,8 +151,9 @@ module Katello
     #param :id, String, :desc => N_("UUID of the consumer")
     #desc 'Schedules the consumer identity certificate regeneration'
     def regenerate_identity_certificates
-      Candlepin::Consumer.new(params[:uuid]).regenerate_identity_certificates
-      render :json => Resources::Candlepin::Consumer.get(@host.uuid)
+      uuid = @host.subscription_facet.uuid
+      Candlepin::Consumer.new(uuid).regenerate_identity_certificates
+      render :json => Resources::Candlepin::Consumer.get(uuid)
     end
 
     api :PUT, "/systems/:id/enabled_repos", N_("Update the information about enabled repositories")

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -171,6 +171,15 @@ module Katello
       end
     end
 
+    def test_regenerate_indentity_certificates
+      consumer_stub = stub(:regenerate_identity_certificates => true)
+
+      Candlepin::Consumer.expects(:new).with(@host.subscription_facet.uuid).returns(consumer_stub)
+      Resources::Candlepin::Consumer.expects(:get).with(@host.subscription_facet.uuid)
+
+      post :regenerate_identity_certificates, :id => @host.subscription_facet.uuid
+    end
+
     it "test_regenerate_identity_certificates_protected" do
       Resources::Candlepin::Consumer.stubs(:get)
       assert_protected_action(:regenerate_identity_certificates, :edit_content_hosts) do


### PR DESCRIPTION
Fixing call to params[:uuid] which doesn't exist. Rather, it's params[:id] but using subscription facet instead.