### PR TITLE
fixes #16762 - fix search for installable_errata on hosts

### DIFF
--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -171,7 +171,8 @@ module Katello
         self.joins("INNER JOIN #{facet_repository} on #{facet_repository}.content_facet_id = #{table_name}.id",
                    "INNER JOIN #{repo_join_table} on #{repo_join_table}.repository_id = #{facet_repository}.repository_id",
                    "INNER JOIN #{content_table} on #{content_table}.id = #{repo_join_table}.#{content_model.unit_id_field}",
-                   "INNER JOIN #{facet_join_table} on #{facet_join_table}.#{content_model.unit_id_field} = #{content_table}.id")
+                   "INNER JOIN #{facet_join_table} on #{facet_join_table}.#{content_model.unit_id_field} = #{content_table}.id").
+             where("#{facet_join_table}.content_facet_id = #{self.table_name}.id")
       end
 
       private

--- a/test/fixtures/models/hosts.yml
+++ b/test/fixtures/models/hosts.yml
@@ -16,3 +16,8 @@ without_content_facet:
   name: "Host3.example.com"
   type: 'Host::Managed'
 
+without_errata:
+  organization: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
+  location: <%= ActiveRecord::FixtureSet.identify(:location1) %>
+  name: "Host4.example.com"
+  type: 'Host::Managed'

--- a/test/fixtures/models/katello_content_facets.yml
+++ b/test/fixtures/models/katello_content_facets.yml
@@ -9,3 +9,9 @@ two:
   content_view_id: <%= ActiveRecord::FixtureSet.identify(:library_dev_view) %>
   lifecycle_environment_id: <%= ActiveRecord::FixtureSet.identify(:dev) %>
   uuid: "abcdefghi"
+
+without_errata:
+  host_id:  <%= ActiveRecord::FixtureSet.identify(:without_errata) %>
+  content_view_id: <%= ActiveRecord::FixtureSet.identify(:library_view) %>
+  lifecycle_environment_id: <%= ActiveRecord::FixtureSet.identify(:library) %>
+  uuid: "abcdefghi"

--- a/test/models/host/content_facet_test.rb
+++ b/test/models/host/content_facet_test.rb
@@ -75,6 +75,21 @@ module Katello
       refute_includes found, other_host
     end
 
+    def test_installable_errata_search
+      content_facet.bound_repositories = [Katello::Repository.find(katello_repositories(:rhel_6_x86_64_library_view_1).id)]
+      content_facet.save!
+
+      host_without_errata = hosts(:without_errata)
+      host_without_errata.content_facet.bound_repositories = [Katello::Repository.find(katello_repositories(:rhel_6_x86_64_library_view_1).id)]
+      host_without_errata.content_facet.save!
+
+      errata = katello_errata(:security)
+      found = ::Host.search_for("installable_errata = #{errata.errata_id}")
+
+      refute_includes found, host_without_errata
+      assert_includes found, content_facet.host
+    end
+
     def test_available_and_applicable_errta
       @view_repo = Katello::Repository.find(katello_repositories(:rhel_6_x86_64).id)
       content_facet.bound_repositories = [@view_repo]


### PR DESCRIPTION
Prior to this change, if a host was associated with a repository
that had errrata, performing a search for hosts where
installable_errata was from that repository, the search
would also return those hosts that did not need it.