### PR TITLE
Fixes #15725 - fixing cv/env and register overwritting

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -21,7 +21,7 @@ module Katello
 
     before_action :proxy_request_path, :proxy_request_body
     before_action :set_organization_id, :except => :hypervisors_update
-    before_action :find_hypervisor_environment_and_content_view, :only => [:hypervisors_update]
+    before_action :find_hypervisor_organization, :only => [:hypervisors_update]
 
     def repackage_message
       yield
@@ -113,8 +113,9 @@ module Katello
     def hypervisors_update
       login = User.consumer? ? User.anonymous_api_admin.login : User.current.login
       task = User.as(login) do
-        sync_task(::Actions::Katello::Host::Hypervisors, @environment, @content_view,
-                            params.except(:controller, :action, :format))
+        params['owner'] = @organization.label #override owner label if
+        params['env'] = nil #hypervisors don't need an environment
+        sync_task(::Actions::Katello::Host::Hypervisors, params.except(:controller, :action, :format))
       end
       render :json => task.output[:results]
     end
@@ -301,31 +302,14 @@ module Katello
       environment
     end
 
-    # Hypervisors are restricted to the content host's environment and content view
-    def find_hypervisor_environment_and_content_view
+    def find_hypervisor_organization
       if User.consumer?
-        @host = find_host(User.current.uuid)
-        @organization = @host.content_facet.content_view.organization
-        @environment = @host.content_facet.lifecycle_environment
-        @content_view = @host.content_facet.content_view
-        params[:owner] = @organization.label
-        params[:env] = @content_view.cp_environment_label(@environment)
-      else
+        host = find_host(User.current.uuid)
+        @organization = host.organization
+      elsif params[:owner]
         @organization = Organization.find_by(:label => params[:owner])
-        deny_access unless @organization
-        if params[:env] == 'Library'
-          @environment = @organization.library
-          deny_access unless @environment && @environment.readable?
-          @content_view = @environment.default_content_view
-          deny_access unless @content_view && @content_view.readable?
-        else
-          (env_name, cv_name) = params[:env].split('/')
-          @environment = @organization.kt_environments.find_by(:label => env_name)
-          deny_access unless @environment && @environment.readable?
-          @content_view = @environment.content_views.find_by(:label => cv_name)
-          deny_access unless @content_view && @content_view.readable?
-        end
       end
+      deny_access unless @organization
     end
 
     def find_organization

--- a/app/lib/actions/katello/host/hypervisors.rb
+++ b/app/lib/actions/katello/host/hypervisors.rb
@@ -2,12 +2,12 @@ module Actions
   module Katello
     module Host
       class Hypervisors < Actions::EntryAction
-        def plan(environment, content_view, hypervisor_params)
+        def plan(hypervisor_params)
           sequence do
             hypervisor_results = plan_action(::Actions::Candlepin::Consumer::Hypervisors, hypervisor_params)
             return if hypervisor_results.error
 
-            plan_action(Katello::Host::HypervisorsUpdate, environment, content_view, hypervisor_results.output[:results])
+            plan_action(Katello::Host::HypervisorsUpdate, hypervisor_results.output[:results])
 
             plan_self(:results => hypervisor_results.output[:results])
           end

--- a/app/lib/actions/katello/host/hypervisors_update.rb
+++ b/app/lib/actions/katello/host/hypervisors_update.rb
@@ -4,9 +4,8 @@ module Actions
       class HypervisorsUpdate < Actions::EntryAction
         middleware.use ::Actions::Middleware::RemoteAction
 
-        def plan(environment, content_view, hypervisor_results)
-          plan_self(:environment_id => environment.id, :content_view_id => content_view.id,
-                    :hypervisor_results => hypervisor_results)
+        def plan(hypervisor_results)
+          plan_self(:hypervisor_results => hypervisor_results)
         end
 
         def run
@@ -14,49 +13,51 @@ module Actions
         end
 
         def finalize
