### PR TITLE
fixes #6757 - composite view to allow duplicate repos

### DIFF
--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -18,9 +18,9 @@ module Actions
           sequence do
             plan_action(ContentView::AddToEnvironment, version, library)
             concurrence do
-              content_view.repositories_to_publish.each do |repository|
+              content_view.repositories_to_publish_by_library_instance.each do |_library_instance, repositories|
                 sequence do
-                  clone_to_version = plan_action(Repository::CloneToVersion, repository, version)
+                  clone_to_version = plan_action(Repository::CloneToVersion, repositories, version)
                   plan_action(Repository::CloneToEnvironment, clone_to_version.new_repository, library)
                 end
               end

--- a/app/lib/actions/katello/repository/clone_to_version.rb
+++ b/app/lib/actions/katello/repository/clone_to_version.rb
@@ -5,23 +5,27 @@ module Actions
         # allows accessing the build object from the superior action
         attr_accessor :new_repository
 
-        def plan(repository, content_view_version, incremental = false)
+        def plan(repositories, content_view_version, incremental = false)
           content_view = content_view_version.content_view
-          filters = incremental ? [] : content_view.filters.applicable(repository)
-          self.new_repository = repository.build_clone(content_view: content_view,
-                                                       version: content_view_version)
+          filters = incremental ? [] : content_view.filters.applicable(repositories.first)
+
+          self.new_repository = repositories.first.build_clone(content_view: content_view,
+                                                               version: content_view_version)
+
           sequence do
             plan_action(Repository::Create, new_repository, true, false)
 
-            if new_repository.yum?
-              plan_action(Repository::CloneYumContent, repository, new_repository, filters, !incremental,
-                          :generate_metadata => !incremental, :index_content => !incremental, :simple_clone => incremental)
-            elsif new_repository.docker?
-              plan_action(Repository::CloneDockerContent, repository, new_repository)
-            elsif new_repository.ostree?
-              plan_action(Repository::CloneOstreeContent, repository, new_repository)
-            elsif new_repository.file?
-              plan_action(Repository::CloneFileContent, repository, new_repository)
+            repositories.each do |repository|
+              if new_repository.yum?
+                plan_action(Repository::CloneYumContent, repository, new_repository, filters, !incremental,
+                            :generate_metadata => !incremental, :index_content => !incremental, :simple_clone => incremental)
+              elsif new_repository.docker?
+                plan_action(Repository::CloneDockerContent, repository, new_repository)
+              elsif new_repository.ostree?
+                plan_action(Repository::CloneOstreeContent, repository, new_repository)
+              elsif new_repository.file?
+                plan_action(Repository::CloneFileContent, repository, new_repository)
+              end
             end
           end
         end

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -227,13 +227,8 @@ module Katello
       v1 = ContentViewVersion.find(katello_content_view_versions(:library_view_version_1).id)
       v2 = ContentViewVersion.find(katello_content_view_versions(:library_view_version_2).id)
 
-      refute composite.update_attributes(component_ids: [v1.id, v2.id])
-      assert_equal 2, composite.errors.count # docker and yum repos
-      assert composite.errors.full_messages.first =~ /^Repository conflict/
-
-      assert_raises(RuntimeError) do
-        composite.components << v1
-      end
+      assert composite.update_attributes(component_ids: [v1.id, v2.id])
+      assert_equal 0, composite.errors.count # docker and yum repos
     end
 
     def test_puppet_module_conflicts


### PR DESCRIPTION
This commit removes the restriction that component content views
added to a composite content view are not allowed to contain
the same source repository.  This is to handle the case where
the user is managing multiple instances of the repos with different
views/purposes and want to combine them through composites.

With this, when publishing a composite content view, if there are
N instances of the same repository, the version published for
the composite will only have 1 repository that combines them
all.

This change in behavior also affects incremental update as it
needs to ensure that that single repository is still a combination
of all versions on the composite (e.g. from new incremental versions
as well as the prior published versions).