### PR TITLE
Fixes #16038 - Enabling bulk add/remove/auto-attach subs

### DIFF
--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -113,7 +113,7 @@ module Katello
         new_hash
       end
 
-      @host.subscription_facet.remove_subscriptions(pool_id_quantities.values)
+      sync_task(::Actions::Katello::Host::RemoveSubscriptions, @host, pool_id_quantities.values)
       respond_for_index(:collection => index_response, :template => "index")
     end
 

--- a/app/lib/actions/katello/host/attach_subscriptions.rb
+++ b/app/lib/actions/katello/host/attach_subscriptions.rb
@@ -4,16 +4,21 @@ module Actions
       class AttachSubscriptions < Actions::EntryAction
         middleware.use Actions::Middleware::KeepCurrentUser
 
-        def plan(host, pools_with_quantities)
+        def plan(host, pools_with_quantities_params)
           action_subject(host)
-
           sequence do
             pool_ids = []
+            pools_with_quantities = pools_with_quantities_params.map do |pool_with_quantity|
+              ::Katello::PoolWithQuantities.fetch(pool_with_quantity)
+            end
+            existing_pool_ids = host.subscription_facet.candlepin_consumer.pool_ids
             pools_with_quantities.each do |pool_with_quantities|
-              pool_ids << pool_with_quantities.pool.id
-              pool_with_quantities.quantities.each do |quantity|
-                plan_action(::Actions::Candlepin::Consumer::AttachSubscription, :uuid => host.subscription_facet.uuid,
-                            :pool_uuid => pool_with_quantities.pool.cp_id, :quantity => quantity)
+              unless existing_pool_ids.include?(pool_with_quantities.pool.cp_id.to_s)
+                pool_ids << pool_with_quantities.pool.id
+                pool_with_quantities.quantities.each do |quantity|
+                  plan_action(::Actions::Candlepin::Consumer::AttachSubscription, :uuid => host.subscription_facet.uuid,
+                              :pool_uuid => pool_with_quantities.pool.cp_id, :quantity => quantity)
+                end
               end
             end
 

--- a/app/lib/actions/katello/host/remove_subscriptions.rb
+++ b/app/lib/actions/katello/host/remove_subscriptions.rb
@@ -4,10 +4,17 @@ module Actions
       class RemoveSubscriptions < Actions::EntryAction
         middleware.use Actions::Middleware::KeepCurrentUser
 
-        def plan(host, entitlements)
+        def plan(host, pools_with_quantities_params)
           action_subject(host)
+          pools_with_quantities = pools_with_quantities_params.map do |pool_with_quantity|
+            ::Katello::PoolWithQuantities.fetch(pool_with_quantity)
+          end
+          cp_consumer = host.subscription_facet.candlepin_consumer
+          entitlements = pools_with_quantities.map do |pool_with_quantities|
+            cp_consumer.filter_entitlements(pool_with_quantities.pool.cp_id, pool_with_quantities.quantities)
+          end
 
-          entitlements.each do |entitlement|
+          entitlements.flatten.each do |entitlement|
             plan_action(::Actions::Candlepin::Consumer::RemoveSubscription, :uuid => host.subscription_facet.uuid,
                         :entitlement_id => entitlement['id'], :pool_id => entitlement['pool']['id'])
             plan_self(:host_name => host.name)

--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -89,11 +89,7 @@ module Katello
       end
 
       def remove_subscriptions(pools_with_quantities)
-        entitlements = pools_with_quantities.map do |pool_with_quantities|
-          candlepin_consumer.filter_entitlements(pool_with_quantities.pool.cp_id, pool_with_quantities.quantities)
-        end
-
-        ForemanTasks.sync_task(Actions::Katello::Host::RemoveSubscriptions, self.host, entitlements.flatten)
+        ForemanTasks.sync_task(Actions::Katello::Host::RemoveSubscriptions, self.host, pools_with_quantities)
       end
 
       def self.find_host(name, organization)

--- a/app/models/katello/pool_with_quantities.rb
+++ b/app/models/katello/pool_with_quantities.rb
@@ -7,5 +7,17 @@ module Katello
       @quantities = quantities
       @quantities = [@quantities] if !@quantities.nil? && !@quantities.is_a?(Array)
     end
+
+    def to_hash
+      {"pool_id" => pool.id, "quantities" => quantities.as_json}
+    end
+
+    def self.fetch(params)
+      if params.is_a?(PoolWithQuantities)
+        params
+      else
+        PoolWithQuantities.new(Pool.find(params["pool_id"]), params["quantities"])
+      end
+    end
   end
 end

--- a/app/services/katello/candlepin/consumer.rb
+++ b/app/services/katello/candlepin/consumer.rb
@@ -90,6 +90,10 @@ module Katello
         filtered
       end
 
+      def pool_ids
+        entitlements.map { |ent| ent['pool']['id'].to_s }
+      end
+
       def virtual_guests
         guest_uuids = Resources::Candlepin::Consumer.virtual_guests(self.uuid).map { |guest| guest['uuid'] }
         ::Host.joins(:subscription_facet).where("#{Katello::Host::SubscriptionFacet.table_name}.uuid" => guest_uuids)

