### PR TITLE
fixes #17363 - fix links to subscriptions on activation key

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-add-subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-add-subscriptions.html
@@ -40,11 +40,7 @@
 
       <tbody>
         <tr bst-table-row ng-repeat-start="(name, subscriptions) in groupedSubscriptions">
-          <td class="row-select">
-            <a href='/subscriptions/{{ subscription.id }}/info' class='confined-text'>
-              {{ name }}
-            </a>
-          </td>
+          <td bst-table-cell class="row-select" style="white-space:nowrap">{{ name }}</td>
           <td bst-table-cell colspan="8"></td>
         </tr>
         <tr bst-table-row 
@@ -63,7 +59,11 @@
               <option value="">{{ "Automatic" | translate }}</option>
             </select>
           </td>
-          <td bst-table-cell>{{ subscription | subscriptionConsumedFilter }}</td>
+          <td bst-table-cell>
+            <a href='/subscriptions/{{ subscription.id }}/info' class="confined-text">
+              {{ subscription | subscriptionConsumedFilter }}
+            </a>
+          </td>
           <td bst-table-cell><div subscription-type="subscription"></div></td>
           <td bst-table-cell>{{ subscription.start_date | date:"shortDate" }}</td>
           <td bst-table-cell>{{ subscription.end_date | date:"shortDate" }}</td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-subscriptions-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-subscriptions-list.html
@@ -51,16 +51,16 @@
 
       <tbody>
         <tr bst-table-row ng-repeat-start="(name, subscriptions) in groupedSubscriptions | groupedFilter: subscriptionSearch">
-          <td class="row-select">
-            <a href='/subscriptions/{{ subscription.id }}/info' class="confined-text">
-              {{ name }}
-            </a>
-          </td>
+          <td bst-table-cell class="row-select" style="white-space:nowrap">{{ name }}</td>
           <td bst-table-cell colspan="8" ></td>
         </tr>
         <tr class="grey-table-row" bst-table-row ng-repeat-end ng-repeat="subscription in subscriptions" row-select="subscription">
           <td bst-table-cell>{{ subscription | subscriptionAttachAmountFilter }}</td>
-          <td bst-table-cell>{{ subscription | subscriptionConsumedFilter }}</td>
+          <td bst-table-cell>
+            <a href='/subscriptions/{{ subscription.id }}/info' class="confined-text">
+              {{ subscription | subscriptionConsumedFilter }}
+            </a>
+          </td>
           <td bst-table-cell><div subscription-type="subscription"></div></td>
           <td bst-table-cell>{{ subscription.start_date | date:"shortDate" }}</td>
           <td bst-table-cell>{{ subscription.end_date | date:"shortDate" }}</td>


### PR DESCRIPTION
This commit fixes the issue where the links to subscriptions
from the activation keys page were not working properly.

It does change the link to be on the 'Consumed' column content
versus the subscription name, since there could be multiple
pools for a given subscription.