### PR TITLE
Update foreman-tasks in KATELLO-3.0

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rest-client"
 
   gem.add_dependency "rabl"
-  gem.add_dependency "foreman-tasks", "~> 0.7.1"
+  gem.add_dependency "foreman-tasks", "~> 0.7.18"
   gem.add_dependency "foreman_docker", ">= 0.2.0"
 
   gem.add_dependency "qpid_messaging", ">= 0.30.0", '< 0.31.0'


### PR DESCRIPTION
Before we can merge, we need:

* [x] - update dynflow in rpm/develop (https://github.com/theforeman/foreman-packaging/pull/1190)
* [x] - update dynflow and foreman-tasks in rpm/1.11 (https://github.com/theforeman/foreman-packaging/pull/1195)