### PR TITLE
Fixes #14271 - Show message on empty search results

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-add-subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-add-subscriptions.html
@@ -19,6 +19,10 @@
      You currently don't have any Products to subscribe to, you can add Products after selecting 'Products' under 'Content' in the main menu
   </span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero Products.
+  </span>
+
   <div data-block="table">
     <table ng-class="{'table-mask': detailsTable.working}" class="table table-full">
       <thead>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-associations-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-associations-content-hosts.html
@@ -10,6 +10,10 @@
     This activation key is not associated with any content hosts.
   </span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero Hosts.
+  </span>
+
   <div data-block="table">
     <table class="table table-bordered table-striped" bst-table="table" ng-class="{'table-mask': detailsTable.working}">
       <thead>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-subscriptions-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-subscriptions-list.html
@@ -30,6 +30,9 @@
        You currently don't have any Subscriptions associated with this Activation Key, you can add Subscriptions after selecting the 'Add' tab.
   </span>
 
+  <span data-block="no-search-results-message">
+       Your search returned zero Subscriptions.
+  </span>
 
   <div data-block="table">
     <table ng-class="{'table-mask': detailsTable.working}" class="table table-full">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/views/activation-keys.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/views/activation-keys.html
@@ -16,4 +16,8 @@
   <span data-block="no-rows-message" translate>
     You currently don't have any Activation Keys, you can add Activation Keys using the button on the right.
   </span>
+
+   <span data-block="no-search-results-message">
+     Your search returned zero Activation Keys.
+   </span>
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/bulk-actions-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/bulk-actions-errata.html
@@ -64,6 +64,11 @@
     <span data-block="no-rows-message" translate>
       There are no Errata associated with this Content Host to display.
     </span>
+      
+    <span data-block="no-search-results-message">
+      Your search returned zero Errata.
+    </span>
+
 
     <div data-block="table">
       <table class="table table-striped"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/bulk-actions-host-collections.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/bulk-actions-host-collections.html
@@ -45,6 +45,11 @@
       There are no Host Collections available. You can create new Host Collections after selecting 'Host Collections' under 'Hosts' in main menu.
     </span>
 
+    <span data-block="no-search-results-message">
+      Your search returned zero Host Collections.
+    </span>
+
+
     <div data-block="table">
       <table data-block="table"  class="table table-striped" ng-class="{'table-mask': state.working}">
         <thead>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
@@ -91,6 +91,10 @@
       There are no Errata to display.
     </span>
 
+    <span data-block="no-search-results-message">
+      Your search returned zero Errata.
+    </span>
+
     <div data-block="table">
       <table class="table table-striped table-bordered" ng-class="{'table-mask': detailsTable.working}">
         <thead>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages.html
@@ -68,6 +68,11 @@
     The host has not reported any installed packages, registering with subscription-manager should cause these to be reported.
   </span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero Packages.
+  </span>
+
+
   <div data-block="actions" bst-feature-flag="remote_actions">
     <div ng-hide="denied('edit_hosts', host)" class="nutupane-actions fr">
       <button class="btn btn-primary"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-add-subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-add-subscriptions.html
@@ -16,6 +16,10 @@
       You currently don't have any Products to subscribe to, you can add Products after selecting 'Products' under 'Content' in the main menu
   </span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero Products.
+  </span>
+
   <div data-block="table">
     <table ng-class="{'table-mask': detailsTable.working}"
             class="table table-full">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions-list.html
@@ -27,6 +27,11 @@
        You currently don't have any Subscriptions associated with this Content Host, you can add Subscriptions after selecting the 'Add' tab.
   </span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero Subscriptions.
+  </span>
+
+
   <div data-block="table">
     <table ng-class="{'table-mask': detailsTable.working}"
            class="table table-full" >

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
@@ -25,4 +25,9 @@
   <span data-block="no-rows-message" translate>
     You currently don't have any Content Hosts, you can register one by clicking the button on the right and following the instructions.
   </span>
+
+  <span data-block="no-search-results-message">
+    Your search returned zero Content Hosts.
+  </span>
+  
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/errata-filter-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/errata-filter-details.html
@@ -9,6 +9,10 @@
   <div data-block="header"></div>
   <span data-block="no-rows-message" translate>No Errata to display</span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero Errata.
