### PR TITLE
Fixes #16344 - Show error when content is too big

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/details/gpg-key-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/details/gpg-key-details-info.controller.js
@@ -38,5 +38,16 @@ angular.module('Bastion.gpg-keys').controller('GPGKeyDetailsInfoController',
             }
         };
 
+        $scope.uploadError = function (error, content) {
+            if (angular.isString(content) && content.indexOf("Request Entity Too Large")) {
+                error = translate('File too large.');
+            } else {
+                error = content;
+            }
+            $scope.$parent.errorMessages = [translate('Error during upload: ') + error];
+            $scope.uploadStatus = 'error';
+            $scope.progress.uploading = false;
+        };
+
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/details/views/gpg-key-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/details/views/gpg-key-info.html
@@ -13,6 +13,7 @@
         <form role="form"
               action="{{ uploadURL }}"
               ng-upload="uploadContent(content)"
+              error-catcher="uploadError(error, content)"
               upload-options-enable-controls
               upload-options-enable-rails-csrf>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/repository-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/repository-details-info.controller.js
@@ -99,16 +99,22 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
                     $scope.repository.$get();
                     updateRepositoriesTable();
                 } else {
-                    if (angular.isString(returnData) && returnData.indexOf("Request Entity Too Large")) {
-                        error = translate('File too large. Please use the CLI instead.');
-                    } else {
-                        error = returnData.displayMessage;
-                    }
+                    error = returnData.displayMessage;
                     $scope.uploadErrorMessages = [translate('Error during upload: ') + error];
                 }
 
                 $scope.progress.uploading = false;
             }
+        };
+
+        $scope.uploadError = function (error, content) {
+            if (angular.isString(content) && content.indexOf("Request Entity Too Large")) {
+                error = translate('File too large. Please use the CLI instead.');
+            } else {
+                error = content;
+            }
+            $scope.uploadErrorMessages = [translate('Error during upload: ') + error];
+            $scope.progress.uploading = false;
         };
 
         $scope.syncInProgress = function (task) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-info.html
@@ -317,6 +317,7 @@
           <form role="form"
                 action="{{ uploadURL }}"
                 ng-upload="uploadContent(content)"
+                error-catcher="uploadError(error, content)"
                 upload-options-enable-controls
                 upload-options-enable-rails-csrf>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/manifest-import.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/manifest-import.controller.js
@@ -199,6 +199,16 @@ angular.module('Bastion.subscriptions').controller('ManifestImportController',
             }
         };
 
+        $scope.uploadError = function (error, content) {
+            if (angular.isString(content) && content.indexOf("Request Entity Too Large")) {
+                error = translate('File too large.');
+            } else {
+                error = content;
+            }
+            $scope.uploadErrorMessages = [translate('Error during upload: ') + error];
+            $scope.progress.uploading = false;
+        };
+
         $scope.histories = Subscription.manifestHistory();
 
         $scope.showHistoryMoreLink = false;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/views/manifest-import.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/views/manifest-import.html
@@ -53,6 +53,7 @@
   <form role="form"
         action="{{ uploadURL }}"
         ng-upload="uploadManifest(content, completed)"
+        error-catcher="uploadError(error, content)"
         ng-hide="denied('import_manifest')"
         upload-options-enable-controls
         upload-options-enable-rails-csrf>

--- a/engines/bastion_katello/test/gpg-keys/details/gpg-details-info.controller.test.js
+++ b/engines/bastion_katello/test/gpg-keys/details/gpg-details-info.controller.test.js
@@ -47,4 +47,24 @@ describe('Controller: GPGKeyDetailsInfoController', function() {
         expect($scope.uploadStatus).toBe('error');
         expect($scope.gpgKey.$get).not.toHaveBeenCalled();
     });
+
+    it('should handle a 413 error', function() {
+        var error = 'Could not parse JSON',
+            text = '<html><head> \
+            <title>413 Request Entity Too Large</title> \
+            </head><body> \
+            <h1>Request Entity Too Large</h1> \
+            The requested resource<br />/katello/api/v2/repositories/1/upload_content<br /> \
+            does not allow request data with POST requests, or the amount of data provided in \
+            the request exceeds the capacity limit. \
+            </body></html>';
+
+        spyOn($scope.gpgKey, '$get');
+        $scope.uploadError(error, text);
+
+        expect($scope.errorMessages).toBeDefined();
+        expect($scope.errorMessages[0]).toBe('Error during upload: File too large.');
+        expect($scope.uploadStatus).toBe('error');
+        expect($scope.gpgKey.$get).not.toHaveBeenCalled();
+    });
 });

--- a/engines/bastion_katello/test/repositories/details/repository-details-info.controller.test.js
+++ b/engines/bastion_katello/test/repositories/details/repository-details-info.controller.test.js
@@ -96,7 +96,8 @@ describe('Controller: RepositoryDetailsInfoController', function() {
     });
 
     it('should handle 413 (file too large) responses by showing an error', function() {
-        var text = '<html><head> \
+        var error = 'Could not parse JSON',
+            text = '<html><head> \
             <title>413 Request Entity Too Large</title> \
             </head><body> \
             <h1>Request Entity Too Large</h1> \
@@ -105,11 +106,10 @@ describe('Controller: RepositoryDetailsInfoController', function() {
             the request exceeds the capacity limit. \
             </body></html>';
 
-        $scope.uploadContent(text, true);
+        $scope.uploadError(error, text);
         expect($scope.uploadSuccessMessages.length).toBe(0);
         expect($scope.uploadErrorMessages.length).toBe(1);
         expect($scope.uploadErrorMessages[0]).toContain('File too large');
-
     });
 
     it('should set the upload status to success and refresh the repository if a file upload status is success', function() {

--- a/engines/bastion_katello/test/subscriptions/manifest/manifest-import.controller.test.js
+++ b/engines/bastion_katello/test/subscriptions/manifest/manifest-import.controller.test.js
@@ -119,6 +119,16 @@ describe('Controller: ManifestImportController', function() {
         });
     });
 
+    it('should set an error message if there was a 413 response', function() {
+        $q.all([$scope.organization.$promise]).then(function () {
+            $scope.uploadManifest('Could not parse JSON', 'Request Entity Too Large');
+
+            expect(GlobalNotification.setSuccessMessage).not.toHaveBeenCalled();
+            expect($scope.uploadErrorMessages.length).toBe(1);
+            expect($scope.uploadErrorMessages[0]).toBe("Error during upload: File too large.");
+        });
+    });
+
     it('should set the upload status to success and refresh data if upload status is success', function() {
         $q.all([$scope.organization.$promise]).then(function () {
             spyOn($scope, 'refreshTable');

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |gem|
   # UI
   gem.add_dependency "deface", '>= 1.0.0', '< 2.0.0'
   gem.add_dependency "jquery-ui-rails"
-  gem.add_dependency "bastion", ">= 3.2.0", "< 4.0.0"
+  gem.add_dependency "bastion", ">= 3.3.4", "< 4.0.0"
 
   # Testing
   gem.add_development_dependency "factory_girl_rails"


### PR DESCRIPTION
When you upload a file that's too big, you currently don't get an error message. This fixes that and properly shows an error message.

Requires https://github.com/Katello/bastion/pull/124