### PR TITLE
fixes #17110 - content host provisioning details - fix invalid link

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-provisioning-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-provisioning-info.html
@@ -9,7 +9,7 @@
       <div class="detail">
         <span class="info-label" translate>Name</span>
         <span class="info-value">
-          <a href="/hosts/{{ contentHost.host.name }}">
+          <a href="/hosts/{{ host.name }}">
             {{ host.name }}
           </a>
         </span>


### PR DESCRIPTION
Update to fix the link to the foreman host.
