### PR TITLE
Fixes #16213 - Trying to fix polyglot error

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "anemone"
 
   # UI
-  gem.add_dependency "deface", '>= 1.0.0', '< 2.0.0'
+  gem.add_dependency "deface", '>= 1.0.2', '< 2.0.0'
   gem.add_dependency "jquery-ui-rails"
   gem.add_dependency "bastion", ">= 3.2.0", "< 4.0.0"
 


### PR DESCRIPTION
I'm guessing somewhere a dependency on polyglot got removed and since [deface 1.0.0 doesn't require the polyglot gem as a dependency](https://rubygems.org/gems/deface/versions/1.0.0) but [does require it in the code](https://github.com/spree/deface/blob/6075246227059b8d92d95d27f06b508cb3cf0ce9/lib/deface/dsl/loader.rb#L1), I'm bumping the requirement to the newest version of deface which does require polyglot.