### PR TITLE
Fixes #15407 - adding event queue and listener

### DIFF
--- a/app/lib/actions/katello/event_queue/monitor.rb
+++ b/app/lib/actions/katello/event_queue/monitor.rb
@@ -1,0 +1,129 @@
+module Actions
+  module Katello
+    module EventQueue
+      class Monitor < Actions::Base
+        Event = Algebrick.type do
+          fields! event_type: String, object_id: Integer, created_at: DateTime
+        end
+
+        Fatal = Algebrick.type do
+          fields! backtrace: String, message: String, kind: String
+        end
+
+        Ready = Algebrick.atom
+        Close = Algebrick.atom
+
+        cattr_accessor :triggered_action
+
+        def self.ensure_running(world = ForemanTasks.dynflow.world)
+          world.coordinator.acquire(RunOnceCoordinatorLock.new(world)) do
+            unless ForemanTasks::Task::DynflowTask.for_action(self).running.any?
+              self.triggered_action = ForemanTasks.trigger(self)
+            end
+          end
+        rescue Dynflow::Coordinator::LockError
+          return false
+        end
+
+        def plan
+          # Make sure we don't have two concurrent listening services competing
+          if already_running?
+            fail "Action #{self.class.name} is already active"
+          end
+          plan_self
+        end
+
+        def run(event = nil)
+          match(event,
+                (on nil do
+                  initialize_service
+                end),
+                (on Ready do
+                  listen_for_events
+                end),
+                (on Event do
+                   act_on_event(event)
+                 end),
+                (on Close | Dynflow::Action::Cancellable::Cancel do
+                   close_service
+                 end),
+                (on Fatal do
+                   restart_poller(event)
+                 end),
+                (on Dynflow::Action::Skip do
+                   # do nothing, just skip
+                 end))
+        rescue => e
+          action_logger.error(e.message)
+          close_service
+          error!(e)
+        end
+
+        def restart_poller(_event)
+          suspend do |suspended_action|
+            SuspendedAction.new(suspended_action).notify_ready
+          end
+        end
+
+        def close_service
+          PollerThread.close
+        end
+
+        def initialize_service
+          ::Katello::EventQueue.reset_in_progress
+          PollerThread.initialize(world.logger)
+          suspend do |suspended_action|
+            SuspendedAction.new(suspended_action).notify_ready
+
+            unless Rails.env.test?
+              world.before_termination do
+                finish_service
+              end
+            end
+          end
+        end
+
+        def finish_service
+          suspended_action.ask(Close).wait
+          if self.class.triggered_action
+            self.class.triggered_action.finished.wait
+          else
+            max_attempts = 10
+            (1..max_attempts).each do |attempt|
+              task.reload
+              if !task.pending? || task.paused?
+                break
+              else
+                sleep 1 if attempt != max_attempts
+              end
+            end
+          end
+        end
+
+        def listen_for_events
+          suspend do |suspended_action|
+            PollerThread.instance.poll_for_events(SuspendedAction.new(suspended_action))
+          end
+        end
+
+        def act_on_event(event)
+          User.as_anonymous_admin do
+            output[:last_event] = "#{event.event_type} - #{event.object_id}"
+            ::Katello::EventQueue.event_class(event.event_type).new(event.object_id).run
+          end
+        rescue => e
+          world.logger.error(e.message)
+          world.logger.error(e.backtrace.join("\n"))
+          output[:last_error] = e.message
+        ensure
+          ::Katello::EventQueue.clear_events(event.event_type, event.object_id, event.created_at)
+          suspend
+        end
+
+        def humanized_name
+          _('Monitor Event Queue')
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/event_queue/poller_thread.rb
+++ b/app/lib/actions/katello/event_queue/poller_thread.rb
@@ -1,0 +1,45 @@
+module Actions
+  module Katello
+    module EventQueue
+      class PollerThread
+        SLEEP_INTERVAL = 2
+        cattr_accessor :instance
+
+        def self.initialize(logger)
+          self.instance ||= self.new(logger)
+        end
+
+        def self.close
+          self.instance.close if self.instance
+          self.instance = nil
+        end
+
+        def initialize(logger)
+          @logger = logger
+        end
+
+        def close
+          @thread.kill if @thread
+        end
+
+        def poll_for_events(suspended_action)
+          @thread.kill if @thread
+          @thread = Thread.new do
+            loop do
+              begin
+                until (event = ::Katello::EventQueue.next_event).nil?
+                  suspended_action.notify_queue_item(event.event_type, event.object_id, event.created_at) if event
+                end
+
+                sleep SLEEP_INTERVAL
+              rescue => e
+                suspended_action.notify_fatal(e)
+                raise e
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/event_queue/run_once_coordinator_lock.rb
+++ b/app/lib/actions/katello/event_queue/run_once_coordinator_lock.rb
@@ -1,0 +1,12 @@
+module Actions
+  module Katello
+    module EventQueue
+      class RunOnceCoordinatorLock < Dynflow::Coordinator::LockByWorld
+        def initialize(world)
+          super
+          @data[:id] = 'katello-event-queue'
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/event_queue/suspended_action.rb
+++ b/app/lib/actions/katello/event_queue/suspended_action.rb
@@ -1,0 +1,23 @@
+module Actions
+  module Katello
+    module EventQueue
+      class SuspendedAction
+        def initialize(suspended_action)
+          @suspended_action = suspended_action
+        end
+
+        def notify_queue_item(event_type, object_id, created_at)
+          @suspended_action << Monitor::Event[event_type, object_id, created_at.to_datetime]
+        end
+
+        def notify_ready
+          @suspended_action << Monitor::Ready
+        end
+
+        def notify_fatal(error)
+          @suspended_action << Monitor::Fatal[error.backtrace && error.backtrace.join('\n'), error.message, error.class.name]
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/host/generate_applicability.rb
+++ b/app/lib/actions/katello/host/generate_applicability.rb
@@ -13,9 +13,8 @@ module Actions
         end
 
         def finalize
