### PR TITLE
Fixes #16451 - Handle bad upload errors

### DIFF
--- a/app/lib/actions/katello/repository/import_upload.rb
+++ b/app/lib/actions/katello/repository/import_upload.rb
@@ -13,6 +13,10 @@ module Actions
           plan_action(FinishUpload, repository, import_upload.output)
         end
 
+        def rescue_strategy
+          Dynflow::Action::Rescue::Skip
+        end
+
         def humanized_name
           _("Upload into")
         end


### PR DESCRIPTION
In https://pulp.plan.io/issues/1747, pulp fixed an issue where it was not reporting errors for bad file uploads. This PR is to fix the Katello code so it properly releases the locks that the task creates (which cannot be resumed since the file is invalid).

Requires https://github.com/theforeman/foreman-tasks/pull/199