### PR TITLE
Fixes #15564: ensure host has content facet when getting errata.

### DIFF
--- a/app/controllers/katello/api/v2/host_errata_controller.rb
+++ b/app/controllers/katello/api/v2/host_errata_controller.rb
@@ -28,7 +28,12 @@ module Katello
       end
 
       collection = scoped_search(index_relation, 'updated_at', 'desc', :resource_class => Erratum, :includes => [:cves])
-      @installable_errata_ids = @host.content_facet.installable_errata.pluck("#{Katello::Erratum.table_name}.id")
+
+      @installable_errata_ids = []
+      if @host.content_facet
+        @installable_errata_ids = @host.content_facet.installable_errata.pluck("#{Katello::Erratum.table_name}.id")
+      end
+
       respond_for_index :collection => collection
     end
 
@@ -52,7 +57,11 @@ module Katello
     protected
 
     def index_relation
-      @host.content_facet.installable_errata(@environment, @content_view)
+      relation = Katello::Erratum.none
+      if @host.content_facet
+        relation = @host.content_facet.installable_errata(@environment, @content_view)
+      end
+      relation
     end
 
     private

--- a/test/controllers/api/v2/host_errata_controller_test.rb
+++ b/test/controllers/api/v2/host_errata_controller_test.rb
@@ -21,6 +21,7 @@ module Katello
 
       @host = hosts(:one)
       @host_dev = hosts(:two)
+      @host_without_content_facet = hosts(:without_content_facet)
 
       setup_foreman_routes
       permissions
@@ -28,6 +29,13 @@ module Katello
 
     def test_index
       get :index, :host_id => @host_dev.id
+
+      assert_response :success
+      assert_template 'api/v2/host_errata/index'
+    end
+
+    def test_index_without_content_facet
+      get :index, :host_id => @host_without_content_facet.id
 
       assert_response :success
       assert_template 'api/v2/host_errata/index'

--- a/test/fixtures/models/hosts.yml
+++ b/test/fixtures/models/hosts.yml
@@ -9,3 +9,10 @@ two:
   location: <%= ActiveRecord::FixtureSet.identify(:location1) %>
   name: "Host2.example.com"
   type: 'Host::Managed'
+
+without_content_facet:
+  organization: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
+  location: <%= ActiveRecord::FixtureSet.identify(:location1) %>
+  name: "Host3.example.com"
+  type: 'Host::Managed'
+


### PR DESCRIPTION
We were assuming that all hosts have content facets when returning
errata.  This commit returns an empty list if the host does not have
a content facet.

http://projects.theforeman.org/issues/15564