### PR TITLE
Fixes #16499 - don't update sync plans inside CV publish

### DIFF
--- a/app/lib/actions/katello/repository/create.rb
+++ b/app/lib/actions/katello/repository/create.rb
@@ -46,7 +46,9 @@ module Actions
             end
 
             concurrence do
-              plan_action(::Actions::Pulp::Repos::Update, repository.product) if repository.product.sync_plan
+              if !clone && repository.product.sync_plan
+                plan_action(::Actions::Pulp::Repos::Update, repository.product)
+              end
               plan_self(:repository_id => repository.id, :clone => clone)
             end
           end


### PR DESCRIPTION
Otherwise, HUGE execution plan can be generated