### PR TITLE
Fixes #17266 - Fix tests that depend on CVE 2016-7078

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -298,7 +298,7 @@ module Katello
         User.as_anonymous_admin { Resources::Candlepin::Consumer.get(uuid) }
         fail HttpErrors::NotFound, _("Couldn't find consumer '%s'") % uuid
       end
-      @host = facet.host
+      @host = ::Host::Managed.unscoped.find(facet.host_id)
     end
 
     def find_content_view_environment

--- a/app/controllers/katello/api/v2/capsule_content_controller.rb
+++ b/app/controllers/katello/api/v2/capsule_content_controller.rb
@@ -86,7 +86,7 @@ module Katello
     end
 
     def find_capsule
-      @capsule = SmartProxy.authorized(:manage_capsule_content).find(params[:id])
+      @capsule = SmartProxy.unscoped.authorized(:manage_capsule_content).find(params[:id])
       unless @capsule && @capsule.has_feature?(SmartProxy::PULP_NODE_FEATURE)
         fail _("This request may only be performed on a Smart proxy that has the Pulp Node feature.")
       end

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -14,9 +14,9 @@ module Katello
       @content_view = katello_content_views(:acme_default)
       @environment = katello_environments(:library)
 
+      @organization = get_organization
       @host = FactoryGirl.create(:host, :with_content, :with_subscription, :content_view => @content_view,
                                  :lifecycle_environment => @environment, :organization => @content_view.organization)
-      @organization = get_organization
     end
 
     describe "register with activation key should fail" do

--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -450,6 +450,8 @@ module Katello
       end
 
       assert_protected_action(:remove, allowed_perms, denied_perms) do
+        User.current.update_attribute(:organizations, [host.organization])
+        User.current.update_attribute(:locations, [host.location])
         put :remove, :id => content_view.id,
                      :environment_ids => env_ids,
                      :system_content_view_id => alternate_cv.id,

--- a/test/controllers/api/v2/host_errata_controller_test.rb
+++ b/test/controllers/api/v2/host_errata_controller_test.rb
@@ -81,6 +81,10 @@ module Katello
       bad_perms = [@view_permission, @create_permission, @destroy_permission]
 
       assert_protected_action(:apply, good_perms, bad_perms) do
+        @host.update_attribute(:organization, taxonomies(:organization1))
+        @host.update_attribute(:location, taxonomies(:location1))
+        User.current.update_attribute(:organizations, [@host.organization])
+        User.current.update_attribute(:locations, [@host.location])
         put :apply, :host_id => @host.id, :errata_ids => %w(RHSA-1999-1231)
       end
     end

--- a/test/controllers/api/v2/host_packages_controller_test.rb
+++ b/test/controllers/api/v2/host_packages_controller_test.rb
@@ -104,6 +104,10 @@ module Katello
       bad_perms = [@update_permission, @create_permission, @destroy_permission]
 
       assert_protected_action(:index, good_perms, bad_perms) do
+        User.current.update_attribute(:organizations, [taxonomies(:organization1)])
+        @host.update_attribute(:organization, taxonomies(:organization1))
+        User.current.update_attribute(:locations, [taxonomies(:location1)])
+        @host.update_attribute(:location, taxonomies(:location1))
         get :index, :host_id => @host.id
       end
     end
@@ -111,6 +115,12 @@ module Katello
     def test_permissions
       good_perms = [@update_permission]
       bad_perms = [@view_permission, @create_permission, @destroy_permission]
+
+      # Ensure the user that will run the actions has access to the host taxonomies
+      users(:restricted).update_attribute(:organizations, [taxonomies(:organization1)])
+      @host.update_attribute(:organization, taxonomies(:organization1))
+      users(:restricted).update_attribute(:locations, [taxonomies(:location1)])
+      @host.update_attribute(:location, taxonomies(:location1))
 
       assert_protected_action(:install, good_perms, bad_perms) do
         put :install, :host_id => @host.id, :packages => ["foo*"]

--- a/test/controllers/api/v2/host_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/host_subscriptions_controller_test.rb
@@ -9,6 +9,8 @@ module Katello
 
     def models
       @host = FactoryGirl.create(:host, :with_subscription)
+      users(:restricted).update_attribute(:organizations, [@host.organization])
+      users(:restricted).update_attribute(:locations, [@host.location])
       @pool = katello_pools(:pool_one)
       @entitlements = [{:pool => {:id => @pool.cp_id}, :quantity => '3'}.with_indifferent_access]
     end

--- a/test/controllers/api/v2/hosts_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/hosts_bulk_actions_controller_test.rb
@@ -150,9 +150,15 @@ module Katello
       assert_response :success
     end
 
+    def allow_restricted_user_to_see_host
+      users(:restricted).update_attribute(:organizations, [@org])
+      users(:restricted).update_attribute(:locations, [@host1.location, @host2.location].uniq)
+    end
+
     def test_permissions
       good_perms = [@update_permission]
       bad_perms = [@view_permission, @destroy_permission]
