### PR TITLE
Fixes #15890 - update errata status on host registration

### DIFF
--- a/app/lib/actions/katello/host/register.rb
+++ b/app/lib/actions/katello/host/register.rb
@@ -58,6 +58,7 @@ module Actions
               consumer_attributes.except(:installedProducts, :guestIds, :facts))
           host.subscription_facet.save!
           host.subscription_facet.update_subscription_status
+          host.content_facet.update_errata_status
           host.refresh_global_status!
 
           system = ::Katello::System.find(input[:system_id])


### PR DESCRIPTION
The errata status not updating is causing status mismatches
on provisioning and status and status label.