### PR TITLE
Fixes #15994 - API Delete repository response empty

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -226,8 +226,8 @@ module Katello
     api :DELETE, "/repositories/:id", N_("Destroy a custom repository")
     param :id, :identifier, :required => true
     def destroy
-      sync_task(::Actions::Katello::Repository::Destroy, @repository)
-      respond_for_destroy
+      task = async_task(::Actions::Katello::Repository::Destroy, @repository)
+      respond_for_async :resource => task
     end
 
     api :POST, "/repositories/sync_complete"

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -601,7 +601,7 @@ module Katello
     end
 
     def test_destroy
-      assert_sync_task(::Actions::Katello::Repository::Destroy) do |repo|
+      assert_async_task(::Actions::Katello::Repository::Destroy) do |repo|
         repo.id == @repository.id
       end
 


### PR DESCRIPTION
the response for repository API delete should be the task resource and not just empty hash.
