### PR TITLE
[DO NOT MERGE] fixes #15935 - change in check if autoheal update needed

### DIFF
--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -114,7 +114,7 @@ module Katello
         return true if self.installed_products || self.hypervisor_guest_uuids
 
         %w(release_version service_level autoheal).each do |method|
-          return true if self.send("#{method}_changed?")
+          return true if self.host.subscription_facet.send("#{method}_changed?")
         end
         if self.host.content_facet
           return true if (self.host.content_facet.content_view_id_changed? || self.host.content_facet.lifecycle_environment_id_changed?)


### PR DESCRIPTION
I don't understand why this change fixes things. All other attributes seem to work fine (service level, release). With this change, though, autoheal is properly saved in katello and candlepin.