### PR TITLE
fixes #16502 - cv incremental update - auto-generate description

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/histories/content-view-history.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/histories/content-view-history.controller.js
@@ -36,6 +36,8 @@ angular.module('Bastion.content-views').controller('ContentViewHistoryController
                 message = translate("Published new version");
             } else if (taskType === taskTypes.export) {
                 message = translate("Exported content view");
+            } else if (taskType === taskTypes.incrementalUpdate) {
+                message = translate("Incremental update");
             }
 
             return message;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/histories/views/content-view-history.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/histories/views/content-view-history.html
@@ -24,7 +24,7 @@
        <tr bst-table-row ng-repeat="history in detailsTable.rows">
          <td bst-table-cell>{{ history.created_at | date:'short' }}</td>
          <td bst-table-cell>{{ history.version }} </td>
-         <td bst-table-cell>{{ history.description }} </td>
+         <td bst-table-cell class="preserve-newlines">{{ history.description }}</td>
          <td bst-table-cell>{{ actionText(history) }}</td>
          <td bst-table-cell>{{ history.user }}</td>
          <td bst-table-cell>{{ history.task.result }}</td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
@@ -77,11 +77,7 @@
             {{ version.file_count }} Files
           </div>
         </td>
-        <td bst-table-cell>
-          <div>
-            {{ version.description }}
-          </div>
-        </td>
+        <td bst-table-cell class="preserve-newlines">{{ version.description }}</td>
         <td class="col-sm-2">
           <button class="btn btn-default"
             ng-click="$state.go('content-views.details.promotion', {contentViewId: contentView.id, versionId: version.id})"

--- a/engines/bastion_katello/app/assets/stylesheets/bastion_katello/bastion_katello.scss
+++ b/engines/bastion_katello/app/assets/stylesheets/bastion_katello/bastion_katello.scss
@@ -25,5 +25,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
   }
-
+  .preserve-newlines {
+    white-space: pre-line;
+  }
 }


### PR DESCRIPTION
When publishing content view version incremental update,
auto-generate a description, if the user has not provided
one as part of the update request.

Include in it a summary similar to the following:
```
  Errata:
        RHEA-2012:0002
  Packages:
        penguin-0.9.1-1.noarch
        shark-0.1-1.noarch
        walrus-0.71-1.noarch
        walrus-5.21-1.noarch
  Puppet Modules:
        theforeman-dhcp-1.3.0
        theforeman-dns-1.4.0
```