### PR TITLE
Fixes #15981 - Import sub for custom product after save

### DIFF
--- a/app/lib/actions/katello/product/reindex_subscriptions.rb
+++ b/app/lib/actions/katello/product/reindex_subscriptions.rb
@@ -15,7 +15,7 @@ module Actions
           plan_self(id: product.id, subscription_id: subscription_id)
         end
 
-        def run
+        def finalize
           product = ::Katello::Product.find_by!(:id => input[:id])
           product.import_subscription(input[:subscription_id])
         end


### PR DESCRIPTION
Subscriptions were being imported for a custom product, but not
associating to that product's pool. Importing them after they have
been saved with candlepin id will assure the association is being
created.

To test - Create a custom product, then create an activation key and assure that the
custom product's name is showing in the add tab of that activation key's subscriptions
(instead of displaying 'null').