### PR TITLE
Fixes #16757 - format for version info in content_view API

### DIFF
--- a/app/views/katello/api/v2/content_views/base.json.rabl
+++ b/app/views/katello/api/v2/content_views/base.json.rabl
@@ -5,8 +5,11 @@ attributes :composite
 attributes :repository_ids
 attributes :component_ids
 attributes :default
-attributes :next_version
 attributes :force_puppet_environment
+
+node :next_version do |content_view|
+  content_view.next_version.to_f.to_s
+end
 
 node :last_published do |content_view|
   unless content_view.versions.empty?


### PR DESCRIPTION
When pulling information about a composite content view using:

/katello/api/content_views/:content_view_id
...the components list includes the current version of the component as well as a content_view list that includes the next_version number.

Version is a string and includes a suffix of ".0" while next_version is an integer (no ".0").

