### PR TITLE
Fixes #16441 - resolve upgrade uninitialized constant

### DIFF
--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -219,6 +219,7 @@ module Katello
       # We need to explicitly load this files because Foreman has
       # similar strucuture and if the Foreman files are loaded first,
       # autoloading doesn't work.
+      require_dependency "#{Katello::Engine.root}/app/lib/katello/api/v2/rendering"
       require_dependency "#{Katello::Engine.root}/app/controllers/katello/api/api_controller"
       require_dependency "#{Katello::Engine.root}/app/controllers/katello/api/v2/api_controller"
       require_dependency "#{Katello::Engine.root}/app/services/katello/proxy_status/pulp"


### PR DESCRIPTION
This resolves the error:
NameError: uninitialized constant Api::V2::Rendering
that was seen on a prod install