### PR TITLE
Fixes #16777 - Adjust input widths on rule create

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/package-filter-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/package-filter-details.html
@@ -41,10 +41,10 @@
                ng-change="selectAll(allSelected)"
                ng-hide="denied('edit_content_views', contentView)"/>
       </th>
-      <th translate>RPM Name</th>
-      <th translate>Architecture</th>
-      <th class="col-sm-5" translate>Detail</th>
-      <th class="col-sm-2"></th>
+      <th class="col-sm-3" translate>RPM Name</th>
+      <th class="col-sm-1" translate>Architecture</th>
+      <th class="col-sm-6" translate>Detail</th>
+      <th></th>
     </tr>
   </thead>
 
@@ -68,7 +68,7 @@
       </td>
 
       <td class="container">
-              <span class="col-sm-12" ng-class="{ 'col-sm-7': rule.type != 'all'}">
+              <span ng-class="{ 'col-sm-12': rule.type === 'all', 'col-sm-5': rule.type != 'all'}">
                 <select class="form-control"
                         ng-model="rule.type"
                         ng-change="clearValues(rule)"
@@ -82,7 +82,7 @@
               </span>
 
               <span ng-show="rule.type === 'greater' || rule.type === 'less' || rule.type === 'range'">
-                <span class="col-sm-5">
+                <span class="col-sm-3">
                   <input type="text"
                          class="form-control"
                          ng-model="rule.min_version"
@@ -90,7 +90,7 @@
                          ng-disabled="rule.type === 'less'"/>
                 </span>
                 <span class="fl">-</span>
-                <span class="col-sm-5">
+                <span class="col-sm-3">
                   <input type="text"
                          class="form-control"
                          ng-model="rule.max_version"
@@ -142,7 +142,7 @@
       </td>
 
       <td>
-              <span class="col-sm-12" ng-class="{ 'col-sm-7': rule.type != 'all'}">
+              <span ng-class="{ 'col-sm-12': rule.type === 'all', 'col-sm-3': rule.type != 'all'}">
                 <select class="form-control"
                         ng-model="rule.type"
                         ng-hide="denied('edit_content_views', contentView)"
@@ -158,15 +158,15 @@
               </span>
 
               <span ng-show="rule.type === 'greater' || rule.type === 'less' || rule.type === 'range'">
-                <span class="col-sm-5">
+                <span class="col-sm-4">
                   <input type="text"
                          class="form-control"
                          ng-model="rule.min_version"
                          ng-readonly="!rule.editMode"
                          ng-disabled="rule.type === 'less'"/>
                 </span>
-                <span class="fl" ng-show="rule.type === 'range' && rule.editMode">-</span>
-                <span class="col-sm-5">
+                <span class="fl">-</span>
+                <span class="col-sm-4">
                   <input type="text"
                          class="form-control"
                          ng-model="rule.max_version"
@@ -176,7 +176,7 @@
               </span>
 
               <span ng-show="rule.type === 'equal'">
-                <span class="col-sm-5">
+                <span class="col-sm-9">
                   <input type="text"
                          class="form-control"
                          ng-model="rule.version"


### PR DESCRIPTION
ContentViewFilterRule#Create, inside the content view filter show page,
now displays appropriate widths for all date inputs (greater, less than,
range) such that all inputs display properly on one row without
wrapping.

Before:
![image](https://cloud.githubusercontent.com/assets/761923/19048701/757ffcf4-8975-11e6-946d-a9ccb5385149.png)
After:
![image](https://cloud.githubusercontent.com/assets/761923/19048648/41106cb0-8975-11e6-9235-71d6b72d02f2.png)
