### PR TITLE
Fixes #16745 - environment_id is required to promote CV-version

### DIFF
--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -222,6 +222,12 @@ module Katello
       assert_response 400
     end
 
+    def test_promote_without_environment
+      content_view_version = FactoryGirl.create(:katello_content_view_version)
+      post :promote, :id => content_view_version.id
+      assert_response 400
+    end
+
     def test_incremental_update
       version = @library_dev_staging_view.versions.first
       errata_id = Katello::Erratum.first.uuid


### PR DESCRIPTION
API : `POST /katello/api/v2/content_view_versions/:id/promote`
Enforce parameter `environment_id` while promoting a content_view_version