### PR TITLE
fixes #17402 - lifecycle environment - fix puppet modules filter

### DIFF
--- a/app/controllers/katello/api/v2/puppet_modules_controller.rb
+++ b/app/controllers/katello/api/v2/puppet_modules_controller.rb
@@ -2,5 +2,13 @@ module Katello
   class Api::V2::PuppetModulesController < Api::V2::ApiController
     apipie_concern_subst(:a_resource => N_("a puppet module"), :resource => "puppet_modules")
     include Katello::Concerns::Api::V2::RepositoryContentController
+
+    def custom_index_relation(collection)
+      if @environment && !@environment.library?
+        collection = collection.joins(:content_view_puppet_environments).
+            where("#{Katello::ContentViewPuppetEnvironment.table_name}.environment_id" => @environment.id)
+      end
+      collection
+    end
   end
 end

--- a/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
+++ b/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
@@ -77,7 +77,13 @@ module Katello
         collection = filter_by_repos(Repository.readable, collection)
         collection = filter_by_repos([@repo], collection) if @repo
         collection = filter_by_content_view_version(@version, collection) if @version
-        collection = filter_by_environment(@environment, collection) if @environment
+        if @environment && (@environment.library? || resource_class != Katello::PuppetModule)
+          # if the environment is not library and this is for puppet modules,
+          # we can skip environment filter, as those would be associated to
+          # content view puppet environments and handled by the puppet modules
+          # controller.
+          collection = filter_by_environment(@environment, collection)
+        end
         collection = filter_by_repos(Repository.readable.in_organization(@organization), collection) if @organization
         collection = filter_by_ids(params[:ids], collection) if params[:ids]
         @filter = ContentViewFilter.find(params[:filterId]) if params[:filterId]

--- a/test/actions/katello/content_view_puppet_environment_test.rb
+++ b/test/actions/katello/content_view_puppet_environment_test.rb
@@ -76,6 +76,7 @@ module ::Actions::Katello::ContentViewPuppetEnvironment
     end
 
     it 'plans without existing cv puppet environment' do
+      dev_puppet_env.puppet_modules.delete_all
       dev_puppet_env.delete
 
       plan_action action, puppet_env.content_view_version, :environment => dev
@@ -97,6 +98,7 @@ module ::Actions::Katello::ContentViewPuppetEnvironment
     end
 
     it 'does not plan things when cvep does not already exist and no puppet modules' do
+      dev_puppet_env.puppet_modules.delete_all
       dev_puppet_env.delete
 
       plan_action action, puppet_env.content_view_version, :environment => dev, :puppet_modules_present => false

--- a/test/controllers/api/v2/puppet_modules_controller_test.rb
+++ b/test/controllers/api/v2/puppet_modules_controller_test.rb
@@ -50,6 +50,23 @@ module Katello
       assert_template "katello/api/v2/puppet_modules/index"
     end
 
+    def test_index_with_content_view_version
+      dev_puppet_env = katello_content_view_puppet_environments(:dev_view_puppet_environment)
+      ContentViewPuppetEnvironment.stubs(:archived).returns([dev_puppet_env])
+
+      get :index, :environment_id => dev_puppet_env.environment_id,
+          :content_view_version_id => dev_puppet_env.content_view_version.id
+
+      assert_response :success
+      results_puppet_module = JSON.parse(response.body)['results'].first
+
+      # the content view version in the dev puppet environment only has the 'dhcp' puppet module,
+      # which is the same as @puppet_module
+      assert_equal results_puppet_module['name'], @puppet_module.name
+      assert_equal results_puppet_module['author'], @puppet_module.author
+      assert_equal results_puppet_module['version'], @puppet_module.version
+    end
+
     def test_index_protected
       assert_protected_action(:index, @read_permission, @unauth_permissions) do
         get :index, :repository_id => @repo.id

--- a/test/fixtures/models/katello_content_view_puppet_environment_puppet_modules.yml
+++ b/test/fixtures/models/katello_content_view_puppet_environment_puppet_modules.yml
@@ -1,0 +1,3 @@
+dev_view_puppet_environment_dhcp_puppet_module:
+  content_view_puppet_environment_id: <%= ActiveRecord::FixtureSet.identify(:dev_view_puppet_environment) %>
+  puppet_module_id: <%= ActiveRecord::FixtureSet.identify(:dhcp) %>


### PR DESCRIPTION
This commit will fix the filtering to obtain the list of
puppet modules in a non-library (e.g. dev, test,...)
lifecycle environment.  (Ref: Content -> Lifecycle Environments)