### PR TITLE
Fixes #16232 - Incremental update for multiple host check

### DIFF
--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -216,7 +216,7 @@ module Katello
 
         version_environments_for_systems_map.values
       else
-        @version_environments.select { |ve| !ve[:environment_ids].blank? }
+        @version_environments.select { |ve| !ve[:environments].blank? }
       end
     end
 


### PR DESCRIPTION
The structure of the version environments being checked here does
not use 'environment_ids', but rather 'environments' passed as an
array.

To test:
1) register two clients to the Katello server
2) create and sync a repository with errata
  i.e. https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/
3) publish this repository in a content view
4) install a package with errata (like 'walrus') on both clients
5) downgrade package (to walrus-0.71-1), making errata available
6) associate both clients with content view
7) run this hammer command
content-view version incremental-update /
--content-view-version-id=<ccv_id> /
--errata-ids=<errata_id> /
--lifecycle-environment-ids=1 /
--update-all-hosts=true