### PR TITLE
fixes #16331 - content view version - show description in list

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
@@ -71,7 +71,7 @@
           </div>
         </td>
         <td bst-table-cell>
-          <div class="ellipsis-column">
+          <div>
             {{ version.description }}
           </div>
         </td>


### PR DESCRIPTION
Updating based upon user feedback to show content view
version descriptions when viewing them on the list.