### PR TITLE
Fixes #12347 - setting to control errata status

### DIFF
--- a/app/lib/actions/katello/host/recalculate_errata_status.rb
+++ b/app/lib/actions/katello/host/recalculate_errata_status.rb
@@ -1,0 +1,20 @@
+module Actions
+  module Katello
+    module Host
+      class RecalculateErrataStatus < Actions::Base
+        middleware.use Actions::Middleware::KeepCurrentUser
+
+        def run
+          ::Host.unscoped.find_each do |host|
+            begin
+              host.content_facet.update_errata_status if host.content_facet.try(:uuid)
+            rescue StandardError => error
+              output[:errors] ||= []
+              output[:errors] << (_("Error refreshing status for %s: ") % host.name) + error.message
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/katello/concerns/setting_extensions.rb
+++ b/app/models/katello/concerns/setting_extensions.rb
@@ -6,6 +6,12 @@ module Katello
       included do
         validates :value, inclusion: { in: ::Runcible::Models::YumImporter::DOWNLOAD_POLICIES },
           if: ->(setting) { setting.name == 'default_download_policy' }
+
+        after_save :recalculate_errata_status
+      end
+
+      def recalculate_errata_status
+        ForemanTasks.async_task(Actions::Katello::Host::RecalculateErrataStatus) if value_changed? && name == 'errata_status_installable'
       end
     end
   end

--- a/app/models/katello/errata_status.rb
+++ b/app/models/katello/errata_status.rb
@@ -10,11 +10,12 @@ module Katello
     end
 
     def to_label(_options = {})
+      installable = Setting[:errata_status_installable]
       case to_status
       when NEEDED_SECURITY_ERRATA
-        N_("Security errata applicable")
+        installable ? N_("Security errata installable") : N_("Security errata applicable")
       when NEEDED_ERRATA
-        N_("Non-security errata applicable")
+        installable ? N_("Non-security errata installable") : N_("Non-security errata applicable")
       when UP_TO_DATE
         N_("All errata applied")
       when UNKNOWN
@@ -42,7 +43,12 @@ module Katello
     def to_status(_options = {})
       return UNKNOWN if host.content_facet.nil?
 
-      errata = host.content_facet.try(:applicable_errata)
+      if Setting[:errata_status_installable]
+        errata = host.content_facet.try(:installable_errata)
+      else
+        errata = host.content_facet.try(:applicable_errata)
+      end
+
       if errata.security.any?
         NEEDED_SECURITY_ERRATA
       elsif errata.any?

--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -15,6 +15,7 @@ class Setting::Content < Setting
         self.set('katello_default_atomic_provision', N_("Default provisioning template for new Atomic Operating Systems"), 'Katello Atomic Kickstart Default'),
         self.set('content_action_accept_timeout', N_("Time in seconds to wait for a Host to pickup a remote action"), 20),
         self.set('content_action_finish_timeout', N_("Time in seconds to wait for a Host to finish a remote action"), 3600),
+        self.set('errata_status_installable', N_("Calculate errata host status based only on errata in a Host's Content View and Lifecycle Environment"), false),
         self.set('restrict_composite_view', N_("If set to true, a composite content view may not be published or "\
                  "promoted, unless the component content view versions that it includes exist in the target environment."),
                  false),

--- a/test/actions/katello/host/recalculate_errata_status_test.rb
+++ b/test/actions/katello/host/recalculate_errata_status_test.rb
@@ -1,0 +1,24 @@
+require 'katello_test_helper'
+
+module Katello::Host
+  class RecalculateErrataStatusTest < ActiveSupport::TestCase
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+    include FactoryGirl::Syntax::Methods
+
+    before :all do
+      User.current = users(:admin)
+      @host = FactoryGirl.create(:host, :with_content, :with_subscription, :content_view => katello_content_views(:library_dev_view),
+                                 :lifecycle_environment => katello_environments(:library))
+    end
+
+    describe 'run' do
+      let(:action_class) { ::Actions::Katello::Host::RecalculateErrataStatus }
+
+      it 'plans' do
+        Katello::Host::ContentFacet.any_instance.expects(:update_errata_status).at_least_once
+        ::ForemanTasks.sync_task(action_class)
+      end
+    end
+  end
+end

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -9,5 +9,12 @@ module Katello
       setting.value = "immediate"
       assert setting.valid?
     end
+
+    def test_recalculate_errata_status
+      ForemanTasks.expects(:async_task).with(::Actions::Katello::Host::RecalculateErrataStatus)
+      setting = Setting.where(:name => "errata_status_installable").first
+      setting.value = !setting.value
+      setting.save!
+    end
   end
 end


### PR DESCRIPTION
this allows the user to switch between showing errata status
based on applicable or installable. When changing this setting
the errata status for all hosts will be updated.