### PR TITLE
Fixes #16035: fix next sync calculation for weekly sync plans.

### DIFF
--- a/app/models/katello/sync_plan.rb
+++ b/app/models/katello/sync_plan.rb
@@ -93,7 +93,8 @@ module Katello
           end
           next_sync = now.advance(:hours => hours, :minutes => minutes, :seconds => seconds)
         when WEEKLY
-          days = 7 + self.sync_date.wday - now.wday
+          days = self.sync_date.wday - now.wday
+          days += 7 if days <= 0
           next_sync = now.change(:hour => self.sync_date.hour, :min => self.sync_date.min,
                                  :sec => self.sync_date.sec).advance(:days => days)
         end

--- a/spec/models/sync_plan_spec.rb
+++ b/spec/models/sync_plan_spec.rb
@@ -74,7 +74,7 @@ module Katello
           @plan.sync_date = '1999-11-17 09:26:00 UTC'
 
           Time.stubs(:now).returns(Time.new(2012, 1, 1, 9))
-          @plan.next_sync.must_equal(Time.new(2012, 1, 11, 9, 26, 0, "+00:00"))
+          @plan.next_sync.must_equal(Time.new(2012, 1, 4, 9, 26, 0, "+00:00"))
 
           Time.stubs(:now).returns(Time.new(2012, 1, 11, 9, 30))
           @plan.next_sync.must_equal(Time.new(2012, 1, 18, 9, 26, 0, "+00:00"))


### PR DESCRIPTION
The weekly sync plan calculation was adding an extra 7 days in all cases
where it should have only been adding 7 days if the day of the week was
before the current day.

http://projects.theforeman.org/issues/16035