### PR TITLE
Fixes #15582 - Remove foreman_auth from ping

### DIFF
--- a/app/views/katello/api/v2/ping/show.json.rabl
+++ b/app/views/katello/api/v2/ping/show.json.rabl
@@ -2,7 +2,7 @@ object Katello::Util::Data.ostructize(@resource)
 
 attribute :status
 child :services => :services do
-  [:foreman_tasks, :foreman_auth, :candlepin, :candlepin_auth, :pulp, :pulp_auth].each do |service|
+  Katello::Ping::SERVICES.each do |service|
     child service => service do
       attribute :status
       attribute :duration_ms


### PR DESCRIPTION
The `SERVICES` array now comes from the Ping model to avoid this same
issue in the future.