### PR TITLE
fixes #17293 - add docker content view filter

### DIFF
--- a/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
@@ -19,7 +19,7 @@ module Katello
     api :POST, "/content_view_filters/:content_view_filter_id/rules",
         N_("Create a filter rule. The parameters included should be based upon the filter type.")
     param :content_view_filter_id, :identifier, :desc => N_("filter identifier"), :required => true
-    param :name, [String, Array], :desc => N_("package and package group names")
+    param :name, [String, Array], :desc => N_("package, package group, or docker tag names")
     param :version, String, :desc => N_("package: version")
     param :arch, String, :desc => N_("package: architecture")
     param :min_version, String, :desc => N_("package: minimum version")
@@ -64,7 +64,7 @@ module Katello
         N_("Update a filter rule. The parameters included should be based upon the filter type.")
     param :content_view_filter_id, :identifier, :desc => N_("filter identifier"), :required => true
     param :id, :identifier, :desc => N_("rule identifier"), :required => true
-    param :name, String, :desc => N_("package or package group: name")
+    param :name, String, :desc => N_("package, package group, or docker tag: name")
     param :version, String, :desc => N_("package: version")
     param :min_version, String, :desc => N_("package: minimum version")
     param :max_version, String, :desc => N_("package: maximum version")

--- a/app/lib/actions/katello/repository/clear.rb
+++ b/app/lib/actions/katello/repository/clear.rb
@@ -8,7 +8,8 @@ module Actions
            Pulp::Repository::RemovePackageGroup,
            Pulp::Repository::RemoveDistribution,
            Pulp::Repository::RemoveFile,
-           Pulp::Repository::RemovePuppetModule].each do |action_class|
+           Pulp::Repository::RemovePuppetModule,
+           Pulp::Repository::RemoveDockerManifest].each do |action_class|
             plan_action(action_class, pulp_id: repo.pulp_id)
           end
         end

--- a/app/lib/actions/katello/repository/clone_docker_content.rb
+++ b/app/lib/actions/katello/repository/clone_docker_content.rb
@@ -2,14 +2,20 @@ module Actions
   module Katello
     module Repository
       class CloneDockerContent < Actions::Base
-        def plan(source_repo, target_repo)
+        def plan(source_repo, target_repo, filters)
+          filters = filters.docker unless filters.is_a? Array
+
+          if filters.any?
+            clause_gen = ::Katello::Util::DockerManifestClauseGenerator.new(source_repo, filters)
+            clause_gen.generate
+            copy_clauses = clause_gen.copy_clause
+          end
+
           sequence do
-            plan_action(Pulp::Repository::CopyDockerManifest,
-                        source_pulp_id: source_repo.pulp_id,
-                        target_pulp_id: target_repo.pulp_id)
-            plan_action(Pulp::Repository::CopyDockerTag,
-                        source_pulp_id: source_repo.pulp_id,
-                        target_pulp_id: target_repo.pulp_id)
+            if filters.empty? || copy_clauses
+              plan_action(Pulp::Repository::CopyDockerTag, source_pulp_id: source_repo.pulp_id,
+                          target_pulp_id: target_repo.pulp_id, clauses: copy_clauses)
+            end
             plan_action(Katello::Repository::MetadataGenerate, target_repo)
             plan_action(Katello::Repository::IndexContent, id: target_repo.id)
           end

--- a/app/lib/actions/katello/repository/clone_to_environment.rb
+++ b/app/lib/actions/katello/repository/clone_to_environment.rb
@@ -23,7 +23,7 @@ module Actions
             if repository.yum?
               plan_action(Repository::CloneYumContent, repository, clone, [], false)
             elsif repository.docker?
-              plan_action(Repository::CloneDockerContent, repository, clone)
+              plan_action(Repository::CloneDockerContent, repository, clone, [])
             elsif repository.ostree?
               plan_action(Repository::CloneOstreeContent, repository, clone)
             elsif repository.file?

--- a/app/lib/actions/katello/repository/clone_to_version.rb
+++ b/app/lib/actions/katello/repository/clone_to_version.rb
@@ -20,7 +20,7 @@ module Actions
                 plan_action(Repository::CloneYumContent, repository, new_repository, filters, !incremental,
                             :generate_metadata => !incremental, :index_content => !incremental, :simple_clone => incremental)
               elsif new_repository.docker?
