### PR TITLE
Fixes #15473 - Better detection of hostgroup in UI

### DIFF
--- a/app/views/overrides/activation_keys/_host_environment_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_environment_select.html.erb
@@ -14,7 +14,7 @@
     select_tag env_select_id, lifecycle_environment_options(@hostgroup, :include_blank => blank_or_inherit_with_id(f, :lifecycle_environment)),
                :class => 'form-control',  :name => env_select_name
   else
-    select_tag env_select_id, lifecycle_environment_options(@host, :selected_host_group => @hostgroup, :include_blank => blank_or_inherit_with_id(f, :lifecycle_environment)), :class => 'form-control',  :name => env_select_name
+    select_tag env_select_id, lifecycle_environment_options(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :lifecycle_environment)), :class => 'form-control',  :name => env_select_name
   end
 end %>
 
@@ -26,7 +26,7 @@ end %>
     select_tag cv_select_id,  content_views_for_host(@hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_view)), :data => {"spinner_path" => spinner_path},
                :class => 'form-control',  :name => cv_select_name
   else
-    select_tag cv_select_id,  content_views_for_host(@host, :selected_host_group => @hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_view)), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cv_select_name
+    select_tag cv_select_id,  content_views_for_host(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_view)), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cv_select_name
   end
 end %>
 


### PR DESCRIPTION
This is a small patch that enables katello not to rely on `@hostgroup` class variable that in some cases is not set properly in foreman.

IMHO a proper refactoring of this code would be better, but I have don't have enough knowledge in this code to perform it. Foreman already has `select_f` helper that creates a proper select2 field with many options ready for customization.
The better code should be something along the lines of:
```  HTML+ERB

<% f.fields_for content_facet do |content_f| %>
  <%= select_f, content_f, :lifecycle_environment_id, Organization.current.kt_environments, :id, :name,
    { include_blank => true }
  %>
<% end %>
```