### PR TITLE
Fixes #14218 - Use id, not uuid, for host link with virtual sub

### DIFF
--- a/app/models/katello/glue/candlepin/pool.rb
+++ b/app/models/katello/glue/candlepin/pool.rb
@@ -134,8 +134,8 @@ module Katello
         end
       end
 
-      def host
-        System.find_by(:uuid => host_id) if host_id
+      def hypervisor
+        ::Katello::Host::SubscriptionFacet.find_by(:uuid => host_id).try(:host) if host_id
       end
     end
   end

--- a/app/views/katello/api/v2/subscriptions/base.json.rabl
+++ b/app/views/katello/api/v2/subscriptions/base.json.rabl
@@ -16,9 +16,9 @@ attributes :name => :product_name
 attributes :unmapped_guest
 attributes :virt_only
 
-node :host, :if => lambda { |sub| sub && sub.host } do |subscription|
+node :host, :if => lambda { |sub| sub && sub.hypervisor } do |subscription|
   {
-    id: subscription.host.uuid,
-    name: subscription.host.name
+    id: subscription.hypervisor.id,
+    name: subscription.hypervisor.name
   }
 end


### PR DESCRIPTION
When attaching a VDC subscription to a physical host, a link appears for the
guest subscription, "Guests of foo.example.com" This link is broken as it is
still using the candlepin id instead of the active record id. This commit
changes the link to use the proper id, and also changes the JSON returned.
All places in the UI that are using a subscription's host id should be
updated.