### PR TITLE
Fixes #14107 - Allow specify arch in filter rule

### DIFF
--- a/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
@@ -21,6 +21,7 @@ module Katello
     param :content_view_filter_id, :identifier, :desc => N_("filter identifier"), :required => true
     param :name, [String, Array], :desc => N_("package and package group names")
     param :version, String, :desc => N_("package: version")
+    param :arch, String, :desc => N_("package: architecture")
     param :min_version, String, :desc => N_("package: minimum version")
     param :max_version, String, :desc => N_("package: maximum version")
     param :errata_id, String, :desc => N_("erratum: id")
@@ -117,7 +118,7 @@ module Katello
       end
 
       @rule_params ||= params.fetch(:content_view_filter_rule, {}).
-            permit(:uuid, :version, :min_version, :max_version,
+            permit(:uuid, :version, :min_version, :max_version, :architecture,
                     :errata_id, :start_date, :end_date, :date_type,
                     :types => [], :errata_ids => [], name: [])
     end

--- a/app/controllers/katello/api/v2/packages_controller.rb
+++ b/app/controllers/katello/api/v2/packages_controller.rb
@@ -3,7 +3,7 @@ module Katello
     apipie_concern_subst(:a_resource => N_("a package"), :resource => "packages")
     include Katello::Concerns::Api::V2::RepositoryContentController
 
-    before_action :find_repositories, :only => :auto_complete_name
+    before_action :find_repositories, :only => [:auto_complete_name, :auto_complete_arch]
     before_action :find_host, :only => :index
 
     def auto_complete_name
@@ -11,6 +11,14 @@ module Katello
       rpms = Rpm.in_repositories(@repositories)
       col = "#{Rpm.table_name}.name"
       rpms = rpms.where("#{Rpm.table_name}.name ILIKE ?", "#{params[:term]}%").select(col).group(col).order(col).limit(page_size)
+      render :json => rpms.pluck(col)
+    end
+
+    def auto_complete_arch
+      page_size = Katello::Concerns::FilteredAutoCompleteSearch::PAGE_SIZE
+      rpms = Rpm.in_repositories(@repositories)
+      col = "#{Rpm.table_name}.arch"
+      rpms = rpms.where("#{col} ILIKE ?", "%#{params[:term]}%").select(col).group(col).order(col).limit(page_size)
       render :json => rpms.pluck(col)
     end
 

--- a/app/models/katello/content_view_package_filter.rb
+++ b/app/models/katello/content_view_package_filter.rb
@@ -33,6 +33,10 @@ module Katello
     def query_rpms(repo, rule)
       query_name = rule.name.tr("*", "%")
       query = Rpm.in_repositories(repo).where("#{Rpm.table_name}.name ilike ?", query_name)
+      if rule.architecture
+        query_arch = rule.architecture.tr("*", "%")
+        query = query.where("#{Rpm.table_name}.arch ilike ?", query_arch)
+      end
       if !rule.version.blank?
         query = query.search_version_equal(rule.version)
       elsif !rule.min_version.blank? || !rule.max_version.blank?

--- a/app/views/katello/api/v2/content_view_filter_rules/show.json.rabl
+++ b/app/views/katello/api/v2/content_view_filter_rules/show.json.rabl
@@ -11,6 +11,7 @@ attributes :max_version, :if => lambda { |rule| rule.respond_to?(:max_version) &
 attributes :errata_id, :if => lambda { |rule| rule.respond_to?(:errata_id) && !rule.errata_id.blank? }
 attributes :start_date, :if => lambda { |rule| rule.respond_to?(:start_date) && !rule.start_date.blank? }
 attributes :end_date, :if => lambda { |rule| rule.respond_to?(:end_date) && !rule.end_date.blank? }
+attributes :architecture, :if => lambda { |rule| rule.respond_to?(:architecture) && !rule.architecture.blank? }
 attributes :types, :if => lambda { |rule| rule.respond_to?(:types) && !rule.types.blank? }
 attributes :date_type, :if => lambda { |rule| rule.respond_to?(:date_type) }
 

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -187,6 +187,7 @@ Katello::Engine.routes.draw do
           collection do
             get :auto_complete_search
             get :auto_complete_name
+            get :auto_complete_arch
           end
         end
 

--- a/db/migrate/20161003130853_add_architecture_to_katello_content_view_package_filter_rule.rb
+++ b/db/migrate/20161003130853_add_architecture_to_katello_content_view_package_filter_rule.rb
@@ -1,0 +1,5 @@
+class AddArchitectureToKatelloContentViewPackageFilterRule < ActiveRecord::Migration
+  def change
+    add_column :katello_content_view_package_filter_rules, :architecture, :string
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/package-filter.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/package-filter.controller.js
@@ -154,11 +154,22 @@ angular.module('Bastion.content-views').controller('PackageFilterController',
             });
         };
 
