### PR TITLE
Fixes #15378 - select all properly on cv filter errata

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/available-errata-filter.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/available-errata-filter.controller.js
@@ -35,25 +35,6 @@ angular.module('Bastion.content-views').controller('AvailableErrataFilterControl
             return rules.$save(params, success, failure);
         }
 
-        $scope.nutupane = nutupane = new Nutupane(Erratum, {
-                filterId: $scope.$stateParams.filterId,
-                'sort_order': 'DESC',
-                'sort_by': 'issued',
-                'available_for': 'content_view_filter'
-            },
-            'queryUnpaged'
-        );
-        nutupane.masterOnly = true;
-        nutupane.enableSelectAllResults();
-
-        filterByDate = function (date, type) {
-            date = date.toISOString().split('T')[0];
-            nutupane.addParam(type, date);
-            nutupane.refresh();
-        };
-
-        $scope.detailsTable = nutupane.table;
-
         $scope.addErrata = function (filter) {
             var errataIds,
                 rules,
@@ -100,6 +81,25 @@ angular.module('Bastion.content-views').controller('AvailableErrataFilterControl
                 filterByDate(end, 'end_date');
             }
         });
+
+        $scope.nutupane = nutupane = new Nutupane(Erratum, {
+                filterId: $scope.$stateParams.filterId,
+                'sort_order': 'DESC',
+                'sort_by': 'issued',
+                'available_for': 'content_view_filter'
+            },
+            'queryUnpaged'
+        );
+        nutupane.masterOnly = true;
+
+        filterByDate = function (date, type) {
+            date = date.toISOString().split('T')[0];
+            nutupane.addParam(type, date);
+            nutupane.refresh();
+        };
+
+        $scope.updateTypes($scope.types);
+        $scope.detailsTable = nutupane.table;
 
     }]
 );


### PR DESCRIPTION
This resolves two issues with this page:
1) the gmail-style select all was used even though this page
   is not paginated, resulting in everything being selected
2) When selecting fewer than 3 errata types and navigating away
   from the add tab and back to it, the type selection would remain
   but all errata would be shown