-          ::Host.where(:id => input[:host_ids]).each do |host|
-            host.content_facet.try(:import_applicability)
-            host.content_facet.update_errata_status
+          input[:host_ids].each do |host_id|
+            ::Katello::EventQueue.push_event(::Katello::Events::ImportHostErrata::EVENT_TYPE, host_id)
           end
         end
       end

--- a/app/lib/actions/katello/repository/import_applicability.rb
+++ b/app/lib/actions/katello/repository/import_applicability.rb
@@ -11,7 +11,9 @@ module Actions
 
         def run
           repo = ::Katello::Repository.find(input[:repo_id])
-          repo.import_host_applicability
+          repo.hosts_with_applicability.each do |host|
+            ::Katello::EventQueue.push_event(::Katello::Events::ImportHostErrata::EVENT_TYPE, host.id)
+          end
         end
 
         def rescue_strategy_for_self

--- a/app/models/katello/event.rb
+++ b/app/models/katello/event.rb
@@ -1,0 +1,12 @@
+module Katello
+  class Event < Katello::Model
+    validate :validate_event_type
+
+    def validate_event_type
+      unless EventQueue.supported_event_types.include?(self.event_type)
+        errors.add(:event_type, _("Unsupported event type %{type}. Supported: %{types}") %
+            {:type => self.event_type, :types => EventQueue.supported_event_types.join(',')})
+      end
+    end
+  end
+end

--- a/app/models/katello/events/import_host_errata.rb
+++ b/app/models/katello/events/import_host_errata.rb
@@ -1,0 +1,16 @@
+module Katello
+  module Events
+    class ImportHostErrata
+      EVENT_TYPE = 'import_host_errata'.freeze
+
+      def initialize(object_id)
+        @host = ::Host.find_by_id(object_id)
+        fail "Host not found for ID #{object_id}" if @host.nil?
+      end
+
+      def run
+        @host.content_facet.try(:import_applicability, true) if @host
+      end
+    end
+  end
+end

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -571,16 +571,6 @@ module Katello
       end
     end
 
-    def import_host_applicability
-      self.hosts_with_applicability.find_each do |host|
-        begin
-          host.content_facet.import_applicability if host.content_facet.try(:uuid)
-        rescue => e
-          Rails.logger.error("Could not import applicability for #{host.name}: #{e}")
-        end
-      end
-    end
-
     def hosts_with_applicability
       ::Host.joins(:content_facet => :bound_repositories).where("#{Katello::Repository.table_name}.id" => (self.clones.pluck(:id) + [self.id]))
     end

