### PR TITLE
Fixes #16733: raise useful error when exporting non-yum repo

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -203,6 +203,8 @@ module Katello
         end
       end
 
+      fail HttpErrors::BadRequest, _("Repository content type must be 'yum' to export.") unless @repository.content_type == 'yum'
+
       task = async_task(::Actions::Katello::Repository::Export, [@repository],
                         ::Foreman::Cast.to_bool(params[:export_to_iso]),
                         params[:since].try(:to_datetime),

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -16,6 +16,7 @@ module Katello
       @environment = katello_environments(:dev)
       @content_view_version = katello_content_view_versions(:library_view_version_1)
       @fedora_dev = katello_repositories(:fedora_17_x86_64_dev)
+      @puppet_repo = katello_repositories(:p_forge)
     end
 
     def permissions
@@ -771,6 +772,11 @@ module Katello
 
     def test_export_with_bad_date
       post :export, :id => @repository.id, :since => 'November 32, 1970'
+      assert_response 400
+    end
+
+    def test_export_wrong_type
+      post :export, :id => @puppet_repo.id
       assert_response 400
     end
 


### PR DESCRIPTION
ISS currently only supports exporting yum repositories. However, this
was not enforced by the controller, and if you attempted to export a
repo that was not yum, you would get a baffling error message in the
action.

This patch checks that the repo is the correct type before exporting,
and raises a 400 error if not.