### PR TITLE
fixes #16960 - support rpm/package without file list

### DIFF
--- a/app/services/katello/pulp/rpm.rb
+++ b/app/services/katello/pulp/rpm.rb
@@ -30,11 +30,16 @@ module Katello
       end
 
       def files
+        result = []
         if pulp_facts['files']
-          pulp_facts['files']['file'] + pulp_facts['files']['dir']
-        else
-          []
+          if pulp_facts['files']['file']
+            result << pulp_facts['files']['file']
+          end
+          if pulp_facts['files']['dir']
+            result << pulp_facts['files']['dir']
+          end
         end
+        result.flatten
       end
     end
   end


### PR DESCRIPTION
This commit will gracefully handle the scenario where an
rpm does not have a filelist.  With it, a user can still
view rpm details from the ui (e.g. Content -> Packages -> [pkg])

Note: rpms will generally have file lists; however, an issue
has been observed in pulp where uploaded rpms are missing
that piece of data.