### PR TITLE
Fixes #15389 - errata page is broken

### DIFF
--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -46,10 +46,8 @@ module Katello
     end
 
     def self.applicable_to_hosts(hosts)
-      self.joins(:content_facet_errata).joins(:content_facets).
-         where("#{Katello::Host::ContentFacet.table_name}.host_id" => hosts).
-         select("DISTINCT ON (#{self.table_name}.updated, #{self.table_name}.id) #{self.table_name}.*").
-         order("#{self.table_name}.updated desc, #{self.table_name}.id")
+      self.joins(:content_facets).
+        where("#{Katello::Host::ContentFacet.table_name}.host_id" => hosts).uniq
     end
 
     def <=>(other)

--- a/app/views/dashboard/_errata_widget.html.erb
+++ b/app/views/dashboard/_errata_widget.html.erb
@@ -4,7 +4,7 @@
 
 <% organizations = Organization.current.present? ? [Organization.current] : User.current.allowed_organizations %>
 <% hosts = ::Host::Managed.authorized("view_hosts") %>
-<% errata = Katello::Erratum.applicable_to_hosts(hosts).limit(6) %>
+<% errata = Katello::Erratum.applicable_to_hosts(hosts).order('updated desc').limit(6) %>
 
 <% if errata.empty? %>
   <p class="ca"><%= _("There are no errata that need to be applied to registered content hosts.") %></p>


### PR DESCRIPTION
There was a SQL optimization done in PR #6094 which made the dashboard
faster, but interfered with some other callers of the errata model obj.
Basically, the optmized SQL had a `DISTINCT` baked in, so if you called
`uniq` on the results, you'd get an error since you'd have two
`DISTINCT`s.

It turns out that there was an extra inner join, which created a very
large dataset for postgres to work on. For example, 5.5K hosts with 650
errata may create a dataset of upwards of 84M records. This would
exhaust system resources quickly.

This commit removes the extra inner join, and removes the opimization
in #6094 since its no longer needed.