### PR TITLE
Fixes #16673 - Storing action on content view histories

### DIFF
--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -12,8 +12,11 @@ module Actions
           version = content_view.create_new_version(description)
           library = content_view.organization.library
 
-          history = ::Katello::ContentViewHistory.create!(:content_view_version => version, :user => ::User.current.login,
-                                                          :status => ::Katello::ContentViewHistory::IN_PROGRESS, :task => self.task)
+          history = ::Katello::ContentViewHistory.create!(:content_view_version => version,
+                                                          :user => ::User.current.login,
+                                                          :status => ::Katello::ContentViewHistory::IN_PROGRESS,
+                                                          :action => ::Katello::ContentViewHistory.actions[:publish],
+                                                          :task => self.task)
 
           sequence do
             plan_action(ContentView::AddToEnvironment, version, library)

--- a/app/lib/actions/katello/content_view/remove.rb
+++ b/app/lib/actions/katello/content_view/remove.rb
@@ -41,6 +41,7 @@ module Actions
                                                                     :user => ::User.current.login,
                                                                     :environment => cve.environment,
                                                                     :status => ::Katello::ContentViewHistory::IN_PROGRESS,
+                                                                    :action => ::Katello::ContentViewHistory.actions[:removal],
                                                                     :task => self.task)
               plan_action(ContentViewEnvironment::Destroy,
                           cve,
@@ -51,6 +52,7 @@ module Actions
             versions.each do |version|
               ::Katello::ContentViewHistory.create!(:content_view_version => version,
                                                     :user => ::User.current.login,
+                                                    :action => ::Katello::ContentViewHistory.actions[:removal],
                                                     :status => ::Katello::ContentViewHistory::IN_PROGRESS, :task => self.task)
               plan_action(ContentViewVersion::Destroy, version,
                           :skip_environment_check => true,

--- a/app/lib/actions/katello/content_view/remove_from_environment.rb
+++ b/app/lib/actions/katello/content_view/remove_from_environment.rb
@@ -18,6 +18,7 @@ module Actions
                                                           :environment => environment,
                                                           :user => ::User.current.login,
                                                           :status => ::Katello::ContentViewHistory::IN_PROGRESS,
+                                                          :action => ::Katello::ContentViewHistory.actions[:removal],
                                                           :task => self.task)
 
           plan_action(ContentViewEnvironment::Destroy, cv_env)

--- a/app/lib/actions/katello/content_view/remove_version.rb
+++ b/app/lib/actions/katello/content_view/remove_version.rb
@@ -9,6 +9,7 @@ module Actions
           history = ::Katello::ContentViewHistory.create!(:content_view_version => version,
                                                           :user => ::User.current.login,
                                                           :status => ::Katello::ContentViewHistory::IN_PROGRESS,
+                                                          :action => ::Katello::ContentViewHistory.actions[:removal],
                                                           :task => self.task)
 
           plan_action(ContentViewVersion::Destroy, version)

--- a/app/lib/actions/katello/content_view_version/export.rb
+++ b/app/lib/actions/katello/content_view_version/export.rb
@@ -17,6 +17,7 @@ module Actions
           history = ::Katello::ContentViewHistory.create!(:content_view_version => content_view_version,
                                                           :user => ::User.current.login,
                                                           :status => ::Katello::ContentViewHistory::IN_PROGRESS,
+                                                          :action => ::Katello::ContentViewHistory.actions[:export],
                                                           :task => self.task)
 
           plan_action(Katello::Repository::Export, repos, export_to_iso, since, iso_size,

--- a/app/lib/actions/katello/content_view_version/incremental_update.rb
+++ b/app/lib/actions/katello/content_view_version/incremental_update.rb
@@ -14,6 +14,7 @@ module Actions
           _("Incremental Update")
         end
 
+        # rubocop:disable Metrics/MethodLength
         def plan(old_version, environments, options = {})
           dep_solve = options.fetch(:resolve_dependencies, false)
           description = options.fetch(:description, '')
@@ -29,6 +30,7 @@ module Actions
           new_minor = old_version.content_view.versions.where(:major => old_version.major).maximum(:minor) + 1
           self.new_content_view_version = old_version.content_view.create_new_version(description, old_version.major, new_minor, all_components)
           history = ::Katello::ContentViewHistory.create!(:content_view_version => new_content_view_version, :user => ::User.current.login,
+                                                          :action => ::Katello::ContentViewHistory.actions[:publish],
                                                           :status => ::Katello::ContentViewHistory::IN_PROGRESS, :task => self.task)
 
           copy_action_outputs = []

--- a/db/migrate/20160923143611_add_action_to_content_view_histories.rb
+++ b/db/migrate/20160923143611_add_action_to_content_view_histories.rb
@@ -1,0 +1,34 @@
+class AddActionToContentViewHistories < ActiveRecord::Migration
+  def up
+    add_column :katello_content_view_histories, :action, :integer, default: 0
+
+    Katello::ContentViewHistory.reset_column_information
+
+    Katello::ContentViewHistory.find_each do |history|
+      task_label = history.task.try(:label)
+      unless task_label
+        history.delete
+        next
+      end
+
+      case task_label
+      when "Actions::Katello::ContentViewVersion::Export"
+        history.action = Katello::ContentViewHistory.actions[:export]
+      when "Actions::Katello::ContentView::Publish"
+        history.action = Katello::ContentViewHistory.actions[:publish]
+      when "Actions::Katello::ContentView::Promote"
+        history.action = Katello::ContentViewHistory.actions[:promotion]
+      when "Actions::Katello::ContentView::Remove"
+        history.action = Katello::ContentViewHistory.actions[:removal]
+      else
+        fail "Cannot determine action for task label '#{task_label}'"
+      end
+
+      history.save!
+    end
+  end
+
+  def down
+    remove_column :katello_content_view_histories, :action
+  end
+end

--- a/test/fixtures/models/katello_content_view_histories.yml
+++ b/test/fixtures/models/katello_content_view_histories.yml
@@ -5,3 +5,4 @@ view_version_1_history_1:
   updated_at: <%= Time.now %>
   katello_content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_view_version_1) %>
   katello_environment_id: <%= ActiveRecord::FixtureSet.identify(:library) %>
+  action: 1

--- a/test/models/content_view_history_test.rb
+++ b/test/models/content_view_history_test.rb
@@ -8,18 +8,28 @@ module Katello
       @library_view        = ContentView.find(katello_content_views(:library_view).id)
     end
 
-    def test_no_task
+    def test_humanized_action
       history = ::Katello::ContentViewHistory.create!(:katello_content_view_version_id => @library_view.versions.first.id,
-                                                      :status => 'successful', :user => User.first)
+                                                      :status => 'successful', :user => User.first,
+                                                      :action => Katello::ContentViewHistory.actions[:publish])
 
