### PR TITLE
Fixes #16456: Adds Puppet Path to SmartProxies

### DIFF
--- a/app/lib/actions/katello/capsule_content/create_repos.rb
+++ b/app/lib/actions/katello/capsule_content/create_repos.rb
@@ -17,7 +17,7 @@ module Actions
 
         def create_repo_in_pulp(capsule_content, repository)
           ueber_cert = ::Cert::Certs.ueber_cert(repository.organization)
-          relative_path = repository_relative_path(repository)
+          relative_path = repository_relative_path(repository, capsule_content)
           checksum_type = repository.yum? ? repository.checksum_type : nil
 
           plan_action(Pulp::Repository::Create,
@@ -37,9 +37,9 @@ module Actions
                       capsule_id: capsule_content.capsule.id)
         end
 
-        def repository_relative_path(repository)
+        def repository_relative_path(repository, capsule_content)
           if repository.is_a? ::Katello::ContentViewPuppetEnvironment
-            repository.generate_puppet_path
+            repository.generate_puppet_path(capsule_content.capsule)
           elsif repository.puppet? && (repository.is_a? ::Katello::Repository)
             nil
           else

--- a/app/lib/actions/katello/capsule_content/sync.rb
+++ b/app/lib/actions/katello/capsule_content/sync.rb
@@ -65,13 +65,13 @@ module Actions
           (need_distributor_update + need_importer_update).uniq
         end
 
-        def repos_needing_distributor_updates(capsule, environment, content_view)
-          repos = capsule.repos_available_to_capsule(environment, content_view)
+        def repos_needing_distributor_updates(capsule_content, environment, content_view)
+          repos = capsule_content.repos_available_to_capsule(environment, content_view)
           repos.select do |repo|
-            repo_details = capsule.pulp_repo_facts(repo.pulp_id)
+            repo_details = capsule_content.pulp_repo_facts(repo.pulp_id)
             next unless repo_details
             capsule_distributors = repo_details["distributors"]
-            !repo.distributors_match?(capsule_distributors)
+            !repo.distributors_match?(capsule_distributors, capsule_content.capsule)
           end
         end
 

--- a/app/lib/actions/katello/content_view_puppet_environment/create.rb
+++ b/app/lib/actions/katello/content_view_puppet_environment/create.rb
@@ -3,11 +3,13 @@ module Actions
     module ContentViewPuppetEnvironment
       class Create < Actions::EntryAction
         def plan(puppet_environment, clone = false)
+          internal_capsule = SmartProxy.default_capsule
+          fail _("Content View %s  cannot be published without an internal capsule." % puppet_environment.name) unless internal_capsule
           puppet_environment.save!
           action_subject(puppet_environment)
           plan_self
 
