### PR TITLE
Fixes #13934 - Hide the add/remove tabs when view only

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-docker-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-docker-repositories.html
@@ -7,7 +7,7 @@
   </h3>
 
   <nav>
-    <ul class="nav nav-tabs">
+    <ul class="nav nav-tabs" ng-show="permitted('edit_content_views', contentView)">
       <li ng-class="{active: isState('content-views.details.repositories.docker.list')}">
         <a ui-sref="content-views.details.repositories.docker.list">
           <span translate>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-file-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-file-repositories.html
@@ -7,7 +7,7 @@
   </h3>
 
   <nav>
-    <ul class="nav nav-tabs">
+    <ul class="nav nav-tabs" ng-show="permitted('edit_content_views', contentView)">
       <li ng-class="{active: isState('content-views.details.repositories.file.list')}">
         <a ui-sref="content-views.details.repositories.file.list">
           <span translate>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-ostree-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-ostree-repositories.html
@@ -7,7 +7,7 @@
   </h3>
 
   <nav>
-    <ul class="nav nav-tabs">
+    <ul class="nav nav-tabs" ng-show="permitted('edit_content_views', contentView)">
       <li ng-class="{active: isState('content-views.details.repositories.ostree.list')}">
         <a ui-sref="content-views.details.repositories.ostree.list">
           <span translate>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-repositories.html
@@ -7,7 +7,7 @@
   </h3>
 
   <nav>
-    <ul class="nav nav-tabs">
+    <ul class="nav nav-tabs" ng-show="permitted('edit_content_views', contentView)">
       <li ng-class="{active: isState('content-views.details.repositories.yum.list')}">
         <a ui-sref="content-views.details.repositories.yum.list">
           <span translate>


### PR DESCRIPTION
Hiding the add/remove tabs when a user cannot edit a content view.