### PR TITLE
fixes #17258 - allow non-admin user to change hosts on a collection

### DIFF
--- a/app/controllers/katello/api/v2/host_collections_controller.rb
+++ b/app/controllers/katello/api/v2/host_collections_controller.rb
@@ -87,7 +87,7 @@ module Katello
       host_ids = params[:host_ids].map(&:to_i)
 
       @hosts = ::Host::Managed.where(id: host_ids)
-      @editable_hosts = @hosts.authorized(:edit_host)
+      @editable_hosts = @hosts.authorized(:edit_hosts)
 
       already_added_host_ids = @host_collection.host_ids & host_ids
       unfound_host_ids = host_ids - @hosts.pluck(:id)
@@ -121,7 +121,7 @@ module Katello
       host_ids = params[:host_ids].map(&:to_i)
 
       @hosts = ::Host::Managed.where(id: host_ids)
-      @editable_hosts = @hosts.authorized(:edit_host)
+      @editable_hosts = @hosts.authorized(:edit_hosts)
 
       already_removed_host_ids = @hosts.pluck(:id) - @host_collection.host_ids
       unfound_host_ids = host_ids - @hosts.pluck(:id)


### PR DESCRIPTION
This commit will allow a non-admin user to add/remove hosts
to/from a host collection.

The basic permissions needed are:

Host Collections view_host_collections, edit_host_collections
Host             view_hosts, edit_hosts
Organization     view_organizations