### PR TITLE
Fixes #15414: ensure trailing / on repo full_path to prevent 404.

### DIFF
--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -827,13 +827,13 @@ module Katello
       if docker?
         "#{pulp_uri.host.downcase}:5000/#{pulp_id}"
       elsif file?
-        "#{scheme}://#{pulp_uri.host.downcase}/pulp/isos/#{pulp_id}"
+        "#{scheme}://#{pulp_uri.host.downcase}/pulp/isos/#{pulp_id}/"
       elsif puppet?
-        "#{scheme}://#{pulp_uri.host.downcase}/pulp/puppet/#{pulp_id}"
+        "#{scheme}://#{pulp_uri.host.downcase}/pulp/puppet/#{pulp_id}/"
       elsif ostree?
-        "#{scheme}://#{pulp_uri.host.downcase}/pulp/ostree/web/#{pulp_id}"
+        "#{scheme}://#{pulp_uri.host.downcase}/pulp/ostree/web/#{pulp_id}/"
       else
-        "#{scheme}://#{pulp_uri.host.downcase}/pulp/repos/#{relative_path}"
+        "#{scheme}://#{pulp_uri.host.downcase}/pulp/repos/#{relative_path}/"
       end
     end
 

--- a/test/glue/pulp/repository_test.rb
+++ b/test/glue/pulp/repository_test.rb
@@ -61,10 +61,10 @@ module Katello
       repo = ::Katello::Repository.new(:url => 'http://zodiak.com/ted', :unprotected => false, :relative_path => '/elbow')
 
       assert_equal repo.importer_feed_url, 'http://zodiak.com/ted'
-      assert_equal repo.importer_feed_url(true), "https://#{pulp_host}/pulp/repos//elbow"
+      assert_equal repo.importer_feed_url(true), "https://#{pulp_host}/pulp/repos//elbow/"
 
       repo.unprotected = true
-      assert_equal repo.importer_feed_url(true), "https://#{pulp_host}/pulp/repos//elbow"
+      assert_equal repo.importer_feed_url(true), "https://#{pulp_host}/pulp/repos//elbow/"
     end
 
     def test_relative_path


### PR DESCRIPTION
Pulp uses relative urls in their list of packages so we need to ensure
that the repository full path ends in a slash so as to not get 404s on
the repo page.

http://projects.theforeman.org/issues/15414

See also https://pulp.plan.io/issues/2009