### PR TITLE
Fixes #15945 - Improve the call to action on the task check.

### DIFF
--- a/lib/katello/tasks/upgrade_check.rake
+++ b/lib/katello/tasks/upgrade_check.rake
@@ -13,6 +13,7 @@ namespace :katello do
     task_count = ::ForemanTasks::Task.active.where("label != '#{CP_LISTEN_ACTION}'").count
     task_status = task_count > 0 ? fail : success
     puts "Checking for running tasks..."
-    puts "[#{task_status}] - There are #{task_count} active tasks.\n\n"
+    puts "[#{task_status}] - There are #{task_count} active tasks. "
+    puts "         Please wait for these to complete or cancel them from the Monitor tab.\n\n"
   end
 end


### PR DESCRIPTION
The output does not tell the user what to do next. Improve the output
to tell the user to wait for tasks to complete, or to cancel them.