-      assert history.humanized_action.is_a?(String)
+      assert_equal 'Published new version', history.humanized_action
+    end
+
+    def test_no_action
+      history = ::Katello::ContentViewHistory.new(:katello_content_view_version_id => @library_view.versions.first.id,
+                                                  :status => 'successful', :user => User.first)
+
+      refute history.valid?
+      refute_empty history.errors
     end
 
     def test_promote_no_environment
       task = ForemanTasks::Task.create!(:label => 'Actions::Katello::ContentView::Promote', :state => 'success',
                                         :type => 'ForemanTasks::Task::DynflowTask', :result => 'stopped')
       history = ::Katello::ContentViewHistory.create!(:katello_content_view_version_id => @library_view.versions.first.id,
-                                                      :status => 'successful', :task_id => task.id, :user => User.first)
+                                                      :status => 'successful', :task_id => task.id, :user => User.first,
+                                                      :action => "promotion")
 
       assert history.humanized_action.is_a?(String)
     end

--- a/test/models/content_view_version_test.rb
+++ b/test/models/content_view_version_test.rb
@@ -74,7 +74,7 @@ module Katello
     end
 
     def test_active_history_nil_task
-      @cvv.history = [ContentViewHistory.new(:status => ContentViewHistory::IN_PROGRESS, :user => 'admin')]
+      @cvv.history = [ContentViewHistory.new(:status => ContentViewHistory::IN_PROGRESS, :user => 'admin', :action => 'publish')]
       assert_empty @cvv.active_history
     end
 


### PR DESCRIPTION
Tasks [can be removed/cleaned up](https://github.com/theforeman/foreman-tasks/blob/master/lib/foreman_tasks/tasks/cleanup.rake) so we need a way to permanently store the information regarding the action that is being performed (publish, promotion, etc).