### PR TITLE
Fixes #16729: translate no-search-results-message blocks.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-add-subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-add-subscriptions.html
@@ -19,7 +19,7 @@
      You currently don't have any Products to subscribe to, you can add Products after selecting 'Products' under 'Content' in the main menu
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Products.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-associations-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-associations-content-hosts.html
@@ -10,7 +10,7 @@
     This activation key is not associated with any content hosts.
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Hosts.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-subscriptions-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-subscriptions-list.html
@@ -30,7 +30,7 @@
        You currently don't have any Subscriptions associated with this Activation Key, you can add Subscriptions after selecting the 'Add' tab.
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
        Your search returned zero Subscriptions.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/views/activation-keys.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/views/activation-keys.html
@@ -17,7 +17,7 @@
     You currently don't have any Activation Keys, you can add Activation Keys using the button on the right.
   </span>
 
-   <span data-block="no-search-results-message">
+   <span data-block="no-search-results-message" translate>
      Your search returned zero Activation Keys.
    </span>
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/bulk-actions-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/bulk-actions-errata.html
@@ -65,7 +65,7 @@
       There are no Errata associated with this Content Host to display.
     </span>
       
-    <span data-block="no-search-results-message">
+    <span data-block="no-search-results-message" translate>
       Your search returned zero Errata.
     </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/bulk-actions-host-collections.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/bulk-actions-host-collections.html
@@ -45,7 +45,7 @@
       There are no Host Collections available. You can create new Host Collections after selecting 'Host Collections' under 'Hosts' in main menu.
     </span>
 
-    <span data-block="no-search-results-message">
+    <span data-block="no-search-results-message" translate>
       Your search returned zero Host Collections.
     </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/bulk-actions-subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/bulk-actions-subscriptions.html
@@ -30,7 +30,7 @@
       You currently don't have any Products to subscribe to, you can add Products after selecting 'Products' under 'Content' in the main menu
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Subscriptions.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
@@ -99,7 +99,7 @@
       There are no Errata to display.
     </span>
 
-    <span data-block="no-search-results-message">
+    <span data-block="no-search-results-message" translate>
       Your search returned zero Errata.
     </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-applicable.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-applicable.html
@@ -8,7 +8,7 @@
     The host has not reported any applicable packages for upgrade.
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Packages.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-installed.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-installed.html
@@ -18,7 +18,7 @@
     The host has not reported any installed packages, registering with subscription-manager should cause these to be reported.
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Packages.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-add-subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-add-subscriptions.html
@@ -16,7 +16,7 @@
       You currently don't have any Products to subscribe to, you can add Products after selecting 'Products' under 'Content' in the main menu
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Products.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions-list.html
@@ -27,7 +27,7 @@
        You currently don't have any Subscriptions associated with this Content Host, you can add Subscriptions after selecting the 'Add' tab.
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Subscriptions.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
@@ -26,7 +26,7 @@
     You currently don't have any Content Hosts, you can register one by clicking the button on the right and following the instructions.
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Content Hosts.
   </span>
   

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/errata-filter-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/errata-filter-details.html
@@ -9,7 +9,7 @@
   <div data-block="header"></div>
   <span data-block="no-rows-message" translate>No Errata to display</span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Errata.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filters.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filters.html
@@ -28,7 +28,7 @@
     You currently don't have any Filters included in this Content View, you can add a new Filter by using the button on the right.
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Filters.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/views/content-view-puppet-module-names.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/views/content-view-puppet-module-names.html
@@ -41,7 +41,7 @@
   <span data-block="selection-summary"></span>
   <span data-block="no-rows-message" translate>No puppet modules found</span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Puppet Modules.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/views/content-view-puppet-modules.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/views/content-view-puppet-modules.html
