### PR TITLE
fixes #16997 - allow non-admin user to edit activation key

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-host-collections-table.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-host-collections-table.html
@@ -19,14 +19,14 @@
 
       <button ng-if="isState('activation-keys.details.host-collections.list')"
               class="btn btn-default"
-              ng-hide="denied('edit_activation_key', activationKey)"
+              ng-hide="denied('edit_activation_keys', activationKey)"
               ng-disabled="hostCollectionsTable.numSelected == 0 || hostCollectionsTable.working"
               ng-click="removeHostCollections()">
         {{ 'Remove Selected' | translate }}
       </button>
       <button ng-if="isState('activation-keys.details.host-collections.add')"
               class="btn btn-default"
-              ng-hide="denied('edit_activation_key', activationKey)"
+              ng-hide="denied('edit_activation_keys', activationKey)"
               ng-disabled="hostCollectionsTable.numSelected == 0 || hostCollectionsTable.working"
               ng-click="addHostCollections()">
         {{ 'Add Selected' | translate }}

--- a/lib/katello/permissions/activation_key_permissions.rb
+++ b/lib/katello/permissions/activation_key_permissions.rb
@@ -14,7 +14,9 @@ Foreman::Plugin.find(:katello).security_block :activation_keys do
              :resource_type => 'Katello::ActivationKey'
   permission :edit_activation_keys,
              {
-               'katello/api/v2/activation_keys' => [:update, :content_override, :add_subscriptions, :remove_subscriptions]
+               'katello/api/v2/activation_keys' => [:update, :content_override,
+                                                    :add_subscriptions, :remove_subscriptions,
+                                                    :add_host_collections, :remove_host_collections]
              },
              :resource_type => 'Katello::ActivationKey'
   permission :destroy_activation_keys,


### PR DESCRIPTION
This change is specifically to allow a non-admin user to
add/remove host collections to/from an activation key.

Example filter permissions:

- Activation Keys -> view_activation_keys, create_activation_keys, edit_activation_keys, destroy_activation_keys
- Host Collections -> view_host_collections