### PR TITLE
Refs #14372 - global status not updating correctly on host w/ CV

### DIFF
--- a/app/models/katello/errata_status.rb
+++ b/app/models/katello/errata_status.rb
@@ -55,7 +55,7 @@ module Katello
     end
 
     def relevant?(_options = {})
-      host.content_facet
+      host.content_facet.try(:uuid)
     end
   end
 end


### PR DESCRIPTION
When creating a host with a content view and lifecycle environment,
the global status will not be correct as the errata status will be
marked as relevant when it is not, since the host is still not
registered with pulp. This will check for a uuid, which is only
present if the host is registered with pulp.