+  </span>
+
   <div data-block="actions">
     <button class="btn btn-primary fr"
             ng-show="isState('content-views.details.filters.details.erratum.list') && permitted('edit_content_views', contentView)"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filters.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filters.html
@@ -28,6 +28,9 @@
     You currently don't have any Filters included in this Content View, you can add a new Filter by using the button on the right.
   </span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero Filters.
+  </span>
 
   <div data-block="table">
     <table class="table table-striped table-bordered" ng-show="detailsTable.rows.length > 0"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/views/content-view-puppet-module-names.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/views/content-view-puppet-module-names.html
@@ -40,6 +40,12 @@
 
   <span data-block="selection-summary"></span>
   <span data-block="no-rows-message" translate>No puppet modules found</span>
+
+  <span data-block="no-search-results-message">
+    Your search returned zero Puppet Modules.
+  </span>
+
+
   <div data-block="table">
     <table class="table table-striped table-bordered">
       <thead>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/views/content-view-puppet-modules.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/views/content-view-puppet-modules.html
@@ -18,6 +18,10 @@
     You currently don't have any Puppet Modules included in this Content View, you can add Puppet Modules using the button on the right.
   </span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero Puppet Modules.
+  </span>
+
   <div data-block="table">
     <table class="table table-striped table-bordered" ng-show="detailsTable.rows.length > 0">
       <thead>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
@@ -7,6 +7,10 @@
     This Content View does not have any versions, create your first Content View Version by using the "Publish New Version" button on the right.
   </span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero Content View.
+  </span>
+
   <div data-block="table">
     <table class="table table-striped table-bordered" ng-show="detailsTable.rows.length > 0" bst-table="table">
       <thead>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/views/content-views.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/views/content-views.html
@@ -17,4 +17,8 @@
     You currently don't have any Content Views.  A Content View can be added by using the button on the right.
   </span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero Content Views.
+  </span>
+
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/views/docker-tags.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/views/docker-tags.html
@@ -13,4 +13,8 @@
     You currently don't have any Docker Tags.
   </span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero Docker Tags.
+  </span>
+
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-content-views.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-content-views.html
@@ -7,6 +7,11 @@
     There are no Content Views that match the criteria.
   </span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero Content Views.
+  </span>
+
+
   <table data-block="table" class="table table-striped table-bordered">
     <thead>
       <tr bst-table-head>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-docker.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-docker.html
@@ -14,6 +14,10 @@
     There are no Docker Tags that match the criteria.
   </span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero Docker Tags.
+  </span>
+
   <table data-block="table" class="table table-striped table-bordered">
     <thead>
       <tr bst-table-head>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-errata.html
@@ -14,6 +14,10 @@
     There are no Errata that match the criteria.
   </span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero Errata.
+  </span>
+
   <table data-block="table" class="table table-striped table-bordered">
     <thead>
       <tr bst-table-head>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-ostree.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-ostree.html
@@ -14,6 +14,10 @@
     There are no OSTree Branches that match the criteria.
   </span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero OSTree Branches.
+  </span>
+
   <table data-block="table" class="table table-striped table-bordered">
     <thead>
       <tr bst-table-head>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-packages.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-packages.html
@@ -14,6 +14,10 @@
     There are no Packages that match the criteria.
   </span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero Packages.
+  </span>
+
   <table data-block="table" class="table table-striped table-bordered">
     <thead>
       <tr bst-table-head>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-puppet-modules.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-puppet-modules.html
@@ -22,6 +22,10 @@
       There are no Puppet Modules that match the criteria.
     </span>
 
+    <span data-block="no-search-results-message">
+      Your search returned zero Puppet Modules.
+    </span>
+
     <tbody>
       <tr bst-table-row ng-repeat="puppetModule in detailsTable.rows">
         <td bst-table-cell>{{ puppetModule.name }}</td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-repositories.html
@@ -19,6 +19,10 @@
       There are no Yum Repositories that match the criteria.
     </span>
 
+    <span data-block="no-search-results-message">
+      Your search returned zero Repositories.
+    </span>
+
     <tbody>
       <tr bst-table-row ng-repeat="repository in detailsTable.rows">
         <td bst-table-cell>{{ repository.name }}</td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details-content-hosts.html