-          environment = ::Katello::KTEnvironment.find(input[:environment_id])
-          content_view = ::Katello::ContentView.find(input[:content_view_id])
           hypervisor_results = input[:hypervisor_results]
 
           %w(created updated unchanged).each do |group|
             if hypervisor_results[group]
               hypervisor_results[group].each do |hypervisor|
-                update_or_create_hypervisor(environment, content_view, hypervisor)
+                update_or_create_hypervisor(hypervisor)
               end
             end
           end
         end
 
-        def update_or_create_hypervisor(environment, content_view, hypervisor_json)
-          name = hypervisor_json[:name]
+        # rubocop:disable MethodLength
+        def update_or_create_hypervisor(hypervisor_json)
+          organization = ::Organization.find_by(:label => hypervisor_json[:owner][:key])
 
           # Since host names must be unique yet hypervisors may have unique subscription
           # facets in different orgs
-          duplicate_name = "virt-who-#{name}-#{content_view.organization.id}"
-          host = find_host_by_uuid_or_name(hypervisor_json)
-          if host
-            fail _("Host '%{name}' does not belong to an organization") % {:name => name} unless host.organization
-            if host.organization.id != content_view.organization.id
-              name = duplicate_name
-              host = nil
-            end
-          else
-            name = duplicate_name
+          duplicate_name = "virt-who-#{hypervisor_json[:name]}-#{organization.id}"
+          host = ::Katello::Host::SubscriptionFacet.find_by(:uuid => hypervisor_json[:uuid]).try(:host)
+          host ||= ::Host.find_by(:name => duplicate_name)
+          if host && host.organization.try(:id) != organization.id
+            fail _("Host '%{name}' does not belong to an organization") % {:name => host.name} unless host.organization
+            host = nil
           end
 
-          host ||= create_host_for_hypervisor(name, content_view.organization)
+          host ||= create_host_for_hypervisor(duplicate_name, organization)
           host.subscription_facet ||= ::Katello::Host::SubscriptionFacet.new
           host.subscription_facet.host_id = host.id
           host.subscription_facet.update_from_consumer_attributes(hypervisor_json)
           host.subscription_facet.uuid = hypervisor_json[:uuid]
           host.subscription_facet.save!
 
-          # TODO: Remove this legacy
-          # http://projects.theforeman.org/issues/12556
-          unless ::Katello::Hypervisor.find_by(:name => name)
+          # TODO: Remove this legacy http://projects.theforeman.org/issues/12556
+          unless host.content_host
+            if host.content_facet
+              content_view = host.content_facet.content_view
+              environment = host.content_facet.lifecycle_environment
+            else
+              content_view = host.organization.default_content_view
+              environment = host.organization.library
+            end
+
             hypervisor = ::Katello::Hypervisor.new(:environment_id => environment.id,
                                         :content_view_id => content_view.id)
-            hypervisor.name = name
+            hypervisor.name = host.name
             hypervisor.cp_type = 'hypervisor'
             hypervisor.orchestration_for = :hypervisor
             hypervisor.load_from_cp(hypervisor_json)
@@ -65,11 +66,6 @@ module Actions
           end
 
           host.save!
-        end
-
-        def find_host_by_uuid_or_name(hypervisor_json)
-          facet = ::Katello::Host::SubscriptionFacet.find_by(:uuid => hypervisor_json[:uuid])
-          facet.nil? ? ::Host.find_by(:name => hypervisor_json[:name]) : facet.host
         end
 
         def create_host_for_hypervisor(name, organization, location = nil)

--- a/test/actions/katello/host/hypervisors_test.rb
+++ b/test/actions/katello/host/hypervisors_test.rb
@@ -20,11 +20,9 @@ module Katello::Host
         action.execution_plan.stub_planned_action(::Actions::Candlepin::Consumer::Hypervisors) do |candlepin_action|
           candlepin_action.stubs(output: { :results => 'candlepin results' })
         end
