### PR TITLE
Fixes #16713: do not show subscription info if no org is selected

### DIFF
--- a/app/views/dashboard/_subscription_status_widget.html.erb
+++ b/app/views/dashboard/_subscription_status_widget.html.erb
@@ -2,31 +2,36 @@
   <%= _("Current Subscription Totals") %>
 </h4>
 
-<% organizations = Organization.current.present? ? [Organization.current] : User.current.allowed_organizations %>
-<% subscriptions = Katello::Subscription.in_organization(organizations).includes(:pools) %>
-<% total_active_subscriptions = organizations.map {|org| org.active_pools_count}.reduce(:+) %>
-<% total_expiring_subscriptions = subscriptions.select(&:expiring_soon?).count %>
-<% total_recently_expired_subscriptions = subscriptions.select(&:recently_expired?).count %>
+<% unless Organization.current.present? %>
+  <p class="ca"><%= _("Please select an organization to view subscription totals.") %></p>
+<% else %>
+  <% subscriptions = Katello::Subscription.in_organization([Organization.current]).includes(:pools) %>
+  <% total_active_subscriptions = Organization.current.active_pools_count %>
+  <% total_expiring_subscriptions = subscriptions.select(&:expiring_soon?).count %>
+  <% total_recently_expired_subscriptions = subscriptions.select(&:recently_expired?).count %>
 
-<table class="table table-fixed table-striped table-bordered">
-  <thead>
-    <tr>
-      <th><%= _("Subscription Status") %></th>
-      <th><%= _("Count") %></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><%= _("Active Subscriptions") %></td>
-      <td style="text-align:right;"><%= total_active_subscriptions %></td>
-    </tr>
-    <tr>
-      <td><%= _("Subscriptions Expiring in 120 Days") %></td>
-      <td style="text-align:right;"><%= total_expiring_subscriptions %></td>
-    </tr>
-    <tr>
-      <td><%= _("Recently Expired Subscriptions") %></td>
-      <td style="text-align:right;"><%= total_recently_expired_subscriptions %></td>
-    </tr>
-  </tbody>
-</table>
+  <table class="table table-fixed table-striped table-bordered">
+    <thead>
+      <tr>
+        <th><%= _("Subscription Status") %></th>
+        <th><%= _("Count") %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><%= _("Active Subscriptions") %></td>
+        <td style="text-align:right;"><%= total_active_subscriptions %></td>
+      </tr>
+      <tr>
+        <td><%= _("Subscriptions Expiring in 120 Days") %></td>
+        <td style="text-align:right;"><%= total_expiring_subscriptions %></td>
+      </tr>
+      <tr>
+        <td><%= _("Recently Expired Subscriptions") %></td>
+        <td style="text-align:right;"><%= total_recently_expired_subscriptions %></td>
+      </tr>
+    </tbody>
+  </table>
+<% end %>
+
+

--- a/app/views/dashboard/_subscription_widget.html.erb
+++ b/app/views/dashboard/_subscription_widget.html.erb
@@ -2,58 +2,61 @@
   <%= _("Content Host Subscription Status") %>
 </h4>
 
-<% organizations = Organization.current.present? ? [Organization.current] : User.current.allowed_organizations %>
-<% owner_infos = organizations.map(&:owner_info) %>
-<% invalid_consumer_count = owner_infos.map(&:total_invalid_compliance_consumers).reduce(:+) %>
-<% partial_consumer_count = owner_infos.map(&:total_partial_compliance_consumers).reduce(:+) %>
-<% valid_consumer_count = owner_infos.map(&:total_valid_compliance_consumers).reduce(:+) %>
-<% total_count = owner_infos.map(&:total_consumers).reduce(:+) %>
+<% unless Organization.current.present? %>
+  <p class="ca"><%= _("Please select an organization to view subscription status.") %></p>
+<% else %>
+  <% owner_info = Organization.current.owner_info %>
+  <% invalid_consumer_count = owner_info.total_invalid_compliance_consumers %>
+  <% partial_consumer_count = owner_info.total_partial_compliance_consumers %>
+  <% valid_consumer_count = owner_info.total_valid_compliance_consumers %>
+  <% total_count = owner_info.total_consumers %>
 
