### PR TITLE
Fixes #16764: Return archived content view version repositories

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -130,6 +130,7 @@ module Katello
     def index_relation_content_view(query)
       if params[:content_view_version_id]
         query = query.where(:content_view_version_id => params[:content_view_version_id])
+        query = query.archived unless params[:library] || params[:environment_id]
         query = Katello::Repository.where(:id => query.select(:library_instance_id)) if params[:library]
       elsif params[:content_view_id]
         query = filter_by_content_view(query, params[:content_view_id], params[:environment_id], params[:available_for] == 'content_view')

--- a/app/views/katello/api/v2/repositories/base.json.rabl
+++ b/app/views/katello/api/v2/repositories/base.json.rabl
@@ -22,6 +22,10 @@ node :content_label do |repo|
   repo.content.try(:label)
 end
 
+child :environment => :environment do |_repo|
+  attribute :id, :name
+end
+
 node :content_counts do |repo|
   {
     :ostree_branch => repo.ostree_branches.count,

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -117,11 +117,12 @@ module Katello
       assert_response :success
       assert_template 'api/v2/repositories/index'
       assert_response_ids response, ids
+      assert_empty JSON.parse(response.body)['results'].collect { |repo| repo.environment.nil? }
     end
 
     def test_index_with_content_view_version_id
       version = @view.content_view_versions.first
-      ids = version.repository_ids
+      ids = version.archived_repos(&:id)
 
       response = get :index, params: { :content_view_version_id => version.id, :organization_id => @organization.id }
 


### PR DESCRIPTION
Updates the repositories API to return the archived repositories
when a content view version ID is supplied instead of returning
all repositories across all environments. If a user specifies an
environment or the library parameter, the repositories returned
should be limited to that environment or library.