-          puppet_path = puppet_environment.generate_puppet_path
+          puppet_path = puppet_environment.generate_puppet_path(internal_capsule)
 
           sequence do
             plan_action(Pulp::Repository::Create,

--- a/app/lib/actions/pulp/repository/refresh.rb
+++ b/app/lib/actions/pulp/repository/refresh.rb
@@ -39,7 +39,8 @@ module Actions
         def update_or_associate_distributors(capsule_id, repository, repository_details)
           concurrence do
             existing_distributors = repository_details["distributors"]
-            repository.generate_distributors(capsule_id.present?).each do |distributor|
+            capsule = capsule_id ? SmartProxy.find(capsule_id) : nil
+            repository.generate_distributors(capsule).each do |distributor|
               found = existing_distributors.find { |i| i['distributor_type_id'] == distributor.type_id }
               if found
                 plan_action(::Actions::Pulp::Repository::RefreshDistributor,
@@ -64,7 +65,8 @@ module Actions
         def remove_unnecessary_distributors(capsule_id, repository, repository_details)
           concurrence do
             existing_distributors = repository_details["distributors"]
-            generated_distributors = repository.generate_distributors(capsule_id.present?)
+            capsule = capsule_id ? SmartProxy.find(capsule_id) : nil
+            generated_distributors = repository.generate_distributors(capsule)
             existing_distributors.each do |distributor|
               found = generated_distributors.find { |dist| dist.type_id == distributor['distributor_type_id'] }
               unless found

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -10,6 +10,8 @@ module Katello
         include ForemanTasks::Concerns::ActionSubject
         include LazyAccessor
 
+        alias_method_chain :refresh, :puppet_path
+
         before_create :associate_organizations
         before_create :associate_default_location
         before_create :associate_lifecycle_environments
@@ -43,6 +45,25 @@ module Katello
         def self.default_capsule
           with_features(PULP_FEATURE).first
         end
+      end
+
+      def puppet_path
+        self[:puppet_path] || update_puppet_path
+      end
+
+      def update_puppet_path
+        if has_feature?(PULP_FEATURE)
+          path = ProxyAPI::Pulp.new(:url => self.url).capsule_puppet_path['puppet_content_dir']
+        elsif has_feature?(PULP_NODE_FEATURE)
+          path = ProxyAPI::PulpNode.new(:url => self.url).capsule_puppet_path['puppet_content_dir']
+        end
+        self.update_attribute(:puppet_path, path) if path
+      end
+
+      def refresh_with_puppet_path
+        errors = refresh_without_puppet_path
+        update_puppet_path
+        errors
       end
 
       def pulp_node

--- a/app/models/katello/content_view_puppet_environment.rb
+++ b/app/models/katello/content_view_puppet_environment.rb
@@ -67,10 +67,10 @@ module Katello
       self.environment.nil?
     end
 
-    def generate_puppet_path
+    def generate_puppet_path(capsule)
       # rubocop:disable Style/EmptyElse
       if self.environment
-        File.join(SETTINGS[:katello][:puppet_repo_root], generate_puppet_env_name, 'modules')
+        File.join(capsule.puppet_path, generate_puppet_env_name, 'modules')
       else
         nil #don't generate archived content view puppet environments
       end

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -203,7 +203,7 @@ module Katello
         importer_options
       end
 
-      def generate_distributors(capsule = false)
+      def generate_distributors(capsule = nil)
         case self.content_type
         when Repository::YUM_TYPE
           yum_dist_id = self.pulp_id
@@ -223,7 +223,7 @@ module Katello
           distributors = [dist]
         when Repository::PUPPET_TYPE
           dist_options = { :id => self.pulp_id, :auto_publish => true }
-          repo_path =  File.join(SETTINGS[:katello][:puppet_repo_root],
+          repo_path =  File.join(capsule.puppet_path,
                                  Environment.construct_name(self.organization,
                                                             self.environment,
                                                             self.content_view),
@@ -801,8 +801,8 @@ module Katello
         end
       end
 
-      def distributors_match?(capsule_distributors)
-        generated_distributor_configs = self.generate_distributors(true)
+      def distributors_match?(capsule_distributors, capsule)
+        generated_distributor_configs = self.generate_distributors(capsule)
         generated_distributor_configs.all? do |gen_dist|
           type = gen_dist.class.type_id
           found_on_capsule = capsule_distributors.find { |dist| dist['distributor_type_id'] == type }

--- a/db/migrate/20160906181923_add_puppet_path_to_smart_proxy.rb
+++ b/db/migrate/20160906181923_add_puppet_path_to_smart_proxy.rb
@@ -1,0 +1,5 @@
+class AddPuppetPathToSmartProxy < ActiveRecord::Migration
+  def change
+    add_column :smart_proxies, :puppet_path, :text
+  end
+end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -12,7 +12,6 @@ module Katello
         :use_cp => true,
         :rest_client_timeout => 30,
         :gpg_strict_validation => false,
-        :puppet_repo_root => '/etc/puppet/environments/',
         :redhat_repository_url => 'https://cdn.redhat.com',
         :post_sync_url => 'http://localhost:3000/katello/api/v2/repositories/sync_complete?token=katello',
         :consumer_cert_rpm => 'katello-ca-consumer-latest.noarch.rpm',

--- a/lib/proxy_api/pulp.rb
+++ b/lib/proxy_api/pulp.rb
@@ -11,5 +11,12 @@ module ProxyAPI
     rescue => e
       raise ::ProxyAPI::ProxyException.new(url, e, N_("Unable to detect pulp storage"))
     end
+
+    def capsule_puppet_path
+      @url += "/puppet"
+      @capsule_puppet_path ||= parse(get)
+    rescue => e
+      raise ::ProxyAPI::ProxyException.new(url, e, N_("Unable to detect puppet path"))
+    end
   end
 end

--- a/lib/proxy_api/pulp_node.rb
+++ b/lib/proxy_api/pulp_node.rb
@@ -11,5 +11,12 @@ module ProxyAPI
     rescue => e
       raise ::ProxyAPI::ProxyException.new(url, e, N_("Unable to detect pulp storage"))
     end
+
+    def capsule_puppet_path
+      @url += "/puppet"
+      @capsule_puppet_path ||= parse(get)
+    rescue => e
+      raise ::ProxyAPI::ProxyException.new(url, e, N_("Unable to detect puppet path"))
+    end
   end
 end

--- a/test/actions/katello/content_view_puppet_environment_test.rb
+++ b/test/actions/katello/content_view_puppet_environment_test.rb
@@ -19,6 +19,9 @@ module ::Actions::Katello::ContentViewPuppetEnvironment
     let(:action) { create_action action_class }
 
     it 'plans' do
+      default_capsule = mock
+      default_capsule.expects(:puppet_path).returns('/etc/puppet/environments')
+      SmartProxy.expects(:default_capsule).returns(default_capsule)
       puppet_env.expects(:save!)
       action.expects(:action_subject).with(puppet_env)
 

--- a/test/glue/pulp/repository_test.rb
+++ b/test/glue/pulp/repository_test.rb
@@ -5,6 +5,7 @@ module Katello
   class GluePulpRepoTestBase < ActiveSupport::TestCase
     include TaskSupport
     include Dynflow::Testing
+    include Support::CapsuleSupport
 
     def setup
       set_user
@@ -103,23 +104,23 @@ module Katello
         'http' => true,
         'https' => true
       }
-      @fedora_17_x86_64.expects(:generate_distributors).with(true).at_least_once.returns(
+      @fedora_17_x86_64.expects(:generate_distributors).with(capsule_content.capsule).at_least_once.returns(
           [Runcible::Models::YumDistributor.new('/foo/bar', true, true, yum_config)])
 
       assert @fedora_17_x86_64.distributors_match?([{'distributor_type_id' => Runcible::Models::YumDistributor.type_id,
-                                                     'config' => yum_config}])
+                                                     'config' => yum_config}], capsule_content.capsule)
       refute @fedora_17_x86_64.distributors_match?([{'distributor_type_id' => Runcible::Models::YumCloneDistributor.type_id,
-                                                     'config' => yum_config}])
-      refute @fedora_17_x86_64.distributors_match?([])
+                                                     'config' => yum_config}], capsule_content.capsule)
+      refute @fedora_17_x86_64.distributors_match?([], capsule_content.capsule)
 
       non_nil_checksum = yum_config.clone
       non_nil_checksum['checksum_type'] = 'sha256'
       assert @fedora_17_x86_64.distributors_match?([{'distributor_type_id' => Runcible::Models::YumDistributor.type_id,
-                                                     'config' => non_nil_checksum}])
+                                                     'config' => non_nil_checksum}], capsule_content.capsule)
 
       yum_config['relative_url'] = '/arrow/to/the/knee'
       refute @fedora_17_x86_64.distributors_match?([{'distributor_type_id' => Runcible::Models::YumCloneDistributor.type_id,
-                                                     'config' => yum_config}])
+                                                     'config' => yum_config}], capsule_content.capsule)
     end
 
     def test_distributors_match_docker
@@ -127,14 +128,14 @@ module Katello
         'protected' => true
       }
 
-      @fedora_17_x86_64.expects(:generate_distributors).with(true).at_least_once.returns(
+      @fedora_17_x86_64.expects(:generate_distributors).with(capsule_content.capsule).at_least_once.returns(
           [Runcible::Models::DockerDistributor.new(docker_config)])
 
       assert @fedora_17_x86_64.distributors_match?([{'distributor_type_id' => Runcible::Models::DockerDistributor.type_id,
-                                                     'config' => docker_config}])
+                                                     'config' => docker_config}], capsule_content.capsule)
       docker_config['protected'] = false
       refute @fedora_17_x86_64.distributors_match?([{'distributor_type_id' => Runcible::Models::DockerDistributor.type_id,
-                                                     'config' => docker_config}])
+                                                     'config' => docker_config}], capsule_content.capsule)
     end
 
     def test_importer_matches?


### PR DESCRIPTION
This is adding a new smart-proxy endpoint to allow a smart proxy to use whatever path they want for a puppet repo.