### PR TITLE
Fixes #16186 - Validate uniqueness on package filter rules

### DIFF
--- a/app/models/katello/content_view_package_filter_rule.rb
+++ b/app/models/katello/content_view_package_filter_rule.rb
@@ -9,6 +9,19 @@ module Katello
 
     validates_lengths_from_database
     validates :name, :presence => true
+    validate :ensure_unique_attributes
     validates_with Validators::ContentViewFilterVersionValidator
+
+    def ensure_unique_attributes
+      other = self.class.where(:name => self.name,
+                               :version => self.version,
+                               :content_view_filter_id => self.content_view_filter_id,
+                               :min_version => self.min_version,
+                               :max_version => self.max_version)
+      other = other.where.not(:id => self.id) if self.id
+      if other.exists?
+        errors.add(:base, "This package filter rule already exists.")
+      end
+    end
   end
 end

--- a/test/models/content_view_package_filter_rule_test.rb
+++ b/test/models/content_view_package_filter_rule_test.rb
@@ -61,5 +61,19 @@ module Katello
         @rule.save!
       end
     end
+
+    def test_duplicate_version_error
+      attrs = FactoryGirl.attributes_for(:katello_content_view_package_filter_rule,
+                                         :name => @rule.name,
+                                         :version => @rule.version,
+                                         :content_view_filter_id => @rule.content_view_filter_id,
+                                         :min_version => @rule.min_version,
+                                         :max_version => @rule.max_version)
+      @rule.save!
+      rule_item = ContentViewPackageFilterRule.create(attrs)
+      assert_raises(ActiveRecord::RecordInvalid) do
+        rule_item.save!
+      end
+    end
   end
 end


### PR DESCRIPTION
To test - create a content view package filter and try to add
the same exact rule twice. You should get an error message explaining
that this rule has already been added on the second rule.

It is also worth testing that this won't block any normal usage of
filter rule creation.