### PR TITLE
Fixes #15443 - Use ::Foreman instead of Foreman

### DIFF
--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -66,7 +66,7 @@ module Katello
       query = query.order("#{query.table_name}.id DESC") unless group #secondary order to ensure sort is deterministic
       query = query.includes(includes) if includes.length > 0
 
-      if Foreman::Cast.to_bool(params[:full_result])
+      if ::Foreman::Cast.to_bool(params[:full_result])
         params[:per_page] = total
       else
         query = query.paginate(paginate_options)


### PR DESCRIPTION
This bug was introduced by https://github.com/Katello/katello/pull/6126