### PR TITLE
fixes #17115 - validate ip from RHSM

### DIFF
--- a/app/models/katello/rhsm_fact_parser.rb
+++ b/app/models/katello/rhsm_fact_parser.rb
@@ -23,7 +23,7 @@ module Katello
       {
         'link' => true,
         'macaddress' => facts["net.interface.#{interface}.mac_address"],
-        'ipaddress' => facts["net.interface.#{interface}.ipv4_address"]
+        'ipaddress' => get_rhsm_ip(interface)
       }
     end
 
@@ -70,6 +70,13 @@ module Katello
     end
 
     def ipmi_interface
+    end
+
+    private
+
+    def get_rhsm_ip(interface)
+      ip = facts["net.interface.#{interface}.ipv4_address"]
+      Net::Validations.validate_ip(ip) ? ip : nil
     end
   end
 end

--- a/db/migrate/20161026191118_fix_invalid_interfaces.rb
+++ b/db/migrate/20161026191118_fix_invalid_interfaces.rb
@@ -1,0 +1,15 @@
+class FixInvalidInterfaces < ActiveRecord::Migration
+  class FakeNic < ActiveRecord::Base
+    self.table_name = 'nics'
+
+    def type
+      Nic::Base
+    end
+  end
+
+  def up
+    FakeNic.where(:ip => "Unknown").each do |nic|
+      nic.update_attributes(:ip => nil)
+    end
+  end
+end

--- a/test/models/rhsm_fact_parser_test.rb
+++ b/test/models/rhsm_fact_parser_test.rb
@@ -9,7 +9,9 @@ module Katello
         'net.interface.eth0.1.mac_address' => '00:00:00:00:00:12',
         'net.interface.eth0.1.ipv4_address' => '192.168.0.2',
         'net.interface.ethnone.mac_address' => 'none',
-        'net.interface.eth2.mac_address' => '00:00:00:00:00:13'
+        'net.interface.eth2.mac_address' => '00:00:00:00:00:13',
+        'net.interface.eth3.ipv4_address' => 'Unknown',
+        'net.interface.eth3.mac_address' => '00:00:00:00:00:14'
       }
       @parser = RhsmFactParser.new(@facts)
     end
@@ -42,6 +44,11 @@ module Katello
         'ipaddress' => nil
       }
       assert_equal expected_eth1, @parser.get_facts_for_interface('eth1')
+    end
+
+    def test_get_facts_for_interface_with_invalid_ip
+      assert_equal @facts['net.interface.eth3.mac_address'], @parser.get_facts_for_interface('eth3')['macaddress']
+      assert_empty @parser.get_facts_for_interface('eth3')['ipaddress']
     end
 
     def test_valid_centos_os


### PR DESCRIPTION
On older versions of RHSM, ip values can be sent as a string 'Unknown'.
Foreman historically saves hosts facts without validation, which means the
bogus values get saved. When remote execution then tries to use that
interface's IP it hits an error.

This adds some validation to the RHSM fact parser, and a migration to fix the
bad values we may have created.