### PR TITLE
Fixes #15422 - proper way to override puppet env field

### DIFF
--- a/app/helpers/katello/concerns/hosts_and_hostgroups_helper_extensions.rb
+++ b/app/helpers/katello/concerns/hosts_and_hostgroups_helper_extensions.rb
@@ -1,0 +1,19 @@
+module Katello
+  module Concerns
+    module HostsAndHostgroupsHelperExtensions
+      extend ActiveSupport::Concern
+
+      included do
+        alias_method_chain :puppet_environment_field, :katello
+      end
+
+      def puppet_environment_field_with_katello(form, environments_choice, select_options = {}, html_options = {})
+        html_options.merge!(
+          :label => _("Puppet Environment"),
+          'data-content_puppet_match' => (@host || @hostgroup).new_record? || (@host || @hostgroup).content_and_puppet_match?,
+          :help_inline => link_to(_("Reset Puppet Environment to match selected Content View"), '#', :id => 'reset_puppet_environment'))
+        puppet_environment_field_without_katello(form, environments_choice, select_options, html_options)
+      end
+    end
+  end
+end

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -83,7 +83,7 @@ module Katello
           if content_facet.present?
             self.content_facet.kickstart_repository_id ||= hostgroup.inherited_kickstart_repository_id
           end
-          assign_hostgroup_attributes(%w(content_source_id content_view_id lifecycle_environment_id environment_id))
+          assign_hostgroup_attributes(%w(content_source_id content_view_id lifecycle_environment_id))
         end
         set_hostgroup_defaults_without_katello_attributes
       end

--- a/app/overrides/add_activation_keys_input.rb
+++ b/app/overrides/add_activation_keys_input.rb
@@ -10,12 +10,12 @@ Deface::Override.new(:virtual_path => "hostgroups/_form",
 
 Deface::Override.new(:virtual_path => "hostgroups/_form",
                      :name => "hostgroups_update_environments_select",
-                     :replace => 'erb[loud]:contains("select_f"):contains(":environment_id")',
+                     :insert_before => 'erb[loud]:contains("hostgroup_puppet_environment_field")',
                      :partial => 'overrides/activation_keys/host_environment_select')
 
 Deface::Override.new(:virtual_path => "hosts/_form",
                      :name => "hosts_update_environments_select",
-                     :replace => 'erb[loud]:contains("select_f"):contains(":environment_id")',
+                     :insert_before => 'erb[loud]:contains("host_puppet_environment_field")',
                      :partial => 'overrides/activation_keys/host_environment_select')
 
 Deface::Override.new(:virtual_path => "common/os_selection/_operatingsystem",

--- a/app/views/overrides/activation_keys/_host_environment_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_environment_select.html.erb
@@ -34,14 +34,6 @@ end %>
   <input type="hidden" name="host[content_facet_attributes][id]" value="<%= @host.content_facet.try(:id) %>">
 <% end %>
 
-<% data_url = using_hostgroups_page? ? environment_selected_hostgroups_path : hostgroup_or_environment_selected_hosts_path %>
-<%= select_f f, :environment_id, Environment.all, :id, :to_label, {:include_blank => blank_or_inherit_f(f, :environment)},
-  {:label => _("Puppet Environment"), :onchange => 'update_puppetclasses(this);', 'data-url'=> data_url,
-   'data-content_puppet_match' => (@host || @hostgroup).new_record? || (@host || @hostgroup).content_and_puppet_match?,
-    :help_inline => %(<a id="reset_puppet_environment">#{_("Reset Puppet Environment to match selected Content View")}</a>).html_safe
-  } %>
-
-
 <% proxies = SmartProxy.with_content.unscoped.with_taxonomy_scope(@location,@organization,:path_ids) %>
 <% if proxies.count > 0 %>
     <%= select_f f, :content_source_id, proxies, :id, :name,

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -245,6 +245,14 @@ module Katello
 
       Katello::EventQueue.register_event(Katello::Events::ImportHostErrata::EVENT_TYPE, Katello::Events::ImportHostErrata)
 
+      ::HostsController.class_eval do
+        helper Katello::Concerns::HostsAndHostgroupsHelperExtensions
+      end
+
+      ::HostgroupsController.class_eval do
+        helper Katello::Concerns::HostsAndHostgroupsHelperExtensions
+      end
+
       load 'katello/repository_types.rb'
     end
 


### PR DESCRIPTION
Moved from defacing the view to `alias_method_chain` to the helper method.
Since Foreman is handling the hostgroup's inheritance, #6102 could be reverted.