### PR TITLE
fixes #16503 - composite view ui - newer component version exists

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -159,6 +159,10 @@ module Katello
       self.versions.in_environment(env).order("#{Katello::ContentViewVersion.table_name}.id ASC").readonly(false).last
     end
 
+    def latest_version
+      self.versions.order('major DESC').order('minor DESC').first.try(:version)
+    end
+
     def history
       Katello::ContentViewHistory.joins(:content_view_version).where(
           "#{Katello::ContentViewVersion.table_name}.content_view_id" => self.id)

--- a/app/views/katello/api/v2/content_views/base.json.rabl
+++ b/app/views/katello/api/v2/content_views/base.json.rabl
@@ -62,7 +62,7 @@ child :components => :components do
   end
 
   child :content_view => :content_view do
-    attributes :id, :name, :label, :description, :next_version
+    attributes :id, :name, :label, :description, :next_version, :latest_version
   end
 
   child :archived_repos => :repositories do

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-composite-content-views-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-composite-content-views-list.html
@@ -49,6 +49,9 @@
                 options-format="option.id as option.version for option in options"
                 on-save="saveContentViewVersion(contentViewVersion)">
           </span>
+          <div ng-show="contentViewVersion.version != contentViewVersion.content_view.latest_version" translate>
+              A newer version is available: {{ contentViewVersion.content_view.latest_version }}
+          </div>
         </td>
         <td bst-table-cell>
         <span ng-show="contentViewVersions.environments.length !== 0"

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -352,6 +352,17 @@ module Katello
       assert_equal @library_dev_view.next_version - 1, @library_dev_view.versions.reload.maximum(:major)
     end
 
+    def test_latest_version
+      # if a version hasn't been published, latest version is not available
+      assert_nil @no_environment_view.latest_version
+
+      assert_equal "2.0", @library_view.latest_version
+
+      @library_view.create_new_version
+      @library_view.reload
+      assert_equal "3.0", @library_view.latest_version
+    end
+
     def test_add_repository_from_other_org
       view = @library_view
       other_org = create(:katello_organization)


### PR DESCRIPTION
Update the composite content view UI to let the user know
if a newer version of a component content view exists.