### PR TITLE
fixes #16870 - server_status to call CandlepinPing.ping just once

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -236,11 +236,12 @@ module Katello
     #api :GET, "/status", N_("Shows version information")
     #description N_("This service is available for unauthenticated users")
     def server_status
-      status = { :managerCapabilities => Resources::Candlepin::CandlepinPing.ping['managerCapabilities'],
-                 :result => Resources::Candlepin::CandlepinPing.ping['result'],
-                 :rulesSource => Resources::Candlepin::CandlepinPing.ping['rulesSource'],
-                 :rulesVersion => Resources::Candlepin::CandlepinPing.ping['rulesVersion'],
-                 :standalone => Resources::Candlepin::CandlepinPing.ping['standalone'],
+      candlepin_response = Resources::Candlepin::CandlepinPing.ping
+      status = { :managerCapabilities => candlepin_response['managerCapabilities'],
+                 :result => candlepin_response['result'],
+                 :rulesSource => candlepin_response['rulesSource'],
+                 :rulesVersion => candlepin_response['rulesVersion'],
+                 :standalone => candlepin_response['standalone'],
                  :timeUTC => Time.now.getutc,
                  :version => Katello::VERSION }
 


### PR DESCRIPTION
Call the Katello::Resources::Candlepin::CandlepinPing.ping just once
and store it in a variable referred later on.

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>