### PR TITLE
Refs #16708 - update endpoint for host collections

### DIFF
--- a/app/controllers/katello/api/v2/host_collections_controller.rb
+++ b/app/controllers/katello/api/v2/host_collections_controller.rb
@@ -26,7 +26,6 @@ module Katello
     api :GET, "/host_collections", N_("List host collections")
     api :GET, "/organizations/:organization_id/host_collections", N_("List host collections within an organization")
     api :GET, "/activation_keys/:activation_key_id/host_collections", N_("List host collections in an activation key")
-    api :GET, "/hosts/:host_id/host_collections", N_("List host collections containing a content host")
     param_group :search, Api::V2::ApiController
     param :organization_id, :number, :desc => N_("organization identifier"), :required => false
     param :name, String, :desc => N_("host collection name to filter by")


### PR DESCRIPTION
Route does not exist but the api docs show that route should exist, removing route. Reflecting change in a commit from hammer_cli_katello