### PR TITLE
Fixes #15694 - Change the number of accepted failed tasks to 0.

### DIFF
--- a/lib/katello/tasks/upgrade_check.rake
+++ b/lib/katello/tasks/upgrade_check.rake
@@ -11,7 +11,7 @@ namespace :katello do
 
     # check for any running tasks
     task_count = ::ForemanTasks::Task.active.where("label != '#{CP_LISTEN_ACTION}'").count
-    task_status = task_count > 1 ? fail : success
+    task_status = task_count > 0 ? fail : success
     puts "Checking for running tasks..."
     puts "[#{task_status}] - There are #{task_count} active tasks.\n\n"
   end


### PR DESCRIPTION
Since the query already excludes the candlepin listen event, the number of tasks acceptable should be 0.
As a result, the script will pass incorrectly.