### PR TITLE
Fixes #17208 - Applicable errata filters by env

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/errata-content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/errata-content-hosts.controller.js
@@ -34,7 +34,7 @@ angular.module('Bastion.errata').controller('ErrataContentHostsController',
         $scope.detailsTable = nutupane.table;
         $scope.nutupane.searchTransform = function(term) {
             var addition = '( ' + $scope.errataSearchString($scope.restrictInstallable) + ' )';
-            if (angular.isDefined($scope.environment_id)) {
+            if (angular.isDefined($scope.environmentId)) {
                 addition = addition + ' and lifecycle_environment_id = ' + $scope.environmentId;
             }
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/errata-details-content-hosts.html
@@ -38,7 +38,7 @@
         </div>
 
         <div class="col-md-1">
-          <a ng-show="environmentFilter" ng-click="selectEnvironment(null)">
+          <a ng-show="environmentFilter" ng-click="selectEnvironment(undefined)">
             <i class="fa fa-remove"></i>
           </a>
         </div>


### PR DESCRIPTION
Applicable errata can now be successfully filtered by lifecycle
environment, and the lifecycle environment can be cleared successfully.

Test this by going to
Content > Errata > [Errata ID] > Content Hosts (tab) and filtering by
environment. Then, click the 'x' to clear the filter.