### PR TITLE
Fixes #15722 - rename *_filter to *_action

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,9 +79,6 @@ SingleLineBlockParams:
 Style/Next:
   Enabled: false # don't enforce next in loops over if/unless
 
-Rails/ActionFilter:
-  Enabled: false # Rails 4.0 check
-
 FormatString:
   Enabled: false # we use % for i18n
 

--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -2,26 +2,26 @@ module Katello
   class Api::Rhsm::CandlepinProxiesController < Api::V2::ApiController
     include Katello::Authentication::ClientAuthentication
 
-    before_filter :disable_strong_params
+    before_action :disable_strong_params
 
     wrap_parameters false
 
-    around_filter :repackage_message
-    before_filter :find_host, :only => [:consumer_show, :consumer_destroy, :consumer_checkin, :enabled_repos,
+    around_action :repackage_message
+    before_action :find_host, :only => [:consumer_show, :consumer_destroy, :consumer_checkin, :enabled_repos,
                                         :upload_package_profile, :regenerate_identity_certificates, :facts,
                                         :available_releases, :serials]
-    before_filter :authorize, :only => [:consumer_create, :list_owners, :rhsm_index]
-    before_filter :authorize_client_or_user, :only => [:consumer_show, :upload_package_profile, :regenerate_identity_certificates]
-    before_filter :authorize_client_or_admin, :only => [:hypervisors_update]
-    before_filter :authorize_proxy_routes, :only => [:get, :post, :put, :delete]
-    before_filter :authorize_client, :only => [:consumer_destroy, :consumer_checkin,
+    before_action :authorize, :only => [:consumer_create, :list_owners, :rhsm_index]
+    before_action :authorize_client_or_user, :only => [:consumer_show, :upload_package_profile, :regenerate_identity_certificates]
+    before_action :authorize_client_or_admin, :only => [:hypervisors_update]
+    before_action :authorize_proxy_routes, :only => [:get, :post, :put, :delete]
+    before_action :authorize_client, :only => [:consumer_destroy, :consumer_checkin,
                                                :enabled_repos, :facts, :available_releases]
 
-    before_filter :add_candlepin_version_header
+    before_action :add_candlepin_version_header
 
-    before_filter :proxy_request_path, :proxy_request_body
-    before_filter :set_organization_id, :except => :hypervisors_update
-    before_filter :find_hypervisor_environment_and_content_view, :only => [:hypervisors_update]
+    before_action :proxy_request_path, :proxy_request_body
+    before_action :set_organization_id, :except => :hypervisors_update
+    before_action :find_hypervisor_environment_and_content_view, :only => [:hypervisors_update]
 
     def repackage_message
       yield

--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -2,15 +2,15 @@ module Katello
   class Api::V2::ActivationKeysController < Api::V2::ApiController
     include Katello::Concerns::FilteredAutoCompleteSearch
 
-    before_filter :verify_presence_of_organization_or_environment, :only => [:index]
-    before_filter :find_environment, :only => [:index, :create, :update]
-    before_filter :find_optional_organization, :only => [:index, :create, :show]
-    before_filter :find_content_view, :only => [:index]
-    before_filter :find_activation_key, :only => [:show, :update, :destroy, :available_releases, :copy, :product_content,
+    before_action :verify_presence_of_organization_or_environment, :only => [:index]
+    before_action :find_environment, :only => [:index, :create, :update]
+    before_action :find_optional_organization, :only => [:index, :create, :show]
+    before_action :find_content_view, :only => [:index]
+    before_action :find_activation_key, :only => [:show, :update, :destroy, :available_releases, :copy, :product_content,
                                                   :available_host_collections, :add_host_collections, :remove_host_collections,
                                                   :content_override, :add_subscriptions, :remove_subscriptions,
                                                   :subscriptions]
-    before_filter :authorize
+    before_action :authorize
 
     wrap_parameters :include => (ActivationKey.attribute_names + %w(host_collection_ids service_level auto_attach content_view_environment))
 

--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -8,7 +8,7 @@ module Katello
     # support for session (thread-local) variables must be the last filter in this class
     include Foreman::ThreadSession::Cleaner
 
-    skip_before_filter :setup_has_many_params # TODO: get this working #8862
+    skip_before_action :setup_has_many_params # TODO: get this working #8862
 
     resource_description do
       api_version 'v2'

--- a/app/controllers/katello/api/v2/capsule_content_controller.rb
+++ b/app/controllers/katello/api/v2/capsule_content_controller.rb
@@ -4,9 +4,9 @@ module Katello
       api_base_url "/katello/api"
     end
 
-    before_filter :find_capsule
-    before_filter :find_environment, :only => [:add_lifecycle_environment, :remove_lifecycle_environment]
-    before_filter :find_optional_organization, :only => [:sync_status]
+    before_action :find_capsule
+    before_action :find_environment, :only => [:add_lifecycle_environment, :remove_lifecycle_environment]
+    before_action :find_optional_organization, :only => [:sync_status]
 
     def_param_group :lifecycle_environments do
       param :id, Integer, :desc => N_('Id of the capsule'), :required => true

--- a/app/controllers/katello/api/v2/content_uploads_controller.rb
+++ b/app/controllers/katello/api/v2/content_uploads_controller.rb
@@ -1,7 +1,7 @@
 module Katello
   class Api::V2::ContentUploadsController < Api::V2::ApiController
-    before_filter :find_repository
-    skip_before_filter :check_content_type, :only => [:update]
+    before_action :find_repository
+    skip_before_action :check_content_type, :only => [:update]
 
     include ::Foreman::Controller::FilterParameters
     filter_parameters :content

--- a/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
@@ -1,7 +1,7 @@
 module Katello
   class Api::V2::ContentViewFilterRulesController < Api::V2::ApiController
-    before_filter :find_filter
-    before_filter :find_rule, :except => [:index, :create]
+    before_action :find_filter
+    before_action :find_rule, :except => [:index, :create]
 
     api :GET, "/content_view_filters/:content_view_filter_id/rules", N_("List filter rules")
     param :content_view_filter_id, :identifier, :desc => N_("filter identifier"), :required => true

--- a/app/controllers/katello/api/v2/content_view_filters_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filters_controller.rb
@@ -2,8 +2,8 @@ module Katello
   class Api::V2::ContentViewFiltersController < Api::V2::ApiController
     include Katello::Concerns::FilteredAutoCompleteSearch
 
-    before_filter :find_content_view
-    before_filter :find_filter, :except => [:index, :create, :auto_complete_search]
+    before_action :find_content_view
+    before_action :find_filter, :except => [:index, :create, :auto_complete_search]
 
     wrap_parameters :include => (ContentViewFilter.attribute_names + %w(repository_ids))
 

--- a/app/controllers/katello/api/v2/content_view_histories_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_histories_controller.rb
@@ -2,7 +2,7 @@ module Katello
   class Api::V2::ContentViewHistoriesController < Api::V2::ApiController
     include Katello::Concerns::FilteredAutoCompleteSearch
 
-    before_filter :find_content_view
+    before_action :find_content_view
 
     api :GET, "/content_views/:id/history", N_("Show a content view's history")
     param :id, :number, :desc => N_("content view numeric identifier"), :required => true

--- a/app/controllers/katello/api/v2/content_view_puppet_modules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_puppet_modules_controller.rb
@@ -2,8 +2,8 @@ module Katello
   class Api::V2::ContentViewPuppetModulesController < Api::V2::ApiController
     include Katello::Concerns::FilteredAutoCompleteSearch
 
-    before_filter :find_content_view, :except => [:autocomplete_search]
-    before_filter :find_content_view_puppet_module, :only => [:show, :update, :destroy]
+    before_action :find_content_view, :except => [:autocomplete_search]
+    before_action :find_content_view_puppet_module, :only => [:show, :update, :destroy]
 
     api :GET, "/content_views/:content_view_id/content_view_puppet_modules", N_("List content view puppet modules")
     param :content_view_id, :identifier, :desc => N_("content view identifier"), :required => true

--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -3,13 +3,13 @@ module Katello
     include Concerns::Api::V2::BulkHostsExtensions
     include Katello::Concerns::FilteredAutoCompleteSearch
 
-    before_filter :find_content_view_version, :only => [:show, :promote, :destroy, :export]
-    before_filter :find_content_view, :except => [:incremental_update]
-    before_filter :find_environment, :only => [:promote, :index]
-    before_filter :authorize_promotable, :only => [:promote]
-    before_filter :authorize_destroy, :only => [:destroy]
-    before_filter :find_version_environments, :only => [:incremental_update]
-    before_filter :find_puppet_module, :only => [:index]
+    before_action :find_content_view_version, :only => [:show, :promote, :destroy, :export]
+    before_action :find_content_view, :except => [:incremental_update]
+    before_action :find_environment, :only => [:promote, :index]
+    before_action :authorize_promotable, :only => [:promote]
+    before_action :authorize_destroy, :only => [:destroy]
+    before_action :find_version_environments, :only => [:incremental_update]
+    before_action :find_puppet_module, :only => [:index]
 
     api :GET, "/content_view_versions", N_("List content view versions")
     api :GET, "/content_views/:content_view_id/content_view_versions", N_("List content view versions")

--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -3,10 +3,10 @@ module Katello
     include Concerns::Authorization::Api::V2::ContentViewsController
     include Katello::Concerns::FilteredAutoCompleteSearch
 
-    before_filter :find_content_view, :except => [:index, :create, :auto_complete_search]
-    before_filter :find_organization, :only => [:create]
-    before_filter :find_optional_organization, :only => [:index, :auto_complete_search]
-    before_filter :find_environment, :only => [:index, :remove_from_environment]
+    before_action :find_content_view, :except => [:index, :create, :auto_complete_search]
+    before_action :find_organization, :only => [:create]
+    before_action :find_optional_organization, :only => [:index, :auto_complete_search]
+    before_action :find_environment, :only => [:index, :remove_from_environment]
 
     wrap_parameters :include => (ContentView.attribute_names + %w(repository_ids component_ids))
 

--- a/app/controllers/katello/api/v2/environments_controller.rb
+++ b/app/controllers/katello/api/v2/environments_controller.rb
@@ -34,11 +34,11 @@ module Katello
     end
 
     respond_to :json
-    before_filter :find_organization, :only => [:create, :paths, :auto_complete_search]
-    before_filter :find_optional_organization, :only => [:index, :show, :update, :destroy]
-    before_filter :find_prior, :only => [:create]
-    before_filter :find_environment, :only => [:show, :update, :destroy, :repositories]
-    before_filter :find_content_view, :only => [:repositories]
+    before_action :find_organization, :only => [:create, :paths, :auto_complete_search]
+    before_action :find_optional_organization, :only => [:index, :show, :update, :destroy]
+    before_action :find_prior, :only => [:create]
+    before_action :find_environment, :only => [:show, :update, :destroy, :repositories]
+    before_action :find_content_view, :only => [:repositories]
 
     wrap_parameters :include => (KTEnvironment.attribute_names + %w(prior prior_id new_name))
 

--- a/app/controllers/katello/api/v2/gpg_keys_controller.rb
+++ b/app/controllers/katello/api/v2/gpg_keys_controller.rb
@@ -1,10 +1,10 @@
 module Katello
   class Api::V2::GpgKeysController < Api::V2::ApiController
     include Katello::Concerns::FilteredAutoCompleteSearch
-    before_filter :authorize
-    before_filter :find_organization, :only => [:create, :index, :auto_complete_search]
-    before_filter :find_gpg_key, :only => [:show, :update, :destroy, :content]
-    skip_before_filter :check_content_type, :only => [:create, :content]
+    before_action :authorize
+    before_action :find_organization, :only => [:create, :index, :auto_complete_search]
+    before_action :find_gpg_key, :only => [:show, :update, :destroy, :content]
+    skip_before_action :check_content_type, :only => [:create, :content]
 
     def_param_group :gpg_key do
       param :name, :identifier, :action_aware => true, :required => true, :desc => N_("identifier of the gpg key")

--- a/app/controllers/katello/api/v2/host_autocomplete_controller.rb
+++ b/app/controllers/katello/api/v2/host_autocomplete_controller.rb
@@ -3,7 +3,7 @@ module Katello
     include ::Api::TaxonomyScope
     include Foreman::Controller::AutoCompleteSearch
 
-    before_filter :find_optional_nested_object
+    before_action :find_optional_nested_object
 
     resource_description do
       api_version 'v2'

--- a/app/controllers/katello/api/v2/host_collections_controller.rb
+++ b/app/controllers/katello/api/v2/host_collections_controller.rb
@@ -1,12 +1,12 @@
 module Katello
   class Api::V2::HostCollectionsController < Api::V2::ApiController
     include Katello::Concerns::FilteredAutoCompleteSearch
-    before_filter :find_host_collection, :only => [:copy, :show, :update, :destroy, :destroy_hosts,
+    before_action :find_host_collection, :only => [:copy, :show, :update, :destroy, :destroy_hosts,
                                                    :add_hosts, :remove_hosts, :hosts]
-    before_filter :find_activation_key
-    before_filter :find_host
-    before_filter :find_optional_organization, :only => [:index]
-    before_filter :find_organization, :only => [:create, :auto_complete_search]
+    before_action :find_activation_key
+    before_action :find_host
+    before_action :find_optional_organization, :only => [:index]
+    before_action :find_organization, :only => [:create, :auto_complete_search]
 
     wrap_parameters :include => (HostCollection.attribute_names + %w(host_ids))
 

--- a/app/controllers/katello/api/v2/host_errata_controller.rb
+++ b/app/controllers/katello/api/v2/host_errata_controller.rb
@@ -2,11 +2,11 @@ module Katello
   class Api::V2::HostErrataController < Api::V2::ApiController
     include Katello::Concerns::FilteredAutoCompleteSearch
 
-    before_filter :find_host, :only => :index
-    before_filter :find_host_editable, :except => :index
-    before_filter :find_errata_ids, :only => :apply
-    before_filter :find_environment, :only => :index
-    before_filter :find_content_view, :only => :index
+    before_action :find_host, :only => :index
+    before_action :find_host_editable, :except => :index
+    before_action :find_errata_ids, :only => :apply
+    before_action :find_environment, :only => :index
+    before_action :find_content_view, :only => :index
 
     resource_description do
       api_version 'v2'

--- a/app/controllers/katello/api/v2/host_packages_controller.rb
+++ b/app/controllers/katello/api/v2/host_packages_controller.rb
@@ -2,10 +2,10 @@ module Katello
   class Api::V2::HostPackagesController < Api::V2::ApiController
     include Katello::Concerns::FilteredAutoCompleteSearch
 
-    before_filter :require_packages_or_groups, :only => [:install, :remove]
-    before_filter :require_packages_only, :only => [:upgrade]
-    before_filter :find_editable_host_with_facet, :except => :index
-    before_filter :find_host, :only => :index
+    before_action :require_packages_or_groups, :only => [:install, :remove]
+    before_action :require_packages_only, :only => [:upgrade]
+    before_action :find_editable_host_with_facet, :except => :index
+    before_action :find_host, :only => :index
 
     resource_description do
       api_version 'v2'

--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -1,8 +1,8 @@
 module Katello
   class Api::V2::HostSubscriptionsController < Katello::Api::V2::ApiController
-    before_filter :find_host, :except => :create
-    before_filter :check_subscriptions, :only => [:add_subscriptions, :remove_subscriptions]
-    before_filter :find_content_view_environment, :only => :create
+    before_action :find_host, :except => :create
+    before_action :check_subscriptions, :only => [:add_subscriptions, :remove_subscriptions]
+    before_action :find_content_view_environment, :only => :create
 
     def_param_group :subscription_facet_attributes do
       param :release_version, String, :desc => N_("Release version for this Host to use (7Server, 7.1, etc)")

--- a/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
@@ -2,15 +2,15 @@ module Katello
   class Api::V2::HostsBulkActionsController < Api::V2::ApiController
     include Concerns::Api::V2::BulkHostsExtensions
 
-    before_filter :find_host_collections, :only => [:bulk_add_host_collections, :bulk_remove_host_collections]
-    before_filter :find_environment, :only => [:environment_content_view]
-    before_filter :find_content_view, :only => [:environment_content_view]
-    before_filter :find_editable_hosts, :except => [:destroy_hosts, :applicable_errata]
-    before_filter :find_deletable_hosts, :only => [:destroy_hosts]
-    before_filter :find_readable_hosts, :only => [:applicable_errata, :available_incremental_updates]
-    before_filter :find_errata, :only => [:available_incremental_updates]
+    before_action :find_host_collections, :only => [:bulk_add_host_collections, :bulk_remove_host_collections]
+    before_action :find_environment, :only => [:environment_content_view]
+    before_action :find_content_view, :only => [:environment_content_view]
+    before_action :find_editable_hosts, :except => [:destroy_hosts, :applicable_errata]
+    before_action :find_deletable_hosts, :only => [:destroy_hosts]
+    before_action :find_readable_hosts, :only => [:applicable_errata, :available_incremental_updates]
+    before_action :find_errata, :only => [:available_incremental_updates]
 
-    before_filter :validate_content_action, :only => [:install_content, :update_content, :remove_content]
+    before_action :validate_content_action, :only => [:install_content, :update_content, :remove_content]
 
     PARAM_ACTIONS = {
       :install_content => {

--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -5,7 +5,7 @@ module Katello
     include Api::V2::Rendering
     include ForemanTasks::Triggers
 
-    before_filter :local_find_taxonomy, :only => %w(repo_discover cancel_repo_discover
+    before_action :local_find_taxonomy, :only => %w(repo_discover cancel_repo_discover
                                                     download_debug_certificate
                                                     redhat_provider update
                                                     autoattach_subscriptions)

--- a/app/controllers/katello/api/v2/packages_controller.rb
+++ b/app/controllers/katello/api/v2/packages_controller.rb
@@ -3,7 +3,7 @@ module Katello
     apipie_concern_subst(:a_resource => N_("a package"), :resource => "packages")
     include Katello::Concerns::Api::V2::RepositoryContentController
 
-    before_filter :find_repositories, :only => :auto_complete_name
+    before_action :find_repositories, :only => :auto_complete_name
 
     def auto_complete_name
       page_size = Katello::Concerns::FilteredAutoCompleteSearch::PAGE_SIZE

--- a/app/controllers/katello/api/v2/ping_controller.rb
+++ b/app/controllers/katello/api/v2/ping_controller.rb
@@ -4,8 +4,8 @@ module Katello
       api_version "v2"
     end
 
-    skip_before_filter :authorize
-    before_filter :require_login, :only => [:index]
+    skip_before_action :authorize
+    before_action :require_login, :only => [:index]
 
     api :GET, "/ping", N_("Shows status of system and it's subcomponents")
     description N_("This service is only available for authenticated users")

--- a/app/controllers/katello/api/v2/products_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/products_bulk_actions_controller.rb
@@ -1,6 +1,6 @@
 module Katello
   class Api::V2::ProductsBulkActionsController < Api::V2::ApiController
-    before_filter :find_products
+    before_action :find_products
 
     api :PUT, "/products/bulk/destroy", N_("Destroy one or more products")
     param :ids, Array, :desc => N_("List of product ids"), :required => true

--- a/app/controllers/katello/api/v2/products_controller.rb
+++ b/app/controllers/katello/api/v2/products_controller.rb
@@ -2,11 +2,11 @@ module Katello
   class Api::V2::ProductsController < Api::V2::ApiController
     include Katello::Concerns::FilteredAutoCompleteSearch
 
-    before_filter :find_activation_key, :only => [:index]
-    before_filter :find_organization, :only => [:create, :index, :auto_complete_search]
-    before_filter :find_product, :only => [:update, :destroy, :sync]
-    before_filter :find_organization_from_product, :only => [:update]
-    before_filter :authorize_gpg_key, :only => [:update, :create]
+    before_action :find_activation_key, :only => [:index]
+    before_action :find_organization, :only => [:create, :index, :auto_complete_search]
+    before_action :find_product, :only => [:update, :destroy, :sync]
+    before_action :find_organization_from_product, :only => [:update]
+    before_action :authorize_gpg_key, :only => [:update, :create]
 
     resource_description do
       api_version "v2"

--- a/app/controllers/katello/api/v2/repositories_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_bulk_actions_controller.rb
@@ -1,6 +1,6 @@
 module Katello
   class Api::V2::RepositoriesBulkActionsController < Api::V2::ApiController
-    before_filter :find_repositories
+    before_action :find_repositories
 
     api :PUT, "/repositories/bulk/destroy", N_("Destroy one or more repositories")
     param :ids, Array, :desc => N_("List of repository ids"), :required => true

--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -2,23 +2,23 @@ module Katello
   class Api::V2::RepositoriesController < Api::V2::ApiController
     include Katello::Concerns::FilteredAutoCompleteSearch
 
-    before_filter :find_optional_organization, :only => [:index, :auto_complete_search]
-    before_filter :find_product, :only => [:index, :auto_complete_search]
-    before_filter :find_product_for_create, :only => [:create]
-    before_filter :find_organization_from_product, :only => [:create]
-    before_filter :find_repository, :only => [:show, :update, :destroy, :sync, :export,
+    before_action :find_optional_organization, :only => [:index, :auto_complete_search]
+    before_action :find_product, :only => [:index, :auto_complete_search]
+    before_action :find_product_for_create, :only => [:create]
+    before_action :find_organization_from_product, :only => [:create]
+    before_action :find_repository, :only => [:show, :update, :destroy, :sync, :export,
                                               :remove_content, :upload_content,
                                               :import_uploads, :gpg_key_content]
-    before_filter :find_content, :only => :remove_content
-    before_filter :find_organization_from_repo, :only => [:update]
-    before_filter :find_gpg_key, :only => [:create, :update]
-    before_filter :error_on_rh_product, :only => [:create]
-    before_filter :error_on_rh_repo, :only => [:destroy]
+    before_action :find_content, :only => :remove_content
+    before_action :find_organization_from_repo, :only => [:update]
+    before_action :find_gpg_key, :only => [:create, :update]
+    before_action :error_on_rh_product, :only => [:create]
+    before_action :error_on_rh_repo, :only => [:destroy]
 
-    skip_before_filter :authorize, :only => [:sync_complete, :gpg_key_content]
-    skip_before_filter :require_org, :only => [:sync_complete]
-    skip_before_filter :require_user, :only => [:sync_complete]
-    skip_before_filter :check_content_type, :only => [:upload_content]
+    skip_before_action :authorize, :only => [:sync_complete, :gpg_key_content]
+    skip_before_action :require_org, :only => [:sync_complete]
+    skip_before_action :require_user, :only => [:sync_complete]
+    skip_before_action :check_content_type, :only => [:upload_content]
 
     def_param_group :repo do
       param :name, String, :required => true

--- a/app/controllers/katello/api/v2/repository_sets_controller.rb
+++ b/app/controllers/katello/api/v2/repository_sets_controller.rb
@@ -2,9 +2,9 @@ module Katello
   class Api::V2::RepositorySetsController < Api::V2::ApiController
     respond_to :json
 
-    before_filter :find_product
-    before_filter :custom_product?
-    before_filter :find_product_content, :except => [:index]
+    before_action :find_product
+    before_action :custom_product?
+    before_action :find_product_content, :except => [:index]
 
     resource_description do
       api_version "v2"

--- a/app/controllers/katello/api/v2/root_controller.rb
+++ b/app/controllers/katello/api/v2/root_controller.rb
@@ -1,7 +1,7 @@
 module Katello
   class Api::V2::RootController < Api::V2::ApiController
-    skip_before_filter :authorize # ok - only shows URLs available
-    skip_before_filter :require_user
+    skip_before_action :authorize # ok - only shows URLs available
+    skip_before_action :require_user
 
     resource_description do
       api_version 'v2'

--- a/app/controllers/katello/api/v2/subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/subscriptions_controller.rb
@@ -2,15 +2,15 @@ module Katello
   class Api::V2::SubscriptionsController < Api::V2::ApiController
     include Katello::Concerns::FilteredAutoCompleteSearch
 
-    before_filter :find_activation_key
-    before_filter :find_host, :only => :index
-    before_filter :find_optional_organization, :only => [:index, :available, :show]
-    before_filter :find_organization, :only => [:upload, :delete_manifest,
+    before_action :find_activation_key
+    before_action :find_host, :only => :index
+    before_action :find_optional_organization, :only => [:index, :available, :show]
+    before_action :find_organization, :only => [:upload, :delete_manifest,
                                                 :refresh_manifest, :manifest_history]
-    before_filter :find_provider
-    before_filter :deprecated, :only => [:create, :destroy]
+    before_action :find_provider
+    before_action :deprecated, :only => [:create, :destroy]
 
-    skip_before_filter :check_content_type, :only => [:upload]
+    skip_before_action :check_content_type, :only => [:upload]
 
     resource_description do
       description "Subscriptions management."

--- a/app/controllers/katello/api/v2/sync_controller.rb
+++ b/app/controllers/katello/api/v2/sync_controller.rb
@@ -1,8 +1,8 @@
 module Katello
   class Api::V2::SyncController < Api::V2::ApiController
-    before_filter :find_optional_organization, :only => [:index]
-    before_filter :find_object, :only => [:index]
-    before_filter :ensure_library, :only => [:index]
+    before_action :find_optional_organization, :only => [:index]
+    before_action :find_object, :only => [:index]
+    before_action :ensure_library, :only => [:index]
 
     api :GET, "/organizations/:organization_id/products/:product_id/sync", N_("Get status of repo synchronisation for given product")
     api :GET, "/repositories/:repository_id/sync", N_("Get status of synchronisation for given repository")

--- a/app/controllers/katello/api/v2/sync_plans_controller.rb
+++ b/app/controllers/katello/api/v2/sync_plans_controller.rb
@@ -3,8 +3,8 @@ module Katello
     respond_to :json
 
     include Katello::Concerns::FilteredAutoCompleteSearch
-    before_filter :find_organization, :only => [:create, :index, :auto_complete_search]
-    before_filter :find_plan, :only => [:update, :show, :destroy, :sync,
+    before_action :find_organization, :only => [:create, :index, :auto_complete_search]
+    before_action :find_plan, :only => [:update, :show, :destroy, :sync,
                                         :add_products, :remove_products]
 
     def_param_group :sync_plan do

--- a/app/controllers/katello/api/v2/uebercerts_controller.rb
+++ b/app/controllers/katello/api/v2/uebercerts_controller.rb
@@ -1,6 +1,6 @@
 module Katello
   class Api::V2::UebercertsController < Api::V2::ApiController
-    before_filter :find_organization, :only => [:show]
+    before_action :find_organization, :only => [:show]
 
     resource_description do
       api_version 'v2'

--- a/app/controllers/katello/application_controller.rb
+++ b/app/controllers/katello/application_controller.rb
@@ -11,20 +11,20 @@ module Katello
 
     helper ::ApplicationHelper
     helper ::TaxonomyHelper
-    before_filter :set_gettext_locale
+    before_action :set_gettext_locale
     helper_method :current_organization
-    before_filter :require_org
+    before_action :require_org
     #before_filter :check_deleted_org
 
     protect_from_forgery # See ActionController::RequestForgeryProtection for details
 
-    after_filter :flash_to_headers
+    after_action :flash_to_headers
 
     # Skipping Foreman's filter that clears the user
     # from the current thread. If this filter is enabled
     # Katello's rescue_from don't have access to User.current.
-    skip_around_filter :clear_thread
-    after_filter :clear_katello_thread
+    skip_around_action :clear_thread
+    after_action :clear_katello_thread
 
     #custom 404 (render_404) and 500 (render_error) pages
     # this is always in the top

--- a/app/controllers/katello/concerns/api/api_controller.rb
+++ b/app/controllers/katello/concerns/api/api_controller.rb
@@ -7,7 +7,7 @@ module Katello
         include ForemanTasks::Triggers
 
         respond_to :json
-        before_filter :set_gettext_locale
+        before_action :set_gettext_locale
       end
 
       # override warden current_user (returns nil because there is no user in that scope)

--- a/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
+++ b/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
@@ -6,12 +6,12 @@ module Katello
       included do
         include Katello::Concerns::FilteredAutoCompleteSearch
 
-        before_filter :find_repository
-        before_filter :find_optional_organization, :only => [:index, :auto_complete_search]
-        before_filter :find_environment, :only => [:index, :auto_complete_search]
-        before_filter :find_content_view_version, :only => [:index, :auto_complete_search]
-        before_filter :find_filter, :only => [:index, :auto_complete_search]
-        before_filter :find_content_resource, :only => [:show]
+        before_action :find_repository
+        before_action :find_optional_organization, :only => [:index, :auto_complete_search]
+        before_action :find_environment, :only => [:index, :auto_complete_search]
+        before_action :find_content_view_version, :only => [:index, :auto_complete_search]
+        before_action :find_filter, :only => [:index, :auto_complete_search]
+        before_action :find_content_resource, :only => [:show]
       end
 
       extend ::Apipie::DSL::Concern

--- a/app/controllers/katello/concerns/authorization/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/concerns/authorization/api/v2/content_views_controller.rb
@@ -3,9 +3,9 @@ module Katello
     extend ActiveSupport::Concern
 
     included do
-      before_filter :authorize_destroy, :only => [:destroy]
-      before_filter :authorize_remove_from_environment, :only => [:remove_from_environment]
-      before_filter :authorize_remove, :only => [:remove]
+      before_action :authorize_destroy, :only => [:destroy]
+      before_action :authorize_remove_from_environment, :only => [:remove_from_environment]
+      before_action :authorize_remove, :only => [:remove]
     end
 
     private

--- a/app/controllers/katello/concerns/smart_proxies_controller_extensions.rb
+++ b/app/controllers/katello/concerns/smart_proxies_controller_extensions.rb
@@ -5,7 +5,7 @@ module Katello
 
       included do
         append_view_path('app/views/foreman')
-        before_filter :find_resource_and_status, :only => [:pulp_storage, :pulp_status]
+        before_action :find_resource_and_status, :only => [:pulp_storage, :pulp_status]
         alias_method_chain :action_permission, :katello
         alias_method_chain :show, :content
 

--- a/app/controllers/katello/errors_controller.rb
+++ b/app/controllers/katello/errors_controller.rb
@@ -1,7 +1,7 @@
 module Katello
   class ErrorsController < Katello::ApplicationController
-    skip_before_filter :require_user, :require_org
-    skip_before_filter :authorize # ok - is used by warden
+    skip_before_action :require_user, :require_org
+    skip_before_action :authorize # ok - is used by warden
 
     # handles unknown routes from both / and /api namespaces
     def routing

--- a/app/controllers/katello/organizations_controller.rb
+++ b/app/controllers/katello/organizations_controller.rb
@@ -1,6 +1,6 @@
 module Katello
   class OrganizationsController < Katello::ApplicationController
-    before_filter :search_filter, :only => [:auto_complete_search]
+    before_action :search_filter, :only => [:auto_complete_search]
 
     def rules
       {

--- a/app/controllers/katello/products_controller.rb
+++ b/app/controllers/katello/products_controller.rb
@@ -2,9 +2,9 @@ module Katello
   class ProductsController < Katello::ApplicationController
     respond_to :html, :js
 
-    before_filter :find_product, :only => [:available_repositories, :toggle_repository]
-    before_filter :find_provider, :only => [:available_repositories, :toggle_repository]
-    before_filter :find_content, :only => [:toggle_repository]
+    before_action :find_product, :only => [:available_repositories, :toggle_repository]
+    before_action :find_provider, :only => [:available_repositories, :toggle_repository]
+    before_action :find_content, :only => [:toggle_repository]
 
     include ForemanTasks::Triggers
 

--- a/app/controllers/katello/providers_controller.rb
+++ b/app/controllers/katello/providers_controller.rb
@@ -1,7 +1,7 @@
 module Katello
   class ProvidersController < Katello::ApplicationController
-    before_filter :find_rh_provider, :only => [:redhat_provider, :redhat_provider_tab]
-    before_filter :search_filter, :only => [:auto_complete_search]
+    before_action :find_rh_provider, :only => [:redhat_provider, :redhat_provider_tab]
+    before_action :search_filter, :only => [:auto_complete_search]
 
     respond_to :html, :js
 


### PR DESCRIPTION
Corresponds to https://github.com/theforeman/foreman/pull/3657. 

Renaming *_filter methods to use the new Rails *_action methods instead.