@@ -50,6 +50,10 @@
     No Content Hosts match this Erratum.
   </span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero Content Hosts.
+  </span>
+
   <div data-block="table">
     <p bst-alert="warning" ng-show="detailsTable.rows.length > 0 && stateIncludes('errata.details.content-hosts.unavailable')">
       <span translate>The Content View or Lifecycle Environment needs to be updated in order to make errata available to these hosts.</span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details-repositories.html
@@ -39,6 +39,10 @@
     No Repositories contain this Erratum.
   </span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero Erratum.
+  </span>
+
   <div data-block="table">
     <table class="table table-striped table-bordered"
            ng-class="{'table-mask': detailsTable.working}"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata.html
@@ -55,4 +55,9 @@
     </span>
   </span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero Errata.
+  </span>
+
+
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/views/gpg-keys.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/views/gpg-keys.html
@@ -17,4 +17,7 @@
     You currently don't have any Gpg keys, you can add Gpg keys using the button on the right.
   </span>
 
+   <span data-block="no-search-results-message">
+     Your search returned zero Gpg keys.
+   </span>
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-add-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-add-hosts.html
@@ -20,6 +20,10 @@
     You currently don't have any Content Hosts, you can create new Content Hosts by selecting Contents Host from main menu and then clicking the button on the right.
   </span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero Content Hosts.
+  </span>
+
   <div data-block="table">
     <table ng-class="{'table-mask': detailsTable.working}"
            class="table table-full table-striped"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-hosts-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-hosts-list.html
@@ -19,6 +19,10 @@
     You currently don't have any Hosts in this Host Group, you can add Content Hosts after selecting the 'Add' tab.
   </span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero Content Hosts.
+  </span>
+
   <div data-block="table">
     <table ng-class="{'table-mask': detailsTable.working}"
            class="table table-full table-striped"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/views/host-collections.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/views/host-collections.html
@@ -18,4 +18,9 @@
   <span data-block="no-rows-message" translate>
     You currently don't have any Host Collections, you can add Host Collections using the button on the right.
   </span>
+
+  <span data-block="no-search-results-message">
+    Your search returned zero Host Collections.
+  </span>
+
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/views/packages-details-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/views/packages-details-repositories.html
@@ -39,6 +39,10 @@
     No Repositories contain this Package.
   </span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero Repositories.
+  </span>
+
   <div data-block="table">
     <table class="table table-striped table-bordered"
            ng-class="{'table-mask': detailsTable.working}"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/views/packages.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/views/packages.html
@@ -16,4 +16,9 @@
     There are no Packages in this organization.  Create one or more Products with Packages to view Packages on this page.
   </span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero Packages.
+  </span>
+
+
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-repositories.html
@@ -90,6 +90,10 @@
       You currently don't have any Repositories included in this Product, you can add Repositories using the button on the right.
     </span>
 
+    <span data-block="no-search-results-message">
+      Your search returned zero Repositories.
+    </span>
+
     <div data-block="table">
       <table bst-table="detailsTable"
              class="table table-striped"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/products.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/products.html
@@ -32,4 +32,8 @@
     You currently don't have any Products<span bst-feature-flag="custom_products">, you can add Products using the button on the right</span>.
   </span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero Products.
+  </span>
+
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/puppet-modules/views/puppet-modules.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/puppet-modules/views/puppet-modules.html
@@ -13,4 +13,8 @@
     You currently don't have any Puppet Modules.
   </span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero Puppet Modules.
+  </span>
+
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/subscriptions.html
@@ -16,4 +16,8 @@
   <span data-block="no-rows-message" translate>
     You currently don't have any Subscriptions, you can add Subscriptions by importing a manifest using the button on the right labeled 'Manage Manifest'.
   </span>
+
+   <span data-block="no-search-results-message">
+     Your search returned zero Subscriptions.
+   </span>
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/views/sync-plans.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/views/sync-plans.html
@@ -17,4 +17,8 @@
     You currently don't have any Sync Plans.  A Sync Plan can be created by using the button on the right.
   </span>
 
+  <span data-block="no-search-results-message">
+    Your search returned zero Sync Plans.
+  </span>
+
 </div>


### PR DESCRIPTION
On an empty search result, a message that no results are returned
will be shown instead of a message that says "No _____ exists"