### PR TITLE
Fixes #16063 - content facet builds when not present

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -75,8 +75,20 @@ module Katello
       end
 
       def inherited_attributes_with_katello
-        self.content_facet.kickstart_repository_id ||= hostgroup.inherited_kickstart_repository_id if content_facet.present?
-        inherited_attributes_without_katello.concat(%w(content_source_id content_view_id lifecycle_environment_id))
+        if hostgroup.present?
+          if content_facet.present?
+            self.content_facet.kickstart_repository_id ||= hostgroup.inherited_kickstart_repository_id
+          else
+            # facent may not be present when created via autoprovisioning
+            if hostgroup.inherited_content_view_id && hostgroup.inherited_lifecycle_environment_id
+              build_content_facet(
+                :kickstart_repository_id => hostgroup.inherited_kickstart_repository_id,
+                :content_view_id => hostgroup.inherited_content_view_id,
+                :lifecycle_environment_id => hostgroup.inherited_lifecycle_environment_id)
+            end
+          end
+        end
+        inherited_attributes_without_katello.concat(%w(content_source_id))
       end
 
       def import_package_profile(simple_packages)


### PR DESCRIPTION
Katello as well as the facet framework assumes that the only entrypoint for
host objects are our UI and API controllers (host#create). Facet framework
hooks into there and it just works.

Except there is more. Discovered hosts can be provisioned either via edit host
form (which works with facets) but also via autoprovisioning which is an
alternative path which is missed by Facet framework.

Until Shim comes up with a nicer solution, I propose this "dirty" patch that
explicitly builds the facet object when it's not present. This fixes the issue
in Foreman 1.13, 1.12 and Satellite 6.2 and 6.3. The symptoms are that all
auto-provisioned hosts are completely missing all content flags (source, view,
environment, kickstart repo) and fails provisioning.

I also created and tested downstream version against Satellite 6.2 because
there is opened ticket for 6.2 errata (there were several changes in the
codebase already), so the patch looks like this:

``` ruby
      def set_hostgroup_defaults_with_katello_attributes
        if hostgroup.present?
          if content_facet.present?
            self.content_facet.kickstart_repository_id ||= hostgroup.inherited_kickstart_repository_id
          else
            if hostgroup.inherited_content_view_id && hostgroup.inherited_lifecycle_environment_id
              build_content_facet(
                :kickstart_repository_id => hostgroup.inherited_kickstart_repository_id,
                :content_source_id => hostgroup.inherited_content_source_id,
                :content_view_id => hostgroup.inherited_content_view_id,
                :lifecycle_environment_id => hostgroup.inherited_lifecycle_environment_id)
            end
          end
          assign_hostgroup_attributes(%w(content_source_id content_view_id lifecycle_environment_id environment_id))
        end
        set_hostgroup_defaults_without_katello_attributes
      end
```

References:

Original issue I need to fix in Foreman and Satellite:

http://projects.theforeman.org/issues/16063

Planned change in Facet framework:

http://projects.theforeman.org/issues/16987

BZ for 6.2:

https://bugzilla.redhat.com/show_bug.cgi?id=1364544
