### PR TITLE
fixes #17129 - allow deletion of cv & version associated w/ hg

### DIFF
--- a/app/models/katello/concerns/hostgroup_extensions.rb
+++ b/app/models/katello/concerns/hostgroup_extensions.rb
@@ -5,7 +5,8 @@ module Katello
 
       included do
         before_save :add_organization_for_environment
-        belongs_to :kickstart_repository, :class_name => "::Katello::Repository", :foreign_key => :kickstart_repository_id
+        belongs_to :kickstart_repository, :class_name => "::Katello::Repository",
+                   :foreign_key => :kickstart_repository_id, :inverse_of => :kickstart_hostgroups
         belongs_to :content_source, :class_name => "::SmartProxy", :foreign_key => :content_source_id, :inverse_of => :hostgroups
         belongs_to :content_view, :inverse_of => :hostgroups, :class_name => "::Katello::ContentView"
         belongs_to :lifecycle_environment, :inverse_of => :hostgroups, :class_name => "::Katello::KTEnvironment"

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -42,7 +42,7 @@ module Katello
     has_many :hosts,      :class_name => "::Host::Managed", :through => :content_facets,
                           :inverse_of => :content_view
     has_many :hostgroups, :class_name => "::Hostgroup", :foreign_key => :content_view_id,
-                          :inverse_of => :content_view, :dependent => :restrict_with_exception
+                          :inverse_of => :content_view, :dependent => :nullify
 
     validates_lengths_from_database :except => [:label]
     validates :label, :uniqueness => {:scope => :organization_id},

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -67,6 +67,9 @@ module Katello
     has_many :kickstart_content_facets, :class_name => "Katello::Host::ContentFacet", :foreign_key => :kickstart_repository_id,
                           :inverse_of => :kickstart_repository, :dependent => :nullify
 
+    has_many :kickstart_hostgroups, :class_name => "::Hostgroup", :foreign_key => :kickstart_repository_id,
+             :inverse_of => :kickstart_repository, :dependent => :nullify
+
     # rubocop:disable HasAndBelongsToMany
     # TODO: change this into has_many :through association
     has_and_belongs_to_many :filters, :class_name => "Katello::ContentViewFilter",


### PR DESCRIPTION
This commit contains changes to allow deletion of a content
view version and view that has associations to a hostgroup
via the content view and media (synced content) settings.

Without it,
- deleting a version would show:

```
ERROR: update or delete on table "katello_repositories"
violates foreign key constraint
"hostgroups_kickstart_repository_id_fk"
on table "hostgroups" DETAIL: Key (id)=(25) is still
referenced from table "hostgroups"
```
- deleting a view would show:

```
Cannot delete record because of dependent hostgroups
```
