### PR TITLE
Fixes #16893 - rely on DB to determine errata type in host collection

### DIFF
--- a/app/models/katello/host_collection.rb
+++ b/app/models/katello/host_collection.rb
@@ -78,19 +78,7 @@ module Katello
       host_collections.each do |host_collection|
         host_collection_state = :ok
         unless host_collection.hosts.empty?
-          host_collection.errata.each do |erratum|
-            case erratum.errata_type
-            when Erratum::SECURITY
-              # there is a critical errata, so stop searching...
-              host_collection_state = :critical
-              break
-
-            when Erratum::BUGZILLA
-            when Erratum::ENHANCEMENT
-              # set state to warning, but continue searching...
-              host_collection_state = :warning
-            end
-          end
+          host_collection_state = host_collection.security_updates? ? :critical : :warning
         end
 
         host_collections_hash[host_collection_state] ||= []
@@ -100,15 +88,15 @@ module Katello
     end
 
     def security_updates?
-      errata.any? { |erratum| erratum.errata_type == Erratum::SECURITY }
+      errata(Erratum::SECURITY).any?
     end
 
     def bugzilla_updates?
-      errata.any? { |erratum| erratum.errata_type == Erratum::BUGZILLA }
+      errata(Erratum::BUGZILLA).any?
     end
 
     def enhancement_updates?
-      errata.any? { |erratum| erratum.errata_type == Erratum::ENHANCEMENT }
+      errata(Erratum::ENHANCEMENT).any?
     end
 
     def self.humanize_class_name(_name = nil)


### PR DESCRIPTION
Previously, the errata checks in host collections would iterate over
all errata in memory to determine if any errata were critical. If there
were a lot of errata to iterate over (say, over 500K), this could take
nearly a minute and force passenger to consume lots of CPU.

This patch alters this behavior so a DB query is used, times appear to be
sub-second now.