### PR TITLE
Fixes #16282: Explicitly require i18n, components and ui.router modules

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/activation-keys.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/activation-keys.module.js
@@ -9,6 +9,7 @@ angular.module('Bastion.activation-keys', [
     'ngResource',
     'ui.router',
     'Bastion',
+    'Bastion.i18n',
     'Bastion.utils',
     'Bastion.components',
     'Bastion.host-collections'

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.module.js
@@ -8,5 +8,7 @@
 angular.module('Bastion.capsule-content', [
     'ngResource',
     'ui.router',
-    'Bastion'
+    'Bastion',
+    'Bastion.i18n',
+    'Bastion.components'
 ]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsules/capsules.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsules/capsules.module.js
@@ -7,5 +7,8 @@
  */
 angular.module('Bastion.capsules', [
     'ngResource',
-    'Bastion'
+    'ui.router',
+    'Bastion',
+    'Bastion.i18n',
+    'Bastion.components'
 ]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/common/common.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/common/common.module.js
@@ -6,6 +6,8 @@
  *   Module for common functionality.
  */
 angular.module('Bastion.common', [
+    'ui.router',
     'Bastion',
+    'Bastion.i18n',
     'Bastion.components'
 ]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.module.js
@@ -9,6 +9,7 @@ angular.module('Bastion.content-hosts', [
     'ngResource',
     'ui.router',
     'Bastion',
+    'Bastion.i18n',
     'Bastion.common',
     'Bastion.components',
     'Bastion.components.formatters',

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/content-views.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/content-views.module.js
@@ -9,6 +9,7 @@ angular.module('Bastion.content-views', [
     'ngResource',
     'ui.router',
     'Bastion',
+    'Bastion.i18n',
     'Bastion.utils',
     'Bastion.content-views.versions',
     'Bastion.components',

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-versions.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-versions.module.js
@@ -9,6 +9,7 @@ angular.module('Bastion.content-views.versions', [
     'ngResource',
     'ui.router',
     'Bastion',
+    'Bastion.i18n',
     'Bastion.components',
     'Bastion.repositories',
     'Bastion.packages',

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-manifests/docker-manifests.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-manifests/docker-manifests.module.js
@@ -9,6 +9,11 @@
      *   Module for Docker Manifest related functionality.
      */
     angular
-        .module('Bastion.docker-manifests', ['Bastion']);
+        .module('Bastion.docker-manifests', [
+            'ui.router',
+            'Bastion',
+            'Bastion.i18n',
+            'Bastion.components'
+        ]);
 
 })();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/docker-tags.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/docker-tags.module.js
@@ -7,6 +7,9 @@
  */
 angular.module('Bastion.docker-tags', [
     'ngResource',
+    'ui.router',
     'Bastion',
+    'Bastion.i18n',
+    'Bastion.components',
     'Bastion.components.formatters'
 ]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/environments.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/environments.module.js
@@ -9,6 +9,7 @@ angular.module('Bastion.environments', [
     'ngResource',
     'ui.router',
     'Bastion',
+    'Bastion.i18n',
     'Bastion.utils',
     'Bastion.components',
     'Bastion.errata',

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.module.js
@@ -7,7 +7,9 @@
  */
 angular.module('Bastion.errata', [
     'ngResource',
+    'ui.router',
     'Bastion',
     'Bastion.common',
+    'Bastion.i18n',
     'Bastion.components.formatters'
 ]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/gpg-keys.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/gpg-keys.module.js
@@ -9,6 +9,7 @@ angular.module('Bastion.gpg-keys', [
     'ngResource',
     'ui.router',
     'Bastion',
+    'Bastion.i18n',
     'Bastion.common',
     'Bastion.components',
     'ngUpload'

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/host-collections.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/host-collections.module.js
@@ -9,6 +9,7 @@ angular.module('Bastion.host-collections', [
     'ngResource',
     'ui.router',
     'Bastion',
+    'Bastion.i18n',
     'Bastion.common',
     'Bastion.utils'
 ]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/hosts.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/hosts.module.js
@@ -8,5 +8,7 @@
 angular.module('Bastion.hosts', [
     'ngResource',
     'ui.router',
-    'Bastion'
+    'Bastion',
+    'Bastion.i18n',
+    'Bastion.components'
 ]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/organizations.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/organizations.module.js
@@ -7,5 +7,8 @@
  */
 angular.module('Bastion.organizations', [
     'ngResource',
-    'Bastion'
+    'ui.router',
+    'Bastion',
+    'Bastion.i18n',
+    'Bastion.components'
 ]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/ostree-branches/ostree-branches.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/ostree-branches/ostree-branches.module.js
@@ -6,6 +6,10 @@
  *   Module for Ostree Branch related functionality.
  */
 angular.module('Bastion.ostree-branches', [
+    'ngResource',
+    'ui.router',
     'Bastion',
-    'Bastion.common'
+    'Bastion.i18n',
+    'Bastion.common',
+    'Bastion.components'
 ]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/package-groups/package-groups.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/package-groups/package-groups.module.js
@@ -9,6 +9,12 @@
      *   Module for Package Group related functionality.
      */
     angular
-        .module('Bastion.package-groups', ['Bastion']);
+        .module('Bastion.package-groups', [
+            'ui.router',
+            'ngResource',
+            'Bastion',
+            'Bastion.i18n',
+            'Bastion.components'
+        ]);
 
 })();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/packages.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/packages.module.js
@@ -6,6 +6,9 @@
  *   Module for package related functionality.
  */
 angular.module('Bastion.packages', [
+    'ngResource',
+    'ui.router',
     'Bastion',
+    'Bastion.i18n',
     'Bastion.common'
 ]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.module.js
@@ -9,6 +9,7 @@ angular.module('Bastion.products', [
     'ngResource',
     'ui.router',
     'Bastion',
+    'Bastion.i18n',
     'Bastion.utils',
     'Bastion.components',
     'Bastion.sync-plans',

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/puppet-modules/puppet-modules.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/puppet-modules/puppet-modules.module.js
@@ -9,6 +9,12 @@
      *   Module for Puppet Module related functionality.
      */
     angular
-        .module('Bastion.puppet-modules', ['Bastion', 'Bastion.common']);
+        .module('Bastion.puppet-modules', [
+            'ngResource',
+            'ui.router',
+            'Bastion',
+            'Bastion.common',
+            'Bastion.i18n'
+        ]);
 
 })();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/repositories.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/repositories.module.js
@@ -10,6 +10,7 @@ angular.module('Bastion.repositories', [
     'ui.router',
     'ngUpload',
     'Bastion',
+    'Bastion.i18n',
     'Bastion.utils',
     'Bastion.common',
     'Bastion.components',

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/settings/settings.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/settings/settings.module.js
@@ -7,6 +7,8 @@
  */
 angular.module('Bastion.settings', [
     'ngResource',
+    'ui.router',
     'Bastion',
+    'Bastion.i18n',
     'Bastion.common'
 ]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/subscriptions.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/subscriptions.module.js
@@ -9,6 +9,7 @@ angular.module('Bastion.subscriptions', [
     'ngResource',
     'ui.router',
     'Bastion',
+    'Bastion.i18n',
     'Bastion.organizations',
     'Bastion.common',
     'Bastion.components',

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/sync-plans.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/sync-plans.module.js
@@ -9,6 +9,7 @@ angular.module('Bastion.sync-plans', [
     'ngResource',
     'ui.router',
     'Bastion',
+    'Bastion.i18n',
     'Bastion.common',
     'Bastion.components.formatters'
 ]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/tasks.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/tasks.module.js
@@ -8,7 +8,9 @@
 angular.module('Bastion.tasks', [
     'ngResource',
     'ui.router',
-    'Bastion'
+    'Bastion',
+    'Bastion.components',
+    'Bastion.i18n'
 ]);
 
 /**


### PR DESCRIPTION
Changes in Bastion required explicit requires on some modules
that were detected by breaking tests.