### PR TITLE
fixes #15487: API: GET repositories by organization

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -36,6 +36,7 @@ module Katello
 
     api :GET, "/repositories", N_("List of enabled repositories")
     api :GET, "/content_views/:id/repositories", N_("List of repositories for a content view")
+    api :GET, "/organizations/:organization_id/repositories", N_("List of repositories in an organization")
     api :GET, "/organizations/:organization_id/environments/:environment_id/repositories", _("List repositories in the environment")
     api :GET, "/products/:product_id/repositories", N_("List of repositories for a product")
     api :GET, "/environments/:environment_id/products/:product_id/repositories", N_("List of repositories belonging to a product in an environment")

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -171,6 +171,7 @@ Katello::Engine.routes.draw do
             get :redhat_provider
           end
           api_resources :products, :only => [:index]
+          api_resources :repositories, :only => [:index]
           api_resources :subscriptions, :only => [:index] do
             collection do
               match '/available' => 'subscriptions#available', :via => :get


### PR DESCRIPTION
Small change to make repositories consistent with the likes
of products and content views.