### PR TITLE
fixes #15918 - allow non-admin user to perform incremental update

### DIFF
--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -141,7 +141,7 @@ module Katello
         restrict_hosts = nil
       end
 
-      find_bulk_hosts(:editable, params[:update_hosts], restrict_hosts)
+      find_bulk_hosts(:edit_hosts, params[:update_hosts], restrict_hosts)
     end
 
     def find_content_view_version


### PR DESCRIPTION
Small fix to enable a non-admin user to perform an incremental
update.

The following permissions will now allow the user to perform
the incremental update from the UI and have it applied to hosts:
  - Organization => view_organizations
  - Lifecycle Environment => view_lifecycle_environments,
    promote_or_remove_content_views_to_environments
  - Content Views => view_content_views, publish_content_views,
    promote_or_remove_content_views
  - Host => view_hosts, edit_hosts