### PR TITLE
fixes #15933 - ui - update to repo Last Sync

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-info.html
@@ -206,7 +206,10 @@
 
           <div class="detail">
             <span class="info-label" translate>Last Sync</span>
-            <span class="info-value" translate>
+            <span class="info-value" ng-show="repository.last_sync == null" translate>
+              Not Synced
+            </span>
+            <span class="info-value" ng-hide="repository.last_sync == null || repository.last_sync.ended_at == null" translate>
               {{ repository.last_sync_words }} Ago ({{ repository.last_sync.ended_at | date:'medium' }} Local Time)
             </span>
           </div>


### PR DESCRIPTION
Minor update to the 'Last Sync' info shown on repository details.

- If repo hasn't been synced, show 'Not Synced'
- If repo sync is in progress, show ''.  In this case, Sync State
  gives user link to the sync task
- If repo sync has completed, show the information prior to
  this change (e.g. '17 minutes Ago (2016-08-01 15:00:13 UTC Local Time)')