### PR TITLE
Fixes #17281 - helper method default_location_ids

### DIFF
--- a/app/models/katello/concerns/environment_extensions.rb
+++ b/app/models/katello/concerns/environment_extensions.rb
@@ -38,7 +38,7 @@ module Katello
         def build_by_katello_id(org, env, content_view)
           env_name = Environment.construct_name(org, env, content_view)
           katello_id = Environment.construct_katello_id(org, env, content_view)
-          environment = Environment.new(:name => env_name, :organization_ids => [org.id], :location_ids => [::Location.default_location.id])
+          environment = Environment.new(:name => env_name, :organization_ids => [org.id], :location_ids => ::Location.default_location_ids)
           environment.katello_id = katello_id
           environment
         end

--- a/app/models/katello/concerns/location_extensions.rb
+++ b/app/models/katello/concerns/location_extensions.rb
@@ -40,6 +40,11 @@ module Katello
           # In the future, we should have a better way to identify the 'default' location
           Location.where(:katello_default => true).first
         end
+
+        def default_location_ids
+          return [] unless default_location
+          [default_location.id]
+        end
       end
     end
   end

--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -237,6 +237,10 @@ class ActiveSupport::TestCase
     loc.katello_default = true
     loc.save!
   end
+
+  def reset_default_location
+    Location.where(katello_default: true).update_all(katello_default: false)
+  end
 end
 
 def disable_lazy_accessors

--- a/test/models/concerns/environment_extensions_test.rb
+++ b/test/models/concerns/environment_extensions_test.rb
@@ -48,6 +48,13 @@ module Katello
       env.save!
     end
 
+    def test_locations_disabled_build_by_katello_id
+      reset_default_location
+      assert_nothing_raised do
+        Environment.build_by_katello_id(@org, @env, @content_view)
+      end
+    end
+
     def test_find_by_katello_id
       assert_nil Environment.find_by_katello_id(@org, @env, @content_view)
 

--- a/test/models/foreman/location_test.rb
+++ b/test/models/foreman/location_test.rb
@@ -29,5 +29,11 @@ module Katello
         loc.save!
       end
     end
+
+    def test_default_location_ids
+      loc_ids = Location.default_location_ids
+      refute_nil loc_ids
+      assert_equal(loc_ids, [Location.default_location.id])
+    end
   end
 end


### PR DESCRIPTION
Created `Location#default_location_ids` to avoid chain break in-case locations are disabled(`Location.default_location is nil`).