### PR TITLE
[WIP] fixes #16574 - control which product content is shown

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -236,9 +236,6 @@ module Katello
         fail HttpErrors::BadRequest, _("Value must be 0/1, or 'default'")
       end
 
-      unless @activation_key.valid_content_label?(content_params[:content_label])
-        fail HttpErrors::BadRequest, _("Invalid content label: %s") % content_params[:content_label]
-      end
       content_params
     end
 

--- a/app/controllers/katello/api/v2/products_controller.rb
+++ b/app/controllers/katello/api/v2/products_controller.rb
@@ -31,7 +31,7 @@ module Katello
     param :custom, :bool, :desc => N_("Filter products by custom")
     param :include_available_content, :bool, :desc => N_("Whether to include available content attribute in results")
     param :sync_plan_id, :identifier, :desc => N_("Filter products by sync plan id")
-    param :available_for, String, :desc => N_("Interpret specified object to return only Products that can be associated with specified object.  Only 'sync_plan' is supported."),
+    param :available_for, String, :desc => N_("Interpret specified object to return only Products that can be associated with specified object.  Only 'sync_plan' and 'organization' are supported."),
           :required => false
     param_group :search, Api::V2::ApiController
     def index
@@ -44,7 +44,7 @@ module Katello
       query = query.where(:provider_id => @organization.anonymous_provider.id) if params[:custom]
       query = query.where(:name => params[:name]) if params[:name]
       query = query.enabled if params[:enabled]
-      query = query.where(:id => @activation_key.products) if @activation_key
+      query = query.where(:id => @activation_key.products) if @activation_key && params[:available_for] != 'organization'
 
       if params[:subscription_id]
         pool = Pool.with_identifier(params[:subscription_id])

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-products.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-products.controller.js
@@ -29,18 +29,41 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyProductsContr
             return isAvailableContent;
         };
 
-        $scope.activationKey.$promise.then(function () {
-            ActivationKey.products({id: $scope.activationKey.id,
-                                    'organization_id': CurrentOrganization,
-                                    enabled: true,
-                                    'full_result': true,
-                                    'include_available_content': true
-                                   }, function (response) {
+        $scope.productType = "redhat";
+        $scope.allProducts = false;
+
+        $scope.refreshProducts = function () {
+            var params;
+
+            if ($scope.activationKey.$resolved === false) {
+                return;
+            }
+
+            $scope.displayArea.working = true;
+
+            params = {
+                id: $scope.activationKey.id,
+                'organization_id': CurrentOrganization,
+                enabled: true,
+                'full_result': true,
+                'include_available_content': true
+            }
+
+            var custom;
+            if ($scope.productType === "custom") {
+                params['custom'] = true;
+            }
+            if ($scope.allProducts == true) {
+                params['available_for'] = "organization";
+            }
+            ActivationKey.products(params, function (response) {
                 $scope.products = response.results;
                 $scope.displayArea.isAvailableContent = $scope.isAnyAvailableContent($scope.products);
                 $scope.displayArea.working = false;
             });
-        });
+        };
 
+        $scope.activationKey.$promise.then($scope.refreshProducts());
+        $scope.$watch('productType', $scope.refreshProducts());
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-products.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-products.html
@@ -12,9 +12,26 @@
 </div>
 
 <div class="details details-full pull-left">
+  <div data-block="search-filter">
+    <div class="col-sm-3">
+      <select class="form-control" ng-model="productType">
+        <option value="redhat">{{ "Red Hat Products" | translate }}</option>
+        <option value="custom">{{ "Custom Products" | translate }}</option>
+      </select>
+    </div>
+    <div class="col-sm-3">
+      <label  class="checbox-inline" title="{{ 'Show all products in organization, not just those provided through attached subscriptions' | translate }}">
+        <input type="checkbox" ng-model="allProducts" ng-change="refreshProducts()"/>
+        <span translate>All Products</span>
+      </label>
+    </div>
+  </div>
+</div>
+
+<div class="details details-full pull-left">
   <section>
-    <div ng-hide="displayArea.isAvailableContent" translate>
-      No repository content provided through subscriptions.
+    <div ng-hide="displayArea.isAvailableContent" ng-hide="displayArea.working" translate>
+      No repository content.
     </div>
 
     <div ng-repeat="product in products" ng-hide="product.available_content.length < 1"


### PR DESCRIPTION
Goal is to allow an activation key to override content enable/disable defaults, even for repos that are not (yet) available. The specific use case is for an activation key with no subscriptions meant to auto-attach to a VDC guest sub at registration. This scenario very often requires getting katello-agent which comes from a default disabled repo (satellite tools). In addition, showing custom products is also useful.