### PR TITLE
Fixes #16744 - sync plan response format change

### DIFF
--- a/app/controllers/katello/api/v2/sync_plans_controller.rb
+++ b/app/controllers/katello/api/v2/sync_plans_controller.rb
@@ -45,11 +45,7 @@ module Katello
     param :organization_id, :number, :desc => N_("Filter sync plans by organization name or label"), :required => true
     param_group :sync_plan
     def create
-      sync_date = sync_plan_params[:sync_date].to_time(:utc)
-
-      unless sync_date.is_a?(Time)
-        fail _("Date format is incorrect.")
-      end
+      sync_date = sync_plan_params[:sync_date].try(:to_time, :utc)
 
       @sync_plan = SyncPlan.new(sync_plan_params)
       @sync_plan.sync_date = sync_date

--- a/app/models/katello/sync_plan.rb
+++ b/app/models/katello/sync_plan.rb
@@ -22,17 +22,13 @@ module Katello
     validates :name, :presence => true, :uniqueness => {:scope => :organization_id}
     validates :interval, :inclusion => {:in => TYPES}, :allow_blank => false
     validates :enabled, :inclusion => [true, false]
-    validate :validate_sync_date
+    validate :sync_date, :presence => true
     validates_with Validators::KatelloNameFormatValidator, :attributes => :name
 
     scoped_search :on => :name, :complete_value => true
     scoped_search :on => :organization_id, :complete_value => true, :only_explicit => true
     scoped_search :on => :interval, :complete_value => true
     scoped_search :on => :enabled, :complete_value => true
-
-    def validate_sync_date
-      errors.add :base, _("Start Date and Time can't be blank") if self.sync_date.nil?
-    end
 
     def plan_day
       WEEK_DAYS[self.sync_date.strftime('%A').to_i]


### PR DESCRIPTION
sync plan create api returns 500 for missing or improperly formatted sync date, It should return a bad request.

