### PR TITLE
fixes #16780 - add user to subscription facet

### DIFF
--- a/app/models/katello/concerns/user_extensions.rb
+++ b/app/models/katello/concerns/user_extensions.rb
@@ -6,6 +6,7 @@ module Katello
       included do
         has_many :task_statuses, :dependent => :destroy, :class_name => "Katello::TaskStatus"
         has_many :activation_keys, :dependent => :nullify, :class_name => "Katello::ActivationKey"
+        has_many :subscription_facets, :dependent => :nullify, :class_name => "Katello::Host::SubscriptionFacet"
 
         def self.remote_user
           SETTINGS[:katello][:pulp][:default_login]

--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -3,6 +3,7 @@ module Katello
     class SubscriptionFacet < Katello::Model
       self.table_name = 'katello_subscription_facets'
       belongs_to :host, :inverse_of => :subscription_facet, :class_name => "::Host::Managed"
+      belongs_to :user, :inverse_of => :subscription_facets, :class_name => "::User"
 
       has_many :activation_keys, :through => :subscription_facet_activation_keys, :class_name => "Katello::ActivationKey"
       has_many :subscription_facet_activation_keys, :class_name => "Katello::SubscriptionFacetActivationKey", :dependent => :destroy, :inverse_of => :subscription_facet

--- a/app/views/katello/api/v2/subscription_facet/base.json.rabl
+++ b/app/views/katello/api/v2/subscription_facet/base.json.rabl
@@ -1,1 +1,5 @@
 attributes :id, :uuid, :last_checkin, :service_level, :release_version, :autoheal, :registered_at, :registered_through
+
+child :user => :user do
+  attributes :id, :login
+end

--- a/db/migrate/20161003204325_add_user_to_katello_subscription_facets.rb
+++ b/db/migrate/20161003204325_add_user_to_katello_subscription_facets.rb
@@ -1,0 +1,7 @@
+class AddUserToKatelloSubscriptionFacets < ActiveRecord::Migration
+  def change
+    add_column :katello_subscription_facets, :user_id, :integer
+    add_index :katello_subscription_facets, [:user_id], :unique => true
+    add_foreign_key "katello_subscription_facets", "users", :column => "user_id"
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -281,7 +281,7 @@
         <span class="info-value"
               translate
               ng-show="host.subscription_facet_attributes.activation_keys.length == 0">
-          {{ contentHost.registered_by }}
+          {{ host.subscription_facet_attributes.user.login }}
         </span>
         <span class="info-value"
               ng-show="host.subscription_facet_attributes.activation_keys.length > 0"


### PR DESCRIPTION
This commit will store the user that registered a host
as part of the subscription facet.  This only only applies
if the user registered with username/password and not
activation key.