--- a/app/services/katello/event_queue.rb
+++ b/app/services/katello/event_queue.rb
@@ -1,0 +1,39 @@
+module Katello
+  class EventQueue
+    @event_types = {}
+
+    def self.clear_events(event_type, object_id, on_or_earlier_than)
+      Katello::Event.where(:in_progress => true, :object_id => object_id, :event_type => event_type).where('created_at <= ?', on_or_earlier_than).destroy_all
+    end
+
+    def self.next_event
+      first = Katello::Event.where(:in_progress => false).order(:created_at => 'asc').limit(1)
+      events = Katello::Event.where(:in_progress => false, :object_id => first.pluck(:object_id),
+                                    :event_type => first.pluck(:event_type)).order(:created_at => 'asc')
+      last = events.last
+      events.update_all(:in_progress => true)
+      last
+    end
+
+    def self.reset_in_progress
+      Katello::Event.where(:in_progress => true).update_all(:in_progress => false)
+    end
+
+    def self.push_event(event_type, id)
+      Event.create!(:event_type => event_type, :object_id => id)
+    end
+
+    def self.register_event(event_type, klass)
+      @event_types[event_type] = klass.name
+    end
+
+    def self.supported_event_types
+      @event_types.keys
+    end
+
+    def self.event_class(event_type)
+      fail _("Invalid event_type %s") % event_type if @event_types[event_type].nil?
+      @event_types[event_type].constantize
+    end
+  end
+end

--- a/db/migrate/20160613150922_add_event_queue.rb
+++ b/db/migrate/20160613150922_add_event_queue.rb
@@ -1,0 +1,12 @@
+class AddEventQueue < ActiveRecord::Migration
+  def change
+    create_table :katello_events, :force => true do |t|
+      t.integer :object_id, :null => false
+      t.string :event_type, :null => false
+      t.boolean :in_progress, :default => false, :null => false
+      t.timestamps
+    end
+
+    add_index :katello_events, [:object_id, :event_type, :in_progress, :created_at], :name => :katello_events_oid_et_ip_ca
+  end
+end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -116,6 +116,7 @@ module Katello
       unless ForemanTasks.dynflow.config.remote? || File.basename($PROGRAM_NAME) == 'rake' || Rails.env.test?
         ForemanTasks.dynflow.config.on_init do |world|
           ::Actions::Candlepin::ListenOnCandlepinEvents.ensure_running(world)
+          ::Actions::Katello::EventQueue::Monitor.ensure_running(world)
         end
       end
     end
@@ -241,6 +242,8 @@ module Katello
       ::SettingsController.class_eval do
         helper Katello::Concerns::SettingsHelperExtensions
       end
+
+      Katello::EventQueue.register_event(Katello::Events::ImportHostErrata::EVENT_TYPE, Katello::Events::ImportHostErrata)
 
       load 'katello/repository_types.rb'
     end

--- a/test/actions/katello/event_queue_monitor_test.rb
+++ b/test/actions/katello/event_queue_monitor_test.rb
@@ -1,0 +1,36 @@
+require 'katello_test_helper'
+
+class Actions::Katello::EventQueueMonitorTest < ActiveSupport::TestCase
+  include Dynflow::Testing
+
+  describe 'run' do
+    let(:action_class) { ::Actions::Katello::EventQueue::Monitor }
+    let(:polling_class) { ::Actions::Katello::EventQueue::PollerThread }
+    let(:suspended_class) { ::Actions::Katello::EventQueue::SuspendedAction }
+    let(:planned_action) do
+      create_and_plan_action action_class
+    end
+
+    it 'on ready should listen' do
+      suspended_class.any_instance.expects(:notify_ready).once
+      action_class.any_instance.stubs(:suspend).yields(nil)
+      polling_class.any_instance.expects(:poll_for_events).once
+
+      action = run_action planned_action
+      action.run(action_class::Ready)
+    end
+
+    it 'should process events' do
+      host = FactoryGirl.create(:host)
+      action_class.any_instance.stubs(:suspend).yields(nil)
+      ::Katello::EventQueue.push_event(::Katello::Events::ImportHostErrata::EVENT_TYPE, host.id)
+      event = Katello::EventQueue.next_event
+
+      suspended_class.any_instance.expects(:notify_ready).once
+      Katello::Events::ImportHostErrata.any_instance.expects(:run).once
+
+      action = run_action planned_action
+      action.run(action_class::Event[event.event_type, event.object_id, event.created_at.to_datetime])
+    end
+  end
+end

