### PR TITLE
Fixes #17265 - Updating repo url of puppet repositories fails

### DIFF
--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -255,6 +255,7 @@ module Katello
           dist.auto_publish = true
           distributors = [dist]
         when Repository::PUPPET_TYPE
+          capsule ||= SmartProxy.default_capsule
           dist_options = { :id => self.pulp_id, :auto_publish => true }
           repo_path =  File.join(capsule.puppet_path,
                                  Environment.construct_name(self.organization,


### PR DESCRIPTION
**Error trace:**
```
undefined method `puppet_path' for nil:NilClass (NoMethodError)
/home/.../katello/app/models/katello/glue/pulp/repo.rb:259:in `generate_distributors'
```