-<table class="table table-fixed table-striped table-bordered">
-  <thead>
-    <tr>
-      <th></th>
-      <th><%= _("Count") %></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <%= link_to('/content_hosts?search=subscription_status=invalid') do %>
-          <i class="label label-danger" style="margin-right: 6px">&nbsp;</i><%= _("Invalid") %>
-        <% end %>
-      </td>
-      <td style="text-align:right">
-        <%= link_to( "#{invalid_consumer_count}", '/content_hosts?search=subscription_status=invalid')%>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <%= link_to('/content_hosts?search=subscription_status=partial') do %>
-          <i class="label label-warning" style="margin-right: 6px">&nbsp;</i><%= _("Partial") %>
-        <% end %>
-      </td>
-      <td style="text-align:right">
-        <%= link_to( "#{partial_consumer_count}", '/content_hosts?search=subscription_status=partial')%>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <%= link_to('/content_hosts?search=subscription_status=valid') do %>
-          <i class="label label-success" style="margin-right: 6px">&nbsp;</i><%= _("Valid") %>
-        <% end %>
-      </td>
-      <td style="text-align:right">
-        <%= link_to( "#{valid_consumer_count}", '/content_hosts?search=subscription_status=valid')%>
-      </td>
-    </tr>
-    <tr>
-      <td><h4>
-          <%= link_to("Total Content Hosts", '/content_hosts')%>
-      </h4></td>
-      <td style="text-align:right;">
-        <%= link_to( "#{total_count}", '/content_hosts')%>
-      </td>
-    </tr>
-  </tbody>
-</table>
+  <table class="table table-fixed table-striped table-bordered">
+    <thead>
+      <tr>
+        <th></th>
+        <th><%= _("Count") %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <%= link_to('/content_hosts?search=subscription_status=invalid') do %>
+            <i class="label label-danger" style="margin-right: 6px">&nbsp;</i><%= _("Invalid") %>
+          <% end %>
+        </td>
+        <td style="text-align:right">
+          <%= link_to( "#{invalid_consumer_count}", '/content_hosts?search=subscription_status=invalid')%>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <%= link_to('/content_hosts?search=subscription_status=partial') do %>
+            <i class="label label-warning" style="margin-right: 6px">&nbsp;</i><%= _("Partial") %>
+          <% end %>
+        </td>
+        <td style="text-align:right">
+          <%= link_to( "#{partial_consumer_count}", '/content_hosts?search=subscription_status=partial')%>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <%= link_to('/content_hosts?search=subscription_status=valid') do %>
+            <i class="label label-success" style="margin-right: 6px">&nbsp;</i><%= _("Valid") %>
+          <% end %>
+        </td>
+        <td style="text-align:right">
+          <%= link_to( "#{valid_consumer_count}", '/content_hosts?search=subscription_status=valid')%>
+        </td>
+      </tr>
+      <tr>
+        <td><h4>
+            <%= link_to("Total Content Hosts", '/content_hosts')%>
+        </h4></td>
+        <td style="text-align:right;">
+          <%= link_to( "#{total_count}", '/content_hosts')%>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+<% end %>


### PR DESCRIPTION
Previously, the dashboard would iterate over each organization the user
had access to and sum up the subscription info. If the user had a large
number of orgs, this could make the dashboard extremely slow, since
each organization required two calls to candlepin to find the
subscription counts.

Instead, display a message stating that an organization needs to be
selected in order to show subscription info. It is unlikely a user
would want to see a "roll-up" view of subs across orgs, since
subscriptions are tightly coupled to a particular org.