### PR TITLE
Fixes #15818 - Show which capsule a host is registered through

### DIFF
--- a/app/models/katello/concerns/subscription_facet_host_extensions.rb
+++ b/app/models/katello/concerns/subscription_facet_host_extensions.rb
@@ -23,6 +23,7 @@ module Katello
         scoped_search :on => :autoheal, :in => :subscription_facet, :complete_value => true
         scoped_search :on => :service_level, :in => :subscription_facet, :complete_value => true
         scoped_search :on => :last_checkin, :in => :subscription_facet, :complete_value => true
+        scoped_search :on => :registered_through, :in => :subscription_facet, :complete_value => true
         scoped_search :on => :registered_at, :in => :subscription_facet, :rename => :registered_at
         scoped_search :on => :uuid, :in => :subscription_facet, :rename => :subscription_uuid
         scoped_search :in => :activation_keys, :on => :name, :rename => :activation_key, :complete_value => true, :ext_method => :find_by_activation_key

--- a/app/views/katello/api/v2/subscription_facet/base.json.rabl
+++ b/app/views/katello/api/v2/subscription_facet/base.json.rabl
@@ -1,1 +1,1 @@
-attributes :id, :uuid, :last_checkin, :service_level, :release_version, :autoheal, :registered_at
+attributes :id, :uuid, :last_checkin, :service_level, :release_version, :autoheal, :registered_at, :registered_through

--- a/db/migrate/20160727144242_add_registered_through_to_katello_subscription_facets.rb
+++ b/db/migrate/20160727144242_add_registered_through_to_katello_subscription_facets.rb
@@ -1,0 +1,5 @@
+class AddRegisteredThroughToKatelloSubscriptionFacets < ActiveRecord::Migration
+  def change
+    add_column :katello_subscription_facets, :registered_through, :string
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -61,6 +61,11 @@
         </div>
       </div>
 
+      <div class="detail">
+        <span class="info-label" translate>Registered Through</span>
+        <span class="info-value">{{ host.subscription_facet_attributes.registered_through || "Unknown"}}</span>
+      </div>
+
       <div ng-show="host.subscription_facet_attributes.virtual_host" class="detail">
         <span class="info-label" translate>Virtual Host</span>
         <div class="info-value">

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -298,5 +298,19 @@ module Katello
         refute_nil @host.subscription_facet.reload.last_checkin
       end
     end
+
+    describe "get parent host" do
+      it "can get parent host" do
+        capsule = "foocapsule.example.com"
+
+        host_and_capsule = {"HTTP_X_FORWARDED_SERVER" => "#{capsule}, foo.example.com"}
+        just_capsule = {"HTTP_X_FORWARDED_SERVER" => "#{capsule}"}
+        nil_host = {}
+
+        assert_equal @controller.get_parent_host(host_and_capsule), "#{capsule}"
+        assert_equal @controller.get_parent_host(just_capsule), "#{capsule}"
+        assert_includes [Facter.value(:fqdn), SETTINGS[:fqdn]], @controller.get_parent_host(nil_host)
+      end
+    end
   end
 end


### PR DESCRIPTION
This displays the system that a host is registered through in a
'registered_through' field that is searchable and displayed in the
content host details page. If the host is registered to the main
katello server, the field will display that.