### PR TITLE
fixes #17207 - fix content_facet_attributes updating

### DIFF
--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -222,6 +222,7 @@ module Katello
       ::PuppetClassImporter.send :include, Katello::Services::PuppetClassImporterExtensions
 
       #facet extensions
+      ::Host::Managed.send :include, ::Katello::Concerns::ContentFacetHostExtensions
       Facets.register(Katello::Host::ContentFacet, :content_facet) do
         api_view :list => 'katello/api/v2/content_facet/base_with_root', :single => 'katello/api/v2/content_facet/show'
         api_docs :content_facet_attributes, ::Katello::Api::V2::HostContentsController
@@ -231,9 +232,7 @@ module Katello
         api_view :list => 'katello/api/v2/subscription_facet/base_with_root', :single => 'katello/api/v2/subscription_facet/show'
         api_docs :subscription_facet_attributes, ::Katello::Api::V2::HostSubscriptionsController
       end
-
       ::Host::Managed.send :include, ::Katello::Concerns::SubscriptionFacetHostExtensions
-      ::Host::Managed.send :include, ::Katello::Concerns::ContentFacetHostExtensions
 
       #Api controller extensions
       ::Api::V2::HostsController.send :include, Katello::Concerns::Api::V2::HostsControllerExtensions

--- a/test/models/concerns/content_facet_host_extensions_test.rb
+++ b/test/models/concerns/content_facet_host_extensions_test.rb
@@ -7,6 +7,7 @@ module Katello
   class ContentFacetHostExtensionsBaseTest < ActiveSupport::TestCase
     let(:library) { katello_environments(:library) }
     let(:view)  { katello_content_views(:library_dev_view) }
+    let(:view2) { katello_content_views(:library_dev_staging_view) }
     let(:dev) { katello_environments(:dev) }
     let(:empty_host) { ::Host::Managed.create!(:name => 'foobar', :managed => false) }
     let(:host) do
@@ -21,6 +22,15 @@ module Katello
       assert_includes ::Host.in_content_view_environment(:lifecycle_environment => library), host
       assert_includes ::Host.in_content_view_environment(:content_view => view, :lifecycle_environment => library), host
       refute_includes ::Host.in_content_view_environment(:content_view => view, :lifecycle_environment => dev), host
+    end
+
+    def test_content_facet_update
+      host.update_attributes!(:content_facet_attributes => { :content_view_id => view2.id })
+      host.reload.content_facet.reload
+
+      refute_nil host.content_facet.uuid # not reset to nil
+      assert_equal library.id, host.content_facet.lifecycle_environment_id # unchanged
+      assert_equal view2.id, host.content_facet.content_view_id # changed
     end
   end
 end


### PR DESCRIPTION
This commit fixes an issue where updating the content view
on a content host would result in the content facet uuid
being set to nil.