### PR TITLE
Fixes #16481 - Enables repo sync with credentials

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -33,6 +33,8 @@ module Katello
       param :download_policy, ["immediate", "on_demand", "background"], :desc => N_("download policy for yum repos (either 'immediate', 'on_demand', or 'background')")
       param :mirror_on_sync, :bool, :desc => N_("true if this repository when synced has to be mirrored from the source and stale rpms removed.")
       param :verify_ssl_on_sync, :bool, :desc => N_("if true, Katello will verify the upstream url's SSL certifcates are signed by a trusted CA.")
+      param :upstream_username, String, :desc => N_("Username of the upstream repository user used for authentication")
+      param :upstream_password, String, :desc => N_("Password of the upstream repository user used for authentication")
     end
 
     api :GET, "/repositories", N_("List of enabled repositories")
@@ -147,7 +149,8 @@ module Katello
       repository.docker_upstream_name = repo_params[:docker_upstream_name] if repo_params[:docker_upstream_name]
       repository.mirror_on_sync = ::Foreman::Cast.to_bool(repo_params[:mirror_on_sync]) if repo_params.key?(:mirror_on_sync)
       repository.verify_ssl_on_sync = ::Foreman::Cast.to_bool(repo_params[:verify_ssl_on_sync]) if repo_params.key?(:verify_ssl_on_sync)
-
+      repository.upstream_username = repo_params[:upstream_username] if repo_params.key?(:upstream_username)
+      repository.upstream_password = repo_params[:upstream_password] if repo_params.key?(:upstream_password)
       sync_task(::Actions::Katello::Repository::Create, repository, false, true)
       repository = Repository.find(repository.id)
       respond_for_show(:resource => repository)
@@ -224,6 +227,8 @@ module Katello
     param :download_policy, ["immediate", "on_demand", "background"], :desc => N_("download policy for yum repos (either 'immediate', 'on_demand', or 'background')")
     param :mirror_on_sync, :bool, :desc => N_("true if this repository when synced has to be mirrored from the source and stale rpms removed.")
     param :verify_ssl_on_sync, :bool, :desc => N_("if true, Katello will verify the upstream url's SSL certifcates are signed by a trusted CA.")
+    param :upstream_username, String, :desc => N_("Username of the upstream repository user for authentication")
+    param :upstream_password, String, :desc => N_("Password of the upstream repository user for authentication")
     def update
       repo_params = repository_params
       sync_task(::Actions::Katello::Repository::Update, @repository, repo_params)
@@ -384,7 +389,7 @@ module Katello
     end
 
     def repository_params
-      keys = [:download_policy, :mirror_on_sync, :verify_ssl_on_sync]
+      keys = [:download_policy, :mirror_on_sync, :verify_ssl_on_sync, :upstream_password, :upstream_username]
       keys += [:label, :content_type] if params[:action] == "create"
       if params[:action] == 'create' || @repository.custom?
         keys += [:url, :gpg_key_id, :unprotected, :name, :checksum_type, :docker_upstream_name]

--- a/app/lib/actions/katello/repository/create.rb
+++ b/app/lib/actions/katello/repository/create.rb
@@ -28,7 +28,9 @@ module Actions
                                         download_policy: repository.download_policy,
                                         with_importer: true,
                                         mirror_on_sync: repository.mirror_on_sync?,
-                                        ssl_validation: certs[:ssl_validation])
+                                        ssl_validation: certs[:ssl_validation],
+                                        upstream_username: repository.upstream_username,
+                                        upstream_password: repository.upstream_password)
 
             return if create_action.error
 

--- a/app/lib/actions/pulp/repository/create.rb
+++ b/app/lib/actions/pulp/repository/create.rb
@@ -21,6 +21,8 @@ module Actions
           param :capsule_id
           param :mirror_on_sync
           param :ssl_validation
+          param :upstream_username
+          param :upstream_password
         end
 
         def run
@@ -60,6 +62,8 @@ module Actions
           importer.ssl_validation  = input[:ssl_validation]
           importer.download_policy = input[:download_policy] if input[:content_type] == ::Katello::Repository::YUM_TYPE
           importer.remove_missing  = input[:mirror_on_sync] if input[:content_type] == ::Katello::Repository::YUM_TYPE
+          importer.basic_auth_username = input[:upstream_username] if input[:upstream_username].present?
+          importer.basic_auth_password = input[:upstream_password] if input[:upstream_password].present?
           importer
         end
 
@@ -70,6 +74,8 @@ module Actions
           importer.ssl_client_cert = input[:ssl_client_cert]
           importer.ssl_client_key  = input[:ssl_client_key]
           importer.ssl_validation  = input[:ssl_validation]
+          importer.basic_auth_username = input[:upstream_username] if input[:upstream_username].present?
+          importer.basic_auth_password = input[:upstream_password] if input[:upstream_password].present?
           importer
         end
 
@@ -80,6 +86,8 @@ module Actions
           importer.ssl_client_cert = input[:ssl_client_cert]
           importer.ssl_client_key  = input[:ssl_client_key]
           importer.ssl_validation  = input[:ssl_validation]
+          importer.basic_auth_username = input[:upstream_username] if input[:upstream_username].present?
+          importer.basic_auth_password = input[:upstream_password] if input[:upstream_password].present?
           importer
         end
 