-        plan_action(action, @content_view_environment, @content_view, @hypervisor_params)
+        plan_action(action, @hypervisor_params)
         assert_action_planed_with(action, ::Actions::Candlepin::Consumer::Hypervisors, @hypervisor_params)
-        assert_action_planed_with(action, ::Actions::Katello::Host::HypervisorsUpdate) do |environment, content_view, results, *_|
-          environment.must_equal @content_view_environment
-          content_view.must_equal @content_view
+        assert_action_planed_with(action, ::Actions::Katello::Host::HypervisorsUpdate) do |results, *_|
           results.must_equal 'candlepin results'
         end
       end

--- a/test/actions/katello/host/hypervisors_update_test.rb
+++ b/test/actions/katello/host/hypervisors_update_test.rb
@@ -6,92 +6,72 @@ module Katello::Host
     include Support::Actions::Fixtures
     include FactoryGirl::Syntax::Methods
 
-    before :all do
+    before :each do
       User.current = users(:admin)
       @organization = FactoryGirl.build(:katello_organization)
       @content_view = katello_content_views(:library_dev_view)
       @content_view_environment = katello_content_view_environments(:library_dev_view_library)
       Dynflow::Testing::DummyPlannedAction.any_instance.stubs(:error).returns(nil)
 
-      @host = FactoryGirl.build(:host, :with_subscription, :content_view => @content_view,
+      @host = FactoryGirl.create(:host, :with_subscription, :content_view => @content_view,
                                 :lifecycle_environment => @content_view_environment,
-                                :content_host => katello_systems(:simple_server))
-      @host.organization = @organization
-      @content_view.organization = @organization
-      @hypervisor_results = { 'created' => [{ :name => 'hypervisor', :uuid => @host.subscription_facet.uuid }],
+                                :content_host => katello_systems(:simple_server), :organization => @organization)
+      @hypervisor_results = { 'created' => [{ :name => @host.name, :uuid => @host.subscription_facet.uuid,
+                                              :owner => {'key' => @organization.label} }],
                               'updated' => [], 'deleted' => [] }
+      @hypervisor_name = "virt-who-#{@host.name}-#{@organization.id}"
+      @host.update_attributes!(:name => @hypervisor_name)
       ::Katello::Hypervisor.stubs(:find_by).returns(true)
-      ::Katello::KTEnvironment.stubs(:find).returns(@content_view_environment)
-      ::Katello::ContentView.stubs(:find).returns(@content_view)
     end
 
     let(:action_class) { ::Actions::Katello::Host::Hypervisors }
 
-    # rubocop:disable MethodCalledOnDoEndBlock
     describe 'Hypervisors Update' do
       it 'new hypervisor' do
-        uuid = @hypervisor_results['created'][0][:uuid]
-        ::Katello::Host::SubscriptionFacet.expects(:find_by).with(:uuid => uuid).returns(nil)
-        ::Host.expects(:find_by).with(:name => 'hypervisor').returns(nil)
-        ::Katello::Host::SubscriptionFacet.expects(:new).returns(@host.subscription_facet)
+        @host.subscription_facet.destroy!
+        @host.reload
+        new_facet = ::Katello::Host::SubscriptionFacet.new
+        ::Katello::Host::SubscriptionFacet.expects(:new).returns(new_facet)
+
         action = create_action(::Actions::Katello::Host::HypervisorsUpdate)
-        plan_action(action, @content_view_environment, @content_view, @hypervisor_results)
+
+        plan_action(action, @hypervisor_results)
         finalize_action(action)
       end
 
       it 'existing hypervisor, no facet' do
-        uuid = @hypervisor_results['created'][0][:uuid]
-        subscription_facet = @host.subscription_facet
-        @host.subscription_facet = nil
-        ::Katello::Host::SubscriptionFacet.expects(:find_by).with(:uuid => uuid).returns(nil)
-        ::Host.expects(:find_by).with(:name => 'hypervisor').returns(@host)
-        ::Katello::Host::SubscriptionFacet.expects(:new).returns(subscription_facet)
+        @host.subscription_facet.destroy!
+        @host.reload
+        ::Host.expects(:find_by).with(:name => @hypervisor_name).returns(@host)
         action = create_action(::Actions::Katello::Host::HypervisorsUpdate)
-        plan_action(action, @content_view_environment, @content_view, @hypervisor_results)
+
+        plan_action(action, @hypervisor_results)
         finalize_action(action)
       end
 
       it 'existing hypervisor, renamed' do
         @hypervisor_results['created'][0][:name] = 'hypervisor.renamed'
-        uuid = @hypervisor_results['created'][0][:uuid]
-        @host.subscription_facet.host_id = @host.id
-        ::Katello::Host::SubscriptionFacet.expects(:find_by).with(:uuid => uuid).returns(@host.subscription_facet)
         ::Host.expects(:find_by).never
         ::Katello::Host::SubscriptionFacet.expects(:new).never
         action = create_action(::Actions::Katello::Host::HypervisorsUpdate)
-        plan_action(action, @content_view_environment, @content_view, @hypervisor_results)
+
+        plan_action(action, @hypervisor_results)
         finalize_action(action)
       end
 
       it 'existing hypervisor, no org' do
         Dynflow::Testing::DummyPlannedAction.any_instance.stubs(:error).returns("ERROR")
         @host.organization = nil
-        uuid = @hypervisor_results['created'][0][:uuid]
-        ::Katello::Host::SubscriptionFacet.expects(:find_by).with(:uuid => uuid).returns(nil)
-        ::Host.expects(:find_by).with(:name => 'hypervisor').returns(@host)
+        @host.save!
+
         action = create_action(::Actions::Katello::Host::HypervisorsUpdate)
-        plan_action(action, @content_view_environment, @content_view, @hypervisor_results)
+
+        plan_action(action, @hypervisor_results)
         action = finalize_action(action)
 
         action.state.must_equal :error
-        action.error.message.must_equal "Host 'hypervisor' does not belong to an organization"
-      end
-
-      it 'hypervisor duplicate' do
-        @hypervisor_results['created'][0][:name] = 'hypervisor'
-        uuid = @hypervisor_results['created'][0][:uuid]
-        @host.subscription_facet.host_id = @host.id
-        @content_view.organization = FactoryGirl.build(:katello_organization)
-        ::Katello::Host::SubscriptionFacet.expects(:find_by).with(:uuid => uuid).returns(@host.subscription_facet)
-        ::Host::Managed.expects(:new).with do |params|
-          params[:name].must_equal "virt-who-hypervisor-#{@content_view.organization.id}"
-        end.returns(@host)
-        action = create_action(::Actions::Katello::Host::HypervisorsUpdate)
-        plan_action(action, @content_view_environment, @content_view, @hypervisor_results)
-        action = finalize_action(action)
-        action.state.must_equal :success
+        action.error.message.must_equal "Host '#{@host.name}' does not belong to an organization"
       end
     end
-    # rubocop:enable MethodCalledOnDoEndBlock
   end
 end

--- a/test/factories/subscription_facet_factory.rb
+++ b/test/factories/subscription_facet_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :katello_subscription_facets, :aliases => [:subscription_facet], :class => ::Katello::Host::SubscriptionFacet do
-    sequence(:uuid) { |n| "uuid-#{n}" }
+    sequence(:uuid) { |n| "uuid-#{n}-#{rand(500)}" }
     facts('memory.memtotal' => "12 GB")
   end
 end


### PR DESCRIPTION
This fixes one minor issue and one major issue:

* When registering via virt-who we should not be registering
  with the passed in Environment and Content view. This is
  because no Content facet exists.  In fact candlepin seems to
  completely ignore this parameter and does not save environment
  for hypervisors

* When registering using ESX or a libvirt remote connection, if
  the virt-who host is already registered, the registration will be
  overwritten/lost and the host's registration will be useless