### PR TITLE
Fixes #16242 - Enable HoundCI for ruby linting

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,13 @@
+scss:
+  enabled: false
+
+ruby:
+  config_file: .rubocop.yml
+
+jshint:
+  enabled: false
+
+eslint:
+  enabled: false
+
+fail_on_violations: true


### PR DESCRIPTION
This should free up some Jenkins resources by not having to run a rubocop job.