### PR TITLE
fixes #16332 - cv package filter - increase display size

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/package-filter-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/package-filter-details.html
@@ -70,7 +70,7 @@
         </span>
 
         <span ng-show="rule.type === 'greater' || rule.type === 'less' || rule.type === 'range'">
-          <span class="col-sm-2">
+          <span class="col-sm-5">
             <input type="text"
                    class="form-control"
                    ng-model="rule.min_version"
@@ -78,7 +78,7 @@
                    ng-disabled="rule.type === 'less'"/>
           </span>
           <span class="fl">-</span>
-          <span class="col-sm-2">
+          <span class="col-sm-5">
             <input type="text"
                    class="form-control"
                    ng-model="rule.max_version"
@@ -88,7 +88,7 @@
         </span>
 
         <span ng-show="rule.type === 'equal'">
-          <span class="col-sm-4">
+          <span class="col-sm-5">
             <input type="text" class="form-control"
                    ng-model="rule.version"
                    ng-hide="denied('edit_content_views', contentView)"/>
@@ -135,7 +135,7 @@
         </span>
 
         <span ng-show="rule.type === 'greater' || rule.type === 'less' || rule.type === 'range'">
-          <span class="col-sm-2">
+          <span class="col-sm-5">
             <input type="text"
                    class="form-control"
                    ng-model="rule.min_version"
@@ -143,7 +143,7 @@
                    ng-disabled="rule.type === 'less'"/>
           </span>
           <span class="fl" ng-show="rule.type === 'range' && rule.editMode">-</span>
-          <span class="col-sm-2">
+          <span class="col-sm-5">
             <input type="text"
                    class="form-control"
                    ng-model="rule.max_version"
@@ -153,7 +153,7 @@
         </span>
 
         <span ng-show="rule.type === 'equal'">
-          <span class="col-sm-4">
+          <span class="col-sm-5">
             <input type="text"
                    class="form-control"
                    ng-model="rule.version"


### PR DESCRIPTION
This change is to increase the space allocated to enter
and display package version info on a content view
package filter.  Previously, the text would be truncated
for typical version strings.