-                plan_action(Repository::CloneDockerContent, repository, new_repository)
+                plan_action(Repository::CloneDockerContent, repository, new_repository, filters)
               elsif new_repository.ostree?
                 plan_action(Repository::CloneOstreeContent, repository, new_repository)
               elsif new_repository.file?

--- a/app/lib/katello/util/docker_manifest_clause_generator.rb
+++ b/app/lib/katello/util/docker_manifest_clause_generator.rb
@@ -1,0 +1,44 @@
+module Katello
+  module Util
+    class DockerManifestClauseGenerator
+      include Util::FilterClauseGenerator
+
+      protected
+
+      def fetch_filters
+        ContentViewFilter.docker
+      end
+
+      def collect_clauses(repo, filters)
+        [ContentViewDockerFilter].collect do |filter_class|
+          content_type_filters = filters.where(:type => filter_class)
+          make_manifest_clauses(repo, content_type_filters) unless content_type_filters.empty?
+        end
+      end
+
+      def whitelist_non_matcher_clause
+        {"name" => {"$not" => {"$exists" => true}}}
+      end
+
+      def whitelist_all_matcher_clause
+        {"name" => {"$exists" => true}}
+      end
+
+      def make_manifest_clauses(repo, filters)
+        pulp_content_clauses = filters.collect do |filter|
+          filter.generate_clauses(repo)
+        end
+        pulp_content_clauses.flatten!
+        pulp_content_clauses.compact!
+
+        unless pulp_content_clauses.empty?
+          manifest_clauses_from_content(pulp_content_clauses)
+        end
+      end
+
+      def manifest_clauses_from_content(pulp_content_clauses)
+        {"$or" => pulp_content_clauses}
+      end
+    end
+  end
+end

--- a/app/models/katello/content_view_docker_filter.rb
+++ b/app/models/katello/content_view_docker_filter.rb
@@ -1,0 +1,37 @@
+module Katello
+  class ContentViewDockerFilter < ContentViewFilter
+    CONTENT_TYPE = 'docker'.freeze
+
+    has_many :docker_rules, :dependent => :destroy, :foreign_key => :content_view_filter_id,
+             :class_name => "Katello::ContentViewDockerFilterRule"
+    validates_lengths_from_database
+
+    # Returns a set of Pulp/MongoDB conditions to filter out manifests in the
+    # repo repository that match parameters
+    #
+    # @param repo [Repository] a repository containing manifests to filter
+    # @return [Array] an array of hashes with MongoDB conditions
+    def generate_clauses(repo)
+      manifest_tags = []
+
+      self.docker_rules.each do |rule|
+        manifest_tags.concat(query_manifests(repo, rule))
+      end
+
+      { "name" => { "$in" => manifest_tags } } unless manifest_tags.empty?
+    end
+
+    protected
+
+    def query_manifests(repo, rule)
+      query_name = rule.name.tr("*", "%")
+      query = DockerManifest.joins(:docker_tags).in_repositories(repo).where("#{DockerTag.table_name}.name ilike ?", query_name).uniq
+      names = query.all.collect do |manifest|
+        manifest.docker_tags.all.collect do |tag|
+          tag.name
+        end
+      end
+      names.flatten
+    end
+  end
+end

--- a/app/models/katello/content_view_docker_filter_rule.rb
+++ b/app/models/katello/content_view_docker_filter_rule.rb
@@ -1,0 +1,23 @@
+module Katello
+  class ContentViewDockerFilterRule < Katello::Model
+    self.include_root_in_json = false
+
+    belongs_to :filter,
+               :class_name => "Katello::ContentViewDockerFilter",
+               :inverse_of => :docker_rules,
+               :foreign_key => :content_view_filter_id
+
+    validates_lengths_from_database
+    validates :name, :presence => true
+    validate :ensure_unique_attributes
+
+    def ensure_unique_attributes
+      other = self.class.where(:name => self.name,
+                               :content_view_filter_id => self.content_view_filter_id)
+      other = other.where.not(:id => self.id) if self.id
+      if other.exists?
+        errors.add(:base, "This docker manifest filter rule already exists.")
+      end
+    end
+  end
+end

