### PR TITLE
Fixes #17244 - Errata widget does not break on filtered hosts

### DIFF
--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -52,8 +52,9 @@ module Katello
     end
 
     def self.applicable_to_hosts_dashboard(hosts)
+      ids = hosts.to_sql.sub(/SELECT.*FROM/, "SELECT #{::Host.connection.quote_table_name('hosts')}.#{::Host.connection.quote_column_name('id')} FROM")
       self.joins(:content_facets).
-        where("#{Katello::Host::ContentFacet.table_name}.host_id" => hosts).
+        where("#{Katello::Host::ContentFacet.table_name}.host_id IN (#{ids})").
         select("DISTINCT ON (#{self.table_name}.updated, #{self.table_name}.id) #{self.table_name}.*").
         order("#{self.table_name}.updated desc").limit(6)
     end


### PR DESCRIPTION
Due to an issue with how rails handles inner queries with complex
conditions, we need to manually generate the SQL for the errata widget
to correctly select the correct host ids in case there is a filter in
place on one of the related tables (for example, compute_resource).
This fix is similar to the fix for
http://projects.theforeman.org/issues/16704