### PR TITLE
fixes #16399 - include cv and env on errata host list

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details-content-hosts.html
@@ -80,8 +80,8 @@
             </a>
           </td>
           <td bst-table-cell>{{ contentHost.operatingsystem_name }}</td>
-          <td bst-table-cell>{{ contentHost.content.lifecycle_environment_name }}</td>
-          <td bst-table-cell>{{ contentHost.content.content_view_name || "" }}</td>
+          <td bst-table-cell>{{ contentHost.content_facet_attributes.lifecycle_environment_name }}</td>
+          <td bst-table-cell>{{ contentHost.content_facet_attributes.content_view_name || "" }}</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
As part of host unification, the content host properties were
moved under the facet; however, the content host listing
on the errata page had not been updated for the new structure.