### PR TITLE
Fixes #15394 - Quantity updates after subs are removed from host

### DIFF
--- a/app/lib/actions/candlepin/consumer/remove_subscription.rb
+++ b/app/lib/actions/candlepin/consumer/remove_subscription.rb
@@ -7,10 +7,16 @@ module Actions
         input_format do
           param :uuid, String
           param :entitlement_id, String
+          param :pool_id, String
         end
 
         def run
           ::Katello::Resources::Candlepin::Consumer.remove_entitlement(input[:uuid], input[:entitlement_id])
+        end
+
+        def finalize
+          pool = ::Katello::Pool.where(:cp_id => input[:pool_id]).first
+          pool.import_data if pool
         end
       end
     end

--- a/app/lib/actions/katello/host/remove_subscriptions.rb
+++ b/app/lib/actions/katello/host/remove_subscriptions.rb
@@ -9,7 +9,7 @@ module Actions
 
           entitlements.each do |entitlement|
             plan_action(::Actions::Candlepin::Consumer::RemoveSubscription, :uuid => host.subscription_facet.uuid,
-                        :entitlement_id => entitlement['id'])
+                        :entitlement_id => entitlement['id'], :pool_id => entitlement['pool']['id'])
             plan_self(:host_name => host.name)
           end
         end

--- a/test/actions/katello/host/remove_subscriptions_test.rb
+++ b/test/actions/katello/host/remove_subscriptions_test.rb
@@ -18,14 +18,14 @@ module Katello::Host
         action = create_action action_class
         action.expects(:action_subject).with(@host)
 
-        entitlements = [{'id' => 3}, {'id' => 4}]
+        entitlements = [{'id' => 3, 'pool' => {'id' => 'foo'}}, {'id' => 4, 'pool' => {'id' => 'bar'}}]
 
         plan_action action, @host, entitlements
 
         assert_action_planed_with action, Actions::Candlepin::Consumer::RemoveSubscription, :uuid => @host.subscription_facet.uuid,
-                                  :entitlement_id => 3
+                                          :entitlement_id => 3, :pool_id => 'foo'
         assert_action_planed_with action, Actions::Candlepin::Consumer::RemoveSubscription, :uuid => @host.subscription_facet.uuid,
-                                          :entitlement_id => 4
+                                          :entitlement_id => 4, :pool_id => 'bar'
       end
     end
   end


### PR DESCRIPTION
When removing subscriptions from a host, the subscription quanities
now update so that the quantity for that subscription/pool will be
correct.