@@ -18,7 +18,7 @@
     You currently don't have any Puppet Modules included in this Content View, you can add Puppet Modules using the button on the right.
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Puppet Modules.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
@@ -7,7 +7,7 @@
     This Content View does not have any versions, create your first Content View Version by using the "Publish New Version" button on the right.
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Content View.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/views/content-views.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/views/content-views.html
@@ -17,7 +17,7 @@
     You currently don't have any Content Views.  A Content View can be added by using the button on the right.
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Content Views.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/views/docker-tags.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/views/docker-tags.html
@@ -13,7 +13,7 @@
     You currently don't have any Docker Tags.
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Docker Tags.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-content-views.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-content-views.html
@@ -7,7 +7,7 @@
     There are no Content Views that match the criteria.
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Content Views.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-docker.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-docker.html
@@ -14,7 +14,7 @@
     There are no Docker Tags that match the criteria.
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Docker Tags.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-errata.html
@@ -14,7 +14,7 @@
     There are no Errata that match the criteria.
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Errata.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-ostree.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-ostree.html
@@ -14,7 +14,7 @@
     There are no OSTree Branches that match the criteria.
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero OSTree Branches.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-packages.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-packages.html
@@ -14,7 +14,7 @@
     There are no Packages that match the criteria.
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Packages.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-puppet-modules.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-puppet-modules.html
@@ -22,7 +22,7 @@
       There are no Puppet Modules that match the criteria.
     </span>
 
-    <span data-block="no-search-results-message">
+    <span data-block="no-search-results-message" translate>
       Your search returned zero Puppet Modules.
     </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-repositories.html
@@ -19,7 +19,7 @@
       There are no Yum Repositories that match the criteria.
     </span>
 
-    <span data-block="no-search-results-message">
+    <span data-block="no-search-results-message" translate>
       Your search returned zero Repositories.
     </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details-content-hosts.html
@@ -50,7 +50,7 @@
     No Content Hosts match this Erratum.
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Content Hosts.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details-repositories.html
@@ -39,7 +39,7 @@
     No Repositories contain this Erratum.
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Erratum.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata.html
@@ -55,7 +55,7 @@
     </span>
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Errata.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/views/gpg-keys.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/views/gpg-keys.html
@@ -17,7 +17,7 @@
     You currently don't have any GPG keys, you can add GPG keys using the button on the right.
   </span>
 
-   <span data-block="no-search-results-message">
+   <span data-block="no-search-results-message" translate>
      Your search returned zero GPG keys.
    </span>
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-add-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-add-hosts.html
@@ -20,7 +20,7 @@
     You currently don't have any Content Hosts, you can create new Content Hosts by selecting Contents Host from main menu and then clicking the button on the right.
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Content Hosts.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-hosts-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-hosts-list.html
@@ -19,7 +19,7 @@
     You currently don't have any Hosts in this Host Group, you can add Content Hosts after selecting the 'Add' tab.
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Content Hosts.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/views/host-collections.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/views/host-collections.html
@@ -19,7 +19,7 @@
     You currently don't have any Host Collections, you can add Host Collections using the button on the right.
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Host Collections.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/views/packages-details-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/views/packages-details-repositories.html
@@ -39,7 +39,7 @@
     No Repositories contain this Package.
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Repositories.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/views/packages.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/views/packages.html
@@ -34,7 +34,7 @@
     </span>
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Packages.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-repositories.html
@@ -90,7 +90,7 @@
       You currently don't have any Repositories included in this Product, you can add Repositories using the button on the right.
     </span>
 
-    <span data-block="no-search-results-message">
+    <span data-block="no-search-results-message" translate>
       Your search returned zero Repositories.
     </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/products.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/products.html
@@ -32,7 +32,7 @@
     You currently don't have any Products<span bst-feature-flag="custom_products">, you can add Products using the button on the right</span>.
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Products.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/puppet-modules/views/puppet-modules.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/puppet-modules/views/puppet-modules.html
@@ -13,7 +13,7 @@
     You currently don't have any Puppet Modules.
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Puppet Modules.
   </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/subscriptions.html
@@ -17,7 +17,7 @@
     You currently don't have any Subscriptions, you can add Subscriptions by importing a manifest using the button on the right labeled 'Manage Manifest'.
   </span>
 
-   <span data-block="no-search-results-message">
+   <span data-block="no-search-results-message" translate>
      Your search returned zero Subscriptions.
    </span>
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/views/sync-plans.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/views/sync-plans.html
@@ -17,7 +17,7 @@
     You currently don't have any Sync Plans.  A Sync Plan can be created by using the button on the right.
   </span>
 
-  <span data-block="no-search-results-message">
+  <span data-block="no-search-results-message" translate>
     Your search returned zero Sync Plans.
   </span>
 


### PR DESCRIPTION
None of our uses of the no-search-results-message blocks were
translated.  This commit adds the necessary directive.

http://projects.theforeman.org/issues/16729