### PR TITLE
Fixes #15759 - docker tag page empty alert handled

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/views/docker-tags-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/views/docker-tags-details.html
@@ -17,7 +17,7 @@
           </div>
         </header>
 
-        <div bst-alert success-messages="successMessages" error-messages="errorMessages"></div>
+        <div ng-show="panel.error" bst-alert="warning" success-messages="successMessages" error-messages="errorMessages"></div>
 
         <div class="details" style="margin: 0 0 2em">
 


### PR DESCRIPTION
straightforward change (in the below file) to hide the alert notification div if there are no errors on the page.

engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/views/docker-tags-details.html