### PR TITLE
Fixes #16209 - do not regenerate applicability if nothing changed

### DIFF
--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -28,10 +28,12 @@ module Katello
           Rails.logger.warn("System #{self.host.name} (#{self.host.id}) requested binding to unknown repo #{repo_path}")
         end
 
-        self.bound_repositories = repos
-        self.save!
-        self.propagate_yum_repos
-        ForemanTasks.async_task(Actions::Katello::Host::GenerateApplicability, [self.host])
+        unless self.bound_repositories.sort == repos.sort
+          self.bound_repositories = repos
+          self.save!
+          self.propagate_yum_repos
+          ForemanTasks.async_task(Actions::Katello::Host::GenerateApplicability, [self.host])
+        end
         self.bound_repositories.pluck(:relative_path)
       end
 

--- a/test/models/host/content_facet_test.rb
+++ b/test/models/host/content_facet_test.rb
@@ -197,6 +197,18 @@ module Katello
       assert_equal content_facet.bound_repositories, [repo]
     end
 
+    def test_save_bound_repos_by_paths_same_path
+      content_facet.content_view = repo.content_view
+      content_facet.lifecycle_environment = repo.environment
+      content_facet.bound_repositories = [repo]
+      ForemanTasks.expects(:async_task).never
+      content_facet.expects(:propagate_yum_repos).never
+
+      content_facet.update_repositories_by_paths(["/pulp/repos/#{repo.relative_path}"])
+
+      assert_equal content_facet.bound_repositories, [repo]
+    end
+
     def test_propagate_yum_repos
       content_facet.bound_repositories << repo
       ::Katello::Pulp::Consumer.any_instance.expects(:bind_yum_repositories).with([repo.pulp_id])


### PR DESCRIPTION
Previously, POSTing to `enabled_repos` from a client would always result in an
applicability generation task running, even if the list of repos sent up was
identical to what Katello already had stored locally. This caused performance
issues, especially if clients were being restarted.

Instead, only kick off an applicability generation if the repo list is altered.