### PR TITLE
Fixes #15435 - fix scoped_search for grouped queries

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/content-view-puppet-module-names.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/content-view-puppet-module-names.controller.js
@@ -10,15 +10,26 @@
  *   Provides functionality to the puppet modules name list.
  */
 angular.module('Bastion.content-views').controller('ContentViewPuppetModuleNamesController',
-    ['$scope', 'Nutupane', 'ContentView', function ($scope, Nutupane, ContentView) {
+    ['$scope', 'Nutupane', 'ContentView', 'CurrentOrganization', 'PuppetModule',
+    function ($scope, Nutupane, ContentView, CurrentOrganization, PuppetModule) {
 
         var nutupane = new Nutupane(
             ContentView,
             {id: $scope.$stateParams.contentViewId},
             'availablePuppetModuleNames'
         );
-
+        nutupane.masterOnly = true;
         $scope.detailsTable = nutupane.table;
+
+        $scope.detailsTable.fetchAutocomplete = function (term) {
+            var promise;
+
+            promise = PuppetModule.autocomplete({'organization_id': CurrentOrganization, search: term}).$promise;
+
+            return promise.then(function (data) {
+                return data;
+            });
+        };
 
         $scope.selectVersion = function (moduleName) {
             $scope.transitionTo('content-views.details.puppet-modules.versions',

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/views/content-view-puppet-module-names.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/views/content-view-puppet-module-names.html
@@ -22,14 +22,24 @@
   <span data-block="header" translate>Select A New Puppet Module To Add</span>
   <span data-block="messages"></span>
   <div data-block="search">
+    <div class="input-group input-group">
     <input type="text"
            class="form-control"
-           placeholder="{{ 'Filter' | translate }}"
-           ng-model="filterTerm"/>
+           placeholder="{{ 'Search...' | translate }}"
+           ng-model="detailsTable.searchTerm"
+           bst-on-enter="detailsTable.search(detailsTable.searchTerm)"
+           ng-trim="false"
+           typeahead="item.label for item in detailsTable.fetchAutocomplete($viewValue)"
+           typeahead-empty
+           typeahead-template-url="components/views/autocomplete-scoped-search.html"/>
+    <span class="input-group-btn">
+      <button ng-click="detailsTable.search(detailsTable.searchTerm)" class="btn btn-default" type="button"><i class="fa fa-search"></i></button>
+    </span>
+    </div>
   </div>
 
   <span data-block="selection-summary"></span>
-
+  <span data-block="no-rows-message" translate>No puppet modules found</span>
   <div data-block="table">
     <table class="table table-striped table-bordered">
       <thead>

--- a/engines/bastion_katello/test/content-views/details/puppet-modules/content-view-puppet-module-names.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/puppet-modules/content-view-puppet-module-names.controller.test.js
@@ -6,6 +6,9 @@ describe('Controller: ContentViewPuppetModuleNamesController', function() {
     beforeEach(inject(function($injector) {
         $controller = $injector.get('$controller');
         ContentView = $injector.get('MockResource').$new();
+        PuppetModule = $injector.get('MockResource').$new();
+        PuppetModule.autocomplete = function(){return {$promise: {then: function(callback) {callback([])}}}};
+
         ContentView.availablePuppetModuleNames = function () {};
 
         $scope = $injector.get('$rootScope').$new();
@@ -14,7 +17,9 @@ describe('Controller: ContentViewPuppetModuleNamesController', function() {
 
         dependencies = {
             $scope: $scope,
-            ContentView: ContentView
+            ContentView: ContentView,
+            PuppetModule: PuppetModule,
+            CurrentOrganization: 1
         };
 
         $controller('ContentViewPuppetModuleNamesController', dependencies);
@@ -32,5 +37,12 @@ describe('Controller: ContentViewPuppetModuleNamesController', function() {
         expect($scope.transitionTo).toHaveBeenCalledWith('content-views.details.puppet-modules.versions',
             {contentViewId: 1, moduleName: "puppet"}
         );
+    });
+
+    it("Auto completes to puppet modules", function() {
+        spyOn(PuppetModule, 'autocomplete').andCallThrough();
+
+        $scope.detailsTable.fetchAutocomplete('foobar');
+        expect(PuppetModule.autocomplete).toHaveBeenCalledWith({'organization_id': 1, search: 'foobar'})
     });
 });

--- a/test/controllers/api/v2/api_controller_test.rb
+++ b/test/controllers/api/v2/api_controller_test.rb
@@ -64,5 +64,20 @@ module Katello
       results = @controller.scoped_search(query, "errata_id", "asc", options)[:results]
       assert_equal ["RHBA-2014-013", "RHEA-2014-111", "RHSA-1999-1231"], results.map(&:errata_id)
     end
+
+    def test_scoped_search_group
+      types = Katello::Erratum.pluck(:errata_type).uniq
+      4.times do
+        Katello::Erratum.create!(:errata_id => "RHRA-#{rand(9999)}", :errata_type => 'security', :uuid => rand(9999).to_s)
+      end
+      @controller.stubs(:params).returns({})
+
+      @options[:group] = 'errata_type'
+      results = @controller.scoped_search(@query, 'errata_type', @default_sort[1], @options)
+
+      assert_equal types.count, results[:subtotal]
+      assert_equal types.count, results[:total]
+      assert_equal types.sort, results[:results].map { |i| i['errata_type'] }.sort
+    end
   end
 end

--- a/test/fixtures/models/katello_errata.yml
+++ b/test/fixtures/models/katello_errata.yml
@@ -11,6 +11,7 @@ security:
 
 bugfix:
   errata_id:  "RHBA-2014-013"
+  errata_type: "enhancement"
   title: "Divide by zero"
   uuid: "100dividedby0"
   created_at: <%= Time.now %>
@@ -20,6 +21,7 @@ bugfix:
 
 enhancement:
   errata_id: "RHEA-2014-111"
+  errata_type: "bugfix"
   title: "bionic man"
   uuid: "wecanrebuildhim"
   created_at: <%= Time.now %>


### PR DESCRIPTION
this fixes the content view puppet module names page
fixing the totals to be correct and showing the duplicates
it also fixes some broken interaction with that page such as
* allowing scoped_search based search
* displaying a proper message when there are no results