### PR TITLE
Fixes #16258 - Skip importer ssl verify for puppet module

### DIFF
--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -181,27 +181,26 @@ module Katello
       def importer_ssl_options(capsule = nil)
         if capsule
           ueber_cert = ::Cert::Certs.ueber_cert(organization)
-          {
+          importer_options = {
             :ssl_client_cert => ueber_cert[:cert],
             :ssl_client_key => ueber_cert[:key],
-            :ssl_ca_cert => ::Cert::Certs.ca_cert,
-            :ssl_validation => verify_ssl_on_sync?
+            :ssl_ca_cert => ::Cert::Certs.ca_cert
           }
-        elsif redhat? && self.content_view.default?
-          {
+        elsif self.try(:redhat?) && self.content_view.default?
+          importer_options = {
             :ssl_client_cert => self.product.certificate,
             :ssl_client_key => self.product.key,
-            :ssl_ca_cert => Resources::CDN::CdnResource.ca_file_contents,
-            :ssl_validation => verify_ssl_on_sync?
+            :ssl_ca_cert => Resources::CDN::CdnResource.ca_file_contents
           }
         else
-          {
+          importer_options = {
             :ssl_client_cert => nil,
             :ssl_client_key => nil,
-            :ssl_ca_cert => nil,
-            :ssl_validation => verify_ssl_on_sync?
+            :ssl_ca_cert => nil
           }
         end
+        importer_options.merge!(:ssl_validation => verify_ssl_on_sync?) unless self.is_a?(::Katello::ContentViewPuppetEnvironment)
+        importer_options
       end
 
       def generate_distributors(capsule = false)

--- a/test/glue/pulp/repository_test.rb
+++ b/test/glue/pulp/repository_test.rb
@@ -14,6 +14,7 @@ module Katello
       @fedora_17_x86_64 = Repository.find(FIXTURES['katello_repositories']['fedora_17_x86_64']['id'])
       @fedora_17_library_library_view = Repository.find(FIXTURES['katello_repositories']['fedora_17_library_library_view']['id'])
       @library_dev_staging_view = katello_content_views(:library_dev_staging_view)
+      @cvpe_one = katello_content_view_puppet_environments(:archive_view_puppet_environment)
       @fedora_17_x86_64.relative_path = 'test_path/'
       @fedora_17_x86_64.url = "file:///var/www/test_repos/zoo"
     end
@@ -73,6 +74,12 @@ module Katello
 
       repo.unprotected = true
       assert_equal repo.importer_feed_url(true), "https://#{pulp_host}/pulp/repos//elbow/"
+    end
+
+    def test_importer_ssl_options
+      ::Cert::Certs.stubs(:ueber_cert).returns(:cert => 'foo', :key => 'bar')
+      assert @fedora_17_x86_64.importer_ssl_options(true).key?(:ssl_validation)
+      refute @cvpe_one.importer_ssl_options(true).key?(:ssl_validation)
     end
 
     def test_relative_path


### PR DESCRIPTION
ContentViewPuppetModules were being checked for verify_ssl_on_sync?
but this is not a field for CVPMs