### PR TITLE
fixes #17142 - list affected activation keys during cvv removal

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/content-view-version-deletion-activation-keys.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/content-view-version-deletion-activation-keys.controller.js
@@ -28,7 +28,14 @@ angular.module('Bastion.content-views').controller('ContentViewVersionDeletionAc
         nutupane = new Nutupane(ActivationKey, params);
 
         nutupane.searchTransform = function (term) {
-            var addition = "(environment_id:(" + $scope.selectedEnvironmentIds().join(" OR ") + "))";
+            var addition,
+                envClausses = [];
+
+            angular.forEach($scope.selectedEnvironmentNames(), function(env) {
+                envClausses.push("environment = " + env);
+            });
+            addition = '(' + envClausses.join(" OR ") + ')';
+            addition = addition + " AND content_view_id = " + $scope.contentView.id;
             if (term === "" || angular.isUndefined(term)) {
                 return addition;
             }

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/content-view-version-deletion.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/content-view-version-deletion.controller.js
@@ -109,6 +109,10 @@ angular.module('Bastion.content-views').controller('ContentViewVersionDeletionCo
             return _.map($scope.deleteOptions.environments, 'id');
         };
 
+        $scope.selectedEnvironmentNames = function () {
+            return _.map($scope.deleteOptions.environments, 'name');
+        };
+
         $scope.totalHostCount = function () {
             return _.reduce($scope.deleteOptions.environments, function (sum, env) {
                 return sum + env['host_count'];


### PR DESCRIPTION
When deleting a content view version, if it is associated with
one or more activation keys, clicking the 'Show affected
Activation Keys' link in the UI removal wizard should list them.