### PR TITLE
Fixes #15978 - Remove katello api base url for...

### DIFF
--- a/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
@@ -12,6 +12,11 @@ module Katello
 
     before_action :validate_content_action, :only => [:install_content, :update_content, :remove_content]
 
+    resource_description do
+      api_version 'v2'
+      api_base_url "/api"
+    end
+
     PARAM_ACTIONS = {
       :install_content => {
         :package => :install_packages,


### PR DESCRIPTION
Remove katello api base url for host bulk actions

The path should have always been `/api/hosts/bulk/[install|update|remove]_content`

Co-requisite: https://github.com/Katello/hammer-cli-katello/pull/452