### PR TITLE
Fixes #11871 - subscription rows mismatched colors when grouped

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-add-subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-add-subscriptions.html
@@ -20,7 +20,7 @@
   </span>
 
   <div data-block="table">
-    <table ng-class="{'table-mask': detailsTable.working}" class="table table-full table-striped">
+    <table ng-class="{'table-mask': detailsTable.working}" class="table table-full">
       <thead>
         <tr bst-table-head row-select>
           <th bst-table-column="quantity" sortable class="align-center"><span translate>Quantity</span></th>
@@ -43,7 +43,11 @@
           </td>
           <td bst-table-cell colspan="8"></td>
         </tr>
-        <tr bst-table-row ng-repeat-end ng-repeat="subscription in subscriptions" row-select="subscription">
+        <tr bst-table-row 
+            ng-repeat-end
+            class="grey-table-row"
+            ng-repeat="subscription in subscriptions"
+            row-select="subscription">
           <td bst-table-cell>
             <span ng-hide="subscription.multi_entitlement">
               1

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-subscriptions-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-subscriptions-list.html
@@ -32,7 +32,7 @@
 
 
   <div data-block="table">
-    <table ng-class="{'table-mask': detailsTable.working}" class="table table-full table-striped">
+    <table ng-class="{'table-mask': detailsTable.working}" class="table table-full">
       <thead>
         <tr bst-table-head row-select>
           <th bst-table-column="quantity" sortable class="align-center"><span translate>Quantity</span></th>
@@ -55,7 +55,7 @@
           </td>
           <td bst-table-cell colspan="8" ></td>
         </tr>
-        <tr bst-table-row ng-repeat-end ng-repeat="subscription in subscriptions" row-select="subscription">
+        <tr class="grey-table-row" bst-table-row ng-repeat-end ng-repeat="subscription in subscriptions" row-select="subscription">
           <td bst-table-cell>{{ subscription | subscriptionAttachAmountFilter }}</td>
           <td bst-table-cell>{{ subscription | subscriptionConsumedFilter }}</td>
           <td bst-table-cell><div subscription-type="subscription"></div></td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-add-subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-add-subscriptions.html
@@ -18,7 +18,7 @@
 
   <div data-block="table">
     <table ng-class="{'table-mask': detailsTable.working}"
-            class="table table-full table-striped">
+            class="table table-full">
        <thead>
          <tr bst-table-head row-select>
            <th bst-table-column="quantity" sortable class="align-center"><span translate>Quantity</span></th>
@@ -41,7 +41,7 @@
            </td>
            <td bst-table-cell colspan="8"></td>
          </tr>
-         <tr bst-table-row ng-repeat-end ng-repeat="subscription in subscriptions" row-select="subscription">
+         <tr class="grey-table-row" bst-table-row ng-repeat-end ng-repeat="subscription in subscriptions" row-select="subscription">
            <td bst-table-cell>
              <span ng-hide="subscription.multi_entitlement">
                1

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions-list.html
@@ -29,7 +29,7 @@
 
   <div data-block="table">
     <table ng-class="{'table-mask': detailsTable.working}"
-           class="table table-full table-striped" >
+           class="table table-full" >
       <thead>
         <tr bst-table-head row-select>
           <th bst-table-column="quantity" sortable class="align-center"><span translate>Quantity</span></th>
@@ -52,7 +52,7 @@
           </td>
           <td bst-table-cell colspan="8"></td>
         </tr>
-        <tr bst-table-row ng-repeat-end ng-repeat="subscription in subscriptions" row-select="subscription">
+        <tr class="grey-table-row" bst-table-row ng-repeat-end ng-repeat="subscription in subscriptions" row-select="subscription">
           <td bst-table-cell>{{ subscription.quantity_consumed }}</td>
           <td bst-table-cell>
             <a ui-sref="subscriptions.details.info({subscriptionId: subscription.subscription_id})">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/subscriptions-table-collapsed.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/subscriptions-table-collapsed.html
@@ -1,4 +1,4 @@
-<table class="table table-striped table-full" ng-class="{'table-mask': table.working}">
+<table class="table table-full" ng-class="{'table-mask': table.working}">
   <thead>
     <tr bst-table-head>
       <th bst-table-column="consumed" sortable><span translate>Consumed</span></th>
@@ -12,6 +12,7 @@
       </td>
     </tr>
     <tr bst-table-row
+        class="grey-table-row"
         ng-repeat-end
         ng-repeat="subscription in subscriptions"
         active-row="stateIncludes('subscriptions.details', {subscriptionId: subscription.id})">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/subscriptions-table-full.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/subscriptions-table-full.html
@@ -1,4 +1,4 @@
-<table class="table table-striped" ng-class="{'table-mask': table.working}" ng-show="table.rows.length > 0">
+<table class="table" ng-class="{'table-mask': table.working}" ng-show="table.rows.length > 0">
   <thead>
     <tr bst-table-head>
       <th bst-table-column="consumed" class="align-center"><span translate>Consumed</span></th>
@@ -17,7 +17,7 @@
         <b>{{ name }}</b>
       </td>
     </tr>
-    <tr bst-table-row ng-repeat-end ng-repeat="subscription in subscriptions">
+    <tr class="grey-table-row" bst-table-row ng-repeat-end ng-repeat="subscription in subscriptions">
       <td bst-table-cell>
         <a ui-sref="subscriptions.details.info({subscriptionId: subscription.id})">
           {{ subscription | subscriptionConsumedFilter }}

--- a/engines/bastion_katello/app/assets/stylesheets/bastion_katello/bastion_katello.scss
+++ b/engines/bastion_katello/app/assets/stylesheets/bastion_katello/bastion_katello.scss
@@ -1,9 +1,11 @@
 .bastion {
+  @import "colors";
   @import "gpg-keys";
   @import "systems";
   @import "tasks";
   @import "environments";
   @import "errata";
+  @import "subscriptions";
 
   a {
     &.confined-text {

--- a/engines/bastion_katello/app/assets/stylesheets/bastion_katello/colors.scss
+++ b/engines/bastion_katello/app/assets/stylesheets/bastion_katello/colors.scss
@@ -1,0 +1,1 @@
+$grey-table-row: #f5f5f5;

--- a/engines/bastion_katello/app/assets/stylesheets/bastion_katello/subscriptions.scss
+++ b/engines/bastion_katello/app/assets/stylesheets/bastion_katello/subscriptions.scss
@@ -1,0 +1,3 @@
+.grey-table-row {
+    background-color: $grey-table-row;
+}


### PR DESCRIPTION
Anywhere in the UI where we show subscriptions and there are grouped
rows of subscriptions, the rows are mismatched colors
They are changed to now be the same color within groupings

[mismatched rows](http://bit.ly/28XGKOk)
[matching rows](http://bit.ly/28XGMpp)