### PR TITLE
Fixes #15579 - Fix how we order puppet modules

### DIFF
--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -99,9 +99,11 @@ module Katello
       query = PuppetModule.in_repositories(repositories)
       query = query.where(:name => params[:name]) if params[:name]
       query = query.where("#{PuppetModule.table_name}.uuid NOT in (?)", current_uuids) if current_uuids.present?
+      custom_sort = ->(sort_query) { sort_query.order('author, name, sortable_version DESC') }
 
       respond_for_index :template => 'puppet_modules',
-                        :collection => scoped_search(query, 'name', 'ASC', :resource_class => PuppetModule)
+                        :collection => scoped_search(query, nil, nil, :resource_class => PuppetModule,
+                                                     :custom_sort => custom_sort)
     end
 
     api :GET, "/content_views/:id/available_puppet_module_names",

--- a/app/models/katello/puppet_module.rb
+++ b/app/models/katello/puppet_module.rb
@@ -27,8 +27,11 @@ module Katello
     validates :name, :presence => true
     validates :author, :presence => true
 
+    before_save :set_sortable_version
+
     def self.latest_module(name, author, repositories)
-      in_repositories(repositories).where(:name => name, :author => author).order(:version).first
+      in_repositories(repositories).where(:name => name, :author => author).
+        order(:sortable_version => :desc).first
     end
 
     def self.repository_association_class
@@ -75,8 +78,12 @@ module Katello
       self.update_attributes!(custom_json)
     end
 
-    def sortable_version
-      Util::Package.sortable_version(self.version)
+    private
+
+    def set_sortable_version
+      if version_changed? && !version.nil?
+        self.sortable_version = Util::Package.sortable_version(version)
+      end
     end
   end
 end

--- a/db/migrate/20160701180402_add_sortable_version_to_puppet_modules.rb
+++ b/db/migrate/20160701180402_add_sortable_version_to_puppet_modules.rb
@@ -1,0 +1,26 @@
+class AddSortableVersionToPuppetModules < ActiveRecord::Migration
+  class PuppetModule < ActiveRecord::Base
+    self.table_name = "katello_puppet_modules"
+  end
+
+  # copied from Util::Package
+  def sortable_version(version)
+    return "" if version.blank?
+    pieces = version.scan(/([A-Za-z]+|\d+)/).flatten.map do |chunk|
+      chunk =~ /\d+/ ? "#{"%02d" % chunk.length}-#{chunk}" : "$#{chunk}"
+    end
+    pieces.join(".")
+  end
+
+  def up
+    add_column :katello_puppet_modules, :sortable_version, :string
+
+    Katello::PuppetModule.find_each do |puppet_mod|
+      puppet_mod.update_attribute(:sortable_version, sortable_version(puppet_mod.version))
+    end
+  end
+
+  def down
+    remove_column :katello_puppet_modules, :sortable_version
+  end
+end

--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -185,6 +185,18 @@ module Katello
       assert_template 'katello/api/v2/content_views/puppet_modules'
     end
 
+    def test_available_puppet_modules_filtered_order
+      # the UI relies on these being ordered by author/name/version
+      create(:puppet_module, :version => "1.12.0")
+      create(:puppet_module, :version => "1.3.0")
+      PuppetModule.stubs(:in_repositories).returns(PuppetModule.all)
+
+      get :available_puppet_modules, :id => @library_dev_staging_view.id, :name => "trystero"
+
+      results = JSON.parse(response.body)['results']
+      assert_equal '1.12.0', results.first['version']
+    end
+
     def test_available_puppet_modules_protected
       allowed_perms = [@view_permission]
       denied_perms = [@create_permission, @update_permission, :destroy_content_views]

--- a/test/factories/puppet_module_factory.rb
+++ b/test/factories/puppet_module_factory.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :puppet_module, :class => Katello::PuppetModule do
+    name "trystero"
+    author "tpynchon"
+    sequence(:version) { |n| "1.2.#{n}" }
+    sequence(:uuid)
+  end
+end

--- a/test/fixtures/models/katello_puppet_modules.yml
+++ b/test/fixtures/models/katello_puppet_modules.yml
@@ -3,21 +3,25 @@ abrt:
   author:   "johndoe"
   version:  1.0
   uuid:     3bd47a52-0847-42b5-90ff-20630asddfat
+  sortable_version: 01-1.01-0
   
 dhcp:
   name:     "dhcp"
   author:   "johndoe"
   version:  0.1
   uuid:     3bd47a52-0847-42b5-90ff-20630asdddda
+  sortable_version: 01-0.01-1
   
 foreman:
   name:     "foreman"
   author:   "theforeman"
   version:  1.0
   uuid:     3bd47a52-0847-42b5-90ff-206307b48b22
+  sortable_version: 01-1.01-0
   
 foreman_proxy:
   name:     "foreman_proxy"
   author:   "theforeman"
   version:  1.0
   uuid:     3bd47a52-0847-42b5-90ff-adslkdkkda32
+  sortable_version: 01-1.01-0


### PR DESCRIPTION
When we converted puppet modules from being stored in elasticsearch to the database in https://github.com/Katello/katello/pull/5432, we stopped ordering by sortable_version. Instead we used id and version in different places. Id doesn't work for obvious reasons but we can't order by versions because when string sorting for example 1.9 and 1.12, we get back 1.9 first in desc order when we really need 1.12. This reintroduces sortable_version.