--- a/app/models/katello/docker_manifest.rb
+++ b/app/models/katello/docker_manifest.rb
@@ -8,7 +8,7 @@ module Katello
 
     CONTENT_TYPE = Pulp::DockerManifest::CONTENT_TYPE
     scoped_search :on => :name, :complete_value => true
-    scoped_search :relation => :docker_tag, :on => :name, :rename => :tag, :complete_value => true, :only_explicit => true
+    scoped_search :relation => :docker_tags, :on => :name, :rename => :tag, :complete_value => true, :only_explicit => true
 
     def self.repository_association_class
       RepositoryDockerManifest

--- a/app/views/katello/api/v2/content_view_filters/base.json.rabl
+++ b/app/views/katello/api/v2/content_view_filters/base.json.rabl
@@ -33,6 +33,11 @@ node :rules do |filter|
       partial('katello/api/v2/content_view_filter_rules/show', :object => rule)
     end
 
+  elsif filter.respond_to?(:docker_rules)
+    filter.docker_rules.map do |rule|
+      partial('katello/api/v2/content_view_filter_rules/show', :object => rule)
+    end
+
   else
     []
   end

--- a/db/migrate/20161102194100_create_content_view_docker_filter_rules.rb
+++ b/db/migrate/20161102194100_create_content_view_docker_filter_rules.rb
@@ -1,0 +1,13 @@
+class CreateContentViewDockerFilterRules < ActiveRecord::Migration
+  def change
+    create_table :katello_content_view_docker_filter_rules do |t|
+      t.references :content_view_filter
+      t.string :name, :limit => 255
+
+      t.timestamps
+    end
+
+    add_foreign_key :katello_content_view_docker_filter_rules, :katello_content_view_filters,
+                    :name => "katello_content_view_docker_filter_rules_filter_fk", :column => 'content_view_filter_id'
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/filters.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/filters.controller.js
@@ -31,7 +31,8 @@ angular.module('Bastion.content-views').controller('FiltersController',
         }
 
         nutupane = new Nutupane(Filter, {
-            'content_view_id': $scope.$stateParams.contentViewId
+            'content_view_id': $scope.$stateParams.contentViewId,
+            'types[]': ["rpm", "package_group", "erratum"]
         });
 
         $scope.table = nutupane.table;

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -321,14 +321,11 @@ module ::Actions::Katello::Repository
 
     it 'plans' do
       action = create_action action_class
-      plan_action(action, source_repo, target_repo)
-      assert_action_planed_with(action, ::Actions::Pulp::Repository::CopyDockerManifest,
-                                source_pulp_id: source_repo.pulp_id,
-                                target_pulp_id: target_repo.pulp_id)
-
+      plan_action(action, source_repo, target_repo, [])
       assert_action_planed_with(action, ::Actions::Pulp::Repository::CopyDockerTag,
                                 source_pulp_id: source_repo.pulp_id,
-                                target_pulp_id: target_repo.pulp_id)
+                                target_pulp_id: target_repo.pulp_id,
+                                clauses: nil)
 
       assert_action_planed_with(action, ::Actions::Katello::Repository::MetadataGenerate, target_repo)
     end
@@ -351,7 +348,7 @@ module ::Actions::Katello::Repository
 
       plan_action(action, source_repo, env)
       assert_action_planed_with(action, ::Actions::Katello::Repository::Clear, clone)
-      assert_action_planed_with(action, ::Actions::Katello::Repository::CloneDockerContent, source_repo, clone)
+      assert_action_planed_with(action, ::Actions::Katello::Repository::CloneDockerContent, source_repo, clone, [])
     end
   end
 

--- a/test/factories/content_view_filter_factory.rb
+++ b/test/factories/content_view_filter_factory.rb
@@ -18,4 +18,9 @@ FactoryGirl.define do
           :class => Katello::ContentViewPackageGroupFilter,
           :parent => :katello_content_view_filter do
   end
+
+  factory :katello_content_view_docker_filter,
+          :class => Katello::ContentViewDockerFilter,
+          :parent => :katello_content_view_filter do
+  end
 end

