### PR TITLE
Fixes #16367: fix styling of buttons on CH errata page.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
@@ -64,7 +64,7 @@
       </div>
 
         <span bst-feature-flag="remote_actions">
-          <span class="input-group-btn">
+          <span class="btn-group" uib-dropdown>
             <button class="btn btn-primary"
                     translate
                     ng-hide="denied('edit_hosts', host)"


### PR DESCRIPTION
The styling of the buttons on the content host errata page was broken
because we were using an .input-group instead of a .button-group.  Since
these buttons are not in a form they should be using a .button-group.

http://projects.theforeman.org/issues/16367