### PR TITLE
Fixes #15697 - host API dont expose content_source_id

### DIFF
--- a/app/views/katello/api/v2/content_facet/show.json.rabl
+++ b/app/views/katello/api/v2/content_facet/show.json.rabl
@@ -26,4 +26,4 @@ child :host_collections => :host_collections do
   attributes :id, :name
 end
 
-attributes :description, :facts
+attributes :description, :facts, :content_source_id


### PR DESCRIPTION
`content_source_id` attribute is exposed to the 'host/show' API response. An appropriate test has written in `katello/test/controllers/api/v2/hosts_controller_test.rb` file 