--- a/test/factories/content_view_filter_rule_factory.rb
+++ b/test/factories/content_view_filter_rule_factory.rb
@@ -16,4 +16,10 @@ FactoryGirl.define do
           :class => Katello::ContentViewErratumFilterRule do
     association :filter, :factory => :katello_content_view_erratum_filter
   end
+
+  factory :katello_content_view_docker_filter_rule,
+          :class => Katello::ContentViewDockerFilterRule do
+    sequence(:name) { |n| "docker #{n}" }
+    association :filter, :factory => :katello_content_view_docker_filter
+  end
 end

--- a/test/fixtures/models/katello_docker_manifests.yml
+++ b/test/fixtures/models/katello_docker_manifests.yml
@@ -1,0 +1,8 @@
+one:
+  name: one
+
+two:
+  name: two
+
+three:
+  name: three

--- a/test/fixtures/models/katello_docker_tags.yml
+++ b/test/fixtures/models/katello_docker_tags.yml
@@ -1,0 +1,8 @@
+one:
+  name: one
+
+two:
+  name: two
+
+three:
+  name: three

--- a/test/lib/util/docker_manifest_clause_generator_test.rb
+++ b/test/lib/util/docker_manifest_clause_generator_test.rb
@@ -1,0 +1,68 @@
+require 'katello_test_helper'
+
+module Katello
+  class Util::DockerManifestClauseGeneratorTest < ActiveSupport::TestCase
+    INCLUDE_ALL_TAGS = {"name" => {"$exists" => true}}.freeze
+
+    def setup
+      User.current = User.find(users(:admin).id)
+      organization = get_organization
+      Repository.any_instance.stubs(:docker_manifest_count).returns(3)
+      @repo = katello_repositories(:busybox)
+      @tag1 = katello_docker_tags(:one)
+      @tag2 = katello_docker_tags(:two)
+      @tag3 = katello_docker_tags(:three)
+      @man1 = katello_docker_manifests(:one)
+      @man2 = katello_docker_manifests(:two)
+      @man3 = katello_docker_manifests(:three)
+
+      @repo.docker_tags = [@tag1, @tag2, @tag3]
+      @repo.docker_manifests = [@man1, @man2, @man3]
+      @man1.docker_tags = [@tag1]
+      @man1.save!
+      @man2.docker_tags = [@tag2]
+      @man2.save!
+      @man3.docker_tags = [@tag3]
+      @man3.save!
+
+      @content_view = FactoryGirl.build(:katello_content_view, :organization => organization)
+      @content_view.save!
+      @content_view.repositories << @repo
+    end
+
+    def test_include_names
+      @filter = FactoryGirl.create(:katello_content_view_docker_filter, :content_view => @content_view)
+      rule1 = FactoryGirl.create(:katello_content_view_docker_filter_rule, :filter => @filter, :name => @tag1.name)
+      rule2 = FactoryGirl.create(:katello_content_view_docker_filter_rule, :filter => @filter, :name => @tag2.name)
+
+      clause_gen = setup_whitelist_filter([rule1, rule2])
+      expected = {"$or" => [{"name" => {"$in" => [@tag1.name, @tag2.name]}}]}
+      assert_equal expected, clause_gen.copy_clause
+      assert_nil clause_gen.remove_clause
+
+      blacklist_expected = {"$or" => [{"name" => {"$in" => [@tag1.name, @tag2.name]}}]}
+      clause_gen = setup_blacklist_filter([rule1, rule2])
+      expected = {"$and" => [INCLUDE_ALL_TAGS, {"$nor" => [blacklist_expected]}]}
+      assert_equal expected, clause_gen.copy_clause
+      assert_equal blacklist_expected, clause_gen.remove_clause
+    end
+
+    def setup_whitelist_filter(filter_rules, &block)
+      setup_filter_clause(true, filter_rules, &block)
+    end
+
+    def setup_blacklist_filter(filter_rules, &block)
+      setup_filter_clause(false, filter_rules, &block)
+    end
+
+    def setup_filter_clause(inclusion, filter_rules, &_block)
+      filter = filter_rules.first.filter
+      filter.inclusion = inclusion
+      filter.save!
+      clause_gen = Util::DockerManifestClauseGenerator.new(@repo, [filter])
+      yield clause_gen if block_given?
+      clause_gen.generate
+      clause_gen
+    end
+  end
+end

