### PR TITLE
fixes #16560 - use new snippets for config management

### DIFF
--- a/app/views/foreman/unattended/finish-katello.erb
+++ b/app/views/foreman/unattended/finish-katello.erb
@@ -22,6 +22,7 @@ service network restart
   pm_set = @host.puppetmaster.empty? ? false : true
   puppet_enabled = pm_set || @host.params['force-puppet']
   salt_enabled = @host.params['salt_master'] ? true : false
+  chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
 %>
 
 <%= snippet "subscription_manager_registration" %>
@@ -44,29 +45,16 @@ yum -t -y -e 0 update
 
 <%= snippet('remote_execution_ssh_keys') %>
 
-<% if salt_enabled %>
-yum -t -y -e 0 install salt-minion
-cat > /etc/salt/minion << EOF
-<%= snippet 'saltstack_minion' %>
-EOF
-# Setup salt-minion to run on system reboot
-/sbin/chkconfig --level 345 salt-minion on
-# Running salt-call to trigger key signing
-salt-call --no-color --grains >/dev/null
+<% if chef_enabled %>
+<%= snippet 'chef_client' %>
 <% end -%>
 
 <% if puppet_enabled %>
-yum -t -y -e 0 install puppet
-echo "Configuring puppet"
-cat > /etc/puppet/puppet.conf << EOF
-<%= snippet 'puppet.conf' %>
-EOF
+<%= snippet 'puppet_setup' %>
+<% end -%>
 
-# Setup puppet to run on system reboot
-/sbin/chkconfig --level 345 puppet on
-
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag <%= @host.puppetmaster.blank? ? '' : "--server #{@host.puppetmaster}" %> --no-daemonize
-/sbin/service puppet start
+<% if salt_enabled %>
+<%= snippet 'saltstack_setup' %>
 <% end -%>
 
 exit 0

--- a/app/views/foreman/unattended/kickstart-katello.erb
+++ b/app/views/foreman/unattended/kickstart-katello.erb
@@ -18,6 +18,7 @@ oses:
   pm_set = @host.puppetmaster.empty? ? false : true
   puppet_enabled = pm_set || @host.params['force-puppet']
   salt_enabled = @host.params['salt_master'] ? true : false
+  chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
   section_end = (rhel_compatible && os_major <= 5) ? '' : '%end'
 %>
 install
@@ -113,30 +114,16 @@ yum -t -y -e 0 update
 
 <%= snippet('remote_execution_ssh_keys') %>
 
-<% if salt_enabled %>
-yum -t -y -e 0 install salt-minion
-cat > /etc/salt/minion << EOF
-<%= snippet 'saltstack_minion' %>
-EOF
-# Setup salt-minion to run on system reboot
-/sbin/chkconfig --level 345 salt-minion on
-# Running salt-call to trigger key signing
-salt-call --no-color --grains >/dev/null
+<% if chef_enabled %>
+<%= snippet 'chef_client' %>
 <% end -%>
 
 <% if puppet_enabled %>
-# and add the puppet package
-yum -t -y -e 0 install puppet
+<%= snippet 'puppet_setup' %>
+<% end -%>
 
-echo "Configuring puppet"
-cat > /etc/puppet/puppet.conf << EOF
-<%= snippet 'puppet.conf' %>
-EOF
-
-# Setup puppet to run on system reboot
-/sbin/chkconfig --level 345 puppet on
-
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag <%= @host.puppetmaster.blank? ? '' : "--server #{@host.puppetmaster}" %> --no-daemonize
+<% if salt_enabled %>
+<%= snippet 'saltstack_setup' %>
 <% end -%>
 
 sync

--- a/app/views/foreman/unattended/userdata-katello.erb
+++ b/app/views/foreman/unattended/userdata-katello.erb
@@ -63,31 +63,24 @@ write_files:
   pm_set = @host.puppetmaster.empty? ? false : true
   puppet_enabled = non_atomic && (pm_set || @host.params['force-puppet'])
   salt_enabled = non_atomic && (@host.params['salt_master'] ? true : false)
+  chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
 %>
-<% if salt_enabled %>
-    yum -t -y -e 0 install salt-minion
-    cat > /etc/salt/minion << EOF
-    <%= indent 4 do
-          snippet 'saltstack_minion'
-        end %>
-    EOF
-    # Setup salt-minion to run on system reboot
-    /sbin/chkconfig --level 345 salt-minion on
-    # Running salt-call to trigger key signing
-    salt-call --no-color --grains >/dev/null
+<% if chef_enabled %>
+<%= indent 4 do
+      snippet 'chef_client'
+    end  %>
 <% end -%>
-<% if puppet_enabled %>
-    yum install -y puppet
-    cat > /etc/puppet/puppet.conf << EOF
-    <%= indent 4 do
-          snippet 'puppet.conf'
-        end %>
-    EOF
-    # Setup puppet to run on system reboot
-    /sbin/chkconfig --level 345 puppet on
 
-    /usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag <%= @host.puppetmaster.blank? ? '' : "--server #{@host.puppetmaster}" %> --no-daemonize
-    /sbin/service puppet start
+<% if puppet_enabled %>
+<%= indent 4 do
+      snippet 'puppet_setup'
+    end %>
+<% end -%>
+
+<% if salt_enabled %>
+<%= indent 4 do
+      snippet 'saltstack_setup'
+    end %>
 <% end -%>
 phone_home:
  url: <%= foreman_url('built') %>


### PR DESCRIPTION
Goes along with https://github.com/theforeman/community-templates/pull/299.  Users will need to specifically set an "enable-puppet4" param if they want puppet 4.

The eventual goal is to get rid of these templates, but after looking at this today, it's pretty involved.  We need to make Katello work with the redhat snippet in foreman https://github.com/theforeman/community-templates/blob/develop/snippets/redhat_register.erb#L16-L42, among some other changes possibly.