### PR TITLE
Fixes #15764 - Add subscription uuid scoped search

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -27,6 +27,7 @@ module Katello
         scoped_search :in => :host_collections, :on => :name, :complete_value => true, :rename => :host_collection
         scoped_search :in => :installed_packages, :on => :nvra, :complete_value => true, :rename => :installed_package
         scoped_search :in => :installed_packages, :on => :name, :complete_value => true, :rename => :installed_package_name
+        scoped_search :in => :subscription_facet, :on => :uuid, :complete_value => false, :rename => :subscription_manager_id
 
         attr_accessible :content_source_id, :host_collection_ids
       end


### PR DESCRIPTION
Helps searching for the subscription uuid,
and in host search one can search for name / uuid

`Host::Managed.search_for("subscription_uuid=dfc7712c-7363-4fe9-a8bd-8121f279b367")`
Or in short
`Host::Managed.search_for("dfc7712c-7363-4fe9-a8bd-8121f279b367")`