### PR TITLE
 Fixes #16398 - properly import vdc pools with stack id

### DIFF
--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -619,6 +619,15 @@ module Katello
             JSON.parse(Candlepin::CandlepinResource.get(path, self.default_headers).body)
           end
 
+          def find_for_stacking_id(owner_key, stacking_id)
+            Subscription.get_for_owner(owner_key).each do |subscription|
+              if subscription['product']['attributes'].any? { |attr| attr['name'] == 'stacking_id' && attr['value'] == stacking_id }
+                return subscription['product']
+              end
+            end
+            nil
+          end
+
           def create(attr)
             JSON.parse(self.post(path, attr.to_json, self.default_headers).body).with_indifferent_access
           end


### PR DESCRIPTION
in some manifests the sourceStackingId is not really a product id
in candlepin, so we must investigate all products to find the correct one