### PR TITLE
Fixes #16857 - Allow access to errata data from Job templates

### DIFF
--- a/app/models/katello/input_template_renderer.rb
+++ b/app/models/katello/input_template_renderer.rb
@@ -1,0 +1,7 @@
+class InputTemplateRenderer
+  include UnattendedHelper
+
+  def errata(id)
+    Katello::Erratum.with_identifiers(id).map(&:attributes).first.slice!('created_at', 'updated_at')
+  end
+end

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -211,5 +211,6 @@ Foreman::Plugin.register :katello do
     RemoteExecutionFeature.register(:katello_group_update, N_("Katello: Update Package Group"), :description => N_("Update package group via Katello interface"), :provided_inputs => ['package'])
     RemoteExecutionFeature.register(:katello_group_remove, N_("Katello: Remove Package Group"), :description => N_("Remove package group via Katello interface"), :provided_inputs => ['package'])
     RemoteExecutionFeature.register(:katello_errata_install, N_("Katello: Install Errata"), :description => N_("Install errata via Katello interface"), :provided_inputs => ['errata'])
+    allowed_template_helpers :errata
   end
 end


### PR DESCRIPTION
This will allow `<%= errata(<Errata_ID>) -%>` in job templates.

e.g allow you to use something like this for the "katello_errata_install" action.
```
<% 
reboot = false
input(:errata).split(/\s*,\s*/).each do |id|
    if errata(id)['reboot_suggested']
        reboot = true
    end
end
%>

<%= render_template('Package Action - SSH Default', :action => 'update', :package => "--advisories=#{input(:errata)}") %>

<%= render_template('Power Action - SSH Default', :action => 'restart') if reboot %>
```


