### PR TITLE
Fixes #15209 - Subscription status updates after host registration

### DIFF
--- a/app/lib/actions/katello/host/register.rb
+++ b/app/lib/actions/katello/host/register.rb
@@ -57,6 +57,7 @@ module Actions
           host.subscription_facet.update_from_consumer_attributes(host.subscription_facet.candlepin_consumer.
               consumer_attributes.except(:installedProducts, :guestIds, :facts))
           host.subscription_facet.save!
+          host.subscription_facet.update_subscription_status
           host.refresh_global_status!
 
           system = ::Katello::System.find(input[:system_id])


### PR DESCRIPTION
Hosts were updating their global status when registering, but not updating
their subscription status as that is Katello-specific and won't be included
in refresh_global_status! method.

To test: register a content host and make sure the subscription status is red.