### PR TITLE
Fixes #16429: Support large file uploads

### DIFF
--- a/app/lib/actions/katello/repository/import_upload.rb
+++ b/app/lib/actions/katello/repository/import_upload.rb
@@ -2,12 +2,12 @@ module Actions
   module Katello
     module Repository
       class ImportUpload < Actions::EntryAction
-        def plan(repository, upload_id)
+        def plan(repository, upload_id, unit_key = {})
           action_subject(repository)
           import_upload = plan_action(Pulp::Repository::ImportUpload,
                                       pulp_id: repository.pulp_id,
                                       unit_type_id: repository.unit_type_id,
-                                      unit_key: {},
+                                      unit_key: unit_key,
                                       upload_id: upload_id)
 
           plan_action(FinishUpload, repository, import_upload.output)

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -731,10 +731,19 @@ module Katello
       end
     end
 
-    def test_import_uploads
+    def test_import_upload_ids
       assert_sync_task ::Actions::Katello::Repository::ImportUpload, @repository, '1'
 
       put :import_uploads, :id => @repository.id, :upload_ids => [1]
+
+      assert_response :success
+    end
+
+    def test_import_uploads
+      unit_key = {'size' => '12333', 'checksum' => 'asf23421324', 'name' => 'test'}
+      assert_sync_task ::Actions::Katello::Repository::ImportUpload, @repository, '1', unit_key
+
+      put :import_uploads, :id => @repository.id, :uploads => [{'id' => 1}.merge(unit_key)]
 
       assert_response :success
     end


### PR DESCRIPTION
@daviddavis @jlsherrill Looking for some opinion before I fully implement. Uploading of "isos" requires specifying name, checksum and size during the import phase when using the chunked content uploads API for large files. Which option do you prefer given altering the current API, adding additional parameters:

Option A
```
{
  upload_ids: [
    {
      upload_id: 1
    },
    {
      upload_id: 2,
      size: 394080948,
      checksum: 2,
      name: my_iso
    }
  ]
}
```


Option B
```
{
  upload_ids: [1,2,3]
}

{
  uploads: [
    {
      upload_id: 2,
      size: 394080948,
      checksum: 2,
      name: my_iso
    }
  ]
}
```

Option C
```
{
  upload_ids: [1,2,3],
  uploads: [
    {
      upload_id: 2,
      size: 394080948,
      checksum: 2,
      name: my_iso
    }
  ]
}
```