### PR TITLE
Fixes #15187: Expose content comparison for all content types

### DIFF
--- a/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
+++ b/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
@@ -54,7 +54,17 @@ module Katello
       param :repository_id, :identifier, :desc => N_("Library repository id to restrict comparisons to")
       def compare
         fail _("No content_view_version_ids provided") if params[:content_view_version_ids].empty?
-        @versions = ContentViewVersion.readable.where(:id => params[:content_view_version_ids])
+        @versions = ::Katello::ContentViewVersion.readable.where(:id => params[:content_view_version_ids])
+
+        sort_options = []
+        options = {}
+        if default_sort.is_a?(Array)
+          sort_options = default_sort
+        elsif default_sort.is_a?(Proc)
+          options[:custom_sort] = default_sort
+        else
+          fail "Unsupported default_sort type"
+        end
 
         if @versions.count != params[:content_view_version_ids].uniq.length
           missing = params[:content_view_version_ids] - @versions.pluck(:id)
@@ -62,11 +72,16 @@ module Katello
         end
 
         collection = resource_class.all
-        repos = Katello::Repository.where(:content_view_version_id => @versions.pluck(:id))
-        repos = repos.where(:library_instance_id => @repo.id) if @repo
+        if resource_class == ::Katello::PuppetModule
+          repos = Katello::ContentViewPuppetEnvironment.where(:content_view_version_id => @versions.pluck(:id))
+        else
+          repos = Katello::Repository.where(:content_view_version_id => @versions.pluck(:id))
+        end
+        repos = repos.where(:id => @repo.id) if @repo
 
-        collection = scoped_search(filter_by_repos(repos, collection).uniq, default_sort[0], default_sort[1])
+        collection = scoped_search(filter_by_repos(repos, collection).uniq, sort_options[0], sort_options[1], options)
         collection[:results] = collection[:results].map { |item| ContentViewVersionComparePresenter.new(item, @versions, @repo) }
+
         respond_for_index(:collection => collection)
       end
 
@@ -152,7 +167,7 @@ module Katello
 
       def find_content_view_version
         if params[:content_view_version_id]
-          @version = ContentViewVersion.readable.find_by(:id => params[:content_view_version_id])
+          @version = ::Katello::ContentViewVersion.readable.find_by(:id => params[:content_view_version_id])
           fail HttpErrors::NotFound, _("Couldn't find content view version '%s'") % params[:content_view_version_id] if @version.nil?
         end
       end

--- a/app/models/katello/authorization/content_view_version.rb
+++ b/app/models/katello/authorization/content_view_version.rb
@@ -11,8 +11,8 @@ module Katello
 
     module ClassMethods
       def readable
-        view_ids = ContentView.readable.collect { |v| v.id }
-        joins(:content_view).where("#{Katello::ContentView.table_name}.id" => view_ids)
+        view_ids = ::Katello::ContentView.readable.collect { |v| v.id }
+        joins(:content_view).where("#{::Katello::ContentView.table_name}.id" => view_ids)
       end
     end
   end

--- a/app/presenters/katello/content_view_version_compare_presenter.rb
+++ b/app/presenters/katello/content_view_version_compare_presenter.rb
@@ -1,5 +1,7 @@
 module Katello
   class ContentViewVersionComparePresenter
+    attr_reader :item, :versions, :repository
+
     def initialize(content_item, content_view_versions, repository)
       @item = content_item
       @versions = content_view_versions

--- a/app/views/katello/api/v2/common/compare.json.rabl
+++ b/app/views/katello/api/v2/common/compare.json.rabl
@@ -1,0 +1,21 @@
+object false
+
+extends "katello/api/v2/common/metadata"
+
+child @collection[:results] => :results do
+#  extends 'katello/api/v2/%s/base' % controller_name
+
+  node :item do |content|
+    if content.item.class == ::Katello::Rpm
+      content.item.nvra
+    elsif content.item.class == ::Katello::DockerTag
+      content.item.repository.name + "-" + content.item.name
+    else
+      content.item.name
+    end
+  end
+
+  node :comparison do |content|
+    content.comparison
+  end
+end

--- a/app/views/katello/api/v2/packages/show.json.rabl
+++ b/app/views/katello/api/v2/packages/show.json.rabl
@@ -1,4 +1,4 @@
 object @resource
 
 extends "katello/api/v2/packages/base"
-extends "katello/api/v2/packages/backend", :object => Katello::Pulp::Rpm.new(@resource.uuid)
+extends "katello/api/v2/packages/backend", :object => Katello::Pulp::Rpm.new(@object.uuid)

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -109,6 +109,7 @@ Katello::Engine.routes.draw do
 
         api_resources :ostree_branches, :only => [:index, :show] do
           collection do
