### PR TITLE
Fixes #17132 - update correct fact for mem total

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -142,7 +142,7 @@
 
       <div class="detail">
         <span class="info-label" translate>RAM </span>
-        <span class="info-value">{{ host.facts["dmi::memory::size"] }}</span>
+        <span class="info-value">{{ host.facts["memory::memtotal"] }}</span>
       </div>
 
       <div class="divider"></div>


### PR DESCRIPTION
Content hosts with more than 10 GB of ram are staying at the default value. Updating webui fact to show correct info.