### PR TITLE
fixes #17108 - content view erratum filter: default types

### DIFF
--- a/app/models/katello/content_view_erratum_filter_rule.rb
+++ b/app/models/katello/content_view_erratum_filter_rule.rb
@@ -2,6 +2,8 @@ module Katello
   class ContentViewErratumFilterRule < Katello::Model
     self.include_root_in_json = false
 
+    before_create :default_types
+
     ISSUED = "issued".freeze
     UPDATED = "updated".freeze
     DATE_TYPES = [ISSUED, UPDATED].freeze
@@ -31,6 +33,12 @@ module Katello
 
     def pulp_date_type
       self.date_type == ISSUED ? "issued" : "updated"
+    end
+
+    def default_types
+      if errata_id.nil? && types.blank?
+        self.types = ContentViewErratumFilter::ERRATA_TYPES.keys
+      end
     end
   end
 end

--- a/test/lib/util/package_clause_generator_test.rb
+++ b/test/lib/util/package_clause_generator_test.rb
@@ -123,10 +123,12 @@ module Katello
 
       @filter = FactoryGirl.create(:katello_content_view_erratum_filter, :content_view => @content_view)
       foo_rule = FactoryGirl.create(:katello_content_view_erratum_filter_rule,
-                                    :filter => @filter, :start_date => from, :end_date => to)
+                                    :filter => @filter, :start_date => from, :end_date => to,
+                                    :types => ["bugfix", "enhancement", "security"])
 
-      expected = [{"updated" => {"$gte" => from.to_time.utc.as_json,
-                                 "$lte" => to.to_time.utc.as_json}}]
+      expected = [{"$and" => [{"updated" => {"$gte" => from.to_time.utc.as_json,
+                                             "$lte" => to.to_time.utc.as_json}},
+                              {"type" => { "$in" => ["bugfix", "enhancement", "security"]}}]}]
       assert_errata_rules([foo_rule], expected)
     end
 
@@ -137,10 +139,12 @@ module Katello
       @filter = FactoryGirl.create(:katello_content_view_erratum_filter, :content_view => @content_view)
       foo_rule = FactoryGirl.create(:katello_content_view_erratum_filter_rule,
                                     :date_type => ContentViewErratumFilterRule::ISSUED,
-                                    :filter => @filter, :start_date => from, :end_date => to)
+                                    :filter => @filter, :start_date => from, :end_date => to,
+                                    :types => ["security", "bugfix"])
 
-      expected = [{"issued" => {"$gte" => from.to_time.utc.as_json,
-                                "$lte" => to.to_time.utc.as_json}}]
+      expected = [{"$and" => [{"issued" => {"$gte" => from.to_time.utc.as_json,
+                                            "$lte" => to.to_time.utc.as_json}},
+                              {"type" => {"$in" => ["security", "bugfix"]}}]}]
       assert_errata_rules([foo_rule], expected)
     end
 
@@ -151,10 +155,13 @@ module Katello
       @filter = FactoryGirl.create(:katello_content_view_erratum_filter, :content_view => @content_view)
       foo_rule = FactoryGirl.create(:katello_content_view_erratum_filter_rule,
                                     :date_type => ContentViewErratumFilterRule::UPDATED,
-                                    :filter => @filter, :start_date => from, :end_date => to)
+                                    :filter => @filter, :start_date => from, :end_date => to,
+                                    :types => ["enhancement"])
 
-      expected = [{"updated" => {"$gte" => from.to_time.utc.as_json,
-                                 "$lte" => to.to_time.utc.as_json}}]
+      expected = [{"$and" => [{"updated" => {"$gte" => from.to_time.utc.as_json,
+                                             "$lte" => to.to_time.utc.as_json}},
+                              {"type" => { "$in" => ["enhancement"]}}]}]
+
       assert_errata_rules([foo_rule], expected)
     end
 

--- a/test/models/content_view_erratum_filter_rule_test.rb
+++ b/test/models/content_view_erratum_filter_rule_test.rb
@@ -90,5 +90,28 @@ module Katello
         @rule.save!
       end
     end
+
+    def test_default_types_with_errata_id
+      # if an errata_id is set, then types is left empty
+      @rule.save!
+      assert_empty @rule.types
+    end
+
+    def test_default_types_with_types
+      # if an errata_id is not set and types is set, that value is stored
+      @rule.errata_id = nil
+      @rule.start_date = @start_date
+      @rule.types = ['enhancement']
+      @rule.save!
+      assert_equal @rule.types, ['enhancement']
+    end
+
+    def test_default_types_without_types
+      # if an errata_id is not set and types is not set, they will be set by default
+      @rule.errata_id = nil
+      @rule.start_date = @start_date
+      @rule.save!
+      assert_equal @rule.types, ContentViewErratumFilter::ERRATA_TYPES.keys
+    end
   end
 end


### PR DESCRIPTION
When creating a content view erratum by date/type filter rule,
if the user does not provide a value for 'types', default
it to all supported types (e.g. enhancement,bugfix,security).

This behavior is consistent with the default provided
by the UI.
