### PR TITLE
Fixes #16137 - subscription_facet.activation_keys should be uniq

### DIFF
--- a/db/migrate/20150930183738_migrate_content_hosts.rb
+++ b/db/migrate/20150930183738_migrate_content_hosts.rb
@@ -200,7 +200,7 @@ class MigrateContentHosts < ActiveRecord::Migration
   def create_subscription_facet(host, system)
     logger.info("Creating subscription facet for host #{host.name}.")
     subscription_facet = host.subscription_facet = MigrateContentHosts::SubscriptionFacet.new
-    subscription_facet.activation_keys = system.activation_keys
+    subscription_facet.activation_keys = system.activation_keys.uniq
     subscription_facet.uuid = system.uuid
     subscription_facet.save!
   end


### PR DESCRIPTION
`system_activation_keys` did not have a uniq constraint on it but `subscription_facet_activation_keys` does so when migrating from one to the other duplications need to be avoided.