### PR TITLE
Fixes #16808 - add download_policy to capsules

### DIFF
--- a/app/controllers/katello/concerns/api/v2/smart_proxies_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/smart_proxies_controller_extensions.rb
@@ -1,0 +1,35 @@
+module Katello
+  module Concerns
+    module Api::V2::SmartProxiesControllerExtensions
+      extend ActiveSupport::Concern
+
+      included do
+        def_param_group :smart_proxy do
+          param :smart_proxy, Hash, :required => true, :action_aware => true do
+            param :name, String, :required => true
+            param :url, String, :required => true
+            param :download_policy, String, :required => false, :desc => N_('Download Policy of the capsule, must be one of %s') %
+                                      SmartProxy::DOWNLOAD_POLICIES.join(', ')
+            param_group :taxonomies, ::Api::V2::BaseController
+          end
+        end
+
+        api :POST, "/smart_proxies/", N_("Create a smart proxy")
+        param_group :smart_proxy, :as => :create
+
+        def create
+          @smart_proxy = SmartProxy.new(smart_proxy_params)
+          process_response @smart_proxy.save
+        end
+
+        api :PUT, "/smart_proxies/:id/", N_("Update a smart proxy")
+        param :id, String, :required => true
+        param_group :smart_proxy
+
+        def update
+          process_response @smart_proxy.update_attributes(smart_proxy_params)
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/katello/concerns/smart_proxy_helper_extensions.rb
+++ b/app/helpers/katello/concerns/smart_proxy_helper_extensions.rb
@@ -30,6 +30,29 @@ module Katello
         "#{available_percent}%"
       end
 
+      def download_policies
+        policies = [
+          {
+            :name => _("On Demand"),
+            :label => ::Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND
+          },
+          {
+            :name => _("Background"),
+            :label => ::Runcible::Models::YumImporter::DOWNLOAD_BACKGROUND
+          },
+          {
+            :name => _("Immediate"),
+            :label => ::Runcible::Models::YumImporter::DOWNLOAD_IMMEDIATE
+          },
+          {
+            :name => _("Inherit from Repository"),
+            :label => SmartProxy::DOWNLOAD_INHERIT
+          }
+        ]
+
+        policies.map { |p| OpenStruct.new(p) }
+      end
+
       def storage_warning(available)
         gb_size = available.to_i / 1_048_576
         case gb_size

--- a/app/lib/actions/katello/capsule_content/create_repos.rb
+++ b/app/lib/actions/katello/capsule_content/create_repos.rb
@@ -33,7 +33,7 @@ module Actions
                       path: relative_path,
                       with_importer: true,
                       docker_upstream_name: repository.pulp_id,
-                      download_policy: repository.capsule_download_policy,
+                      download_policy: repository.capsule_download_policy(capsule_content.capsule),
                       capsule_id: capsule_content.capsule.id)
         end
 

--- a/app/lib/actions/katello/repository/clone_to_environment.rb
+++ b/app/lib/actions/katello/repository/clone_to_environment.rb
@@ -15,7 +15,7 @@ module Actions
               clone.copy_library_instance_attributes
               clone.save!
 
-              if ::Katello::Repository.needs_distributor_updates([clone]).first
+              if ::Katello::Repository.needs_distributor_updates([clone], ::Katello::CapsuleContent.new(::SmartProxy.default_capsule)).first
                 plan_action(Pulp::Repository::Refresh, clone)
               end
             end

--- a/app/lib/actions/pulp/repository/refresh.rb
+++ b/app/lib/actions/pulp/repository/refresh.rb
@@ -15,7 +15,7 @@ module Actions
 
         def update_or_associate_importer(capsule_id, repository, repository_details)
           existing_importers = repository_details["importers"]
-          importer = repository.generate_importer(!capsule_id.nil?)
+          importer = repository.generate_importer(::SmartProxy.find_by(:id => capsule_id))
           found = existing_importers.find { |i| i['importer_type_id'] == importer.id }
 
           if found

--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -1,8 +1,11 @@
 class Setting::Content < Setting
   #rubocop:disable Metrics/MethodLength
+  #rubocop:disable Metrics/AbcSize
   def self.load_defaults
     return unless super
 
