### PR TITLE
Fixes #15808 - Provide more info for incremental update task name

### DIFF
--- a/test/actions/katello/content_view_test.rb
+++ b/test/actions/katello/content_view_test.rb
@@ -315,5 +315,28 @@ module ::Actions::Katello::ContentView
                   {:errata_ids => ["FOO"]}, true, [], "BadDescription")
       end
     end
+
+    it 'generates correct message' do
+      data = {:version_outputs =>
+               [{:version_id => 1,
+                 :output =>
+                  {:added_units =>
+                    {:erratum => ["RHEA-FOO"],
+                     :rpm =>
+                      ["shark-0.1-1.noarch",
+                       "penguin-0.9.1-1.noarch",
+                       "walrus-5.21-1.noarch"],
+                     :puppet_module => []
+                    }
+                  }
+                }]
+              }
+      total_count = action.total_counts(data)
+      assert_equal total_count[:errata_count], 1
+      assert_equal total_count[:rpm_count], 3
+      assert_equal total_count[:content_view_count], 1
+
+      assert_equal action.content_output(total_count), "with 3 Package(s), and 1 Errata"
+    end
   end
 end


### PR DESCRIPTION
The task name for incremental update will now provide more information i.e.

(update with content)
Incremental Update of 2 Content View Version(s) with 3 Package(s), and 1 Errata
Incremental Update of 2 Content View Version(s) with 3 Package(s)

(update with no content)
Incremental Update of 1 Content View Version(s)