### PR TITLE
Fixes #15869: use ngRepeat aliasing instead of filter.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-docker-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-docker-repositories.html
@@ -92,7 +92,7 @@
       <tbody>
         <tr bst-table-row
             row-select="repository"
-            ng-repeat="repository in repositoriesTable.rows | filter:repositorySearch | filter:repositoryFilter | as:'filteredItems'">
+            ng-repeat="repository in repositoriesTable.rows | filter:repositorySearch | filter:repositoryFilter as filteredItems">
           <td bst-table-cell>
             <a ui-sref="products.details.repositories.info({productId: repository.product.id, repositoryId: repository.id})">
               {{ repository.name }}

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-ostree-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-ostree-repositories.html
@@ -91,7 +91,7 @@
       <tbody>
         <tr bst-table-row
             row-select="repository"
-            ng-repeat="repository in repositoriesTable.rows | filter:repositorySearch | filter:repositoryFilter | as:'filteredItems'">
+            ng-repeat="repository in repositoriesTable.rows | filter:repositorySearch | filter:repositoryFilter as filteredItems">
           <td bst-table-cell>
             <a ui-sref="products.details.repositories.info({productId: repository.product.id, repositoryId: repository.id})">
               {{ repository.name }}

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-repositories.html
@@ -92,7 +92,7 @@
       <tbody>
         <tr bst-table-row
             row-select="repository"
-            ng-repeat="repository in repositoriesTable.rows | filter:repositorySearch | filter:repositoryFilter | as:'filteredItems'">
+            ng-repeat="repository in repositoriesTable.rows | filter:repositorySearch | filter:repositoryFilter as filteredItems">
           <td bst-table-cell>
             <a ui-sref="products.details.repositories.info({productId: repository.product.id, repositoryId: repository.id})">
               {{ repository.name }}


### PR DESCRIPTION
Angular 1.3 introduced aliasing syntax into ngRepeat.  Doing this also
managed to break the custom 'as' filter we were using to accomplish this
same behavior.  This commit uses Angular's aliasing instead of our own
custom filter.

http://projects.theforeman.org/issues/15869