+    download_policies = proc { Hash[::Runcible::Models::YumImporter::DOWNLOAD_POLICIES.map { |p| [p, p] }] }
+    proxy_download_policies = proc { Hash[::SmartProxy::DOWNLOAD_POLICIES.map { |p| [p, p] }] }
     self.transaction do
       [
         self.set('katello_default_provision', N_("Default provisioning template for new Operating Systems"), 'Katello Kickstart Default'),
@@ -17,13 +20,15 @@ class Setting::Content < Setting
         self.set('content_action_finish_timeout', N_("Time in seconds to wait for a Host to finish a remote action"), 3600),
         self.set('errata_status_installable', N_("Calculate errata host status based only on errata in a Host's Content View and Lifecycle Environment"), false),
         self.set('restrict_composite_view', N_("If set to true, a composite content view may not be published or "\
-                 "promoted, unless the component content view versions that it includes exist in the target environment."),
-                 false),
+                 "promoted, unless the component content view versions that it includes exist in the target environment."), false),
         self.set('pulp_sync_node_action_accept_timeout', N_("Time in seconds to wait for a pulp node to remote action"), 20),
         self.set('pulp_sync_node_action_finish_timeout', N_("Time in seconds to wait for a pulp node to finish sync"), 12.hours.to_i),
         self.set('check_services_before_actions', N_("Whether or not to check the status of backend services such as pulp and candlepin prior to performing some actions."), true),
         self.set('force_post_sync_actions', N_("Force post sync actions such as indexing and email even if no content was available."), false),
-        self.set('default_download_policy', N_("Default download policy for repositories (either 'immediate', 'on_demand', or 'background')"), "on_demand"),
+        self.set('default_download_policy', N_("Default download policy for repositories (either 'immediate', 'on_demand', or 'background')"), "on_demand",
+                 N_('Default Repository download policy'), nil, :collection => download_policies),
+        self.set('default_proxy_download_policy', N_("Default download policy for Smart Proxy syncs (either 'inherit', immediate', 'on_demand', or 'background')"), "on_demand",
+                 N_('Default Smart Proxy download policy'), nil, :collection => proxy_download_policies),
         self.set('pulp_docker_registry_port', N_("The port used by Pulp Crane to provide Docker Registries"), 5000),
         self.set('pulp_export_destination', N_("On-disk location for exported repositories"), N_("/var/lib/pulp/katello-export")),
         self.set('pulp_client_key', N_("Path for ssl key used for pulp server auth"), "/etc/pki/katello/private/pulp-client.key"),

--- a/app/overrides/add_smart_proxy_form.rb
+++ b/app/overrides/add_smart_proxy_form.rb
@@ -7,3 +7,8 @@ Deface::Override.new(:virtual_path => "smart_proxies/_form",
                      :name => "add_smart_proxies_tab_pane",
                      :insert_after => 'erb[loud]:contains("render"):contains("taxonomies/loc_org_tabs")',
                      :partial => 'overrides/smart_proxies/environment_tab_pane')
+
+Deface::Override.new(:virtual_path => "smart_proxies/_form",
+                     :name => "add_smart_proxies_download_policy",
+                     :insert_bottom => '#primary',
+                     :partial => 'overrides/smart_proxies/download_policy')

--- a/app/views/overrides/smart_proxies/_download_policy.erb
+++ b/app/views/overrides/smart_proxies/_download_policy.erb
@@ -1,0 +1,3 @@
+<% if @smart_proxy.has_feature?(SmartProxy::PULP_NODE_FEATURE) %>
+  <%= select_f(f, :download_policy, download_policies, :label, :name, :size => "col-md-8" ) %>
+<% end %>

--- a/db/migrate/20160930150810_add_smart_proxy_download_policy.rb
+++ b/db/migrate/20160930150810_add_smart_proxy_download_policy.rb
@@ -1,0 +1,14 @@
+class AddSmartProxyDownloadPolicy < ActiveRecord::Migration
+  def up
+    #set default to on_demand, but update existing proxies to inherit
+    add_column :smart_proxies, :download_policy, :string, :null => true
+    SmartProxy.reset_column_information
+    SmartProxy.all.each do |proxy|
+      proxy.update_attributes(:download_policy => SmartProxy::DOWNLOAD_INHERIT)
+    end
+  end
+
+  def down
+    remove_column :smart_proxies, :download_policy
+  end
+end

