### PR TITLE
Fixes #16037 - Settings to setup pulp crane port

### DIFF
--- a/app/models/katello/concerns/container_extensions.rb
+++ b/app/models/katello/concerns/container_extensions.rb
@@ -14,7 +14,7 @@ module Katello
         repo_url = repository_pull_url_without_katello
         if Repository.where(:pulp_id => repository_name).count > 0
           manifest_capsule = self.capsule || CapsuleContent.default_capsule.capsule
-          "#{URI(manifest_capsule.url).hostname}:5000/#{repo_url}"
+          "#{URI(manifest_capsule.url).hostname}:#{Setting['pulp_docker_registry_port']}/#{repo_url}"
         else
           repo_url
         end

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -149,7 +149,7 @@ module Katello
       def docker_feed_url(capsule = false)
         pulp_uri = URI.parse(SETTINGS[:katello][:pulp][:url])
         if capsule
-          "https://#{pulp_uri.host.downcase}:5000"
+          "https://#{pulp_uri.host.downcase}:#{Setting['pulp_docker_registry_port']}"
         else
           self.url if self.respond_to?(:url)
         end
@@ -830,7 +830,7 @@ module Katello
       pulp_uri = URI.parse(smart_proxy ? smart_proxy.url : SETTINGS[:katello][:pulp][:url])
       scheme   = (self.unprotected && !force_https) ? 'http' : 'https'
       if docker?
-        "#{pulp_uri.host.downcase}:5000/#{pulp_id}"
+        "#{pulp_uri.host.downcase}:#{Setting['pulp_docker_registry_port']}/#{pulp_id}"
       elsif file?
         "#{scheme}://#{pulp_uri.host.downcase}/pulp/isos/#{pulp_id}/"
       elsif puppet?

--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -1,4 +1,5 @@
 class Setting::Content < Setting
+  #rubocop:disable Metrics/MethodLength
   def self.load_defaults
     return unless super
 
@@ -22,6 +23,7 @@ class Setting::Content < Setting
         self.set('check_services_before_actions', N_("Whether or not to check the status of backend services such as pulp and candlepin prior to performing some actions."), true),
         self.set('force_post_sync_actions', N_("Force post sync actions such as indexing and email even if no content was available."), false),
         self.set('default_download_policy', N_("Default download policy for repositories (either 'immediate', 'on_demand', or 'background')"), "immediate"),
+        self.set('pulp_docker_registry_port', N_("The port used by Pulp Crane to provide Docker Registries"), 5000),
         self.set('pulp_export_destination', N_("On-disk location for exported repositories"), N_("/var/lib/pulp/katello-export")),
         self.set('pulp_client_key', N_("Path for ssl key used for pulp server auth"), "/etc/pki/katello/private/pulp-client.key"),
         self.set('pulp_client_cert', N_("Path for ssl cert used for pulp server auth"), "/etc/pki/katello/certs/pulp-client.crt"),

--- a/test/models/concerns/container_extensions_test.rb
+++ b/test/models/concerns/container_extensions_test.rb
@@ -6,6 +6,7 @@ module Katello
   class ContainerExtensionsTest < ActiveSupport::TestCase
     def setup
       @container = FactoryGirl.create(:container)
+      Setting['pulp_docker_registry_port'] = 6000
     end
 
     def test_container_repo_url
@@ -16,7 +17,7 @@ module Katello
       @container.stubs(:capsule).returns(capsule)
       Repository.expects(:where).with(:pulp_id => @container.repository_name).returns(counter)
       url = @container.repository_pull_url
-      assert_equal "#{hostname}:5000/#{@container.repository_name}:#{@container.tag}", url
+      assert_equal "#{hostname}:6000/#{@container.repository_name}:#{@container.tag}", url
     end
 
     def test_container_repo_url_no_capsule
@@ -30,7 +31,7 @@ module Katello
       @container.stubs(:capsule).returns
       Repository.expects(:where).with(:pulp_id => @container.repository_name).returns(counter)
       url = @container.repository_pull_url
-      assert_equal "#{hostname}:5000/#{@container.repository_name}:#{@container.tag}", url
+      assert_equal "#{hostname}:6000/#{@container.repository_name}:#{@container.tag}", url
     end
   end
 end


### PR DESCRIPTION
The pulp crane port used to be hard coded in Katello
Made it configurable.
Other settings will be added in the pulp-puppet/katello installers