### PR TITLE
Fixes #16033: set search key for AK CH table.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-associations.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-associations.controller.js
@@ -25,12 +25,6 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyAssociationsC
             'paged': true
         };
 
-        $scope.table.working = true;
-
-        if ($scope.contentHosts) {
-            $scope.table.working = false;
-        }
-
         contentHostsNutupane = new Nutupane(Host, params);
         contentHostsNutupane.searchTransform = function (term) {
             var searchQuery, addition = "activation_key_id=" + $scope.$stateParams.activationKeyId;
@@ -43,7 +37,14 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyAssociationsC
         };
 
         contentHostsNutupane.masterOnly = true;
+        contentHostsNutupane.setSearchKey('contentHostSearch');
+
         $scope.detailsTable = contentHostsNutupane.table;
+        $scope.detailsTable.working = true;
+
+        if ($scope.contentHosts) {
+            $scope.detailsTable.working = false;
+        }
 
         $scope.activationKey.$promise.then(function () {
             contentHostsNutupane.setParams(params);


### PR DESCRIPTION
We need to set the search key for the activation key content host
table in order for the search to work properly in the parent table.
Also fixed a couple of references to the parent table that should have
been references to the details table.

http://projects.theforeman.org/issues/16033