@@ -89,6 +97,8 @@ module Actions
           importer.feed            = input[:feed]
           importer.enable_v1       = false
           importer.ssl_validation  = input[:ssl_validation]
+          importer.basic_auth_username = input[:upstream_username] if input[:upstream_username].present?
+          importer.basic_auth_password = input[:upstream_password] if input[:upstream_password].present?
           importer
         end
 

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -217,7 +217,11 @@ module Katello
             :ssl_ca_cert => nil
           }
         end
-        importer_options.merge!(:ssl_validation => verify_ssl_on_sync?) unless self.is_a?(::Katello::ContentViewPuppetEnvironment)
+        unless self.is_a?(::Katello::ContentViewPuppetEnvironment)
+          importer_options.merge!(:ssl_validation => verify_ssl_on_sync?)
+          importer_options[:basic_auth_username] = upstream_username if upstream_username.present?
+          importer_options[:basic_auth_password] = upstream_password if upstream_password.present?
+        end
         importer_options
       end
 

--- a/app/views/katello/api/v2/repositories/show.json.rabl
+++ b/app/views/katello/api/v2/repositories/show.json.rabl
@@ -18,6 +18,7 @@ attributes :content_id, :content_view_version_id, :library_instance_id
 attributes :product_type
 attributes :promoted? => :promoted
 attributes :ostree_branch_names => :ostree_branches
+attributes :upstream_username
 
 if @resource.is_a?(Katello::Repository)
   if @resource.distribution_version || @resource.distribution_arch || @resource.distribution_family || @resource.distribution_variant

--- a/db/migrate/20160907231049_add_username_password_to_repository.rb
+++ b/db/migrate/20160907231049_add_username_password_to_repository.rb
@@ -1,0 +1,6 @@
+class AddUsernamePasswordToRepository < ActiveRecord::Migration
+  def change
+    add_column :katello_repositories, :upstream_username, :string, :limit => 255
+    add_column :katello_repositories, :upstream_password, :string, :limit => 255
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/details/views/repository-info.html
@@ -133,6 +133,24 @@
             </span>
           </div>
 
+          <div class="detail">
+            <span class="info-label" translate>Upstream Username</span>
+            <span class="info-value"
+                  bst-edit-text="repository.upstream_username"
+                  on-save="save(repository)"
+                  readonly="product.redhat || denied('edit_products', product)">
+            </span>
+          </div>
+
+          <div class="detail">
+            <span class="info-label" translate>Upstream Password</span>
+            <span class="info-value"
+                  bst-edit-text="repository.upstream_password"
+                  on-save="save(repository)"
+                  readonly="product.redhat || denied('edit_products', product)">
+            </span>
+          </div>
+
           <div class="detail" ng-show="repository.content_type === 'yum'">
             <span class="info-label" translate>Yum Metadata Checksum</span>
             <span class="info-value"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/views/repository-new.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repositories/new/views/repository-new.html
@@ -75,6 +75,27 @@
         </h6>
       </div>
 
+      <div bst-form-group label="{{ 'Upstream Username' | translate }}" >
+        <input id="upstream_username"
+               name="upstream_username"
+               ng-model="repository.upstream_username"
+               type="text"/>
+        <h6 translate>
+          Username of the upstream repository user for authentication. Leave empty if repository does not require authentication.
+        </h6>
+      </div>
+
+      <div bst-form-group label="{{ 'Upstream Password' | translate }}" >
+        <input id="upstream_password"
+               name="upstream_password"
+               ng-model="repository.upstream_password"
+               type="password"/>
+        <h6 translate>
+            Password of the upstream repository user for authentication. Leave empty if repository does not require authentication.
+        </h6>
+      </div>
+
+
       <div bst-form-group label="{{ 'Download Policy' | translate }}" ng-show="repository.content_type === 'yum'">
         <select id="download_policy"
                 name="download_policy"

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -462,6 +462,41 @@ module Katello
       assert_template 'api/v2/repositories/show'
     end
 
+    def test_create_with_username_password
+      upstream_username = "genius"
+      upstream_password = "genius_password"
+      product = mock
+      product.expects(:add_repo).with(
+        'Fedora_Repository',
+        'Fedora Repository',
+        'http://www.google.com',
+        'yum',
+        false,
+        nil,
+        nil,
+        nil
+      ).returns(@repository)
+
+      product.expects(:gpg_key).returns(nil)
+      product.expects(:organization).returns(@organization)
+      product.expects(:redhat?).returns(false)
+      @repository.expects(:upstream_username=).with(upstream_username)
+      @repository.expects(:upstream_password=).with(upstream_password)
+
+      assert_sync_task(::Actions::Katello::Repository::Create, @repository, false, true)
+
+      Product.stubs(:find).returns(product)
+      post :create, :name => 'Fedora Repository',
+                    :product_id => @product.id,
+                    :url => 'http://www.google.com',
+                    :content_type => 'yum',
+                    :unprotected => false,
+                    :upstream_username => upstream_username,
+                    :upstream_password => upstream_password
+      assert_response :success
+      assert_template 'api/v2/repositories/show'
+    end
+
     def test_create_with_protected_docker
       product = mock
       product.expects(:add_repo).with(


### PR DESCRIPTION
Attached to code to enable syncing from an
upstream repo that requires username/password
using basic http authentication