### PR TITLE
fixes #16265 - cv repos - indicate 'not synced'

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-docker-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-docker-repositories.html
@@ -100,6 +100,9 @@
           </td>
           <td bst-table-cell>{{ repository.product.name }}</td>
           <td bst-table-cell>
+            <span ng-show="repository.url && repository.last_sync == null" translate>
+              Not Synced
+            </span>
             <span ng-show="repository.url">
               {{ repository.last_sync.ended_at | date:"short" }}
             </span>
@@ -112,12 +115,12 @@
             <span ng-hide="repository.url" translate>N/A</span>
           </td>
           <td bst-table-cell>
-            <div ng-if="repository.content_counts.docker_manifest && repository.content_counts.docker_manifest > 0">
+            <div>
               <span translate>
                 {{ repository.content_counts.docker_manifest }} Docker Manifests
               </span>
             </div>
-            <div ng-if="repository.content_counts.docker_tag && repository.content_counts.docker_tag > 0">
+            <div>
               <span translate>
                 {{ repository.content_counts.docker_tag }} Docker Tags
               </span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-file-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-file-repositories.html
@@ -99,6 +99,9 @@
           </td>
           <td bst-table-cell>{{ repository.product.name }}</td>
           <td bst-table-cell>
+            <span ng-show="repository.url && repository.last_sync == null" translate>
+              Not Synced
+            </span>
             <span ng-show="repository.url">
               {{ repository.last_sync.ended_at | date:"short" }}
             </span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-ostree-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-ostree-repositories.html
@@ -99,6 +99,9 @@
           </td>
           <td bst-table-cell>{{ repository.product.name }}</td>
           <td bst-table-cell>
+            <span ng-show="repository.url && repository.last_sync == null" translate>
+              Not Synced
+            </span>
             <span ng-show="repository.url">
               {{ repository.last_sync.ended_at | date:"short" }}
             </span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-repositories.html
@@ -100,6 +100,9 @@
           </td>
           <td bst-table-cell>{{ repository.product.name }}</td>
           <td bst-table-cell>
+            <span ng-show="repository.url && repository.last_sync == null" translate>
+              Not Synced
+            </span>
             <span ng-show="repository.url">
               {{ repository.last_sync.ended_at | date:"short" }}
             </span>
@@ -112,14 +115,14 @@
             <span ng-hide="repository.url" translate>N/A</span>
           </td>
           <td bst-table-cell>
-            <div ng-if="repository.content_counts.rpm && repository.content_counts.rpm > 0">
+            <div>
               <a ui-sref="products.details.repositories.manage-content.packages({productId: repository.product.id, repositoryId: repository.id})"
                  ng-show="repository.content_type == 'yum'"
                  translate>
                 {{ repository.content_counts.rpm }} Packages
               </a>
             </div>
-            <div ng-if="repository.content_counts.erratum && repository.content_counts.erratum > 0">
+            <div>
               <a ui-sref="errata.index({repositoryId: repository.id})"
                  ng-show="repository.content_type == 'yum'"
                  translate>


### PR DESCRIPTION
Minor change to the content view repositories UI based
on user feedback to show 'Not Synced' and empty counts,
when a repository has not yet been synced.