### PR TITLE
Fixes #16036 - Can add/remove subs by UUID

### DIFF
--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -108,7 +108,7 @@ module Katello
     def remove_subscriptions
       #combine the quantities for duplicate pools into PoolWithQuantities objects
       pool_id_quantities = params[:subscriptions].inject({}) do |new_hash, subscription|
-        new_hash[subscription['id']] ||= PoolWithQuantities.new(Pool.find(subscription['id']))
+        new_hash[subscription['id']] ||= PoolWithQuantities.new(Pool.with_identifier(subscription['id']))
         new_hash[subscription['id']].quantities << subscription['quantity']
         new_hash
       end
@@ -125,7 +125,7 @@ module Katello
     end
     def add_subscriptions
       pools_with_quantities = params[:subscriptions].map do |sub_params|
-        PoolWithQuantities.new(Pool.find(sub_params['id']), sub_params['quantity'])
+        PoolWithQuantities.new(Pool.with_identifier(sub_params['id']), sub_params['quantity'])
       end
 
       sync_task(::Actions::Katello::Host::AttachSubscriptions, @host, pools_with_quantities)

--- a/app/models/katello/glue/candlepin/activation_key.rb
+++ b/app/models/katello/glue/candlepin/activation_key.rb
@@ -47,7 +47,7 @@ module Katello
       end
 
       def subscribe(pool_id, quantity = 1)
-        pool = Katello::Pool.find(pool_id)
+        pool = Katello::Pool.with_identifier(pool_id)
         subscription = pool.subscription
         add_custom_product(subscription.product_id) unless subscription.redhat?
         Resources::Candlepin::ActivationKey.add_pools self.cp_id, pool.cp_id, quantity
@@ -56,7 +56,7 @@ module Katello
 
       def unsubscribe(pool_id)
         fail _("Subscription id is nil.") unless pool_id
-        pool = Katello::Pool.find(pool_id)
+        pool = Katello::Pool.with_identifier(pool_id)
         subscription = pool.subscription
         remove_custom_product(subscription.product_id) unless subscription.redhat?
         Resources::Candlepin::ActivationKey.remove_pools self.cp_id, pool.cp_id


### PR DESCRIPTION
The following 2 calls

hammer activation-key add-subscriptions --subscription-id=<>
hammer host subscription attach --subscription-id=<>
Can now accept both DB Id/Pool UUID. They were only accepting
DB Id prior to this release