### PR TITLE
Fixes #15583: sync status page gets confused by other syncs

### DIFF
--- a/app/controllers/katello/sync_management_controller.rb
+++ b/app/controllers/katello/sync_management_controller.rb
@@ -63,11 +63,8 @@ module Katello
       repos.each do |repo|
         if latest_task(repo).try(:state) != 'running'
           ForemanTasks.async_task(::Actions::Katello::Repository::Sync, repo)
-          collected << format_sync_progress(repo)
-        else
-          notify.error N_("There is already an active sync process for the '%s' repository. Please try again later") %
-                          repo.name
         end
+        collected << format_sync_progress(repo)
       end
       collected
     end

--- a/test/controllers/sync_management_controller_test.rb
+++ b/test/controllers/sync_management_controller_test.rb
@@ -65,6 +65,18 @@ module Katello
       assert_response :success
     end
 
+    def test_sync_repos
+      @request.env['HTTP_ACCEPT'] = 'application/json'
+      @request.env['CONTENT_TYPE'] = 'application/json'
+      @controller.expects(:latest_task).returns(:state => 'running')
+      @controller.expects(:format_sync_progress).returns('formatted-progress')
+
+      post :sync, :repoids => [@repository.id]
+
+      assert_response :success
+      assert_equal %([\"formatted-progress\"]), @response.body
+    end
+
     def test_sync_protected
       allowed_perms = [@sync_permission]
       denied_perms = []


### PR DESCRIPTION
If you load the sync status page and then kick off a sync via other
means, a new sync kicked off via the page will result in error.

It looks like the defunct notification framework was still being used,
causing issues.

This patch simply finds the existing running sync if one exists, and
returns that in the sync status page.