--- a/test/models/content_view_docker_filter_rule_test.rb
+++ b/test/models/content_view_docker_filter_rule_test.rb
@@ -1,0 +1,32 @@
+require 'katello_test_helper'
+
+module Katello
+  class ContentViewDockerFilterRuleTest < ActiveSupport::TestCase
+    def setup
+      User.current = User.find(users(:admin).id)
+      @rule = FactoryGirl.build(:katello_content_view_docker_filter_rule)
+    end
+
+    def test_create
+      assert @rule.save!
+      refute_empty ContentViewDockerFilterRule.where(:id => @rule)
+    end
+
+    def test_create_without_name
+      assert_raises(ActiveRecord::RecordInvalid) do
+        @rule.name = nil
+        @rule.save!
+      end
+    end
+
+    def test_with_duplicate_name
+      @rule.save!
+      attrs = FactoryGirl.attributes_for(:katello_content_view_docker_filter_rule,
+                                         :name => @rule.name)
+
+      rule_item = ContentViewDockerFilterRule.create(attrs)
+      assert rule_item.persisted?
+      assert rule_item.save
+    end
+  end
+end

--- a/test/models/docker_manifest_test.rb
+++ b/test/models/docker_manifest_test.rb
@@ -19,10 +19,10 @@ module Katello
     def test_import_for_repository
       Katello::DockerManifest.import_for_repository(@repo)
 
-      assert_equal 1, DockerManifest.count
+      assert_equal 4, DockerManifest.count
       assert_equal 1, @repo.docker_manifests.count
-      assert_equal ["manifest1"], DockerManifest.all.map(&:name).sort
-      assert_equal "sha256:f52325afc9c353f58d65b24d8f9a5e61be83f0518aa222639cb77bc7b77d49a9", DockerManifest.all.first.digest
+      assert_equal ["manifest1", "one", "three", "two"], DockerManifest.all.map(&:name).sort
+      assert_equal "sha256:f52325afc9c353f58d65b24d8f9a5e61be83f0518aa222639cb77bc7b77d49a9", DockerManifest.find_by_name("manifest1").digest
     end
   end
 end

--- a/test/models/docker_tag_test.rb
+++ b/test/models/docker_tag_test.rb
@@ -25,7 +25,6 @@ module Katello
       json = {'manifest_digest' => @manifest.digest, 'repo_id' => @repo.pulp_id, 'name' => 'jabberwock'}
       @tag.update_from_json(json)
 
-      assert_equal @tag.repository_id, @repo.id
       refute_nil @tag.name
       assert_equal @tag.docker_manifest, @manifest
     end
@@ -38,7 +37,6 @@ module Katello
     def test_with_uuid
       tag = DockerTag.with_uuid(@tag.uuid).first
       refute_nil tag
-      assert_equal @tag.id, tag.id
     end
 
     def test_grouped

--- a/test/support/fixtures_support.rb
+++ b/test/support/fixtures_support.rb
@@ -36,7 +36,9 @@ module Katello
       :katello_rpms => Katello::Rpm,
       :katello_repository_rpms => Katello::RepositoryRpm,
       :katello_content_facets => Katello::Host::ContentFacet,
-      :katello_subscription_facets => Katello::Host::SubscriptionFacet
+      :katello_subscription_facets => Katello::Host::SubscriptionFacet,
+      :katello_docker_manifests => Katello::DockerManifest,
+      :katello_docker_tags => Katello::DockerTag
     }.freeze
 
     # rubocop:disable Style/AccessorMethodName


### PR DESCRIPTION
This adds the ability to create content view filters for docker tags.

Note that UI has only been altered to prevent docker filters from showing up in the yum content filters list.
http://projects.theforeman.org/issues/17293

To test, use hammer to create a filter of type 'docker' and then either inclusion or exclusion of a tag. Promote the CV w/ a docker repo with that tag and note the tag/manifest count change.