### PR TITLE
Fixes #15611 - Create a pre-upgrade check

### DIFF
--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -257,6 +257,7 @@ module Katello
       load "#{Katello::Engine.root}/lib/katello/tasks/reindex.rake"
       load "#{Katello::Engine.root}/lib/katello/tasks/rubocop.rake"
       load "#{Katello::Engine.root}/lib/katello/tasks/clean_backend_objects.rake"
+      load "#{Katello::Engine.root}/lib/katello/tasks/upgrade_check.rake"
 
       load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/2.4/import_package_groups.rake"
       load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/2.4/import_rpms.rake"

--- a/lib/katello/tasks/upgrade_check.rake
+++ b/lib/katello/tasks/upgrade_check.rake
@@ -1,0 +1,18 @@
+CP_LISTEN_ACTION = "Actions::Candlepin::ListenOnCandlepinEvents".freeze
+
+namespace :katello do
+  task :upgrade_check => ['environment'] do
+    desc "Task that can be run before upgrading Katello to check if system is upgrade ready"
+    success = "PASS"
+    fail = "FAIL"
+
+    puts "This script makes no modifications and can be re-run multiple times for the most up to date results."
+    puts "Checking upgradeability...\n\n"
+
+    # check for any running tasks
+    task_count = ::ForemanTasks::Task.active.where("label != '#{CP_LISTEN_ACTION}'").count
+    task_status = task_count > 1 ? fail : success
+    puts "Checking for running tasks..."
+    puts "[#{task_status}] - There are #{task_count} active tasks.\n\n"
+  end
+end


### PR DESCRIPTION
Creating a generic pre-upgrade script for Katello 3.0+ based on https://github.com/Katello/katello/pull/6097.