### PR TITLE
Fixes #16010 - Include referenced objects in hosts

### DIFF
--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -1,5 +1,5 @@
 Foreman::Plugin.register :katello do
-  requires_foreman '>= 1.13'
+  requires_foreman '>= 1.14'
 
   sub_menu :top_menu, :content_menu, :caption => N_('Content'), :after => :monitor_menu do
     menu :top_menu,
@@ -219,4 +219,10 @@ Foreman::Plugin.register :katello do
     'bastion/bastion/index should have a permission that grants access',
     'bastion/bastion/index_ie should have a permission that grants access'
   ])
+
+  add_controller_action_scope(HostsController, :index) do |base_scope|
+    base_scope
+      .includes(:content_view, :lifecycle_environment, :subscription_facet, :applicable_errata)
+      .includes(content_facet: [:bound_repositories, :applicable_errata, :content_view, :lifecycle_environment])
+  end
 end


### PR DESCRIPTION
This results in a 23% total improvement in rendering time between the
model and view layers for HostsController#index in Katello.

Performance improvement can be gained by including the proper tables (N+1 queries) at the beginning, rather than requesting more data from the DB in the view layer:

Before:

```
2016-08-09T09:28:22 ef4eff65 [app] [I] Completed 200 OK in 30798ms (Views: 28758.6ms | ActiveRecord: 1144.1ms)
2016-08-09T09:30:29 ef4eff65 [app] [I] Completed 200 OK in 29078ms (Views: 27504.6ms | ActiveRecord: 1114.1ms)
2016-08-09T09:31:04 ef4eff65 [app] [I] Completed 200 OK in 29546ms (Views: 27802.8ms | ActiveRecord: 1237.9ms)
```

Average: 29807.3ms

After:

```
2016-08-09T09:24:13 ef4eff65 [app] [I] Completed 200 OK in 24099ms (Views: 22732.9ms | ActiveRecord: 705.7ms)
2016-08-09T09:25:48 ef4eff65 [app] [I] Completed 200 OK in 22791ms (Views: 21248.9ms | ActiveRecord: 621.4ms)
2016-08-09T09:26:14 ef4eff65 [app] [I] Completed 200 OK in 21944ms (Views: 20642.8ms | ActiveRecord: 683.7ms)
```

Average: 22944.6ms

Requires https://github.com/theforeman/foreman/pull/3887
