### PR TITLE
Fixes #16588 - Hide non-sub products for keys

### DIFF
--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -87,7 +87,8 @@ module Katello
       all_pools = self.get_pools.map { |pool| pool["id"] }
       added_pools = self.get_key_pools.map { |pool| pool["id"] }
       available_pools = all_pools - added_pools
-      Pool.where(:cp_id => available_pools)
+      Pool.where(:cp_id => available_pools,
+                 :subscription_id => Subscription.with_subscribable_content)
     end
 
     def products

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -24,6 +24,7 @@ module Katello
     OSTREE_TYPE = 'ostree'.freeze
 
     CHECKSUM_TYPES = %w(sha1 sha256).freeze
+    SUBSCRIBABLE_TYPES = [YUM_TYPE, OSTREE_TYPE].freeze
 
     belongs_to :environment, :inverse_of => :repositories, :class_name => "Katello::KTEnvironment"
     belongs_to :product, :inverse_of => :repositories
@@ -115,6 +116,7 @@ module Katello
     scope :non_puppet, -> { where("content_type != ?", PUPPET_TYPE) }
     scope :non_archived, -> { where('environment_id is not NULL') }
     scope :archived, -> { where('environment_id is NULL') }
+    scope :subscribable, -> { where(content_type: SUBSCRIBABLE_TYPES) }
 
     scoped_search :on => :name, :complete_value => true
     scoped_search :rename => :product, :on => :name, :in => :product, :complete_value => true

--- a/app/models/katello/subscription.rb
+++ b/app/models/katello/subscription.rb
@@ -12,6 +12,11 @@ module Katello
 
     scope :in_organization, ->(org) { where(:organization => org) }
 
+    def self.with_subscribable_content
+      joins(:products).
+        where("#{Katello::Product.table_name}.id" => Product.with_subscribable_content)
+    end
+
     def redhat?
       self.products.any? { |product| product.redhat? }
     end

--- a/test/models/activation_key_test.rb
+++ b/test/models/activation_key_test.rb
@@ -125,5 +125,17 @@ module Katello
       @dev_key.stubs(:subscription_facets).returns(['host one', 'host two'])
       assert @dev_key.valid?
     end
+
+    def test_available_subscriptions
+      pool_one = katello_pools(:pool_one)
+      pool_two = katello_pools(:pool_two)
+      fedora = katello_products(:fedora)
+      pool_two.subscription.products.delete(fedora) # pool two no longer contains sub content
+      cp_pools = [{'id' => 'abc123'}, {'id' => 'xyz123'}]
+
+      @dev_key.stubs(:get_pools).returns(cp_pools)
+      @dev_key.stubs(:get_key_pools).returns([])
+      assert_equal [pool_one], @dev_key.available_subscriptions
+    end
   end
 end

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -118,5 +118,20 @@ module Katello
 
       assert @redhat_product.used_by_another_org?
     end
+
+    def test_available_content
+      product = katello_products(:fedora)
+      fedora = katello_repositories(:fedora_17_x86_64)
+      puppet = katello_repositories(:p_forge)
+      puppet.update_attributes(content_id: 2)
+      Repository.any_instance.stubs(:exist_for_environment?).returns(true)
+      product.repositories = [fedora, puppet]
+
+      fedora_content = OpenStruct.new(content: OpenStruct.new(id: fedora.content_id))
+      puppet_content = OpenStruct.new(content: OpenStruct.new(id: puppet.content_id))
+
+      product.stubs(:productContent).returns([fedora_content, puppet_content])
+      assert_equal [fedora_content], product.available_content
+    end
   end
 end

--- a/test/models/subscription_test.rb
+++ b/test/models/subscription_test.rb
@@ -18,5 +18,13 @@ module Katello
       assert @basic.expiring_soon?
       refute @basic.recently_expired?
     end
+
+    def test_with_subscribable_content
+      fedora = katello_products(:fedora)
+      assert_includes Subscription.with_subscribable_content, @other
+
+      @other.products.delete(fedora)
+      refute_includes Subscription.with_subscribable_content, @other
+    end
   end
 end


### PR DESCRIPTION
Hide subscriptions for products that don't contain ostree or yum content on the Activation Key subscriptions page.