### PR TITLE
fixes #16346 - composite view - do not show unpublished views

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-composite-available-content-views.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-composite-available-content-views.html
@@ -42,7 +42,8 @@
       <tbody>
       <tr bst-table-row
           ng-repeat="contentView in detailsTable.rows | filter:contentViewFilter | orderBy:'name'"
-          row-select="contentView">
+          row-select="contentView"
+          ng-hide="contentView.versions.length === 0">
         <td bst-table-cell>{{ contentView.name }}</td>
         <td bst-table-cell>
           <select class="form-control"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-composite-content-views-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-composite-content-views-list.html
@@ -36,7 +36,8 @@
 
       <tbody>
       <tr bst-table-row ng-repeat="contentViewVersion in detailsTable.rows | filter:contentViewVersionFilter | orderBy:'name'"
-          row-select="contentViewVersion">
+          row-select="contentViewVersion"
+          ng-hide="contentViewVersions.length === 0">
         <td bst-table-cell>{{ contentViewVersion.content_view.name }}</td>
         <td bst-table-cell>
           <span bst-edit-select="contentViewVersion.id"


### PR DESCRIPTION
This commit contains a small change so that content views that
have not been published (i.e. no versions exist) are not presented
to the user in the UI.