### PR TITLE
fixes #15557 - errata: flatten array containing errata uuids

### DIFF
--- a/app/controllers/katello/api/v2/errata_controller.rb
+++ b/app/controllers/katello/api/v2/errata_controller.rb
@@ -55,7 +55,7 @@ module Katello
 
     def filter_by_content_view(filter, collection)
       repos = Katello::ContentView.find(filter.content_view_id).repositories
-      uuid = repos.map { |r| r.send("errata").pluck("uuid") }
+      uuid = repos.map { |r| r.send("errata").pluck("uuid") }.flatten
       filter_by_ids(uuid, collection)
     end
 


### PR DESCRIPTION
This commit is to address the following error observed on production
installations when viewing the list of errata to add to a content
view errata filter:

2016-06-30 12:43:15 [app] [E] PG::Error: ERROR:  syntax error at or near ","
 | LINE 1: ...7,11,12,10,8,6))) AND "katello_errata"."uuid" IN (, , 'a02aa...
 |                                                              ^

The error is due to how the list of UUIDs was generated.
Before, the list may look like:

[["05d5a68a-134c-402b-8221-fb279e42b607", "36e329c7-0054-4637-8aab-cf5d062b5274", "7c12381a-c3ac-463f-8b8b-7667423be807", "9524f7e7-2a1e-4eb1-aa5c-8d418caf000a"], [], []]

After, the list would look like:

["05d5a68a-134c-402b-8221-fb279e42b607", "36e329c7-0054-4637-8aab-cf5d062b5274", "7c12381a-c3ac-463f-8b8b-7667423be807", "9524f7e7-2a1e-4eb1-aa5c-8d418caf000a"]