+      allow_restricted_user_to_see_host
 
       assert_protected_action(:bulk_add_host_collections, good_perms, bad_perms) do
         put :bulk_add_host_collections,  :included => {:ids => @host_ids},
@@ -192,6 +198,7 @@ module Katello
     def test_environment_content_view_permission
       good_perms = [@update_permission]
       bad_perms = [@view_permission, @destroy_permission]
+      allow_restricted_user_to_see_host
 
       assert_protected_action(:environment_content_view, good_perms, bad_perms) do
         put :environment_content_view, :included => {:ids => @host_ids}, :organization_id => @org.id,

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -78,9 +78,9 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
 
   def test_create_with_permitted_attributes
     cf_attrs = {:content_view_id => @content_view.id, :lifecycle_environment_id => @environment.id}
-    attrs = @host.clone.attributes.merge("name" => "contenthost", "content_facet_attributes" => cf_attrs)
+    attrs = @host.clone.attributes.merge("name" => "contenthost", "content_facet_attributes" => cf_attrs).compact!
 
-    assert_difference('Host.count') do
+    assert_difference('Host.unscoped.count') do
       post :create, attrs
       assert_response :success
     end
@@ -91,7 +91,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
                 :lifecycle_environment_id => @environment.id,
                 :uuid => "thisshouldntbeabletobesetbyuser"
                }
-    attrs = @host.clone.attributes.merge("name" => "contenthost1", "content_facet_attributes" => cf_attrs)
+    attrs = @host.clone.attributes.merge("name" => "contenthost1", "content_facet_attributes" => cf_attrs).compact!
 
     post :create, attrs
     assert_response :success # the uuid is simply filtered out which allows the host to be still saved

--- a/test/controllers/foreman/hostgroups_controller_test.rb
+++ b/test/controllers/foreman/hostgroups_controller_test.rb
@@ -22,7 +22,7 @@ class HostgroupsControllerTest < ActionController::TestCase
     post :create, :hostgroup => {:name => "foobar", :content_view_id => @library_view.id,
                                  :lifecycle_environment_id => @library.id}
 
-    assert_equal 1, Hostgroup.where(:name => "foobar").count
+    assert_equal 1, Hostgroup.unscoped.where(:name => "foobar").count
     assert_response 302
   end
 end

--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -179,7 +179,7 @@ class ActiveSupport::TestCase
 
   def set_user(user = nil)
     user ||= users(:admin)
-    user = User.find(user.id) if user.id
+    user = User.unscoped.find(user.id) if user.id
     User.current = user
   end
 

--- a/test/lib/tasks/seeds_test.rb
+++ b/test/lib/tasks/seeds_test.rb
@@ -13,7 +13,8 @@ module Katello
 
     def seed
       # Authorisation is disabled usually when run from a rake db:* task
-      User.current = FactoryGirl.build(:user, :admin => true)
+      User.current = FactoryGirl.build(:user, :admin => true,
+                                       :organizations => [], :locations => [])
       load File.expand_path("#{Rails.root}/db/seeds.rb", __FILE__)
     end
 
@@ -57,10 +58,10 @@ module Katello
   class ProvisioningTemplatesTest < SeedsTest
     test "Make sure provisioning templates exist" do
       seed
-      assert ProvisioningTemplate.where(:default => true).exists?
+      assert ProvisioningTemplate.unscoped.where(:default => true).exists?
       template_names = ["Katello Kickstart Default", "Katello Kickstart Default User Data", "Katello Kickstart Default Finish", "subscription_manager_registration", "Katello Atomic Kickstart Default"]
 
-      ProvisioningTemplate.where(:default => true, :vendor => "Katello").each do |template|
+      ProvisioningTemplate.unscoped.where(:default => true, :vendor => "Katello").each do |template|
         assert template_names.include?(template.name)
         refute_empty template.organizations
       end

--- a/test/models/authorization/content_view_version_authorization_test.rb
+++ b/test/models/authorization/content_view_version_authorization_test.rb
@@ -39,6 +39,8 @@ module Katello
 
     def test_non_admin
       User.current = User.find(users(:restricted).id)
+      User.current.organizations = [@host.organization, @view.organization]
+      User.current.locations = [@host.location]
 
       refute @view.version(@library).all_hosts_editable?(@library)
     end

--- a/test/support/controller_support.rb
+++ b/test/support/controller_support.rb
@@ -7,9 +7,11 @@ module ControllerSupport
     permissions = params[:permission].is_a?(Array) ? params[:permission] : [params[:permission]]
 
     permissions.each do |permission|
-      user = User.find(users(:restricted).id)
+      user = User.unscoped.find(users(:restricted).id)
       user.organizations = params[:organizations] if params[:organizations].present?
-      setup_user_with_permissions(permission, user)
+      as_admin do
+        setup_user_with_permissions(permission, user)
+      end
 
       action = params[:action]
       req = params[:request]


### PR DESCRIPTION
A small number of tests in the Katello codebase depended on regular
users being able to see objects without organization/location. This is
now fixed in core through a CVE (users shouldn't view stuff they're not
scoped to see), so in order for Jenkins to pass, we need to make Katello
tests pass with it too.