### PR TITLE
fixes #16731 - hostgroup - fix update action

### DIFF
--- a/app/controllers/katello/concerns/api/v2/hostgroups_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/hostgroups_controller_extensions.rb
@@ -39,7 +39,7 @@ module Katello
         param :id, :identifier, :required => true
         param_group :hostgroup
         def update
-          process_response @hostgroup.update_attributes(params[:hostgroup])
+          process_response @hostgroup.update_attributes(hostgroup_params)
         end
 
         api :GET, "/hostgroups/:id", N_("Show a host group")

--- a/test/controllers/api/v2/hostgroups_controller_test.rb
+++ b/test/controllers/api/v2/hostgroups_controller_test.rb
@@ -1,0 +1,29 @@
+require 'katello_test_helper'
+
+class Api::V2::HostgroupsControllerTest < ActionController::TestCase
+  def setup
+    setup_foreman_routes
+    login_user(User.find(users(:admin).id))
+    models
+  end
+
+  def models
+    @hostgroup = hostgroups(:common)
+  end
+
+  def test_create
+    post :create, :hostgroup => {:name => 'New Hostgroup'}
+
+    assert_response :success
+    assert_template 'api/v2/hostgroups/create'
+    assert_equal assigns[:hostgroup].name, 'New Hostgroup'
+  end
+
+  def test_update
+    put :update, :id => @hostgroup.id, :hostgroup => {:name => 'New Name'}
+
+    assert_response :success
+    assert_template 'api/v2/hostgroups/update'
+    assert_equal assigns[:hostgroup].name, 'New Name'
+  end
+end


### PR DESCRIPTION
This is to address the following error during 'update':
   'ActiveModel::ForbiddenAttributesError'