### PR TITLE
Fixes #16088 - Compatibility with Rails 4.2.7

### DIFF
--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -84,7 +84,7 @@ module Katello
           host_repo_errata.erratum_id = #{Katello::Erratum.table_name}.id").
         where("#{Katello::ContentFacetRepository.table_name}.repository_id = host_repo_errata.repository_id")
 
-      query = query.joins(:content_facets).where("#{Katello::Host::ContentFacet.table_name}.host_id" => [hosts.map(&:id)]) if hosts
+      query = query.joins(:content_facets).where("#{Katello::Host::ContentFacet.table_name}.host_id" => hosts.map(&:id)) if hosts
       query.uniq
     end
 

--- a/test/models/erratum_test.rb
+++ b/test/models/erratum_test.rb
@@ -73,7 +73,7 @@ module Katello
       errata = katello_errata(:security)
       json = errata.attributes.merge('description' => 'an update', 'updated' => DateTime.now, 'reboot_suggested' => true)
       errata.update_from_json(json)
-      errata = Erratum.find(errata)
+      errata = Erratum.find(errata.id)
       assert_equal errata.description, json['description']
       assert errata.reboot_suggested
     end
@@ -83,7 +83,7 @@ module Katello
       last_updated = errata.updated_at
       json = errata.attributes
       errata.update_from_json(json)
-      assert_equal Erratum.find(errata).updated_at, last_updated
+      assert_equal Erratum.find(errata.id).updated_at, last_updated
     end
 
     def test_update_from_json_truncates_title
@@ -94,7 +94,7 @@ module Katello
         "lose our ventures. - William Shakespeare"
       json = errata.attributes.merge('description' => 'an update', 'updated' => DateTime.now, 'title' => title)
       errata.update_from_json(json)
-      assert_equal Erratum.find(errata).title.size, 255
+      assert_equal Erratum.find(errata.id).title.size, 255
     end
 
     def test_update_from_json_duplicate_packages #Issue 9312


### PR DESCRIPTION
Fixes a deprecation that caused tests to fail

"Passing a nested array to Active Record finder methods is deprecated
and will be removed. Flatten your array before using it for 'IN'
conditions."