### PR TITLE
Fixes #15824 - enabling a repository should fail on pulp error

### DIFF
--- a/app/lib/actions/katello/repository_set/enable_repository.rb
+++ b/app/lib/actions/katello/repository_set/enable_repository.rb
@@ -13,7 +13,7 @@ module Actions
             fail ::Katello::Errors::ConflictException, _("The repository is already enabled")
           end
           repository = mapper.build_repository
-          plan_action(Repository::Create, repository)
+          plan_action(Repository::Create, repository, false, true)
           action_subject(repository)
         end
 


### PR DESCRIPTION
When enabling a repository, if there is a pulp error, the task will
be paused after creating the repository in the database, though
it is not created in pulp (since it errored). Moving this to create
in plan phase of Katello::Repository::Create ensures that the task
will stop and not complete on a pulp error, leaving the repository
disabled.