### PR TITLE
Fixes #17498 - Improve ListenOnCandlepinEvents throughput

### DIFF
--- a/app/lib/actions/candlepin/candlepin_listening_service.rb
+++ b/app/lib/actions/candlepin/candlepin_listening_service.rb
@@ -83,7 +83,6 @@ module Actions
                 suspended_action.notify_not_connected(message[:error])
                 break
               end
-              sleep 1
             rescue => e
               suspended_action.notify_fatal(e)
               raise e


### PR DESCRIPTION
Remove "sleep 1" from the loop of processing messages from
katello_event_queue.

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>