### PR TITLE
Fixes #16710 - Setting TargetRubyVersion in rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,7 @@ AllCops:
   Include:
     - app/views/**/*.rabl
     - '**/*.rake'
+  TargetRubyVersion: 2.2
 
 MethodLength:
   Description: 'Avoid methods longer than 30 lines of code.'


### PR DESCRIPTION
Setting TargetRubyVersion in rubocop config for a consistent experience across platforms.