--- a/engines/bastion_katello/lib/bastion_katello/engine.rb
+++ b/engines/bastion_katello/lib/bastion_katello/engine.rb
@@ -34,7 +34,7 @@ module BastionKatello
         ),
         :config => {
           'consumerCertRPM' => consumer_cert_rpm,
-          'defaultDownloadPolicy' => !Foreman.in_rake?('db:migrate') && Setting['default_download_policy'],
+          'defaultDownloadPolicy' => !Foreman.in_rake? && Setting['default_download_policy'],
           'remoteExecutionPresent' => ::Katello.with_remote_execution?,
           'remoteExecutionByDefault' => ::Katello.with_remote_execution? && !Foreman.in_rake?('db:migrate') &&
                                           Setting['remote_execution_by_default']

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -238,6 +238,7 @@ module Katello
       #Api controller extensions
       ::Api::V2::HostsController.send :include, Katello::Concerns::Api::V2::HostsControllerExtensions
       ::Api::V2::HostgroupsController.send :include, Katello::Concerns::Api::V2::HostgroupsControllerExtensions
+      ::Api::V2::SmartProxiesController.send :include, Katello::Concerns::Api::V2::SmartProxiesControllerExtensions
 
       ::SettingsController.class_eval do
         helper Katello::Concerns::SettingsHelperExtensions

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -166,7 +166,7 @@ Foreman::Plugin.register :katello do
   parameter_filter Hostgroup, :content_view_id, :lifecycle_environment_id, :content_source_id,
     :kickstart_repository_id
   parameter_filter Organization, :label, :service_level
-  parameter_filter SmartProxy, :lifecycle_environment_ids => []
+  parameter_filter SmartProxy, :download_policy, :lifecycle_environment_ids => []
 
   logger :glue, :enabled => true
   logger :pulp_rest, :enabled => true

--- a/test/actions/katello/capsule_content_test.rb
+++ b/test/actions/katello/capsule_content_test.rb
@@ -132,7 +132,7 @@ module ::Actions::Katello::CapsuleContent
                          ssl_client_cert: cert[:cert],
                          ssl_client_key: cert[:key],
                          unprotected: repository.unprotected,
-                         download_policy: repository.capsule_download_policy,
+                         download_policy: repository.capsule_download_policy(capsule_content.capsule),
                          checksum_type: repository.checksum_type,
                          path: repository.relative_path,
                          with_importer: true,

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -15,6 +15,8 @@ module ::Actions::Katello::Repository
     let(:custom_repository) { katello_repositories(:fedora_17_x86_64) }
     let(:puppet_repository) { katello_repositories(:p_forge) }
     let(:docker_repository) { katello_repositories(:redis) }
+    let(:proxy) { smart_proxies(:one) }
+    let(:capsule_content) { ::Katello::CapsuleContent.new(proxy) }
 
     before(:all) do
       set_user
@@ -337,6 +339,7 @@ module ::Actions::Katello::Repository
     let(:source_repo) { katello_repositories(:redis) }
 
     it 'plans' do
+      ::Katello::CapsuleContent.stubs(:new).returns(capsule_content)
       action = create_action action_class
       env = mock
       clone = mock
@@ -344,7 +347,7 @@ module ::Actions::Katello::Repository
       clone.expects(:new_record?).returns(false)
       clone.expects(:copy_library_instance_attributes)
       clone.expects(:save!)
-      ::Katello::Repository.expects(:needs_distributor_updates).with([clone]).returns([])
+      ::Katello::Repository.expects(:needs_distributor_updates).with([clone], capsule_content).returns([])
 
       plan_action(action, source_repo, env)
       assert_action_planed_with(action, ::Actions::Katello::Repository::Clear, clone)
@@ -373,6 +376,7 @@ module ::Actions::Katello::Repository
     let(:source_repo) { katello_repositories(:ostree) }
 
     it 'plans' do
+      ::Katello::CapsuleContent.stubs(:new).returns(capsule_content)
       action = create_action action_class
       env = mock
       clone = mock
@@ -380,7 +384,7 @@ module ::Actions::Katello::Repository
       clone.expects(:new_record?).returns(false)
       clone.expects(:copy_library_instance_attributes)
       clone.expects(:save!)
-      ::Katello::Repository.expects(:needs_distributor_updates).with([clone]).returns([])
+      ::Katello::Repository.expects(:needs_distributor_updates).with([clone], capsule_content).returns([])
 
       plan_action(action, source_repo, env)
       assert_action_planed_with(action, ::Actions::Katello::Repository::Clear, clone)

--- a/test/controllers/api/v2/smart_proxies_controller_test.rb
+++ b/test/controllers/api/v2/smart_proxies_controller_test.rb
@@ -1,0 +1,19 @@
+require 'katello_test_helper'
+
+class Api::V2::SmartProxiesControllerTest < ActionController::TestCase
+  def models
+    @smart_proxy = FactoryGirl.create(:smart_proxy, :features => [FactoryGirl.create(:feature, name: 'Pulp')])
+  end
+
+  def setup
+    setup_controller_defaults(false)
+    setup_foreman_routes
+    login_user(User.find(users(:admin).id))
+    models
+  end
+
+  def test_update
+    put :update, :name => 'foobar', :download_policy => 'immediate', :id => @smart_proxy.id
+    assert_response :success
+  end
+end

--- a/test/glue/pulp/repository_test.rb
+++ b/test/glue/pulp/repository_test.rb
@@ -139,19 +139,20 @@ module Katello
     end
 
     def test_importer_matches?
+      capsule = SmartProxy.new(:download_policy => 'on_demand')
       yum_config = {
         'feed' => 'http://foobar.com',
         'download_policy' => 'on_demand',
         'remove_missing' => true
       }
-      @fedora_17_x86_64.expects(:generate_importer).with(true).at_least_once.returns(Runcible::Models::YumImporter.new(yum_config))
+      @fedora_17_x86_64.expects(:generate_importer).with(capsule).at_least_once.returns(Runcible::Models::YumImporter.new(yum_config))
 
-      assert @fedora_17_x86_64.importer_matches?('importer_type_id' => Runcible::Models::YumImporter::ID, 'config' => yum_config)
-      refute @fedora_17_x86_64.importer_matches?('importer_type_id' => Runcible::Models::DockerImporter::ID, 'config' => yum_config)
-      refute @fedora_17_x86_64.importer_matches?(nil)
+      assert @fedora_17_x86_64.importer_matches?({'importer_type_id' => Runcible::Models::YumImporter::ID, 'config' => yum_config}, capsule)
+      refute @fedora_17_x86_64.importer_matches?({'importer_type_id' => Runcible::Models::DockerImporter::ID, 'config' => yum_config}, capsule)
+      refute @fedora_17_x86_64.importer_matches?(nil, capsule)
 
       yum_config['some_other_attribute'] = 'asdf'
-      refute @fedora_17_x86_64.importer_matches?('importer_type_id' => Runcible::Models::YumImporter::ID, 'config' => yum_config)
+      refute @fedora_17_x86_64.importer_matches?({'importer_type_id' => Runcible::Models::YumImporter::ID, 'config' => yum_config}, capsule)
     end
   end
 

--- a/test/models/concerns/smart_proxy_extensions_test.rb
+++ b/test/models/concerns/smart_proxy_extensions_test.rb
@@ -1,0 +1,26 @@
+# encoding: utf-8
+
+require 'katello_test_helper'
+
+module Katello
+  class SmartProxyExtensionsTest < ActiveSupport::TestCase
+    def setup
+      @proxy = SmartProxy.new(:name => :foo, :url => 'http://fakepath.com/foo')
+      ::SmartProxy.any_instance.stubs(:associate_features)
+    end
+
+    def test_sets_default_download_policy
+      Setting[:default_proxy_download_policy] = 'background'
+      @proxy.save!
+
+      assert_equal Setting[:default_proxy_download_policy], @proxy.download_policy
+    end
+
+    def test_save_with_download_policy
+      @proxy.download_policy = 'background'
+      @proxy.save!
+
+      assert_equal 'background', @proxy.reload.download_policy
+    end
+  end
+end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -619,8 +619,9 @@ module Katello
     end
 
     def test_capsule_download_policy
-      assert_equal @content_view_puppet_environment.capsule_download_policy, nil
-      assert_equal @puppet_forge.capsule_download_policy, nil
+      proxy = SmartProxy.new(:download_policy => 'on_demand')
+      assert_equal @content_view_puppet_environment.capsule_download_policy(proxy), nil
+      assert_equal @puppet_forge.capsule_download_policy(proxy), nil
       assert_not_nil @fedora_17_x86_64.download_policy
     end
   end


### PR DESCRIPTION
Updates all existing capsules to 'inherit' which is
today's behavior, but sets the default for new capsules
to on_demand.
