### PR TITLE
Fixes #17166: fix changes to layout names in docker tags.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/views/docker-tags-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/views/docker-tags-details.html
@@ -1,6 +1,6 @@
 <span page-title ng-model="tag">{{ 'Docker Tag: ' | translate }} {{ tag.full_name }}</span>
 
-<div data-extend-template="layouts/page-with-breadcrumbs.html">
+<div data-extend-template="layouts/details-page-with-breadcrumbs.html">
   <div data-block="header">
     <h2>{{ tag.full_name }}</h2>
   </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/views/docker-tags.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/views/docker-tags.html
@@ -1,6 +1,6 @@
 <span page-title>{{ 'Docker Tags' | translate }}</span>
 
-<div data-extend-template="layouts/table.html">
+<div data-extend-template="layouts/table-with-header.html">
 
   <div data-block="header">
     <h2 translate>Docker Tags</h2>


### PR DESCRIPTION
https://github.com/Katello/bastion/pull/136 added some changes to layout
names.  We need to update the docker tags to use the new layout names.

http://projects.theforeman.org/issues/17166