### PR TITLE
Fixes #15935 - allow for subscription facet updates

### DIFF
--- a/app/models/katello/concerns/subscription_facet_host_extensions.rb
+++ b/app/models/katello/concerns/subscription_facet_host_extensions.rb
@@ -12,6 +12,8 @@ module Katello
           :unknown => Katello::SubscriptionStatus::UNKNOWN
         }.freeze
 
+        accepts_nested_attributes_for :subscription_facet, :update_only => true, :reject_if => lambda { |attrs| attrs.values.compact.empty? }
+
         has_one :subscription_facet, :class_name => '::Katello::Host::SubscriptionFacet', :foreign_key => :host_id, :inverse_of => :host, :dependent => :destroy
 
         has_many :activation_keys, :through => :subscription_facet

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -168,8 +168,6 @@ module Katello
       # Model extensions
       ::Environment.send :include, Katello::Concerns::EnvironmentExtensions
       ::Host::Managed.send :include, Katello::Concerns::HostManagedExtensions
-      ::Host::Managed.send :include, ::Katello::Concerns::ContentFacetHostExtensions
-      ::Host::Managed.send :include, ::Katello::Concerns::SubscriptionFacetHostExtensions
       ::Hostgroup.send :include, Katello::Concerns::HostgroupExtensions
       ::Location.send :include, Katello::Concerns::LocationExtensions
       ::Redhat.send :include, Katello::Concerns::RedhatExtensions
@@ -177,7 +175,6 @@ module Katello
       ::Organization.send :include, Katello::Concerns::OrganizationExtensions
       ::User.send :include, Katello::Concerns::UserExtensions
       ::Setting.send :include, Katello::Concerns::SettingExtensions
-
       ::Container.send :include, Katello::Concerns::ContainerExtensions
       ::DockerContainerWizardState.send :include, Katello::Concerns::DockerContainerWizardStateExtensions
 
@@ -234,6 +231,9 @@ module Katello
         api_view :list => 'katello/api/v2/subscription_facet/base_with_root', :single => 'katello/api/v2/subscription_facet/show'
         api_docs :subscription_facet_attributes, ::Katello::Api::V2::HostSubscriptionsController
       end
+
+      ::Host::Managed.send :include, ::Katello::Concerns::SubscriptionFacetHostExtensions
+      ::Host::Managed.send :include, ::Katello::Concerns::ContentFacetHostExtensions
 
       #Api controller extensions
       ::Api::V2::HostsController.send :include, Katello::Concerns::Api::V2::HostsControllerExtensions

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -51,6 +51,24 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     host_index_and_show(host)
   end
 
+  def test_update_subscription_facet
+    Katello::Host::SubscriptionFacet.any_instance.stubs(:backend_update_needed?).returns(false)
+
+    Katello::Candlepin::Consumer.any_instance.stubs(:compliance_reasons).returns([])
+    Katello::Candlepin::Consumer.any_instance.stubs(:virtual_host).returns(nil)
+    Katello::Candlepin::Consumer.any_instance.stubs(:virtual_guests).returns([])
+    Katello::Candlepin::Consumer.any_instance.stubs(:installed_products).returns([])
+
+    host = FactoryGirl.create(:host, :with_subscription)
+    host.subscription_facet.update_attributes!(:autoheal => true)
+
+    put :update, :id => host.id, :subscription_facet_attributes => {:autoheal => false}
+
+    assert_response :success
+
+    refute host.reload.subscription_facet.reload.autoheal
+  end
+
   def test_with_smartproxy
     host = FactoryGirl.create(:host, :with_content, :with_subscription, :content_view => @content_view,
                               :lifecycle_environment => @environment)


### PR DESCRIPTION
This change causes the accepts_nested_attributes_for to be used
from katello and not from foreman.  This basically ignores the
:reject_if => :all_blank, which does not work for subscription_facet
as you might update :autoheal => false which would be blank