### PR TITLE
Fixes #16177 - Unassociate pulp units on capsule sync

### DIFF
--- a/app/lib/actions/pulp/consumer/unassociate_units.rb
+++ b/app/lib/actions/pulp/consumer/unassociate_units.rb
@@ -1,0 +1,20 @@
+module Actions
+  module Pulp
+    module Consumer
+      class UnassociateUnits < ::Actions::Pulp::AbstractAsyncTask
+        input_format do
+          param :capsule_id, Integer
+          param :repo_pulp_id, String
+        end
+
+        def humanized_name
+          _("Unassociate units in repository")
+        end
+
+        def invoke_external_task
+          pulp_resources.repository.unassociate_units(input[:repo_pulp_id])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When syncing a capsule, if there is a change in versions of a unit
in a repo (like puppet module versions), pulp will try to sync
both and publish, which results in an error. This can be avoided
by first unassociating all units from non-yum repos and then
kicking off the sync.