### PR TITLE
Fixes #16327 - "Use Latest" is incorrectly pointing to lower version

### DIFF
--- a/app/models/katello/content_view_puppet_module.rb
+++ b/app/models/katello/content_view_puppet_module.rb
@@ -34,6 +34,11 @@ module Katello
       puppet_module.try(:version)
     end
 
+    def latest_in_modules_by_author?(puppet_module_list)
+      latest_from_list = puppet_module_list.where(:author => self.author).order(:sortable_version => :desc).first
+      self.computed_version.eql?(latest_from_list.try(:version))
+    end
+
     before_save :set_attributes
 
     private

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/content-view.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/content-view.factory.js
@@ -35,16 +35,7 @@ angular.module('Bastion.content-views').factory('ContentView',
                 }},
                 availablePuppetModules: {method: 'GET', params: {action: 'available_puppet_modules'},
                     transformResponse: function (data) {
-                        var response = angular.fromJson(data);
-
-                        angular.forEach(_.groupBy(response.results, 'author'), function (puppetModules) {
-                            var latest = angular.copy(puppetModules[0]);
-                            latest.version = translate('Always Use Latest (currently %s)').replace('%s', latest.version);
-                            latest.useLatest = true;
-                            response.results.push(latest);
-                        });
-
-                        return response;
+                        return angular.fromJson(data);
                     }
                 },
                 availablePuppetModuleNames: {method: 'GET', params: {action: 'available_puppet_module_names'}},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/content-view-puppet-module-versions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/content-view-puppet-module-versions.controller.js
@@ -34,10 +34,6 @@ angular.module('Bastion.content-views').controller('ContentViewPuppetModuleVersi
                 name: module.name
             };
 
-            if (module.useLatest) {
-                contentViewPuppetModuleData.uuid = null;
-            }
-
             contentViewPuppetModule = new ContentViewPuppetModule(contentViewPuppetModuleData);
 
             if ($scope.$stateParams.moduleId) {

--- a/test/fixtures/models/katello_content_view_puppet_modules.yml
+++ b/test/fixtures/models/katello_content_view_puppet_modules.yml
@@ -6,3 +6,8 @@ library_view_abrt_module:
   name:            abrt
   author:          johndoe
   content_view_id: <%= ActiveRecord::FixtureSet.identify(:library_view) %>
+
+library_view_m1_module:
+  name:            m1
+  author:          kavy
+  content_view_id: <%= ActiveRecord::FixtureSet.identify(:library_view) %>

--- a/test/fixtures/models/katello_puppet_modules.yml
+++ b/test/fixtures/models/katello_puppet_modules.yml
@@ -25,3 +25,24 @@ foreman_proxy:
   version:  1.0
   uuid:     3bd47a52-0847-42b5-90ff-adslkdkkda32
   sortable_version: 01-1.01-0
+
+test_apt1:
+  name:     "test_apt"
+  author:   "rht"
+  version:  1.0
+  uuid:     38621fb1-53e5-486e-992b-26c5e7cbd9ea
+  sortable_version: 01-1.01-0
+
+test_apt2:
+  name:     "test_apt"
+  author:   "rht"
+  version:  2.0
+  uuid:     ab77f339-5336-4ad7-a8e7-396b97a7f928
+  sortable_version: 01-2.01-0
+
+test_apt3:
+  name:     "test_apt"
+  author:   "rht"
+  version:  3.0
+  uuid:     65d24ba7-bed4-41ad-a7c9-30e4bb0793bd
+  sortable_version: 01-3.01-0

--- a/test/models/content_view_puppet_module_test.rb
+++ b/test/models/content_view_puppet_module_test.rb
@@ -58,5 +58,22 @@ module Katello
       )
       assert_equal nil, content_view_puppet_module.computed_version
     end
+
+    def test_latest_in_modules_by_author
+      repo = katello_repositories(:p_forge)
+      puppet_module_apt = katello_puppet_modules(:test_apt3)
+      content_view_puppet_module = ContentViewPuppetModule.new(
+        :uuid => puppet_module_apt.uuid,
+        :author => puppet_module_apt.author,
+        :content_view => @library_view
+      )
+      content_view_puppet_module.save!
+      repo.puppet_modules = [katello_puppet_modules(:test_apt1),
+                             katello_puppet_modules(:test_apt2),
+                             katello_puppet_modules(:test_apt3)]
+      modules = PuppetModule.in_repositories(repo)
+      modules = modules.where(:name => puppet_module_apt.name)
+      assert_equal true, content_view_puppet_module.latest_in_modules_by_author?(modules)
+    end
   end
 end


### PR DESCRIPTION
During selection of puppet module - "Use Latest" is incorrectly pointing to lower version than available in the repo.
Use Latest should point to actual Latest version available.
With this commit, actual Latest version will appear on a list as well so that Use Latest will point to correct version.