### PR TITLE
Fixes #15376: prevent 414 on errata applicable host list.

### DIFF
--- a/config/routes/overrides.rb
+++ b/config/routes/overrides.rb
@@ -34,6 +34,8 @@ Foreman::Application.routes.draw do
 
   namespace :api do
     scope "(:api_version)", :module => :v2, :defaults => {:api_version => 'v2'}, :api_version => /v2/, :constraints => ApiConstraints.new(:version => 2, :default => true) do
+      match '/hosts/post_index' => 'hosts#index', :via => :post
+
       resources :hosts, :only => [] do
         member do
           put :host_collections

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/errata-content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/errata-content-hosts.controller.js
@@ -26,7 +26,7 @@ angular.module('Bastion.errata').controller('ErrataContentHostsController',
             'organization_id': CurrentOrganization
         };
 
-        nutupane = new Nutupane(Host, params);
+        nutupane = new Nutupane(Host, params, 'postIndex');
         nutupane.table.closeItem = function () {};
         nutupane.enableSelectAllResults();
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/host.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/host.factory.js
@@ -10,6 +10,7 @@
 angular.module('Bastion.hosts').factory('Host',
     ['BastionResource', function (BastionResource) {
         var resource = BastionResource('/api/v2/hosts/:id/:action', {id: '@id'}, {
+            postIndex: {method: 'POST', params: {action: 'post_index'}},
             update: {method: 'PUT'},
             updateHostCollections: {method: 'PUT', params: {action: 'host_collections'}},
             autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}}

--- a/engines/bastion_katello/test/hosts/host.factory.test.js
+++ b/engines/bastion_katello/test/hosts/host.factory.test.js
@@ -27,4 +27,9 @@ describe('Factory: Host', function() {
 
         Host.updateHostCollections({id: 1}, {"host_collection_ids": [1,2]});
     });
+
+    it("provides a way to get the host index via a post", function() {
+        $httpBackend.expectPOST('/api/v2/hosts/post_index').respond({});
+        Host.postIndex();
+    });
 });


### PR DESCRIPTION
We were getting a 414 Request-URI Too Long when attempting to GET
applicable hosts for several errata simultaneously.  This commit
updates the call to use a POST so there is no limit on the length
of the errata IDs.

http://projects.theforeman.org/issues/15376