+            get :compare
             get :auto_complete_search
           end
         end
@@ -116,6 +117,7 @@ Katello::Engine.routes.draw do
         api_resources :docker_manifests, :only => [:index, :show]
         api_resources :docker_tags, :only => [:index, :show] do
           collection do
+            get :compare
             get :auto_complete_search
           end
         end
@@ -185,6 +187,7 @@ Katello::Engine.routes.draw do
 
         api_resources :packages, :only => [:index, :show] do
           collection do
+            get :compare
             get :auto_complete_search
             get :auto_complete_name
           end
@@ -192,6 +195,7 @@ Katello::Engine.routes.draw do
 
         api_resources :package_groups, :only => [:index, :show] do
           collection do
+            get :compare
             get :auto_complete_search
           end
         end
@@ -221,7 +225,10 @@ Katello::Engine.routes.draw do
           end
         end
         api_resources :puppet_modules, :only => [:index, :show] do
-          get :auto_complete_search, :on => :collection
+          collection do
+            get :compare
+            get :auto_complete_search
+          end
         end
 
         api_resources :repositories, :only => [:index, :create, :show, :destroy, :update] do

--- a/test/controllers/api/v2/docker_tags_controller_test.rb
+++ b/test/controllers/api/v2/docker_tags_controller_test.rb
@@ -3,9 +3,13 @@ require "katello_test_helper"
 module Katello
   class Api::V2::DockerTagsControllerTest < ActionController::TestCase
     def models
-      @repo = Repository.find(katello_repositories(:redis).id)
-      @manifest = @repo.docker_manifests.create!(:name => "abc123", :uuid => "123xyz")
-      @tag = @repo.docker_tags.create!(:name => "wat", :docker_manifest => @manifest)
+      @redis = Repository.find(katello_repositories(:redis).id)
+      @redis_manifest = @redis.docker_manifests.create!(:name => "abc123", :uuid => "123xyz")
+      @redis_tag = @redis.docker_tags.create!(:name => "wat", :docker_manifest => @redis_manifest)
+
+      @busybox = Repository.find(katello_repositories(:busybox_view1).id)
+      @busybox_manifest = @busybox.docker_manifests.create!(:name => "xyz789", :uuid => "789abc")
+      @busybox_tag = @busybox.docker_tags.create!(:name => "huh", :docker_manifest => @busybox_manifest)
     end
 
     def setup
@@ -14,7 +18,7 @@ module Katello
     end
 
     def test_index
-      get :index, :repository_id => @repo.id
+      get :index, :repository_id => @redis.id
       assert_response :success
       assert_template "katello/api/v2/docker_tags/index"
 
@@ -22,14 +26,14 @@ module Katello
       assert_response :success
       assert_template "katello/api/v2/docker_tags/index"
 
-      get :index, :organization_id => @repo.organization.id
+      get :index, :organization_id => @redis.organization.id
       assert_response :success
       assert_template "katello/api/v2/docker_tags/index"
     end
 
     def test_grouped_index
-      organization = @repo.organization
-      repos_stub = stub(:in_organization => [@repo])
+      organization = @redis.organization
+      repos_stub = stub(:in_organization => [@redis])
       Repository.expects(:readable).returns(repos_stub)
       get :index, :organization_id => organization.id,
         :grouped => true
@@ -42,11 +46,26 @@ module Katello
     end
 
     def test_show
-      get :show, :repository_id => @repo.id, :id => @tag.id
+      get :show, :repository_id => @redis.id, :id => @redis_tag.id
 
       assert_response :success
       assert_template "katello/api/v2/docker_tags/show"
       assert_template :layout => 'katello/api/v2/layouts/resource'
+    end
+
+    def test_compare
+      response = get :compare, :content_view_version_ids => [@redis.content_view_version_id, @busybox.content_view_version_id]
+      results = JSON.parse(response.body)["results"]
+
+      assert_response :success
+
+      redis_tags = @redis.docker_tags.map(&:name)
+      redis_results = results.select { |result| redis_tags.include?(result["item"]) }
+      redis_results.each { |result| assert result["comparison"].include?(@redis.content_view_version_id) }
+
+      busybox_tags = @busybox.docker_tags.map(&:name)
+      busybox_results = results.select { |result| busybox_tags.include?(result["item"]) }
+      busybox_results.each { |result| assert result["comparison"].include?(@busybox.content_view_version_id) }
     end
   end
 end


### PR DESCRIPTION
This adds content comparison for content views to the API for packages, puppet modules in addition to errata.
