### PR TITLE
Fixes #16715 - Display subscription-manager fact origin

### DIFF
--- a/app/models/katello/rhsm_fact_name.rb
+++ b/app/models/katello/rhsm_fact_name.rb
@@ -5,5 +5,9 @@ module Katello
     def set_name
       self.short_name = self.name.split(SEPARATOR).last
     end
+
+    def origin
+      'Redhat'
+    end
   end
 end


### PR DESCRIPTION
This allows the fact name to show up in the fact_values page (check with the latest develop branch of Foreman where https://github.com/theforeman/foreman/pull/3874/files is merged). 

The 'Redhat.png' icon is in Foreman already so there is no need to add it to this commit.