### PR TITLE
Fixes #15482 - fixing various product content issues

### DIFF
--- a/app/lib/actions/katello/product/content_destroy.rb
+++ b/app/lib/actions/katello/product/content_destroy.rb
@@ -3,16 +3,14 @@ module Actions
     module Product
       class ContentDestroy < Actions::Base
         def plan(repository)
-          if !repository.product.provider.redhat_provider? &&
-               repository.other_repos_with_same_product_and_content.empty?
-            sequence do
-              plan_action(Candlepin::Product::ContentRemove,
-                          product_id: repository.product.cp_id,
+          fail _("Cannot delete redhat product content") if repository.product.redhat?
+          sequence do
+            plan_action(Candlepin::Product::ContentRemove,
+                        product_id: repository.product.cp_id,
+                        content_id: repository.content_id)
+            if repository.other_repos_with_same_content.empty?
+              plan_action(Candlepin::Product::ContentDestroy,
                           content_id: repository.content_id)
-              if repository.other_repos_with_same_content.empty?
-                plan_action(Candlepin::Product::ContentDestroy,
-                            content_id: repository.content_id)
-              end
             end
           end
         end

--- a/app/lib/actions/katello/product/destroy.rb
+++ b/app/lib/actions/katello/product/destroy.rb
@@ -26,12 +26,10 @@ module Actions
                   plan_action(Katello::Repository::Destroy, repo, repo_options)
                 end
               end
-              concurrence do
-                plan_action(Candlepin::Product::DeletePools,
-                              cp_id: product.cp_id, organization_label: product.organization.label)
-                plan_action(Candlepin::Product::DeleteSubscriptions,
-                              cp_id: product.cp_id, organization_label: product.organization.label)
-              end
+              plan_action(Candlepin::Product::DeletePools,
+                            cp_id: product.cp_id, organization_label: product.organization.label)
+              plan_action(Candlepin::Product::DeleteSubscriptions,
+                            cp_id: product.cp_id, organization_label: product.organization.label)
             end
 
             if !product.used_by_another_org? && !organization_destroy

--- a/app/lib/actions/katello/repository_set/disable_repository.rb
+++ b/app/lib/actions/katello/repository_set/disable_repository.rb
@@ -13,7 +13,7 @@ module Actions
                                          options[:registry_name]).find_repository
           if repository
             action_subject(repository)
-            plan_action(Repository::Destroy, repository)
+            plan_action(Repository::Destroy, repository, :planned_destroy => true)
           else
             fail ::Katello::Errors::NotFound, _('Repository not found')
           end

--- a/test/actions/katello/product_test.rb
+++ b/test/actions/katello/product_test.rb
@@ -50,7 +50,7 @@ module Katello
         action = create_action action_class
         action.stubs(:action_subject).with(@repository)
         plan_action action, @repository
-        refute_action_planed action, candlepin_remove_class
+        assert_action_planed action, candlepin_remove_class
         refute_action_planed action, candlepin_destroy_class
       end
     end

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -301,7 +301,7 @@ fedora_17_x86_64_library_view_2_library:
 fedora_17_unpublished:
   name:                 Fedora 17 x86_64 unpublished
   pulp_id:              6
-  content_id:           1
+  content_id:           8374837483743
   label:                fedora_17_unpublished_label
   relative_path:        'ACME_Corporation/library/fedora_17_unpublished_label'
   environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>


### PR DESCRIPTION
This fixes a couple issues around content addition
and removal including:

* Disabling a redhat repo leaves the content in Library
* Deleting a product with multiple repos results in an error

This needs a lot of testing around anything that adds or removes
content from a candlepin environment such as:

* content view publish and promote where a repo no longer is in the view
* content view removal
* custom repo deletion from Library
* custom product deletion from Library
* redhat repo disabling