### PR TITLE
fixes #15811 - product destroy - update error messages on failure

### DIFF
--- a/app/controllers/katello/api/v2/products_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/products_bulk_actions_controller.rb
@@ -5,7 +5,7 @@ module Katello
     api :PUT, "/products/bulk/destroy", N_("Destroy one or more products")
     param :ids, Array, :desc => N_("List of product ids"), :required => true
     def destroy_products
-      deletable_products = @products.deletable #.select{|p| p.user_deletable?}
+      deletable_products = @products.deletable
       deletable_products.each do |prod|
         async_task(::Actions::Katello::Product::Destroy, prod)
       end

--- a/app/models/katello/product.rb
+++ b/app/models/katello/product.rb
@@ -148,6 +148,12 @@ module Katello
           where("#{Katello::Repository.table_name}.product_id" => self.id)
     end
 
+    def published_content_view_versions
+      Katello::ContentViewVersion.joins(:content_view).joins(:repositories).
+          where("#{Katello::ContentView.table_name}.default" => false).
+          where("#{Katello::Repository.table_name}.product_id" => self.id).order(:content_view_id)
+    end
+
     def anonymous?
       provider.anonymous_provider?
     end


### PR DESCRIPTION
This commit provides more specific error messages when
attempting to delete a product that is not allowed.

Below are a couple of examples using the hammer-cli-katello:
```
hammer> product delete --id 2
Could not destroy the product:
  Cannot delete product with repositories published in a
  content view.  Product: zoo, Content Views: view1, view2, view3

hammer> product delete --id 51
Could not destroy the product:
  Cannot delete Red Hat product: Red Hat Enterprise Linux Server

hammer> product delete --id 3
Product destroyed
```