### PR TITLE
fixes #15822 - cv package filter autocomplete failure

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/package-filter.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/package-filter.controller.js
@@ -158,7 +158,7 @@ angular.module('Bastion.content-views').controller('PackageFilterController',
             var repositoryIds = $scope.contentView['repository_ids'],
                 promise;
 
-            promise = Package.autocompleteName({repoids: repositoryIds, term: term}).$promise;
+            promise = Package.autocompleteName({'repoids[]': repositoryIds, term: term}).$promise;
 
             return promise.then(function (data) {
                 return data.results;


### PR DESCRIPTION
This change is needed to properly support auto-complete
of package names when creating a content view package
filter rule.  Without this change, RAILS only recognizes
the last repoid that is passed in from the UI.

query params before:
    repoids=1&repoids=2

query params after:
    repoids[]=1&repoids[]=2