### PR TITLE
fixes #15678 - move validation to content view model

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -50,6 +50,7 @@ module Katello
                       :presence => true
     validates :name, :presence => true, :uniqueness => {:scope => :organization_id}
     validates :organization_id, :presence => true
+    validate :check_non_composite_components
     validate :check_repo_conflicts
     validate :check_puppet_conflicts
     validates :composite, :inclusion => [true, false]
@@ -314,6 +315,12 @@ module Katello
         h[puppet_module.name] += 1
       end
       counts.select { |_k, v| v > 1 }.keys
+    end
+
+    def check_non_composite_components
+      if !composite? && components.present?
+        errors.add(:base, _("Cannot add component versions to a non-composite content view"))
+      end
     end
 
     def check_repo_conflicts

--- a/app/models/katello/content_view_component.rb
+++ b/app/models/katello/content_view_component.rb
@@ -14,9 +14,6 @@ module Katello
     private
 
     def content_view_types
-      unless content_view.composite?
-        errors.add(:base, _("Cannot add component versions to a non-composite content view"))
-      end
       if content_view_version.content_view.composite?
         errors.add(:base, _("Cannot add composite versions to a composite content view"))
       end

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -176,11 +176,19 @@ module Katello
         @library_dev_view.update_attributes!(:component_ids => [@library_view.versions.first.id])
       end
 
-      component = ContentViewComponent.new(:content_view => @library_dev_view,
-                                           :content_view_version => @library_view.versions.first
-                                          )
-      refute component.valid?
-      refute component.save
+      # cannot add components to a non-composite view
+      assert_raises(ActiveRecord::RecordInvalid) do
+        ContentView.create!(:name => "Carcosa",
+                            :organization_id => @organization.id,
+                            :composite => false,
+                            :component_ids => [@library_view.versions.first.id])
+      end
+
+      # can add composites to a composite
+      assert ContentView.create!(:name => "Carcosa",
+                                 :organization_id => @organization.id,
+                                 :composite => true,
+                                 :component_ids => [@library_view.versions.first.id])
     end
 
     def test_composite_views_with_composite_versions


### PR DESCRIPTION
This commit moves one of the validations performed by the
content_view_component to the content_view model.

This is to address an error that was observed on older
rails (4.1) where attempting to create a content view
with components would result an error.

The following is an example of the error when using
hammer-cli:
```
hammer> content-view create --name test-ccv
--organization-label Default_Organization
--composite --component-ids 2

Could not create the content view:
  undefined method `composite?' for nil:NilClass
```