### PR TITLE
Refs #15755 - index pools in a run phase

### DIFF
--- a/app/lib/actions/katello/product/reindex_subscriptions.rb
+++ b/app/lib/actions/katello/product/reindex_subscriptions.rb
@@ -15,7 +15,7 @@ module Actions
           plan_self(id: product.id, subscription_id: subscription_id)
         end
 
-        def finalize
+        def run
           product = ::Katello::Product.find_by!(:id => input[:id])
           product.import_subscription(input[:subscription_id])
         end


### PR DESCRIPTION
so it does not execute in a transaction.  Its safe for this to
re-run, as it's idempotent, similar to content indexing