-        $scope.fetchAutocomplete = function (term) {
+        $scope.fetchAutocompleteName = function (term) {
             var repositoryIds = $scope.contentView['repository_ids'],
                 promise;
 
             promise = Package.autocompleteName({'repoids[]': repositoryIds, term: term}).$promise;
+
+            return promise.then(function (data) {
+                return data.results;
+            });
+        };
+
+        $scope.fetchAutocompleteArch = function (term) {
+            var repositoryIds = $scope.contentView['repository_ids'],
+                promise;
+
+            promise = Package.autocompleteArch({'repoids[]': repositoryIds, term: term}).$promise;
 
             return promise.then(function (data) {
                 return data.results;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/package-filter-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/package-filter-details.html
@@ -40,6 +40,7 @@
                                   ng-change="selectAll(allSelected)"
                                   ng-hide="denied('edit_content_views', contentView)"/></th>
     <th translate>RPM Name</th>
+    <th translate>Architecture</th>
     <th class="col-sm-5" translate>Detail</th>
     <th class="col-sm-2"></th>
   </tr>
@@ -51,11 +52,18 @@
     <td>
       <input type="text"
              class="form-control"
-             typeahead="package for package in fetchAutocomplete($viewValue)"
+             typeahead="package for package in fetchAutocompleteName($viewValue)"
              ng-hide="denied('edit_content_views', contentView)"
              ng-model="rule.name"/>
     </td>
     <td>
+      <input type="text"
+             class="form-control"
+             typeahead="arch for arch in fetchAutocompleteArch($viewValue)"
+             ng-hide="denied('edit_content_views', contentView)"
+             ng-model="rule.architecture"/>
+    </td>
+    <td class="container">
         <span class="col-sm-12" ng-class="{ 'col-sm-7': rule.type != 'all'}">
           <select class="form-control"
                   ng-model="rule.type"
@@ -116,6 +124,13 @@
       <input class="form-control"
              ng-hide="denied('edit_content_views', contentView)"
              ng-model="rule.name"
+             ng-readonly="!rule.editMode"/>
+    </td>
+    <td>
+      <input class="form-control"
+             ng-hide="denied('edit_content_views', contentView)"
+             ng-model="rule.architecture"
+             typeahead="arch for arch in fetchAutocompleteArch($viewValue)"
              ng-readonly="!rule.editMode"/>
     </td>
     <td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/package.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/package.factory.js
@@ -19,6 +19,12 @@ angular.module('Bastion.packages').factory('Package',
                         data = angular.fromJson(data);
                         return {results: data};
                     }
+                },
+                'autocompleteArch': {method: 'GET', isArray: false, params: {id: 'auto_complete_arch'},
+                    transformResponse: function (data) {
+                        data = angular.fromJson(data);
+                        return {results: data};
+                    }
                 }
             });
     }]

--- a/engines/bastion_katello/test/content-views/details/filters/package-filter.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/filters/package-filter.controller.test.js
@@ -26,6 +26,12 @@ describe('Controller: PackageFilterController', function() {
             };
         };
 
+        Package.autocompleteArch = function () {
+            return {
+                $promise: $q.defer().promise
+            };
+        };
+
         translate = function (string) {
             return string;
         };
@@ -185,14 +191,24 @@ describe('Controller: PackageFilterController', function() {
         expect(result).toBe(false);
     });
 
-    it("should provide a method to retrieve autocomplete results", function () {
+    it("should provide a method to retrieve autocomplete name results", function () {
         var autocomplete;
 
         spyOn(Package, 'autocompleteName').and.callThrough();
-        autocomplete = $scope.fetchAutocomplete('gir');
+        autocomplete = $scope.fetchAutocompleteName('gir');
 
         expect(autocomplete.then).toBeDefined();
         expect(Package.autocompleteName).toHaveBeenCalled();
+    });
+
+    it("should provide a method to retrieve autocomplete arch results", function () {
+        var autocomplete;
+
+        spyOn(Package, 'autocompleteArch').and.callThrough();
+        autocomplete = $scope.fetchAutocompleteArch('x86');
+
+        expect(autocomplete.then).toBeDefined();
+        expect(Package.autocompleteArch).toHaveBeenCalled();
     });
 
 });


### PR DESCRIPTION
This allows users to specify an architecture when creating/editing a package
filter rule.