--- a/test/actions/katello/host/upload_package_profile_test.rb
+++ b/test/actions/katello/host/upload_package_profile_test.rb
@@ -9,7 +9,7 @@ module Katello::Host
     before :all do
       User.current = users(:admin)
       @host = FactoryGirl.build(:host, :with_content, :with_subscription, :content_view => katello_content_views(:library_dev_view),
-                                 :lifecycle_environment => katello_environments(:library))
+                                 :lifecycle_environment => katello_environments(:library), :id => 343)
     end
 
     describe 'Host UploadPackageProfile' do
@@ -19,6 +19,7 @@ module Katello::Host
         profile = [{:name => "foo", :version => "1", :release => "3"}]
         action = create_action action_class
         @host.expects(:import_package_profile)
+
         ::Katello::Pulp::Consumer.any_instance.expects(:upload_package_profile)
         action.stubs(:action_subject).with(@host)
 

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -420,7 +420,9 @@ module ::Actions::Katello::Repository
     let(:action_class) { ::Actions::Katello::Repository::ImportApplicability }
 
     it 'runs' do
-      Katello::Repository.any_instance.expects(:import_host_applicability)
+      host =  FactoryGirl.build(:host, :id => 343)
+      ::Katello::Repository.any_instance.stubs(:hosts_with_applicability).returns([host])
+      Katello::EventQueue.expects(:push_event).with(::Katello::Events::ImportHostErrata::EVENT_TYPE, host.id)
 
       ForemanTasks.sync_task(action_class, :repo_id => repository.id, :contents_changed => true)
     end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -646,11 +646,5 @@ module Katello
       assert_includes @fedora_17_x86_64.hosts_with_applicability, @lib_host
       assert_includes @fedora_17_x86_64.hosts_with_applicability, @view_host
     end
-
-    def test_import_host_applicability
-      Host::ContentFacet.any_instance.expects(:import_applicability).twice
-
-      @fedora_17_x86_64.import_host_applicability
-    end
   end
 end

--- a/test/services/katello/event_queue_test.rb
+++ b/test/services/katello/event_queue_test.rb
@@ -1,0 +1,61 @@
+require 'katello_test_helper'
+
+module Katello
+  class EventQueueTest < ActiveSupport::TestCase
+    def setup
+      @type = Katello::Events::ImportHostErrata::EVENT_TYPE
+    end
+
+    def test_clear_events_only_deletes_last
+      Event.destroy_all
+
+      event = EventQueue.push_event(@type, 1)
+      event2 = EventQueue.push_event(@type, 1)
+      event3 = EventQueue.push_event(@type, 1)
+      event2.update_attributes!(:created_at => event2.created_at - 5.minutes)
+      event3.update_attributes!(:created_at => event3.created_at + 5.minutes)
+      Event.update_all(:in_progress => true)
+      refute_empty Event.all
+
+      EventQueue.clear_events(event.event_type, 1, event.created_at)
+      assert_equal [event3], Event.all
+    end
+
+    def test_clear_events_only_delete_inprogress
+      Event.destroy_all
+
+      event = EventQueue.push_event(@type, 1)
+      EventQueue.clear_events(@type, 1, event.created_at)
+
+      assert_equal [event], Event.all
+      EventQueue.next_event
+      EventQueue.clear_events(@type, 1, event.created_at)
+
+      assert_empty Event.all
+    end
+
+    def test_event_class
+      assert_equal Katello::Events::ImportHostErrata, EventQueue.event_class(@type)
+    end
+
+    def test_supported_event_types
+      assert_includes Katello::EventQueue.supported_event_types, @type
+    end
+
+    def test_next_event
+      EventQueue.register_event('foo', Object)
+
+      event = EventQueue.push_event(@type, 1)
+      event.update_attributes(:created_at => event.created_at + 5.minutes)
+      event2 = EventQueue.push_event('foo', 1)
+      event3 = EventQueue.push_event(@type, 1)
+      event3.update_attributes(:created_at => event.created_at - 5.minutes)
+
+      next_event = EventQueue.next_event
+      assert_equal event, next_event
+      assert event.reload.in_progress
+      assert event3.reload.in_progress
+      refute event2.reload.in_progress
+    end
+  end
+end


### PR DESCRIPTION
This adds a new queing table and model as well
as a dynflow listening task that processes queue items.
The only current event is the import errata task, to serialize
errata import so that we can resolve unique constraint
violations once and for all.