### PR TITLE
Fixes #16921 - Call candlepin's subs just once when enabling a repo

### DIFF
--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -639,7 +639,7 @@ module Katello
             ::Katello::Util::Data.array_with_indifferent_access products
           end
 
-          def _certificate_and_key(id, owner)
+          def product_certificate(id, owner)
             subscriptions_json = Candlepin::CandlepinResource.get("/candlepin/owners/#{owner}/subscriptions", self.default_headers).body
             subscriptions = JSON.parse(subscriptions_json)
 
@@ -655,11 +655,11 @@ module Katello
           end
 
           def certificate(id, owner)
-            self._certificate_and_key(id, owner).try :[], 'cert'
+            self.product_certificate(id, owner).try :[], 'cert'
           end
 
           def key(id, owner)
-            self._certificate_and_key(id, owner).try :[], 'key'
+            self.product_certificate(id, owner).try :[], 'key'
           end
 
           def destroy(product_id)

--- a/app/models/katello/glue/candlepin/product.rb
+++ b/app/models/katello/glue/candlepin/product.rb
@@ -7,12 +7,14 @@ module Katello
       base.class_eval do
         lazy_accessor :productContent, :multiplier, :href, :attrs,
           :initializer => lambda { |_s| convert_from_cp_fields(Resources::Candlepin::Product.get(cp_id)[0]) }
-        # Entitlement Certificate for this product
-        lazy_accessor :certificate,
-          :initializer => lambda { |_s| Resources::Candlepin::Product.certificate(cp_id, self.organization.label) },
+        # Certificate for this product - used for SSL certificate and key
+        lazy_accessor :product_certificate,
+          :initializer => lambda { |_s| Resources::Candlepin::Product.product_certificate(cp_id, self.organization.label) },
           :unless => lambda { |_s| cp_id.nil? }
+        # Entitlement Certificate for this product
+        lazy_accessor :certificate, :initializer => lambda { |_s| product_certificate['cert'] if product_certificate }
         # Entitlement Key for this product
-        lazy_accessor :key, :initializer => lambda { |_s| Resources::Candlepin::Product.key(cp_id, self.organization.label) }, :unless => lambda { |_s| cp_id.nil? }
+        lazy_accessor :key, :initializer => lambda { |_s| product_certificate['key'] if product_certificate }
 
         # we must store custom logger object during product importing so we can log status
         # from various places like callbacks

--- a/spec/models/model_spec_helper.rb
+++ b/spec/models/model_spec_helper.rb
@@ -88,6 +88,7 @@ EOKEY
       # pulp orchestration
       Resources::Candlepin::Product.stubs(:certificate).returns("")
       Resources::Candlepin::Product.stubs(:key).returns("")
+      Resources::Candlepin::Product.stubs(:product_certificate).returns({})
       Resources::Candlepin::Product.stubs(:destroy).returns(true)
 
       Katello.pulp_server.extensions.repository.stubs(:create_or_update_schedule).returns(true)

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -75,12 +75,12 @@ module Katello
       end
 
       it "should receive valid certificate" do
-        Resources::Candlepin::Product.stubs(:certificate).returns("---SOME CERT---")
+        Resources::Candlepin::Product.stubs(:product_certificate).returns('cert' => "---SOME CERT---")
         @p.certificate.must_equal("---SOME CERT---")
       end
 
       it "should receive valid key from candlepin" do
-        Resources::Candlepin::Product.stubs(:key).returns("---SOME KEY---")
+        Resources::Candlepin::Product.stubs(:product_certificate).returns('key' => "---SOME KEY---")
         @p.key.must_equal("---SOME KEY---")
       end
     end


### PR DESCRIPTION
Cache the subscription with certificate and key in new lazy_accessor variable
:subscription and feed :certificate and :key from it, such that just one
expensive call to candlepin's subscriptions is made.

Signed-off-by: Pavel Moravec pmoravec@redhat.com
