### PR TITLE
Fixes #16861 - Allow all errata to be selected for a content-host

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
@@ -154,6 +154,8 @@ angular.module('Bastion.content-hosts').controller('ContentHostErrataController'
             }
         };
 
+        errataNutupane.enableSelectAllResults();
+
         if ($scope.$stateParams.errataId) {
             loadErratum($scope.$stateParams.errataId);
         }

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
@@ -113,6 +113,9 @@
             <th bst-table-column="issued" translate>Issued</th>
           </tr>
         </thead>
+
+	<div data-extend-template="layouts/select-all-results.html"></div>
+
         <tbody>
           <tr bst-table-row ng-repeat="erratum in detailsTable.rows | filter:detailsTable.errataCompare" row-select="erratum">
             <td bst-table-cell>

--- a/engines/bastion_katello/test/content-hosts/content/content-host-errata.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content/content-host-errata.controller.test.js
@@ -46,6 +46,7 @@ describe('Controller: ContentHostErrataController', function() {
             this.setParams = function(args) {nutupaneMock.setParams(args)};
             this.refresh = function() {nutupaneMock.refresh()};
             this.load = function () {nutupaneMock.load()};
+            this.enableSelectAllResults = function () {};
         };
         HostErratum = {
             get: function() {return []},


### PR DESCRIPTION
Right now if you have more than 20 errata that need to be applied to a content-host it won't let you select all of them at once. To test just have a content-host needing 20+ errata, it should let you select all of them and apply them all at once.