--- a/config/routes/overrides.rb
+++ b/config/routes/overrides.rb
@@ -59,6 +59,12 @@ Foreman::Application.routes.draw do
             match '/auto_complete_search' => 'host_autocomplete#auto_complete_search', :via => :get
             match '/bulk/add_host_collections' => 'hosts_bulk_actions#bulk_add_host_collections', :via => :put
             match '/bulk/remove_host_collections' => 'hosts_bulk_actions#bulk_remove_host_collections', :via => :put
+            match '/bulk/remove_host_collections' => 'hosts_bulk_actions#bulk_remove_host_collections', :via => :put
+
+            match '/bulk/add_subscriptions' => 'hosts_bulk_actions#add_subscriptions', :via => :put
+            match '/bulk/remove_subscriptions' => 'hosts_bulk_actions#remove_subscriptions', :via => :put
+            match '/bulk/auto_attach' => 'hosts_bulk_actions#auto_attach', :via => :put
+
             match '/bulk/install_content' => 'hosts_bulk_actions#install_content', :via => :put
             match '/bulk/installable_errata' => 'hosts_bulk_actions#installable_errata', :via => :post
             match '/bulk/update_content' => 'hosts_bulk_actions#update_content', :via => :put

--- a/test/actions/katello/host/attach_subscriptions_test.rb
+++ b/test/actions/katello/host/attach_subscriptions_test.rb
@@ -19,6 +19,10 @@ module Katello::Host
         action = create_action action_class
         action.expects(:action_subject).with(@host)
 
+        candlepin_consumer = mock
+        candlepin_consumer.expects(:pool_ids).returns([])
+        @host.subscription_facet.expects(:candlepin_consumer).returns(candlepin_consumer)
+
         pools_with_quantities = [::Katello::PoolWithQuantities.new(@pool, [1, 2])]
 
         plan_action action, @host, pools_with_quantities

--- a/test/actions/katello/host/remove_subscriptions_test.rb
+++ b/test/actions/katello/host/remove_subscriptions_test.rb
@@ -1,7 +1,7 @@
 require 'katello_test_helper'
 
 module Katello::Host
-  class AttachSubscriptionsTest < ActiveSupport::TestCase
+  class RemoveSubscriptionsTest < ActiveSupport::TestCase
     include Dynflow::Testing
     include Support::Actions::Fixtures
     include FactoryGirl::Syntax::Methods
@@ -9,18 +9,23 @@ module Katello::Host
     before :all do
       User.current = users(:admin)
       @host = FactoryGirl.create(:host, :with_subscription)
+      @pool = katello_pools(:pool_one)
     end
 
-    describe 'auto attach subscriptions' do
+    describe 'remove subscriptions' do
       let(:action_class) { ::Actions::Katello::Host::RemoveSubscriptions }
 
       it 'plans' do
         action = create_action action_class
         action.expects(:action_subject).with(@host)
+        pools_with_quantities = [::Katello::PoolWithQuantities.new(@pool, [1, 2])]
 
         entitlements = [{'id' => 3, 'pool' => {'id' => 'foo'}}, {'id' => 4, 'pool' => {'id' => 'bar'}}]
+        candlepin_consumer = mock
+        candlepin_consumer.expects(:filter_entitlements).returns(entitlements)
+        @host.subscription_facet.expects(:candlepin_consumer).returns(candlepin_consumer)
 
-        plan_action action, @host, entitlements
+        plan_action action, @host, pools_with_quantities
 
         assert_action_planed_with action, Actions::Candlepin::Consumer::RemoveSubscription, :uuid => @host.subscription_facet.uuid,
                                           :entitlement_id => 3, :pool_id => 'foo'

--- a/test/controllers/api/v2/host_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/host_subscriptions_controller_test.rb
@@ -102,8 +102,12 @@ module Katello
     end
 
     def test_remove_subscriptions
-      ForemanTasks.expects(:sync_task).with(::Actions::Katello::Host::RemoveSubscriptions, @host, @entitlements)
-
+      assert_sync_task(::Actions::Katello::Host::RemoveSubscriptions) do |host, pools_with_quantities|
+        assert_equal @host, host
+        assert_equal 1, pools_with_quantities.count
+        assert_equal @pool, pools_with_quantities[0].pool
+        assert_equal ["3"], pools_with_quantities[0].quantities
+      end
       post :remove_subscriptions, :host_id => @host.id, :subscriptions => [{:id => @pool.id, :quantity => 3}]
 
       assert_response :success

--- a/test/models/host/subscription_facet_test.rb
+++ b/test/models/host/subscription_facet_test.rb
@@ -129,12 +129,10 @@ module Katello
 
     def test_remove_subscriptions
       pool = katello_pools(:pool_one)
-      entitlements = [{'pool' => {'id' => pool.cp_id}, 'quantity' => 1, :id => 5}]
+      pq = [PoolWithQuantities.new(pool, [1])]
+      ForemanTasks.expects(:sync_task).with(Actions::Katello::Host::RemoveSubscriptions, host, pq)
 
-      host.subscription_facet.candlepin_consumer.stubs(:entitlements).returns(entitlements)
-      ForemanTasks.expects(:sync_task).with(Actions::Katello::Host::RemoveSubscriptions, host, entitlements)
-
-      host.subscription_facet.remove_subscriptions([PoolWithQuantities.new(pool, [1])])
+      host.subscription_facet.remove_subscriptions(pq)
     end
 
     def test_backend_update_needed?


### PR DESCRIPTION
Api layer bindings for enabling Add/Remove/Auto Attach subscriptions