### PR TITLE
Fixes #16271 - On content view, should have same label "Remove"

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/views/content-view-deletion.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/views/content-view-deletion.html
@@ -1,7 +1,7 @@
 <span page-title ng-model="contentView">{{ 'Remove Content View ' | translate }} {{ contentView.name }}</span>
 
 <div>
-  <h3 translate>Delete {{ contentView.name }}</h3>
+  <h3 translate>Remove {{ contentView.name }}</h3>
 
   <div ng-show="conflictingVersions().length > 0">
     <i class="fa fa-warning"></i>
@@ -38,7 +38,7 @@
 
   <div class="details" ng-show="conflictingVersions().length === 0">
     <p translate>
-      Are you sure you want to delete Content View "{{ contentView.name }}"?
+      Are you sure you want to remove Content View "{{ contentView.name }}"?
     </p>
 
     <div ng-show="versions.length > 0">
@@ -52,7 +52,7 @@
     <div class="fr">
       <button ng-disabled="working" class="btn-danger btn-lg" ng-click="delete()" >
         <i class="fa fa-spinner fa-spin" ng-show="working"></i>
-        <span translate>Delete</span>
+        <span translate>Remove</span>
       </button>
 
       <a ui-sref="content-views.details.versions" ng-disabled="working" class="btn btn-default btn-lg"  translate role="button">


### PR DESCRIPTION
On "Content" Tab,  when you're at a content view, there's a button that says "Remove View". When you click the button, the confirmation submit button says "Delete".

The two pages should have the same text, either both say "Remove" or both say "Delete".
To maintain consistency with other pages under "Content" Tab, modified the label "Delete" confirmation submit button to "Remove" and made changes to locale files also accordingly.