### PR TITLE
Fixes #16763: do not sort over entire `katello_errata.*`

### DIFF
--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -51,6 +51,13 @@ module Katello
         where("#{Katello::Host::ContentFacet.table_name}.host_id" => hosts).uniq
     end
 
+    def self.applicable_to_hosts_dashboard(hosts)
+      self.joins(:content_facets).
+        where("#{Katello::Host::ContentFacet.table_name}.host_id" => hosts).
+        select("DISTINCT ON (#{self.table_name}.updated, #{self.table_name}.id) #{self.table_name}.*").
+        order("#{self.table_name}.updated desc").limit(6)
+    end
+
     def <=>(other)
       return self.errata_id <=> other.errata_id
     end

--- a/app/views/dashboard/_errata_widget.html.erb
+++ b/app/views/dashboard/_errata_widget.html.erb
@@ -4,7 +4,7 @@
 
 <% organizations = Organization.current.present? ? [Organization.current] : User.current.allowed_organizations %>
 <% hosts = ::Host::Managed.authorized("view_hosts") %>
-<% errata = Katello::Erratum.applicable_to_hosts(hosts).order('updated desc').limit(6) %>
+<% errata = Katello::Erratum.applicable_to_hosts_dashboard(hosts) %>
 
 <% if errata.empty? %>
   <p class="ca"><%= _("There are no errata that need to be applied to registered content hosts.") %></p>

--- a/test/models/erratum_test.rb
+++ b/test/models/erratum_test.rb
@@ -65,6 +65,13 @@ module Katello
       refute_includes errata, @enhancement
     end
 
+    def test_applicable_to_hosts_dashboard
+      errata = Erratum.applicable_to_hosts_dashboard([@host, @host_without_errata])
+      assert_includes errata, @security
+      assert_includes errata, @bugfix
+      refute_includes errata, @enhancement
+    end
+
     def test_not_applicable_to_hosts
       assert_empty Erratum.applicable_to_hosts([@host_without_errata])
     end


### PR DESCRIPTION
The dashboard's errata widget had a query that sorted over
`katello_errata.*`.  Instead, use `DISTINCT ON` to sort only on `id`
and `updated`.

This is similar to 4667141bf. That patch was backed out in favor of
42502063, this patch re-adds the same optmization but in a smaller
dashboard-specific scope.