### PR TITLE
Fixes #15817 - Fix publishing CV after puppet module removed

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -449,7 +449,7 @@ module Katello
             name_and_author[:author],
             self.organization.library.repositories.puppet_type
           )
-          puppet_modules << puppet_module
+          puppet_modules << puppet_module if puppet_module
         end
       end
 


### PR DESCRIPTION
Removing a puppet module that's been added to a content view as 'use latest' causes the publish to fail. 