### PR TITLE
Fixes #15269: Content host migration breaks loop

### DIFF
--- a/db/migrate/20150930183738_migrate_content_hosts.rb
+++ b/db/migrate/20150930183738_migrate_content_hosts.rb
@@ -323,7 +323,7 @@ class MigrateContentHosts < ActiveRecord::Migration
       if hostname.nil?
         logger.warn("Content host #{system.uuid} does not have a hostname, removing.")
         unregister_system(system)
-        break
+        next
       end
 
       MigrateContentHosts::Host.reset_column_information


### PR DESCRIPTION
The migration of content hosts to hosts has a loop over systems
as it updates or destroys them. In the case of systems without
a Candlepin fact hostname, the loop was being broken instead of
moving to the next system in line. This led to systems never
being properly migrated that came after a system without a hostname