### PR TITLE
Fixes #16133 - Check modified product id on RH repo enable

### DIFF
--- a/test/actions/katello/repository_set_test.rb
+++ b/test/actions/katello/repository_set_test.rb
@@ -47,6 +47,7 @@ module ::Actions::Katello::RepositorySet
         repository.pulp_id.must_equal expected_pulp_id
         repository.relative_path.must_equal expected_relative_path
       end
+      content.expects(:modifiedProductIds).returns([])
       plan_action action, product, content, substitutions
       assert_action_planed action, ::Actions::Katello::Repository::Create
     end


### PR DESCRIPTION
Enabling Red Hat 'Extended Update Support' repositories is failing
as they modify an exisiting product. The existing product can be found
in 'modifiedProductIds' in the content JSON returned from candlepin.
The product cert and key should be taken from the product that is being
 modified.