### PR TITLE
Fixes #15499: fix JS error on sync management page.

### DIFF
--- a/app/assets/javascripts/katello/sync_management/sync_management.js
+++ b/app/assets/javascripts/katello/sync_management/sync_management.js
@@ -163,7 +163,7 @@ KT.content = (function(){
                 progressBar = $('<a/>').attr('class', 'progress').text(" ");
 
             if(task_id !== undefined) {
-                progress.attr('href', '/foreman_tasks/tasks/' + task_id)
+                progressBar.attr('href', '/foreman_tasks/tasks/' + task_id)
             }
 
             progress = progress ? progress : 0;


### PR DESCRIPTION
There was a JS error on the sync management page that was causing
the page to break.  This fixes the JS error by putting the HREF on
the element as was originally intended.

http://projects.theforeman.org/issues/15499