### PR TITLE
Fixes #17512 - index content in a paged manner

### DIFF
--- a/app/lib/actions/katello/repository/filtered_index_content.rb
+++ b/app/lib/actions/katello/repository/filtered_index_content.rb
@@ -14,13 +14,13 @@ module Actions
           repo = ::Katello::Repository.find(input[:id])
           unit_ids = search_units(repo)
           if repo.puppet?
-            repo.index_db_puppet_modules
+            ::Katello::PuppetModule.import_for_repository(repo)
           elsif repo.docker?
-            repo.index_db_docker_manifests
+            ::Katello::DockerManifest.import_for_repository(repo)
           elsif repo.file?
-            repo.index_db_files
+            ::Katello::FileUnit.import_for_repository(repo)
           else
-            ::Katello::Rpm.import_all(unit_ids, true)
+            ::Katello::Rpm.import_all(unit_ids, :additive => true)
           end
         end
 

--- a/app/lib/actions/katello/repository/index_errata.rb
+++ b/app/lib/actions/katello/repository/index_errata.rb
@@ -8,7 +8,7 @@ module Actions
 
         def run
           repo = ::Katello::Repository.find(input[:id])
-          repo.index_db_errata
+          ::Katello::Erratum.import_for_repository(repo)
         end
       end
     end

--- a/app/lib/actions/katello/repository/index_package_groups.rb
+++ b/app/lib/actions/katello/repository/index_package_groups.rb
@@ -10,7 +10,7 @@ module Actions
 
         def run
           repo = ::Katello::Repository.find(input[:id])
-          repo.index_db_package_groups
+          ::Katello::PackageGroup.import_for_repository(repo)
         end
       end
     end

--- a/app/models/katello/glue/pulp/repos.rb
+++ b/app/models/katello/glue/pulp/repos.rb
@@ -79,22 +79,6 @@ module Katello
         async_tasks
       end
 
-      def package_groups(env, search_args = {})
-        groups = []
-        self.repos(env).each do |repo|
-          groups << repo.package_groups(search_args)
-        end
-        groups.flatten(1)
-      end
-
-      def package_group_categories(env, search_args = {})
-        categories = []
-        self.repos(env).each do |repo|
-          categories << repo.package_group_categories(search_args)
-        end
-        categories.flatten(1)
-      end
-
       def find_packages_by_name(env, name)
         packages = self.repos(env).collect do |repo|
           repo.find_packages_by_name(name).collect do |p|

--- a/app/models/katello/kt_environment.rb
+++ b/app/models/katello/kt_environment.rb
@@ -207,22 +207,6 @@ module Katello
       "environment_#{id}_#{item}"
     end
 
-    def package_groups(search_args = {})
-      groups = []
-      self.products.each do |prod|
-        groups << prod.package_groups(self, search_args)
-      end
-      groups.flatten(1)
-    end
-
-    def package_group_categories(search_args = {})
-      categories = []
-      self.products.each do |prod|
-        categories << prod.package_group_categories(self, search_args)
-      end
-      categories.flatten(1)
-    end
-
     def find_packages_by_name(name)
       products = self.products.collect do |prod|
         prod.find_packages_by_name(self, name).collect do |p|

--- a/app/services/katello/pulp/docker_tag.rb
+++ b/app/services/katello/pulp/docker_tag.rb
@@ -1,0 +1,7 @@
+module Katello
+  module Pulp
+    class DockerTag < PulpContentUnit
+      CONTENT_TYPE = "docker_tag".freeze
+    end
+  end
+end

--- a/app/services/katello/pulp/pulp_content_unit.rb
+++ b/app/services/katello/pulp/pulp_content_unit.rb
@@ -25,20 +25,47 @@ module Katello
       end
 
       def self.fetch_all
-        all_items = items = fetch(0, SETTINGS[:katello][:pulp][:bulk_load_size])
-        until items.empty? #we can't know how many there are, so we have to keep looping until we get nothing
-          items = fetch(all_items.length, SETTINGS[:katello][:pulp][:bulk_load_size])
-          all_items.concat(items)
+        count = 0
+        results = []
+        sub_list = fetch(0, SETTINGS[:katello][:pulp][:bulk_load_size])
+
+        until sub_list.empty? #we can't know how many there are, so we have to keep looping until we get nothing
+          count += sub_list.count
+          if block_given?
+            value = yield(sub_list)
+            value.is_a?(Array) ? results.concat(value) : results << value
+          else
+            results.concat(sub_list)
+          end
+
+          sub_list = fetch(count, SETTINGS[:katello][:pulp][:bulk_load_size])
         end
-        all_items
+        results
       end
 
       def self.fetch_by_uuids(uuids)
-        items = []
+        results = []
         uuids.each_slice(SETTINGS[:katello][:pulp][:bulk_load_size]) do |sub_list|
-          items.concat(fetch(0, sub_list.length, sub_list))
+          fetched = fetch(0, sub_list.length, sub_list)
+          if block_given?
+            value = yield(fetched)
+            value.is_a?(Array) ? results.concat(value) : results << value
+          else
+            results.concat(fetched)
+          end
         end
-        items
+        results
+      end
+
+      def self.ids_for_repository(repo_id)
+        criteria = {:type_ids => [const_get(:CONTENT_TYPE)],
+                    :fields => {:unit => [], :association => ['unit_id']}}
+        Katello.pulp_server.resources.repository.unit_search(repo_id, criteria).map { |i| i['unit_id'] }
+      end
+
+      def self.fetch_for_repository(repo_id)
+        ids = ids_for_repository(repo_id)
+        fetch(0, ids.count, ids)
       end
 
       def self.fetch(offset, page_size, uuids = nil)

--- a/lib/katello/tasks/reimport.rake
+++ b/lib/katello/tasks/reimport.rake
@@ -21,7 +21,9 @@ namespace :katello do
               Katello::Rpm,
               Katello::FileUnit,
               Katello::Subscription,
-              Katello::Pool]
+              Katello::Pool,
+              Katello::DockerManifest,
+              Katello::DockerTag]
 
     models << Katello::OstreeBranch if Katello::RepositoryTypeManager.find(Katello::Repository::OSTREE_TYPE).present?
 
@@ -33,12 +35,6 @@ namespace :katello do
     print "Importing Activation Key Subscriptions\n"
     Katello::ActivationKey.all.each do |ack_key|
       ack_key.import_pools
-    end
-
-    print "Importing Docker Content\n"
-    # For docker repositories, index all associated manifests and tags
-    Katello::Repository.docker_type.each do |docker_repo|
-      docker_repo.index_db_docker_manifests
     end
   end
 end

--- a/test/actions/pulp/repository/sync_test.rb
+++ b/test/actions/pulp/repository/sync_test.rb
@@ -24,7 +24,7 @@ module ::Actions::Pulp::Repository
   class SyncTest < VCRTestBase
     def test_sync
       ForemanTasks.sync_task(::Actions::Pulp::Repository::Sync, :pulp_id => repo.pulp_id).main_action
-      assert_equal 8, repo.pulp_rpm_ids.length
+      assert_equal 8, ::Katello::Pulp::Rpm.ids_for_repository(repo.pulp_id).length
     end
   end
 

--- a/test/actions/pulp/repository/upload_file_test.rb
+++ b/test/actions/pulp/repository/upload_file_test.rb
@@ -19,7 +19,7 @@ module ::Actions::Pulp::Repository
       run_action(::Actions::Pulp::Repository::DeleteUploadRequest,
                   upload_id: upload_request.output[:upload_id])
 
-      assert_equal 1, repo.pulp_puppet_module_ids.length
+      assert_equal 1, ::Katello::Pulp::PuppetModule.ids_for_repository(repo.pulp_id).length
     end
   end
 end

--- a/test/fixtures/vcr_cassettes/services/pulp/erratum.yml
+++ b/test/fixtures/vcr_cassettes/services/pulp/erratum.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/f0e9dcab-0135-427d-872d-38025955ac74/
+    uri: https://robot.example.com/pulp/api/v2/tasks/0009c176-9e5f-418e-8e21-23ad7c1b9603/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -21,13 +21,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:39 GMT
+      - Tue, 29 Nov 2016 19:43:09 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '649'
+      - '629'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -35,498 +35,23 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mMGU5ZGNhYi0wMTM1LTQyN2QtODcyZC0zODAyNTk1NWFj
-        NzQvIiwgInRhc2tfaWQiOiAiZjBlOWRjYWItMDEzNS00MjdkLTg3MmQtMzgw
-        MjU5NTVhYzc0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8wMDA5YzE3Ni05ZTVmLTQxOGUtOGUyMS0yM2FkN2MxYjk2
+        MDMvIiwgInRhc2tfaWQiOiAiMDAwOWMxNzYtOWU1Zi00MThlLThlMjEtMjNh
+        ZDdjMWI5NjAzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Ny0yOVQxODo1ODozOVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAb2JlbGl4LmV4YW1wbGUuY29t
-        LmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVz
-        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAb2JlbGl4LmV4YW1wbGUuY29tIiwg
-        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNTc5YmE3NWY3YmMyNWFhZjA5NTYyZGY3In0sICJpZCI6ICI1NzliYTc1
-        ZjdiYzI1YWFmMDk1NjJkZjcifQ==
-    http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:39 GMT
-- request:
-    method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/f0e9dcab-0135-427d-872d-38025955ac74/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jul 2016 18:58:39 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2292'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mMGU5ZGNhYi0wMTM1LTQyN2QtODcyZC0zODAyNTk1NWFj
-        NzQvIiwgInRhc2tfaWQiOiAiZjBlOWRjYWItMDEzNS00MjdkLTg3MmQtMzgw
-        MjU5NTVhYzc0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wNy0yOVQxODo1ODozOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wNy0yOVQxODo1ODozOVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMmZlODcyZmEtYWVjMC00YWY0LTlhOTItNzVjYWRmYTlh
-        ZWRkLyIsICJ0YXNrX2lkIjogIjJmZTg3MmZhLWFlYzAtNGFmNC05YTkyLTc1
-        Y2FkZmE5YWVkZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiA4LCAicnBtX2RvbmUiOiA4LCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAxNzg3MiwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
-        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXgu
-        ZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2Vy
-        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAb2JlbGl4LmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDE2LTA3LTI5VDE4OjU4OjM5WiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDctMjlU
-        MTg6NTg6MzlaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVu
-        dCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50Ijog
-        MTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAi
-        aWQiOiAiNTc5YmE3NWY3MGJlNmY3MzhlZGQ5ZGE1IiwgImRldGFpbHMiOiB7
-        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAxNzg3MiwgIml0ZW1zX2xlZnQi
-        OiAwLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        c2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDgsICJy
-        cG1fZG9uZSI6IDgsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAi
-        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9y
-        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NzliYTc1ZjdiYzI1YWFmMDk1
-        NjJkZjcifSwgImlkIjogIjU3OWJhNzVmN2JjMjVhYWYwOTU2MmRmNyJ9
-    http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:39 GMT
-- request:
-    method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/2fe872fa-aec0-4af4-9a92-75cadfa9aedd/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jul 2016 18:58:39 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3498'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8yZmU4NzJmYS1hZWMwLTRhZjQtOWE5Mi03NWNh
-        ZGZhOWFlZGQvIiwgInRhc2tfaWQiOiAiMmZlODcyZmEtYWVjMC00YWY0LTlh
-        OTItNzVjYWRmYTlhZWRkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxNi0wNy0yOVQxODo1ODozOVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyOTI0
-        YzM5Ny1iODYyLTQ1NGEtYTgyMC1iMmE0YjY0MDQzZjMiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzA2ZmZlZDItNzE1
-        Ny00M2ZkLThiNWItZWUwMDMzOWVhZjFiIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiZDFkNDhjMGMtOGY2MS00OGNhLTgwMDItOWFkZTQ2MzE5MTBmIiwgIm51
-        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
-        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmM3NmNhOTItYmYwMS00ZjQwLTlm
-        NjYtYWI1MDNhMjMxOTUyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
-        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjJjNjJmNDk5LTRmNjctNGNiMi1iNzk4LWQyMGEzNTZkZDVhYiIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJj
-        b21wcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkNjI3ODc4Ni0xOTJlLTRjOWMt
-        YTY2Mi1kNWM0YjFlMjk4ZDEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
-        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0
-        YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI0Y2E0OTY1My1iZWRkLTQyNDktYTc4YS1lOWJlNDIxNTUyYjgi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI3NzM5MDUzNS05ZDUxLTQwOTItODcxNS04NTQ4ZWNiMjY2MjEiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
-        aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiM2EzYTZi
-        MTUtMTAwMS00N2Y2LTlmNzAtNTE2NzM2NDQxZDRjIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
-        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
-        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjgzMzJlMDMtNGJm
-        NC00Njk3LTk3MTAtNWRhOTIwNDM5NDI4IiwgIm51bV9wcm9jZXNzZWQiOiAw
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5n
-        IExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVw
-        b19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
-        U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiNzRiOWM4MC0yZTM5
-        LTRiYmEtOTQ1YS01ZWYzYjVlM2E3ZTEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVs
-        aXguZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3Jr
-        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXgu
-        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
-        Il9pZCI6IHsiJG9pZCI6ICI1NzliYTc1ZjdiYzI1YWFmMDk1NjJlMDcifSwg
-        ImlkIjogIjU3OWJhNzVmN2JjMjVhYWYwOTU2MmUwNyJ9
-    http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:39 GMT
-- request:
-    method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/f0e9dcab-0135-427d-872d-38025955ac74/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jul 2016 18:58:40 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2292'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mMGU5ZGNhYi0wMTM1LTQyN2QtODcyZC0zODAyNTk1NWFj
-        NzQvIiwgInRhc2tfaWQiOiAiZjBlOWRjYWItMDEzNS00MjdkLTg3MmQtMzgw
-        MjU5NTVhYzc0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wNy0yOVQxODo1ODozOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wNy0yOVQxODo1ODozOVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMmZlODcyZmEtYWVjMC00YWY0LTlhOTItNzVjYWRmYTlh
-        ZWRkLyIsICJ0YXNrX2lkIjogIjJmZTg3MmZhLWFlYzAtNGFmNC05YTkyLTc1
-        Y2FkZmE5YWVkZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiA4LCAicnBtX2RvbmUiOiA4LCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAxNzg3MiwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
-        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXgu
-        ZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2Vy
-        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAb2JlbGl4LmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
-        aW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAic3RhcnRlZCI6ICIyMDE2LTA3LTI5VDE4OjU4OjM5WiIsICJfbnMiOiAi
-        cmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDctMjlU
-        MTg6NTg6MzlaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVu
-        dCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50Ijog
-        MTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAi
-        aWQiOiAiNTc5YmE3NWY3MGJlNmY3MzhlZGQ5ZGE1IiwgImRldGFpbHMiOiB7
-        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAxNzg3MiwgIml0ZW1zX2xlZnQi
-        OiAwLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        c2l6ZV9sZWZ0IjogMCwgImRldGFpbHMiOiB7InJwbV90b3RhbCI6IDgsICJy
-        cG1fZG9uZSI6IDgsICJkcnBtX3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAi
-        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRl
-        bXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9y
-        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NzliYTc1ZjdiYzI1YWFmMDk1
-        NjJkZjcifSwgImlkIjogIjU3OWJhNzVmN2JjMjVhYWYwOTU2MmRmNyJ9
-    http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:40 GMT
-- request:
-    method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/2fe872fa-aec0-4af4-9a92-75cadfa9aedd/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jul 2016 18:58:40 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6911'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8yZmU4NzJmYS1hZWMwLTRhZjQtOWE5Mi03NWNh
-        ZGZhOWFlZGQvIiwgInRhc2tfaWQiOiAiMmZlODcyZmEtYWVjMC00YWY0LTlh
-        OTItNzVjYWRmYTlhZWRkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wNy0yOVQxODo1ODozOVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wNy0yOVQxODo1ODozOVoiLCAi
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIyOTI0YzM5Ny1iODYyLTQ1NGEtYTgyMC1iMmE0YjY0
-        MDQzZjMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNzA2ZmZlZDItNzE1Ny00M2ZkLThiNWItZWUwMDMzOWVhZjFiIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZDFkNDhjMGMtOGY2MS00OGNhLTgwMDIt
-        OWFkZTQ2MzE5MTBmIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmM3
-        NmNhOTItYmYwMS00ZjQwLTlmNjYtYWI1MDNhMjMxOTUyIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjJjNjJmNDk5LTRmNjctNGNiMi1iNzk4LWQyMGEz
-        NTZkZDVhYiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkNjI3ODc4
-        Ni0xOTJlLTRjOWMtYTY2Mi1kNWM0YjFlMjk4ZDEiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI0Y2E0OTY1My1iZWRkLTQyNDktYTc4YS1lOWJl
-        NDIxNTUyYjgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI3NzM5MDUzNS05ZDUxLTQwOTItODcxNS04NTQ4ZWNiMjY2MjEi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzYTNh
-        NmIxNS0xMDAxLTQ3ZjYtOWY3MC01MTY3MzY0NDFkNGMiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyODMzMmUwMy00YmY0
-        LTQ2OTctOTcxMC01ZGE5MjA0Mzk0MjgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI3NGI5YzgwLTJlMzktNGJi
-        YS05NDVhLTVlZjNiNWUzYTdlMSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQG9iZWxpeC5l
-        eGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhh
-        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJl
-        eGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3Rh
-        cnRlZCI6ICIyMDE2LTA3LTI5VDE4OjU4OjM5WiIsICJfbnMiOiAicmVwb19w
-        dWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDctMjlUMTg6
-        NTg6MzlaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBl
-        X2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0
-        ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9y
-        ZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQi
-        LCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklT
-        SEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0
-        YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFf
-        MTciLCAiaWQiOiAiNTc5YmE3NWY3MGJlNmY3MzhlZGQ5ZGE2IiwgImRldGFp
-        bHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0
-        aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
-        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI5MjRjMzk3
-        LWI4NjItNDU0YS1hODIwLWIyYTRiNjQwNDNmMyIsICJudW1fcHJvY2Vzc2Vk
-        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRp
-        c3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3MDZmZmVkMi03MTU3LTQz
-        ZmQtOGI1Yi1lZTAwMzM5ZWFmMWIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
-        Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        UlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJk
-        MWQ0OGMwYy04ZjYxLTQ4Y2EtODAwMi05YWRlNDYzMTkxMGYiLCAibnVtX3By
-        b2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIyYzc2Y2E5Mi1iZjAxLTRmNDAtOWY2Ni1h
-        YjUwM2EyMzE5NTIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
-        ZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwg
-        InN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmM2MmY0
-        OTktNGY2Ny00Y2IyLWI3OTgtZDIwYTM1NmRkNWFiIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImQ2Mjc4Nzg2LTE5MmUtNGM5Yy1hNjYyLWQ1YzRi
-        MWUyOThkMSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAi
-        c3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRjYTQ5
-        NjUzLWJlZGQtNDI0OS1hNzhhLWU5YmU0MjE1NTJiOCIsICJudW1fcHJvY2Vz
-        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        Q2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9y
-        ZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
-        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc3MzkwNTM1LTlkNTEt
-        NDA5Mi04NzE1LTg1NDhlY2IyNjYyMSIsICJudW1fcHJvY2Vzc2VkIjogMX0s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
-        ZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0
-        ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjNhM2E2YjE1LTEwMDEtNDdmNi05ZjcwLTUx
-        NjczNjQ0MWQ0YyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
-        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3
-        ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjI4MzMyZTAzLTRiZjQtNDY5Ny05NzEwLTVkYTkyMDQzOTQy
-        OCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBf
-        dHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYjc0YjljODAtMmUzOS00YmJhLTk0NWEtNWVmM2I1ZTNhN2UxIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjU3OWJhNzVmN2JjMjVhYWYwOTU2MmUwNyJ9LCAiaWQiOiAi
-        NTc5YmE3NWY3YmMyNWFhZjA5NTYyZTA3In0=
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAcm9ib3QuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAid2Fp
+        dGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMUByb2JvdC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU4M2RkYTRkNjcxZTA4ZWFh
+        NmQyNTc2NiJ9LCAiaWQiOiAiNTgzZGRhNGQ2NzFlMDhlYWE2ZDI1NzY2In0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:40 GMT
+  recorded_at: Tue, 29 Nov 2016 19:43:09 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/ef3ef821-d410-4422-b73c-9b60f53b594a/
+    uri: https://robot.example.com/pulp/api/v2/tasks/0009c176-9e5f-418e-8e21-23ad7c1b9603/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -545,113 +70,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:40 GMT
+      - Tue, 29 Nov 2016 19:43:10 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '651'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lZjNlZjgyMS1kNDEwLTQ0MjItYjczYy05YjYwZjUzYjU5
-        NGEvIiwgInRhc2tfaWQiOiAiZWYzZWY4MjEtZDQxMC00NDIyLWI3M2MtOWI2
-        MGY1M2I1OTRhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
-        LTA3LTI5VDE4OjU4OjQwWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
-        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJy
-        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBsZS5jb20i
-        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NzliYTc2MDdiYzI1YWFmMDk1NjJlMDgifSwgImlkIjogIjU3OWJh
-        NzYwN2JjMjVhYWYwOTU2MmUwOCJ9
-    http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:40 GMT
-- request:
-    method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/ef3ef821-d410-4422-b73c-9b60f53b594a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jul 2016 18:58:41 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '670'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lZjNlZjgyMS1kNDEwLTQ0MjItYjczYy05YjYwZjUzYjU5
-        NGEvIiwgInRhc2tfaWQiOiAiZWYzZWY4MjEtZDQxMC00NDIyLWI3M2MtOWI2
-        MGY1M2I1OTRhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTA3LTI5VDE4OjU4OjQwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTA3LTI5VDE4OjU4OjQwWiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBvYmVsaXguZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQi
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        b2JlbGl4LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3NjA3YmMyNWFhZjA5NTYy
-        ZTA4In0sICJpZCI6ICI1NzliYTc2MDdiYzI1YWFmMDk1NjJlMDgifQ==
-    http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:41 GMT
-- request:
-    method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/121c261e-0172-4093-b798-e9dfa038d59d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jul 2016 18:58:42 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '649'
+      - '2282'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -659,66 +84,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xMjFjMjYxZS0wMTcyLTQwOTMtYjc5OC1lOWRmYTAzOGQ1
-        OWQvIiwgInRhc2tfaWQiOiAiMTIxYzI2MWUtMDE3Mi00MDkzLWI3OTgtZTlk
-        ZmEwMzhkNTlkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Ny0yOVQxODo1ODo0MloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAb2JlbGl4LmV4YW1wbGUuY29t
-        LmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVz
-        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAb2JlbGl4LmV4YW1wbGUuY29tIiwg
-        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNTc5YmE3NjI3YmMyNWFhZjA5NTYyZTA5In0sICJpZCI6ICI1NzliYTc2
-        MjdiYzI1YWFmMDk1NjJlMDkifQ==
-    http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:42 GMT
-- request:
-    method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/121c261e-0172-4093-b798-e9dfa038d59d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jul 2016 18:58:42 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2284'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xMjFjMjYxZS0wMTcyLTQwOTMtYjc5OC1lOWRmYTAzOGQ1
-        OWQvIiwgInRhc2tfaWQiOiAiMTIxYzI2MWUtMDE3Mi00MDkzLWI3OTgtZTlk
-        ZmEwMzhkNTlkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8wMDA5YzE3Ni05ZTVmLTQxOGUtOGUyMS0yM2FkN2MxYjk2
+        MDMvIiwgInRhc2tfaWQiOiAiMDAwOWMxNzYtOWU1Zi00MThlLThlMjEtMjNh
+        ZDdjMWI5NjAzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wNy0yOVQxODo1ODo0MloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wNy0yOVQxODo1ODo0MloiLCAidHJhY2ViYWNr
+        Ni0xMS0yOVQxOTo0MzowOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0MzowOVoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvN2Y0MzU3ZmItMzJjYS00Mzg5LThjZmQtM2UwY2ViYmM4
-        MGNmLyIsICJ0YXNrX2lkIjogIjdmNDM1N2ZiLTMyY2EtNDM4OS04Y2ZkLTNl
-        MGNlYmJjODBjZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvMWVlYTA5MGYtYmE3My00ZWMxLTkyMzItZTlhMDI4NzJl
+        NGIxLyIsICJ0YXNrX2lkIjogIjFlZWEwOTBmLWJhNzMtNGVjMS05MjMyLWU5
+        YTAyODcyZTRiMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -729,40 +104,40 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQG9iZWxpeC5leGFt
-        cGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFt
-        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBs
-        ZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBv
-        cnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwg
-        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJz
-        dGFydGVkIjogIjIwMTYtMDctMjlUMTg6NTg6NDJaIiwgIl9ucyI6ICJyZXBv
-        X3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wNy0yOVQxODo1
-        ODo0MloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
-        ZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50Ijog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAxNSwg
-        InJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6
-        ICI1NzliYTc2MjcwYmU2ZjczOGVkZDlkYjIiLCAiZGV0YWlscyI6IHsiY29u
-        dGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVm
-        dCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUi
-        OiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9y
-        X2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3NjI3YmMyNWFhZjA5NTYyZTA5In0s
-        ICJpZCI6ICI1NzliYTc2MjdiYzI1YWFmMDk1NjJlMDkifQ==
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0
+        ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTExLTI5VDE5OjQzOjA5WiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMTEtMjlUMTk6NDM6
+        MDlaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTgzZGRhNGRiMGVhZjIwOTliNjgxODY0IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU4M2RkYTRkNjcxZTA4ZWFhNmQyNTc2NiJ9LCAi
+        aWQiOiAiNTgzZGRhNGQ2NzFlMDhlYWE2ZDI1NzY2In0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:42 GMT
+  recorded_at: Tue, 29 Nov 2016 19:43:10 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/7f4357fb-32ca-4389-8cfd-3e0cebbc80cf/
+    uri: https://robot.example.com/pulp/api/v2/tasks/1eea090f-ba73-4ec1-9232-e9a02872e4b1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -781,13 +156,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:42 GMT
+      - Tue, 29 Nov 2016 19:43:10 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '6911'
+      - '3503'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -795,163 +170,362 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy83ZjQzNTdmYi0zMmNhLTQzODktOGNmZC0zZTBj
-        ZWJiYzgwY2YvIiwgInRhc2tfaWQiOiAiN2Y0MzU3ZmItMzJjYS00Mzg5LThj
-        ZmQtM2UwY2ViYmM4MGNmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy8xZWVhMDkwZi1iYTczLTRlYzEtOTIzMi1lOWEw
+        Mjg3MmU0YjEvIiwgInRhc2tfaWQiOiAiMWVlYTA5MGYtYmE3My00ZWMxLTky
+        MzItZTlhMDI4NzJlNGIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wNy0yOVQxODo1ODo0MloiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wNy0yOVQxODo1ODo0MloiLCAi
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxNi0xMS0yOVQxOTo0MzoxMFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1ZjA1
+        Y2JiMi04MmE0LTRhYWMtYWE2Ni00ZjkwNmMxMmZkYmMiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWYzNmRjZjYtNmFh
+        Yy00NzBiLTkyMjEtM2JmYjI4Y2VjMGVkIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiN2Y0ZWI2Y2YtOTQwMy00N2FkLWFhMmMtM2U4YjI5OWU2NDRmIiwg
+        Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
+        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdkNmIzMDJmLTE3YzIt
+        NGY0Ny05YzJlLTg2NWJmM2E4MzUzZCIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICJiNTgxOWI3OS00ZjI3LTQ1ODMtYmY3OC1mNTMxYjZlZGY3OTYi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5
+        cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTcyNjQ1MDgtMDhi
+        OS00NzJiLWI0N2MtM2Y0NmRkODdlYmVjIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiOThhOTg4YjktNTRhZi00MGY2LTgyMGMtMjYxYWFl
+        OGY4MWM4IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAi
+        c3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiMDFjMGQ5ZTQtYTQ0NS00ZDAwLWFmMDYtOWY4NDE1ODQ3ZWE4
+        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
+        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjdjZWNkMzg5LWQwZmMtNGQ1Ni05OWE3LTBmZDUyN2RjMzE5ZSIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjog
+        InB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJjZmNm
+        ZmFiLTBhNWEtNDlkYS04YzM0LWEzOGUzY2RkYjNlMCIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
+        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMWY0MzUw
+        OTUtMGI3My00NzM4LTgzMjUtMGQ1OWNkM2YwOGY0IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTFAcm9ib3QuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBy
+        b2JvdC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU4M2RkYTRkNjcxZTA4ZWFhNmQyNTc3
+        NiJ9LCAiaWQiOiAiNTgzZGRhNGQ2NzFlMDhlYWE2ZDI1Nzc2In0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:43:10 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/0009c176-9e5f-418e-8e21-23ad7c1b9603/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:43:10 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2282'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wMDA5YzE3Ni05ZTVmLTQxOGUtOGUyMS0yM2FkN2MxYjk2
+        MDMvIiwgInRhc2tfaWQiOiAiMDAwOWMxNzYtOWU1Zi00MThlLThlMjEtMjNh
+        ZDdjMWI5NjAzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0xMS0yOVQxOTo0MzowOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0MzowOVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMWVlYTA5MGYtYmE3My00ZWMxLTkyMzItZTlhMDI4NzJl
+        NGIxLyIsICJ0YXNrX2lkIjogIjFlZWEwOTBmLWJhNzMtNGVjMS05MjMyLWU5
+        YTAyODcyZTRiMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0
+        ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTExLTI5VDE5OjQzOjA5WiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMTEtMjlUMTk6NDM6
+        MDlaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTgzZGRhNGRiMGVhZjIwOTliNjgxODY0IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU4M2RkYTRkNjcxZTA4ZWFhNmQyNTc2NiJ9LCAi
+        aWQiOiAiNTgzZGRhNGQ2NzFlMDhlYWE2ZDI1NzY2In0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:43:10 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/1eea090f-ba73-4ec1-9232-e9a02872e4b1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:43:10 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '6909'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8xZWVhMDkwZi1iYTczLTRlYzEtOTIzMi1lOWEw
+        Mjg3MmU0YjEvIiwgInRhc2tfaWQiOiAiMWVlYTA5MGYtYmE3My00ZWMxLTky
+        MzItZTlhMDI4NzJlNGIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0xMS0yOVQxOTo0MzoxMFoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0MzoxMFoiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI2MTgxYjJlOC0xZjE5LTQ3ZWYtODBjMi1iNjVmYWFk
-        ZTU0ZTQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICI1ZjA1Y2JiMi04MmE0LTRhYWMtYWE2Ni00ZjkwNmMx
+        MmZkYmMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMTkxMzNlODktMzZlOS00YjRkLWJlMzAtODgxZDdmM2U2ZjE2Iiwg
+        aWQiOiAiYWYzNmRjZjYtNmFhYy00NzBiLTkyMjEtM2JmYjI4Y2VjMGVkIiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
         bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZmM1ZjFiYTQtZjQ0NS00M2Q0LWFkOGQt
-        NDQ0OGE3MmY1NTE3IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiN2Y0ZWI2Y2YtOTQwMy00N2FkLWFhMmMt
+        M2U4YjI5OWU2NDRmIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
         TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGIx
-        OTljYTYtMDEwZS00OTI5LTg0NTYtYTYyYWE1NzExN2E5IiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiN2Q2
+        YjMwMmYtMTdjMi00ZjQ3LTljMmUtODY1YmYzYTgzNTNkIiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImI1N2UxYjAxLWVhNTctNGMzNy05ZTIyLTA4ODNm
-        Y2E1NjAwNiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        IDAsICJzdGVwX2lkIjogImI1ODE5Yjc5LTRmMjctNDU4My1iZjc4LWY1MzFi
+        NmVkZjc5NiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
         OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
         InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0YTNmMDk3
-        NS1iNDJjLTQ0YjUtYmJmZS00MWZlODQ4ODJjNjQiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlNzI2NDUw
+        OC0wOGI5LTQ3MmItYjQ3Yy0zZjQ2ZGQ4N2ViZWMiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
         Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJkNjdmNzFlMi0zNzI3LTQ5ZWEtOTFlMC05NTBl
-        NTQ1NGI2NWUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICI5OGE5ODhiOS01NGFmLTQwZjYtODIwYy0yNjFh
+        YWU4ZjgxYzgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
         ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI0ZTA0OGU4OS1mZDgxLTRiMTUtOTg2YS1kYzdmNzFjYTQ3NzMi
+        cF9pZCI6ICIwMWMwZDllNC1hNDQ1LTRkMDAtYWYwNi05Zjg0MTU4NDdlYTgi
         LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
         dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
         c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyMDEw
-        OTU4MS0xNTY2LTRlMTYtYjM4Zi01ZWJiODcwYjFlYmUiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3Y2Vj
+        ZDM4OS1kMGZjLTRkNTYtOTlhNy0wZmQ1MjdkYzMxOWUiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
         aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2YjM4NjZmMS03NWM4
-        LTQzODgtYjJkZS1lZGJkODcwNWMyMGMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiY2ZjZmZhYi0wYTVh
+        LTQ5ZGEtOGMzNC1hMzhlM2NkZGIzZTAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
         TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
         X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjgwNDg0YjlmLTIyMWUtNGU3
-        OS04MGY4LWEwOGFlZjQyMzc4ZCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQG9iZWxpeC5l
-        eGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhh
-        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJl
-        eGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3Rh
-        cnRlZCI6ICIyMDE2LTA3LTI5VDE4OjU4OjQyWiIsICJfbnMiOiAicmVwb19w
-        dWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDctMjlUMTg6
-        NTg6NDJaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBl
-        X2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0
-        ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9y
-        ZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQi
-        LCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklT
-        SEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0
-        YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFf
-        MTciLCAiaWQiOiAiNTc5YmE3NjI3MGJlNmY3MzhlZGQ5ZGIzIiwgImRldGFp
-        bHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0
-        aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
-        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjFmNDM1MDk1LTBiNzMtNDcz
+        OC04MzI1LTBkNTljZDNmMDhmNCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4
+        YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9u
+        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhj
+        ZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInN0YXJ0
+        ZWQiOiAiMjAxNi0xMS0yOVQxOTo0MzoxMFoiLCAiX25zIjogInJlcG9fcHVi
+        bGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTExLTI5VDE5OjQz
+        OjEwWiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9p
+        ZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAic3VtbWFyeSI6IHsiZ2VuZXJhdGUg
+        c3FsaXRlIjogIlNLSVBQRUQiLCAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRh
+        IjogIkZJTklTSEVEIiwgInJwbXMiOiAiRklOSVNIRUQiLCAiY2xvc2VfcmVw
+        b19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJkcnBtcyI6ICJTS0lQUEVEIiwg
+        ImNvbXBzIjogIkZJTklTSEVEIiwgImRpc3RyaWJ1dGlvbiI6ICJGSU5JU0hF
+        RCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6ICJGSU5JU0hFRCIsICJlcnJhdGEi
+        OiAiRklOSVNIRUQiLCAibWV0YWRhdGEiOiAiRklOSVNIRUQifSwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3JfaWQiOiAiRmVkb3JhXzE3
+        IiwgImlkIjogIjU4M2RkYTRlYjBlYWYyMDk5YjY4MTg2NSIsICJkZXRhaWxz
+        IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiSW5pdGlh
+        bGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImluaXRpYWxp
+        emVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1ZjA1Y2JiMi04
+        MmE0LTRhYWMtYWE2Ni00ZjkwNmMxMmZkYmMiLCAibnVtX3Byb2Nlc3NlZCI6
+        IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
+        c2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0
+        cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWYzNmRjZjYtNmFhYy00NzBi
+        LTkyMjEtM2JmYjI4Y2VjMGVkIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJu
+        dW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQ
+        TXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiA4LCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiN2Y0
+        ZWI2Y2YtOTQwMy00N2FkLWFhMmMtM2U4YjI5OWU2NDRmIiwgIm51bV9wcm9j
+        ZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjogImRycG1z
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiN2Q2YjMwMmYtMTdjMi00ZjQ3LTljMmUtODY1
+        YmYzYTgzNTNkIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJz
+        dGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRl
         IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjYxODFiMmU4
-        LTFmMTktNDdlZi04MGMyLWI2NWZhYWRlNTRlNCIsICJudW1fcHJvY2Vzc2Vk
-        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRp
-        c3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI1ODE5Yjc5
+        LTRmMjctNDU4My1iZjc4LWY1MzFiNmVkZjc5NiIsICJudW1fcHJvY2Vzc2Vk
+        IjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJp
+        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICJlNzI2NDUwOC0wOGI5LTQ3MmItYjQ3Yy0zZjQ2ZGQ4
+        N2ViZWMiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0
+        ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5OGE5ODhi
+        OS01NGFmLTQwZjYtODIwYy0yNjFhYWU4ZjgxYzgiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNs
+        b3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVw
+        b19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
         U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxOTEzM2U4OS0zNmU5LTRi
-        NGQtYmUzMC04ODFkN2YzZTZmMTYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
-        Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        UlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJm
-        YzVmMWJhNC1mNDQ1LTQzZDQtYWQ4ZC00NDQ4YTcyZjU1MTciLCAibnVtX3By
-        b2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI0YjE5OWNhNi0wMTBlLTQ5MjktODQ1Ni1h
-        NjJhYTU3MTE3YTkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
-        ZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwg
-        InN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjU3ZTFi
-        MDEtZWE1Ny00YzM3LTllMjItMDg4M2ZjYTU2MDA2IiwgIm51bV9wcm9jZXNz
-        ZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjRhM2YwOTc1LWI0MmMtNDRiNS1iYmZlLTQxZmU4
-        NDg4MmM2NCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAi
-        c3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ2N2Y3
-        MWUyLTM3MjctNDllYS05MWUwLTk1MGU1NDU0YjY1ZSIsICJudW1fcHJvY2Vz
-        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        Q2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9y
-        ZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
-        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRlMDQ4ZTg5LWZkODEt
-        NGIxNS05ODZhLWRjN2Y3MWNhNDc3MyIsICJudW1fcHJvY2Vzc2VkIjogMX0s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
-        ZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0
-        ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjIwMTA5NTgxLTE1NjYtNGUxNi1iMzhmLTVl
-        YmI4NzBiMWViZSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
-        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3
-        ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjZiMzg2NmYxLTc1YzgtNDM4OC1iMmRlLWVkYmQ4NzA1YzIw
-        YyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBf
-        dHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiODA0ODRiOWYtMjIxZS00ZTc5LTgwZjgtYTA4YWVmNDIzNzhkIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjU3OWJhNzYyN2JjMjVhYWYwOTU2MmUxOSJ9LCAiaWQiOiAi
-        NTc5YmE3NjI3YmMyNWFhZjA5NTYyZTE5In0=
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwMWMwZDllNC1hNDQ1LTRk
+        MDAtYWYwNi05Zjg0MTU4NDdlYTgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
+        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcg
+        c3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI3Y2VjZDM4OS1kMGZjLTRkNTYtOTlhNy0wZmQ1
+        MjdkYzMxOWUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2Vi
+        IiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICJiY2ZjZmZhYi0wYTVhLTQ5ZGEtOGMzNC1hMzhlM2NkZGIzZTAi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjFmNDM1MDk1LTBiNzMtNDczOC04MzI1LTBkNTljZDNmMDhmNCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1ODNkZGE0ZDY3MWUwOGVhYTZkMjU3NzYifSwgImlkIjogIjU4
+        M2RkYTRkNjcxZTA4ZWFhNmQyNTc3NiJ9
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:42 GMT
+  recorded_at: Tue, 29 Nov 2016 19:43:10 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/18d2c359-1d5f-497c-8a1d-1d131c96a6b8/
+    uri: https://robot.example.com/pulp/api/v2/tasks/b544cc76-770a-4e4d-929b-cbd27420cf9b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -970,13 +544,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:43 GMT
+      - Tue, 29 Nov 2016 19:43:10 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '651'
+      - '549'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -984,24 +558,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xOGQyYzM1OS0xZDVmLTQ5N2MtOGExZC0xZDEzMWM5NmE2
-        YjgvIiwgInRhc2tfaWQiOiAiMThkMmMzNTktMWQ1Zi00OTdjLThhMWQtMWQx
-        MzFjOTZhNmI4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9iNTQ0Y2M3Ni03NzBhLTRlNGQtOTI5Yi1jYmQyNzQyMGNm
+        OWIvIiwgInRhc2tfaWQiOiAiYjU0NGNjNzYtNzcwYS00ZTRkLTkyOWItY2Jk
+        Mjc0MjBjZjliIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
-        LTA3LTI5VDE4OjU4OjQzWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
-        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJy
-        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBsZS5jb20i
-        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NzliYTc2MzdiYzI1YWFmMDk1NjJlMWEifSwgImlkIjogIjU3OWJh
-        NzYzN2JjMjVhYWYwOTU2MmUxYSJ9
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ODNkZGE0
+        ZTY3MWUwOGVhYTZkMjU3NzcifSwgImlkIjogIjU4M2RkYTRlNjcxZTA4ZWFh
+        NmQyNTc3NyJ9
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:43 GMT
+  recorded_at: Tue, 29 Nov 2016 19:43:10 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/18d2c359-1d5f-497c-8a1d-1d131c96a6b8/
+    uri: https://robot.example.com/pulp/api/v2/tasks/b544cc76-770a-4e4d-929b-cbd27420cf9b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1020,13 +592,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:43 GMT
+      - Tue, 29 Nov 2016 19:43:11 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '670'
+      - '668'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1034,24 +606,646 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xOGQyYzM1OS0xZDVmLTQ5N2MtOGExZC0xZDEzMWM5NmE2
-        YjgvIiwgInRhc2tfaWQiOiAiMThkMmMzNTktMWQ1Zi00OTdjLThhMWQtMWQx
-        MzFjOTZhNmI4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9iNTQ0Y2M3Ni03NzBhLTRlNGQtOTI5Yi1jYmQyNzQyMGNm
+        OWIvIiwgInRhc2tfaWQiOiAiYjU0NGNjNzYtNzcwYS00ZTRkLTkyOWItY2Jk
+        Mjc0MjBjZjliIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTA3LTI5VDE4OjU4OjQzWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTA3LTI5VDE4OjU4OjQzWiIsICJ0cmFjZWJh
+        MDE2LTExLTI5VDE5OjQzOjExWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTExLTI5VDE5OjQzOjExWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBvYmVsaXguZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQi
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        b2JlbGl4LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3NjM3YmMyNWFhZjA5NTYy
-        ZTFhIn0sICJpZCI6ICI1NzliYTc2MzdiYzI1YWFmMDk1NjJlMWEifQ==
+        MUByb2JvdC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBy
+        b2JvdC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU4M2RkYTRlNjcxZTA4ZWFhNmQyNTc3
+        NyJ9LCAiaWQiOiAiNTgzZGRhNGU2NzFlMDhlYWE2ZDI1Nzc3In0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:43 GMT
+  recorded_at: Tue, 29 Nov 2016 19:43:11 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/935f4137-0b60-41ef-b246-9f5bdef6ad2a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:43:12 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '647'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85MzVmNDEzNy0wYjYwLTQxZWYtYjI0Ni05ZjViZGVmNmFk
+        MmEvIiwgInRhc2tfaWQiOiAiOTM1ZjQxMzctMGI2MC00MWVmLWIyNDYtOWY1
+        YmRlZjZhZDJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0x
+        MS0yOVQxOTo0MzoxMloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAcm9ib3QuZXhhbXBsZS5jb20u
+        ZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUByb2JvdC5leGFtcGxlLmNvbSIsICJy
+        ZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjog
+        IjU4M2RkYTUwNjcxZTA4ZWFhNmQyNTc3OCJ9LCAiaWQiOiAiNTgzZGRhNTA2
+        NzFlMDhlYWE2ZDI1Nzc4In0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:43:12 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/935f4137-0b60-41ef-b246-9f5bdef6ad2a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:43:13 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2282'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85MzVmNDEzNy0wYjYwLTQxZWYtYjI0Ni05ZjViZGVmNmFk
+        MmEvIiwgInRhc2tfaWQiOiAiOTM1ZjQxMzctMGI2MC00MWVmLWIyNDYtOWY1
+        YmRlZjZhZDJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0xMS0yOVQxOTo0MzoxMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0MzoxMloiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNThhNzNhMGUtM2ZiMy00ZjRmLTljNTUtMzNlZjZhMWEz
+        Y2M0LyIsICJ0YXNrX2lkIjogIjU4YTczYTBlLTNmYjMtNGY0Zi05YzU1LTMz
+        ZWY2YTFhM2NjNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0
+        ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTExLTI5VDE5OjQzOjEyWiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMTEtMjlUMTk6NDM6
+        MTJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTgzZGRhNTBiMGVhZjIwOTliNjgxODcxIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU4M2RkYTUwNjcxZTA4ZWFhNmQyNTc3OCJ9LCAi
+        aWQiOiAiNTgzZGRhNTA2NzFlMDhlYWE2ZDI1Nzc4In0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:43:13 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/58a73a0e-3fb3-4f4f-9c55-33ef6a1a3cc4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:43:13 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '3503'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy81OGE3M2EwZS0zZmIzLTRmNGYtOWM1NS0zM2Vm
+        NmExYTNjYzQvIiwgInRhc2tfaWQiOiAiNThhNzNhMGUtM2ZiMy00ZjRmLTlj
+        NTUtMzNlZjZhMWEzY2M0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxNi0xMS0yOVQxOTo0MzoxM1oiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhMzIy
+        NzMyZC04ZTA0LTQwNjEtOWJlMC1iMTkzOTExMzc1ODgiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWQ4YWZkNDEtZGE3
+        MS00ZDkwLWFhYjAtYmI5NWY5ZDY3OTA5IiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiYWI0MWM4ZjctNTQwYi00OGQ3LTk1MjgtZTZkOTgyMGZlZTY5Iiwg
+        Im51bV9wcm9jZXNzZWQiOiA2fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
+        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImMxZDUwODkxLTEwOGMt
+        NDAyMy05MjBhLWVmOTgzMDNiM2YxZiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI0NjIxMDdmOC03NmE1LTQ1YTktOGVkZC05YTE5ODY4ZTQ0YzAi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5
+        cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNWUxOGFhMjYtMzIz
+        Ni00ZThmLTg2OTktYWE3NDg2NGY1MzM5IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiZmI0YTBiOTctYjU5OS00NmE5LWE4YTktNDM1NjVm
+        ZWZiZmJmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAi
+        c3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiYWJmY2I5MDQtY2E4Ny00Y2JiLWI2YmEtY2Y4YzdlYWQzMjY2
+        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
+        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjFlZDU3MjViLTQxYjctNGE3Ny1hMWRkLTRjMjRkOTIwOWI4ZCIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjog
+        InB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUxODBm
+        ZGVhLTBhMzAtNGU4Zi1hNzQ1LWZiZjViZjdjOTdjZSIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
+        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiY2NkYzYz
+        NDgtNGQ0NS00YmZkLThkNDctNjM4OTBhNWJkY2M2IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTFAcm9ib3QuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBy
+        b2JvdC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU4M2RkYTUwNjcxZTA4ZWFhNmQyNTc4
+        OCJ9LCAiaWQiOiAiNTgzZGRhNTA2NzFlMDhlYWE2ZDI1Nzg4In0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:43:13 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/935f4137-0b60-41ef-b246-9f5bdef6ad2a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:43:13 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2282'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85MzVmNDEzNy0wYjYwLTQxZWYtYjI0Ni05ZjViZGVmNmFk
+        MmEvIiwgInRhc2tfaWQiOiAiOTM1ZjQxMzctMGI2MC00MWVmLWIyNDYtOWY1
+        YmRlZjZhZDJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0xMS0yOVQxOTo0MzoxMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0MzoxMloiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNThhNzNhMGUtM2ZiMy00ZjRmLTljNTUtMzNlZjZhMWEz
+        Y2M0LyIsICJ0YXNrX2lkIjogIjU4YTczYTBlLTNmYjMtNGY0Zi05YzU1LTMz
+        ZWY2YTFhM2NjNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0
+        ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTExLTI5VDE5OjQzOjEyWiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMTEtMjlUMTk6NDM6
+        MTJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTgzZGRhNTBiMGVhZjIwOTliNjgxODcxIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU4M2RkYTUwNjcxZTA4ZWFhNmQyNTc3OCJ9LCAi
+        aWQiOiAiNTgzZGRhNTA2NzFlMDhlYWE2ZDI1Nzc4In0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:43:13 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/58a73a0e-3fb3-4f4f-9c55-33ef6a1a3cc4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:43:13 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '6909'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy81OGE3M2EwZS0zZmIzLTRmNGYtOWM1NS0zM2Vm
+        NmExYTNjYzQvIiwgInRhc2tfaWQiOiAiNThhNzNhMGUtM2ZiMy00ZjRmLTlj
+        NTUtMzNlZjZhMWEzY2M0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0xMS0yOVQxOTo0MzoxM1oiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0MzoxM1oiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICJhMzIyNzMyZC04ZTA0LTQwNjEtOWJlMC1iMTkzOTEx
+        Mzc1ODgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiYWQ4YWZkNDEtZGE3MS00ZDkwLWFhYjAtYmI5NWY5ZDY3OTA5Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
+        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiYWI0MWM4ZjctNTQwYi00OGQ3LTk1Mjgt
+        ZTZkOTgyMGZlZTY5IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
+        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzFk
+        NTA4OTEtMTA4Yy00MDIzLTkyMGEtZWY5ODMwM2IzZjFmIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjQ2MjEwN2Y4LTc2YTUtNDVhOS04ZWRkLTlhMTk4
+        NjhlNDRjMCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
+        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1ZTE4YWEy
+        Ni0zMjM2LTRlOGYtODY5OS1hYTc0ODY0ZjUzMzkiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJmYjRhMGI5Ny1iNTk5LTQ2YTktYThhOS00MzU2
+        NWZlZmJmYmYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
+        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICJhYmZjYjkwNC1jYTg3LTRjYmItYjZiYS1jZjhjN2VhZDMyNjYi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
+        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxZWQ1
+        NzI1Yi00MWI3LTRhNzctYTFkZC00YzI0ZDkyMDliOGQiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
+        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlMTgwZmRlYS0wYTMw
+        LTRlOGYtYTc0NS1mYmY1YmY3Yzk3Y2UiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
+        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNjZGM2MzQ4LTRkNDUtNGJm
+        ZC04ZDQ3LTYzODkwYTViZGNjNiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4
+        YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9u
+        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhj
+        ZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInN0YXJ0
+        ZWQiOiAiMjAxNi0xMS0yOVQxOTo0MzoxM1oiLCAiX25zIjogInJlcG9fcHVi
+        bGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTExLTI5VDE5OjQz
+        OjEzWiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9p
+        ZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAic3VtbWFyeSI6IHsiZ2VuZXJhdGUg
+        c3FsaXRlIjogIlNLSVBQRUQiLCAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRh
+        IjogIkZJTklTSEVEIiwgInJwbXMiOiAiRklOSVNIRUQiLCAiY2xvc2VfcmVw
+        b19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJkcnBtcyI6ICJTS0lQUEVEIiwg
+        ImNvbXBzIjogIkZJTklTSEVEIiwgImRpc3RyaWJ1dGlvbiI6ICJGSU5JU0hF
+        RCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6ICJGSU5JU0hFRCIsICJlcnJhdGEi
+        OiAiRklOSVNIRUQiLCAibWV0YWRhdGEiOiAiRklOSVNIRUQifSwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3JfaWQiOiAiRmVkb3JhXzE3
+        IiwgImlkIjogIjU4M2RkYTUxYjBlYWYyMDk5YjY4MTg3MiIsICJkZXRhaWxz
+        IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiSW5pdGlh
+        bGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImluaXRpYWxp
+        emVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhMzIyNzMyZC04
+        ZTA0LTQwNjEtOWJlMC1iMTkzOTExMzc1ODgiLCAibnVtX3Byb2Nlc3NlZCI6
+        IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
+        c2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0
+        cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWQ4YWZkNDEtZGE3MS00ZDkw
+        LWFhYjAtYmI5NWY5ZDY3OTA5IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJu
+        dW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQ
+        TXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiA4LCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWI0
+        MWM4ZjctNTQwYi00OGQ3LTk1MjgtZTZkOTgyMGZlZTY5IiwgIm51bV9wcm9j
+        ZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjogImRycG1z
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiYzFkNTA4OTEtMTA4Yy00MDIzLTkyMGEtZWY5
+        ODMwM2IzZjFmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJz
+        dGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQ2MjEwN2Y4
+        LTc2YTUtNDVhOS04ZWRkLTlhMTk4NjhlNDRjMCIsICJudW1fcHJvY2Vzc2Vk
+        IjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJp
+        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICI1ZTE4YWEyNi0zMjM2LTRlOGYtODY5OS1hYTc0ODY0
+        ZjUzMzkiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0
+        ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmYjRhMGI5
+        Ny1iNTk5LTQ2YTktYThhOS00MzU2NWZlZmJmYmYiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNs
+        b3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVw
+        b19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhYmZjYjkwNC1jYTg3LTRj
+        YmItYjZiYS1jZjhjN2VhZDMyNjYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
+        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcg
+        c3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICIxZWQ1NzI1Yi00MWI3LTRhNzctYTFkZC00YzI0
+        ZDkyMDliOGQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2Vi
+        IiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICJlMTgwZmRlYS0wYTMwLTRlOGYtYTc0NS1mYmY1YmY3Yzk3Y2Ui
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImNjZGM2MzQ4LTRkNDUtNGJmZC04ZDQ3LTYzODkwYTViZGNjNiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1ODNkZGE1MDY3MWUwOGVhYTZkMjU3ODgifSwgImlkIjogIjU4
+        M2RkYTUwNjcxZTA4ZWFhNmQyNTc4OCJ9
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:43:13 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/7b468699-5a95-4026-8610-ed6d9e794db1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:43:14 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83YjQ2ODY5OS01YTk1LTQwMjYtODYxMC1lZDZkOWU3OTRk
+        YjEvIiwgInRhc2tfaWQiOiAiN2I0Njg2OTktNWE5NS00MDI2LTg2MTAtZWQ2
+        ZDllNzk0ZGIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ODNkZGE1
+        MTY3MWUwOGVhYTZkMjU3ODkifSwgImlkIjogIjU4M2RkYTUxNjcxZTA4ZWFh
+        NmQyNTc4OSJ9
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:43:14 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/7b468699-5a95-4026-8610-ed6d9e794db1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:43:14 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '668'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy83YjQ2ODY5OS01YTk1LTQwMjYtODYxMC1lZDZkOWU3OTRk
+        YjEvIiwgInRhc2tfaWQiOiAiN2I0Njg2OTktNWE5NS00MDI2LTg2MTAtZWQ2
+        ZDllNzk0ZGIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTExLTI5VDE5OjQzOjE0WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTExLTI5VDE5OjQzOjE0WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUByb2JvdC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBy
+        b2JvdC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU4M2RkYTUxNjcxZTA4ZWFhNmQyNTc4
+        OSJ9LCAiaWQiOiAiNTgzZGRhNTE2NzFlMDhlYWE2ZDI1Nzg5In0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:43:14 GMT
 - request:
     method: post
-    uri: https://obelix.example.com/pulp/api/v2/repositories/
+    uri: https://robot.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1092,13 +1286,13 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:44 GMT
+      - Tue, 29 Nov 2016 19:43:15 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
       - '320'
       Location:
-      - https://obelix.example.com/pulp/api/v2/repositories/Fedora_17/
+      - https://robot.example.com/pulp/api/v2/repositories/Fedora_17/
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1109,14 +1303,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTc5YmE3NjQ3MGJlNmY0YzU3N2VjZDM4In0sICJpZCI6ICJGZWRvcmFfMTci
+        NTgzZGRhNTNiMGVhZjI1ZjQ1ODE5MmVjIn0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:44 GMT
+  recorded_at: Tue, 29 Nov 2016 19:43:15 GMT
 - request:
     method: post
-    uri: https://obelix.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    uri: https://robot.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1139,7 +1333,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:44 GMT
+      - Tue, 29 Nov 2016 19:43:15 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -1150,14 +1344,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzZmYjIxNjY1LTM5NzItNGYxYS1hZGFiLWZjMjk1M2EyNGYwNy8iLCAi
-        dGFza19pZCI6ICI2ZmIyMTY2NS0zOTcyLTRmMWEtYWRhYi1mYzI5NTNhMjRm
-        MDcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2QyZmUzNmM5LWQzMDItNDllNS05MTM5LTViZTU0MGRmZTE5YS8iLCAi
+        dGFza19pZCI6ICJkMmZlMzZjOS1kMzAyLTQ5ZTUtOTEzOS01YmU1NDBkZmUx
+        OWEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:44 GMT
+  recorded_at: Tue, 29 Nov 2016 19:43:15 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/6fb21665-3972-4f1a-adab-fc2953a24f07/
+    uri: https://robot.example.com/pulp/api/v2/tasks/d2fe36c9-d302-49e5-9139-5be540dfe19a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1176,13 +1370,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:44 GMT
+      - Tue, 29 Nov 2016 19:43:15 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1121'
+      - '647'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1190,34 +1384,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82ZmIyMTY2NS0zOTcyLTRmMWEtYWRhYi1mYzI5NTNhMjRm
-        MDcvIiwgInRhc2tfaWQiOiAiNmZiMjE2NjUtMzk3Mi00ZjFhLWFkYWItZmMy
-        OTUzYTI0ZjA3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kMmZlMzZjOS1kMzAyLTQ5ZTUtOTEzOS01YmU1NDBkZmUx
+        OWEvIiwgInRhc2tfaWQiOiAiZDJmZTM2YzktZDMwMi00OWU1LTkxMzktNWJl
+        NTQwZGZlMTlhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Ny0yOVQxODo1ODo0NFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
-        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
-        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
-        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIk5PVF9T
-        VEFSVEVEIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQG9iZWxpeC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5n
-        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
-        QG9iZWxpeC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3Ii
-        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU3OWJhNzY0N2JjMjVhYWYwOTU2
-        MmUxYiJ9LCAiaWQiOiAiNTc5YmE3NjQ3YmMyNWFhZjA5NTYyZTFiIn0=
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0x
+        MS0yOVQxOTo0MzoxNVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAcm9ib3QuZXhhbXBsZS5jb20u
+        ZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMUByb2JvdC5leGFtcGxlLmNvbSIsICJy
+        ZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjog
+        IjU4M2RkYTUzNjcxZTA4ZWFhNmQyNTc4YSJ9LCAiaWQiOiAiNTgzZGRhNTM2
+        NzFlMDhlYWE2ZDI1NzhhIn0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:44 GMT
+  recorded_at: Tue, 29 Nov 2016 19:43:15 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/6fb21665-3972-4f1a-adab-fc2953a24f07/
+    uri: https://robot.example.com/pulp/api/v2/tasks/d2fe36c9-d302-49e5-9139-5be540dfe19a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1236,13 +1420,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:45 GMT
+      - Tue, 29 Nov 2016 19:43:16 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2284'
+      - '2282'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1250,16 +1434,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82ZmIyMTY2NS0zOTcyLTRmMWEtYWRhYi1mYzI5NTNhMjRm
-        MDcvIiwgInRhc2tfaWQiOiAiNmZiMjE2NjUtMzk3Mi00ZjFhLWFkYWItZmMy
-        OTUzYTI0ZjA3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kMmZlMzZjOS1kMzAyLTQ5ZTUtOTEzOS01YmU1NDBkZmUx
+        OWEvIiwgInRhc2tfaWQiOiAiZDJmZTM2YzktZDMwMi00OWU1LTkxMzktNWJl
+        NTQwZGZlMTlhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wNy0yOVQxODo1ODo0NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wNy0yOVQxODo1ODo0NFoiLCAidHJhY2ViYWNr
+        Ni0xMS0yOVQxOTo0MzoxNVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0MzoxNVoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZjM3OGU5OGUtNmQ1NC00MmU5LWE3ZTctMGQ4YTY0YjYz
-        OGNmLyIsICJ0YXNrX2lkIjogImYzNzhlOThlLTZkNTQtNDJlOS1hN2U3LTBk
-        OGE2NGI2MzhjZiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNmJkNTBmOTctYTJmOC00MTRhLTkwYTEtNGQxMDBlYzJl
+        NmQ2LyIsICJ0YXNrX2lkIjogIjZiZDUwZjk3LWEyZjgtNDE0YS05MGExLTRk
+        MTAwZWMyZTZkNiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -1270,40 +1454,40 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQG9iZWxpeC5leGFt
-        cGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFt
-        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBs
-        ZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBv
-        cnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwg
-        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJz
-        dGFydGVkIjogIjIwMTYtMDctMjlUMTg6NTg6NDRaIiwgIl9ucyI6ICJyZXBv
-        X3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wNy0yOVQxODo1
-        ODo0NFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
-        ZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50Ijog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAxNSwg
-        InJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6
-        ICI1NzliYTc2NDcwYmU2ZjczOGVkZDlkYmYiLCAiZGV0YWlscyI6IHsiY29u
-        dGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVm
-        dCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUi
-        OiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9y
-        X2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3NjQ3YmMyNWFhZjA5NTYyZTFiIn0s
-        ICJpZCI6ICI1NzliYTc2NDdiYzI1YWFmMDk1NjJlMWIifQ==
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0
+        ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTExLTI5VDE5OjQzOjE1WiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMTEtMjlUMTk6NDM6
+        MTVaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTgzZGRhNTNiMGVhZjIwOTliNjgxODdlIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU4M2RkYTUzNjcxZTA4ZWFhNmQyNTc4YSJ9LCAi
+        aWQiOiAiNTgzZGRhNTM2NzFlMDhlYWE2ZDI1NzhhIn0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:45 GMT
+  recorded_at: Tue, 29 Nov 2016 19:43:16 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/f378e98e-6d54-42e9-a7e7-0d8a64b638cf/
+    uri: https://robot.example.com/pulp/api/v2/tasks/6bd50f97-a2f8-414a-90a1-4d100ec2e6d6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1322,13 +1506,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:45 GMT
+      - Tue, 29 Nov 2016 19:43:16 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '6911'
+      - '3496'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1336,163 +1520,362 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9mMzc4ZTk4ZS02ZDU0LTQyZTktYTdlNy0wZDhh
-        NjRiNjM4Y2YvIiwgInRhc2tfaWQiOiAiZjM3OGU5OGUtNmQ1NC00MmU5LWE3
-        ZTctMGQ4YTY0YjYzOGNmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy82YmQ1MGY5Ny1hMmY4LTQxNGEtOTBhMS00ZDEw
+        MGVjMmU2ZDYvIiwgInRhc2tfaWQiOiAiNmJkNTBmOTctYTJmOC00MTRhLTkw
+        YTEtNGQxMDBlYzJlNmQ2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wNy0yOVQxODo1ODo0NVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wNy0yOVQxODo1ODo0NFoiLCAi
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxNi0xMS0yOVQxOTo0MzoxNVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiYjU4
+        OTdhMS0xMGE3LTRiYTgtYmUxZi1mMDNmY2Q1ZmJkMzAiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzlkN2I3YmMtYmI4
+        Mi00NTMyLWI3OTAtYTkxYzlhMzgwM2E4IiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiMWU0ZGJiYzgtZjlmMy00MDA5LWJmNmEtYTJmMDk2ZDlhZDA5IiwgIm51
+        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
+        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
+        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmJiZDMxYmItOGIyMi00YzJjLTlm
+        NDctYTNmMWY2NWEzZGQyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
+        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
+        InN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        ImFiYWMzZTQ3LWM5NTMtNDdhZS1hYWI2LWE3N2QwOTJlMjMwMCIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJj
+        b21wcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNmQzZWE5Zi1iZWUwLTQ3YTgt
+        YjgwMC0xNmMzNzZmMWJiMzciLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0
+        YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI2ODEwYmU2Mi0zZWJiLTQxNjYtYjQ4MS03NDkyYzFmNTRkOTgi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICI5OThhNDE4Mi0wYzI5LTQ3ODMtOGFlMC1lYTQ2NGYzYjhjMzgiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmI0MWQ4
+        NTktNmEwMy00OTIyLWEyMmMtMzNiMzRhYjA5ZDg5IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
+        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODJmMTczYjAtMTAz
+        Zi00NWIzLTkwMTYtMTljMmYyOTNkZTc1IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5n
+        IExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVw
+        b19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
+        U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5MWUzZTFiOC05ZTZm
+        LTQ0NDMtYjNhMS1lNTRjMmJkNWQ0Y2EiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUByb2Jv
+        dC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4
+        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNTgzZGRhNTM2NzFlMDhlYWE2ZDI1NzlhIn0sICJp
+        ZCI6ICI1ODNkZGE1MzY3MWUwOGVhYTZkMjU3OWEifQ==
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:43:16 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/d2fe36c9-d302-49e5-9139-5be540dfe19a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:43:16 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2282'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMmZlMzZjOS1kMzAyLTQ5ZTUtOTEzOS01YmU1NDBkZmUx
+        OWEvIiwgInRhc2tfaWQiOiAiZDJmZTM2YzktZDMwMi00OWU1LTkxMzktNWJl
+        NTQwZGZlMTlhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0xMS0yOVQxOTo0MzoxNVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0MzoxNVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNmJkNTBmOTctYTJmOC00MTRhLTkwYTEtNGQxMDBlYzJl
+        NmQ2LyIsICJ0YXNrX2lkIjogIjZiZDUwZjk3LWEyZjgtNDE0YS05MGExLTRk
+        MTAwZWMyZTZkNiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0
+        ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTExLTI5VDE5OjQzOjE1WiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMTEtMjlUMTk6NDM6
+        MTVaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTgzZGRhNTNiMGVhZjIwOTliNjgxODdlIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU4M2RkYTUzNjcxZTA4ZWFhNmQyNTc4YSJ9LCAi
+        aWQiOiAiNTgzZGRhNTM2NzFlMDhlYWE2ZDI1NzhhIn0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:43:16 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/6bd50f97-a2f8-414a-90a1-4d100ec2e6d6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:43:16 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '6909'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy82YmQ1MGY5Ny1hMmY4LTQxNGEtOTBhMS00ZDEw
+        MGVjMmU2ZDYvIiwgInRhc2tfaWQiOiAiNmJkNTBmOTctYTJmOC00MTRhLTkw
+        YTEtNGQxMDBlYzJlNmQ2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0xMS0yOVQxOTo0MzoxNloiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0MzoxNVoiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI3YjQwYzhlOC1hZjY1LTQ4ZmUtYWM2ZC04ZDU3YTA3
-        Zjk0ZDAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICJiYjU4OTdhMS0xMGE3LTRiYTgtYmUxZi1mMDNmY2Q1
+        ZmJkMzAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYTc0OTViYzItYzlkZS00OWNmLWE4NDEtNzk0ZWVhNDgxYTYyIiwg
+        aWQiOiAiMzlkN2I3YmMtYmI4Mi00NTMyLWI3OTAtYTkxYzlhMzgwM2E4Iiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
         bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiODVhM2MyODktMTdlYy00NTAxLWFlYzIt
-        NDMwN2E4ODc2MjJmIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMWU0ZGJiYzgtZjlmMy00MDA5LWJmNmEt
+        YTJmMDk2ZDlhZDA5IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
         TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzU5
-        YzVhOGUtNGI4YS00YjczLWI1MzMtYjg5NTdmYjY1MTJlIiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmJi
+        ZDMxYmItOGIyMi00YzJjLTlmNDctYTNmMWY2NWEzZGQyIiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjQxMWE2NmQ2LWNkYWMtNDkxMy05OTUzLTUzOTgy
-        ZTA4YmI4YyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        IDAsICJzdGVwX2lkIjogImFiYWMzZTQ3LWM5NTMtNDdhZS1hYWI2LWE3N2Qw
+        OTJlMjMwMCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
         OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
         InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNmM3ZmY2
-        Zi04ODA2LTRlMDUtOGQ0MC02MWRlNzcxMTI5NWMiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNmQzZWE5
+        Zi1iZWUwLTQ3YTgtYjgwMC0xNmMzNzZmMWJiMzciLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
         Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI1YTk3OWNiOS03MjBiLTRjZGYtODI2Ny03ZTI0
-        NTA2YjRkOTAiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICI2ODEwYmU2Mi0zZWJiLTQxNjYtYjQ4MS03NDky
+        YzFmNTRkOTgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
         ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI3NTEzOWE3OS0wYWEzLTQ1ZWUtYTg1Ny1iOGY3ZTZiMDg1OWYi
+        cF9pZCI6ICI5OThhNDE4Mi0wYzI5LTQ3ODMtOGFlMC1lYTQ2NGYzYjhjMzgi
         LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
         dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
         c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2MzMx
-        MjBkNi05N2Y1LTRmMDYtOGFhMi02ZDc0MTM0ODQzZjEiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmYjQx
+        ZDg1OS02YTAzLTQ5MjItYTIyYy0zM2IzNGFiMDlkODkiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
         aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3YmMxZjI5MC00YTc3
-        LTRiYWMtODUxOC02MDUwNGE4MzdlMWYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4MmYxNzNiMC0xMDNm
+        LTQ1YjMtOTAxNi0xOWMyZjI5M2RlNzUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
         TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
         X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA1NmU2NmQ5LWUzNzAtNDVk
-        OS04MDkwLWRmNjA0ZDkxZDIxYiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQG9iZWxpeC5l
-        eGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhh
-        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJl
-        eGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3Rh
-        cnRlZCI6ICIyMDE2LTA3LTI5VDE4OjU4OjQ0WiIsICJfbnMiOiAicmVwb19w
-        dWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDctMjlUMTg6
-        NTg6NDVaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBl
-        X2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0
-        ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9y
-        ZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQi
-        LCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklT
-        SEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0
-        YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFf
-        MTciLCAiaWQiOiAiNTc5YmE3NjU3MGJlNmY3MzhlZGQ5ZGMwIiwgImRldGFp
-        bHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0
-        aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
-        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjkxZTNlMWI4LTllNmYtNDQ0
+        My1iM2ExLWU1NGMyYmQ1ZDRjYSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4
+        YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9u
+        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhj
+        ZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInN0YXJ0
+        ZWQiOiAiMjAxNi0xMS0yOVQxOTo0MzoxNVoiLCAiX25zIjogInJlcG9fcHVi
+        bGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTExLTI5VDE5OjQz
+        OjE2WiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9p
+        ZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAic3VtbWFyeSI6IHsiZ2VuZXJhdGUg
+        c3FsaXRlIjogIlNLSVBQRUQiLCAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRh
+        IjogIkZJTklTSEVEIiwgInJwbXMiOiAiRklOSVNIRUQiLCAiY2xvc2VfcmVw
+        b19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJkcnBtcyI6ICJTS0lQUEVEIiwg
+        ImNvbXBzIjogIkZJTklTSEVEIiwgImRpc3RyaWJ1dGlvbiI6ICJGSU5JU0hF
+        RCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6ICJGSU5JU0hFRCIsICJlcnJhdGEi
+        OiAiRklOSVNIRUQiLCAibWV0YWRhdGEiOiAiRklOSVNIRUQifSwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3JfaWQiOiAiRmVkb3JhXzE3
+        IiwgImlkIjogIjU4M2RkYTU0YjBlYWYyMDk5YjY4MTg3ZiIsICJkZXRhaWxz
+        IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiSW5pdGlh
+        bGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImluaXRpYWxp
+        emVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiYjU4OTdhMS0x
+        MGE3LTRiYTgtYmUxZi1mMDNmY2Q1ZmJkMzAiLCAibnVtX3Byb2Nlc3NlZCI6
+        IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
+        c2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0
+        cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzlkN2I3YmMtYmI4Mi00NTMy
+        LWI3OTAtYTkxYzlhMzgwM2E4IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJu
+        dW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQ
+        TXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiA4LCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMWU0
+        ZGJiYzgtZjlmMy00MDA5LWJmNmEtYTJmMDk2ZDlhZDA5IiwgIm51bV9wcm9j
+        ZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjogImRycG1z
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiZmJiZDMxYmItOGIyMi00YzJjLTlmNDctYTNm
+        MWY2NWEzZGQyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJz
+        dGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRl
         IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdiNDBjOGU4
-        LWFmNjUtNDhmZS1hYzZkLThkNTdhMDdmOTRkMCIsICJudW1fcHJvY2Vzc2Vk
-        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRp
-        c3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFiYWMzZTQ3
+        LWM5NTMtNDdhZS1hYWI2LWE3N2QwOTJlMjMwMCIsICJudW1fcHJvY2Vzc2Vk
+        IjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJp
+        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICIwNmQzZWE5Zi1iZWUwLTQ3YTgtYjgwMC0xNmMzNzZm
+        MWJiMzciLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0
+        ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2ODEwYmU2
+        Mi0zZWJiLTQxNjYtYjQ4MS03NDkyYzFmNTRkOTgiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNs
+        b3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVw
+        b19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
         U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNzQ5NWJjMi1jOWRlLTQ5
-        Y2YtYTg0MS03OTRlZWE0ODFhNjIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
-        Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        UlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4
-        NWEzYzI4OS0xN2VjLTQ1MDEtYWVjMi00MzA3YTg4NzYyMmYiLCAibnVtX3By
-        b2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJjNTljNWE4ZS00YjhhLTRiNzMtYjUzMy1i
-        ODk1N2ZiNjUxMmUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
-        ZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwg
-        InN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDExYTY2
-        ZDYtY2RhYy00OTEzLTk5NTMtNTM5ODJlMDhiYjhjIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImE2YzdmZjZmLTg4MDYtNGUwNS04ZDQwLTYxZGU3
-        NzExMjk1YyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAi
-        c3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjVhOTc5
-        Y2I5LTcyMGItNGNkZi04MjY3LTdlMjQ1MDZiNGQ5MCIsICJudW1fcHJvY2Vz
-        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        Q2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9y
-        ZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
-        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc1MTM5YTc5LTBhYTMt
-        NDVlZS1hODU3LWI4ZjdlNmIwODU5ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
-        ZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0
-        ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjYzMzEyMGQ2LTk3ZjUtNGYwNi04YWEyLTZk
-        NzQxMzQ4NDNmMSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
-        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3
-        ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjdiYzFmMjkwLTRhNzctNGJhYy04NTE4LTYwNTA0YTgzN2Ux
-        ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBf
-        dHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMDU2ZTY2ZDktZTM3MC00NWQ5LTgwOTAtZGY2MDRkOTFkMjFiIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjU3OWJhNzY0N2JjMjVhYWYwOTU2MmUyYiJ9LCAiaWQiOiAi
-        NTc5YmE3NjQ3YmMyNWFhZjA5NTYyZTJiIn0=
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5OThhNDE4Mi0wYzI5LTQ3
+        ODMtOGFlMC1lYTQ2NGYzYjhjMzgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
+        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcg
+        c3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJmYjQxZDg1OS02YTAzLTQ5MjItYTIyYy0zM2Iz
+        NGFiMDlkODkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2Vi
+        IiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI4MmYxNzNiMC0xMDNmLTQ1YjMtOTAxNi0xOWMyZjI5M2RlNzUi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjkxZTNlMWI4LTllNmYtNDQ0My1iM2ExLWU1NGMyYmQ1ZDRjYSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1ODNkZGE1MzY3MWUwOGVhYTZkMjU3OWEifSwgImlkIjogIjU4
+        M2RkYTUzNjcxZTA4ZWFhNmQyNTc5YSJ9
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:45 GMT
+  recorded_at: Tue, 29 Nov 2016 19:43:16 GMT
 - request:
     method: post
-    uri: https://obelix.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://robot.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1515,7 +1898,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:45 GMT
+      - Tue, 29 Nov 2016 19:43:16 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -1527,33 +1910,34 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIzYWQ3ZmY4OS02NDg5LTQ2ZjEtYjI1
-        MC1hMmQ1MmZjMjk4MTIiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
-        In0sICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3NjQ3YmMyNWFhZjA5NTYyZTI2
-        In0sICJ1bml0X2lkIjogIjNhZDdmZjg5LTY0ODktNDZmMS1iMjUwLWEyZDUy
-        ZmMyOTgxMiIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
-        YXRhIjogeyJfaWQiOiAiODk0MzQwZTItNGI2Yi00YTJiLTg3YzAtYzc0MzAz
-        Yzc2ZThiIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
-        IjogeyIkb2lkIjogIjU3OWJhNzY0N2JjMjVhYWYwOTU2MmUyNyJ9LCAidW5p
-        dF9pZCI6ICI4OTQzNDBlMi00YjZiLTRhMmItODdjMC1jNzQzMDNjNzZlOGIi
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICI0NjAyNjEwNC0yMGZiLTQ1ODItODQx
+        OS0xNDYwMjg0NWJmNTQiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
+        In0sICJfaWQiOiB7IiRvaWQiOiAiNTgzZGRhNTM2NzFlMDhlYWE2ZDI1Nzk0
+        In0sICJ1bml0X2lkIjogIjQ2MDI2MTA0LTIwZmItNDU4Mi04NDE5LTE0NjAy
+        ODQ1YmY1NCIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
+        YXRhIjogeyJfaWQiOiAiNjY1MDg4NWQtOGJlMC00OTYzLThiM2YtNjdjY2Ez
+        OTYzNjVhIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
+        IjogeyIkb2lkIjogIjU4M2RkYTUzNjcxZTA4ZWFhNmQyNTc5NiJ9LCAidW5p
+        dF9pZCI6ICI2NjUwODg1ZC04YmUwLTQ5NjMtOGIzZi02N2NjYTM5NjM2NWEi
         LCAidW5pdF90eXBlX2lkIjogImVycmF0dW0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogImJiNmRlNmY4LTU1OTctNDhjMi04MTljLTAyODBmZjBhYzI3YSIs
+        X2lkIjogImUxNWJkOGQwLTYwYTEtNDNkOS1hNjc0LWY5NGZjYTk4Yzk2NCIs
         ICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0ifSwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NzliYTc2NDdiYzI1YWFmMDk1NjJlMjUifSwgInVuaXRfaWQiOiAi
-        YmI2ZGU2ZjgtNTU5Ny00OGMyLTgxOWMtMDI4MGZmMGFjMjdhIiwgInVuaXRf
+        ZCI6ICI1ODNkZGE1MzY3MWUwOGVhYTZkMjU3OTUifSwgInVuaXRfaWQiOiAi
+        ZTE1YmQ4ZDAtNjBhMS00M2Q5LWE2NzQtZjk0ZmNhOThjOTY0IiwgInVuaXRf
         dHlwZV9pZCI6ICJlcnJhdHVtIn1d
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:45 GMT
+  recorded_at: Tue, 29 Nov 2016 19:43:16 GMT
 - request:
     method: post
-    uri: https://obelix.example.com/pulp/api/v2/content/units/erratum/search/
+    uri: https://robot.example.com/pulp/api/v2/content/units/erratum/search/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiM2FkN2Zm
-        ODktNjQ4OS00NmYxLWIyNTAtYTJkNTJmYzI5ODEyIiwiODk0MzQwZTItNGI2
-        Yi00YTJiLTg3YzAtYzc0MzAzYzc2ZThiIiwiYmI2ZGU2ZjgtNTU5Ny00OGMy
-        LTgxOWMtMDI4MGZmMGFjMjdhIl19fX0sImluY2x1ZGVfcmVwb3MiOnRydWV9
+        eyJjcml0ZXJpYSI6eyJsaW1pdCI6Mywic2tpcCI6MCwiZmlsdGVycyI6eyJf
+        aWQiOnsiJGluIjpbIjQ2MDI2MTA0LTIwZmItNDU4Mi04NDE5LTE0NjAyODQ1
+        YmY1NCIsIjY2NTA4ODVkLThiZTAtNDk2My04YjNmLTY3Y2NhMzk2MzY1YSIs
+        ImUxNWJkOGQwLTYwYTEtNDNkOS1hNjc0LWY5NGZjYTk4Yzk2NCJdfX19LCJp
+        bmNsdWRlX3JlcG9zIjp0cnVlfQ==
     headers:
       Accept:
       - application/json
@@ -1562,7 +1946,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '180'
+      - '199'
       User-Agent:
       - Ruby
   response:
@@ -1571,7 +1955,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:45 GMT
+      - Tue, 29 Nov 2016 19:43:16 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -1584,177 +1968,123 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJf
-        aHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9lcnJhdHVtLzNh
-        ZDdmZjg5LTY0ODktNDZmMS1iMjUwLWEyZDUyZmMyOTgxMi8iLCAiaXNzdWVk
-        IjogIjIwMTAtMTEtMTAgMDA6MDA6MDAiLCAicmVmZXJlbmNlcyI6IFt7Imhy
-        ZWYiOiAiaHR0cHM6Ly9yaG4ucmVkaGF0LmNvbS9lcnJhdGEvUkhTQS0yMDEw
-        LTA4NTguaHRtbCIsICJ0eXBlIjogInNlbGYiLCAiaWQiOiBudWxsLCAidGl0
-        bGUiOiAiUkhTQS0yMDEwOjA4NTgifSwgeyJocmVmIjogImh0dHBzOi8vYnVn
-        emlsbGEucmVkaGF0LmNvbS9idWd6aWxsYS9zaG93X2J1Zy5jZ2k/aWQ9NjI3
-        ODgyIiwgInR5cGUiOiAiYnVnemlsbGEiLCAiaWQiOiAiNjI3ODgyIiwgInRp
-        dGxlIjogIkNWRS0yMDEwLTA0MDUgYnppcDI6IGludGVnZXIgb3ZlcmZsb3cg
-        ZmxhdyBpbiBCWjJfZGVjb21wcmVzcyJ9LCB7ImhyZWYiOiAiaHR0cHM6Ly93
-        d3cucmVkaGF0LmNvbS9zZWN1cml0eS9kYXRhL2N2ZS9DVkUtMjAxMC0wNDA1
-        Lmh0bWwiLCAidHlwZSI6ICJjdmUiLCAiaWQiOiAiQ1ZFLTIwMTAtMDQwNSIs
-        ICJ0aXRsZSI6ICJDVkUtMjAxMC0wNDA1In0sIHsiaHJlZiI6ICJodHRwOi8v
-        d3d3LnJlZGhhdC5jb20vc2VjdXJpdHkvdXBkYXRlcy9jbGFzc2lmaWNhdGlv
-        bi8jaW1wb3J0YW50IiwgInR5cGUiOiAib3RoZXIiLCAiaWQiOiBudWxsLCAi
-        dGl0bGUiOiBudWxsfV0sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9j
-        b250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6ICJSSFNBLTIwMTA6
-        MDg1OCIsICJmcm9tIjogInNlY3VyaXR5QHJlZGhhdC5jb20iLCAic2V2ZXJp
-        dHkiOiAiSW1wb3J0YW50IiwgInRpdGxlIjogIkltcG9ydGFudDogYnppcDIg
-        c2VjdXJpdHkgdXBkYXRlIiwgImNoaWxkcmVuIjoge30sICJ2ZXJzaW9uIjog
-        IjMiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1
-        cml0eSIsICJwa2dsaXN0IjogW3siX3B1bHBfcmVwb19pZCI6ICJGZWRvcmFf
-        MTciLCAicGFja2FnZXMiOiBbeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZf
-        MC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDItZGV2ZWwiLCAic3VtIjogWyJz
-        aGEyNTYiLCAiZWE2N2M2NjRkYTFmZjk2YTZkYzk0ZDMzMDA5YjczZDhmYWIz
-        MWI1OTgyNDE4M2ZiNDVlOWJhMmViZjgyZDU4MyJdLCAiZmlsZW5hbWUiOiAi
-        YnppcDItZGV2ZWwtMS4wLjUtNy5lbDZfMC5pNjg2LnJwbSIsICJlcG9jaCI6
-        ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8w
-        IiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03LmVs
-        Nl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJzIiwgInN1bSI6IFsi
-        c2hhMjU2IiwgImM5ZjA2NGE2ODYyNTczZmI5ZjJhNmFmZjdjMzYyMWYxOTQw
-        YjQ5MmRmMmVkZmMyZWJiZGMwYjgzMDVmNTExNDciXSwgImZpbGVuYW1lIjog
-        ImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC5pNjg2LnJwbSIsICJlcG9jaCI6
-        ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8w
-        IiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03LmVs
-        Nl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMiIsICJzdW0iOiBbInNoYTI1
-        NiIsICJiOGEzZjcyYmMyYjBkODliYTczNzA5OWFjOThiZjhkMmFmNGJlYTAy
-        ZDMxODg0YzAyZGI5N2Y3ZjY2YzNkNWMyIl0sICJmaWxlbmFtZSI6ICJiemlw
-        Mi0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9lcnJhdHVtLzQ2
+        MDI2MTA0LTIwZmItNDU4Mi04NDE5LTE0NjAyODQ1YmY1NC8iLCAiaXNzdWVk
+        IjogIjIwMTAtMDEtMDEgMDE6MDE6MDEiLCAicmVmZXJlbmNlcyI6IFtdLCAi
+        cHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lkIjog
+        ImVycmF0dW0iLCAiaWQiOiAiUkhFQS0yMDEwOjAwMDEiLCAiZnJvbSI6ICJs
+        emFwK3B1YkByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRsZSI6
+        ICJFbXB0eSBlcnJhdGEiLCAiY2hpbGRyZW4iOiB7fSwgInZlcnNpb24iOiAi
+        MSIsICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3Vy
+        aXR5IiwgInN0YXR1cyI6ICJzdGFibGUiLCAidXBkYXRlZCI6ICIiLCAiZGVz
+        Y3JpcHRpb24iOiAiRW1wdHkgZXJyYXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAi
+        MjAxNi0xMS0yOVQxOTo0MzoxNVoiLCAicHVzaGNvdW50IjogIiIsICJyaWdo
+        dHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxl
+        YXNlIjogIjEiLCAiX2lkIjogIjQ2MDI2MTA0LTIwZmItNDU4Mi04NDE5LTE0
+        NjAyODQ1YmY1NCJ9LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBbIkZl
+        ZG9yYV8xNyJdLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5p
+        dHMvZXJyYXR1bS82NjUwODg1ZC04YmUwLTQ5NjMtOGIzZi02N2NjYTM5NjM2
+        NWEvIiwgImlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAxIiwgInJlZmVy
+        ZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRl
+        bnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIlJIRUEtMjAxMDowMDAy
+        IiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6
+        ICIiLCAidGl0bGUiOiAiT25lIHBhY2thZ2UgZXJyYXRhIiwgImNoaWxkcmVu
+        Ijoge30sICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dlc3RlZCI6IGZh
+        bHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3siX3B1bHBf
+        cmVwb19pZCI6ICJGZWRvcmFfMTciLCAicGFja2FnZXMiOiBbeyJzcmMiOiAi
+        aHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIsICJuYW1lIjogImVsZXBo
+        YW50IiwgInN1bSI6IG51bGwsICJmaWxlbmFtZSI6ICJlbGVwaGFudC0wLjMt
+        MC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiBudWxsLCAidmVyc2lvbiI6ICIw
+        LjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gifV0sICJu
+        YW1lIjogIjEiLCAic2hvcnQiOiAiIn1dLCAic3RhdHVzIjogInN0YWJsZSIs
+        ICJ1cGRhdGVkIjogIiIsICJkZXNjcmlwdGlvbiI6ICJPbmUgcGFja2FnZSBl
+        cnJhdGEiLCAiX2xhc3RfdXBkYXRlZCI6ICIyMDE2LTExLTI5VDE5OjQzOjE1
+        WiIsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24i
+        OiAiIiwgInN1bW1hcnkiOiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAi
+        NjY1MDg4NWQtOGJlMC00OTYzLThiM2YtNjdjY2EzOTYzNjVhIn0sIHsicmVw
+        b3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJfaHJlZiI6
+        ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9lcnJhdHVtL2UxNWJkOGQw
+        LTYwYTEtNDNkOS1hNjc0LWY5NGZjYTk4Yzk2NC8iLCAiaXNzdWVkIjogIjIw
+        MTAtMTEtMTAgMDA6MDA6MDAiLCAicmVmZXJlbmNlcyI6IFt7ImhyZWYiOiAi
+        aHR0cHM6Ly9yaG4ucmVkaGF0LmNvbS9lcnJhdGEvUkhTQS0yMDEwLTA4NTgu
+        aHRtbCIsICJ0eXBlIjogInNlbGYiLCAiaWQiOiBudWxsLCAidGl0bGUiOiAi
+        UkhTQS0yMDEwOjA4NTgifSwgeyJocmVmIjogImh0dHBzOi8vYnVnemlsbGEu
+        cmVkaGF0LmNvbS9idWd6aWxsYS9zaG93X2J1Zy5jZ2k/aWQ9NjI3ODgyIiwg
+        InR5cGUiOiAiYnVnemlsbGEiLCAiaWQiOiAiNjI3ODgyIiwgInRpdGxlIjog
+        IkNWRS0yMDEwLTA0MDUgYnppcDI6IGludGVnZXIgb3ZlcmZsb3cgZmxhdyBp
+        biBCWjJfZGVjb21wcmVzcyJ9LCB7ImhyZWYiOiAiaHR0cHM6Ly93d3cucmVk
+        aGF0LmNvbS9zZWN1cml0eS9kYXRhL2N2ZS9DVkUtMjAxMC0wNDA1Lmh0bWwi
+        LCAidHlwZSI6ICJjdmUiLCAiaWQiOiAiQ1ZFLTIwMTAtMDQwNSIsICJ0aXRs
+        ZSI6ICJDVkUtMjAxMC0wNDA1In0sIHsiaHJlZiI6ICJodHRwOi8vd3d3LnJl
+        ZGhhdC5jb20vc2VjdXJpdHkvdXBkYXRlcy9jbGFzc2lmaWNhdGlvbi8jaW1w
+        b3J0YW50IiwgInR5cGUiOiAib3RoZXIiLCAiaWQiOiBudWxsLCAidGl0bGUi
+        OiBudWxsfV0sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50
+        X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6ICJSSFNBLTIwMTA6MDg1OCIs
+        ICJmcm9tIjogInNlY3VyaXR5QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAi
+        SW1wb3J0YW50IiwgInRpdGxlIjogIkltcG9ydGFudDogYnppcDIgc2VjdXJp
+        dHkgdXBkYXRlIiwgImNoaWxkcmVuIjoge30sICJ2ZXJzaW9uIjogIjMiLCAi
+        cmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIs
+        ICJwa2dsaXN0IjogW3siX3B1bHBfcmVwb19pZCI6ICJGZWRvcmFfMTciLCAi
+        cGFja2FnZXMiOiBbeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMu
+        cnBtIiwgIm5hbWUiOiAiYnppcDItZGV2ZWwiLCAic3VtIjogWyJzaGEyNTYi
+        LCAiZWE2N2M2NjRkYTFmZjk2YTZkYzk0ZDMzMDA5YjczZDhmYWIzMWI1OTgy
+        NDE4M2ZiNDVlOWJhMmViZjgyZDU4MyJdLCAiZmlsZW5hbWUiOiAiYnppcDIt
+        ZGV2ZWwtMS4wLjUtNy5lbDZfMC5pNjg2LnJwbSIsICJlcG9jaCI6ICIwIiwg
+        InZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFy
+        Y2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNy
+        Yy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJzIiwgInN1bSI6IFsic2hhMjU2
+        IiwgImM5ZjA2NGE2ODYyNTczZmI5ZjJhNmFmZjdjMzYyMWYxOTQwYjQ5MmRm
+        MmVkZmMyZWJiZGMwYjgzMDVmNTExNDciXSwgImZpbGVuYW1lIjogImJ6aXAy
+        LWxpYnMtMS4wLjUtNy5lbDZfMC5pNjg2LnJwbSIsICJlcG9jaCI6ICIwIiwg
+        InZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFy
+        Y2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNy
+        Yy5ycG0iLCAibmFtZSI6ICJiemlwMiIsICJzdW0iOiBbInNoYTI1NiIsICJi
+        OGEzZjcyYmMyYjBkODliYTczNzA5OWFjOThiZjhkMmFmNGJlYTAyZDMxODg0
+        YzAyZGI5N2Y3ZjY2YzNkNWMyIl0sICJmaWxlbmFtZSI6ICJiemlwMi0xLjAu
+        NS03LmVsNl8wLng4Nl82NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9u
+        IjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogIng4
+        Nl82NCJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0i
+        LCAibmFtZSI6ICJiemlwMi1kZXZlbCIsICJzdW0iOiBbInNoYTI1NiIsICI3
+        ZjYzMTI0ZTQ2NTViN2M5MmQyM2VjNGMzODIyNmY1ZDM3NDY1Njg4NTNkZmY3
+        NTBmYzg1ZTA1OGU3NGI1Y2Y2Il0sICJmaWxlbmFtZSI6ICJiemlwMi1kZXZl
+        bC0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2
         ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJhcmNo
         IjogIng4Nl82NCJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNy
-        Yy5ycG0iLCAibmFtZSI6ICJiemlwMi1kZXZlbCIsICJzdW0iOiBbInNoYTI1
-        NiIsICI3ZjYzMTI0ZTQ2NTViN2M5MmQyM2VjNGMzODIyNmY1ZDM3NDY1Njg4
-        NTNkZmY3NTBmYzg1ZTA1OGU3NGI1Y2Y2Il0sICJmaWxlbmFtZSI6ICJiemlw
-        Mi1kZXZlbC0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0iLCAiZXBvY2giOiAi
-        MCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIs
-        ICJhcmNoIjogIng4Nl82NCJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03LmVs
-        Nl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJzIiwgInN1bSI6IFsi
-        c2hhMjU2IiwgIjgwMmY0Mzk5ZGJkZDAxNDc2ZTI1NGMzYjMyYzQwYWZmNTlj
-        ZjVkMjNhNDVmYTQ4OGM2OTE3Y2U4OTA0ZDZiNGQiXSwgImZpbGVuYW1lIjog
-        ImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVwb2No
-        IjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2
-        XzAiLCAiYXJjaCI6ICJ4ODZfNjQifV0sICJuYW1lIjogIlJlZCBIYXQgRW50
-        ZXJwcmlzZSBMaW51eCBTZXJ2ZXIgKHYuIDYgZm9yIDY0LWJpdCB4ODZfNjQp
-        IiwgInNob3J0IjogInJoZWwteDg2XzY0LXNlcnZlci02In1dLCAic3RhdHVz
-        IjogImZpbmFsIiwgInVwZGF0ZWQiOiAiMjAxMC0xMS0xMCAwMDowMDowMCIs
-        ICJkZXNjcmlwdGlvbiI6ICJiemlwMiBpcyBhIGZyZWVseSBhdmFpbGFibGUs
-        IGhpZ2gtcXVhbGl0eSBkYXRhIGNvbXByZXNzb3IuIEl0IHByb3ZpZGVzIGJv
-        dGhcbmxpYmJ6MiBsaWJyYXJ5IG11c3QgYmUgcmVzdGFydGVkIGZvciB0aGUg
-        dXBkYXRlIHRvIHRha2UgZWZmZWN0LiIsICJfbGFzdF91cGRhdGVkIjogIjIw
-        MTYtMDctMjlUMTg6NTg6NDRaIiwgInB1c2hjb3VudCI6ICIiLCAicmlnaHRz
-        IjogIkNvcHlyaWdodCAyMDEwIFJlZCBIYXQgSW5jIiwgInNvbHV0aW9uIjog
-        IkJlZm9yZSBhcHBseWluZyB0aGlzIHVwZGF0ZSwgbWFrZSBzdXJlIGFsbCBw
-        cmV2aW91c2x5LXJlbGVhc2VkIGVycmF0YVxucmVsZXZhbnQgdG8geW91ciBz
-        eXN0ZW0gaGF2ZSBiZWVuIGFwcGxpZWQuXG5cblRoaXMgdXBkYXRlIGlzIGF2
-        YWlsYWJsZSB2aWEgdGhlIFJlZCBIYXQgTmV0d29yay4gRGV0YWlscyBvbiBo
-        b3cgdG9cbnVzZSB0aGUgUmVkIEhhdCBOZXR3b3JrIHRvIGFwcGx5IHRoaXMg
-        dXBkYXRlIGFyZSBhdmFpbGFibGUgYXRcbmh0dHA6Ly9rYmFzZS5yZWRoYXQu
-        Y29tL2ZhcS9kb2NzL0RPQy0xMTI1OSIsICJzdW1tYXJ5IjogIlVwZGF0ZWQg
-        YnppcDIgcGFja2FnZXMgdGhhdCBmaXggb25lIHNlY3VyaXR5IGlzc3VlIiwg
-        InJlbGVhc2UiOiAiIiwgIl9pZCI6ICIzYWQ3ZmY4OS02NDg5LTQ2ZjEtYjI1
-        MC1hMmQ1MmZjMjk4MTIifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjog
-        WyJGZWRvcmFfMTciXSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50
-        L3VuaXRzL2VycmF0dW0vODk0MzQwZTItNGI2Yi00YTJiLTg3YzAtYzc0MzAz
-        Yzc2ZThiLyIsICJpc3N1ZWQiOiAiMjAxMC0wMS0wMSAwMTowMTowMSIsICJy
-        ZWZlcmVuY2VzIjogW10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9j
-        b250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6ICJSSEVBLTIwMTA6
-        MDAwMiIsICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20iLCAic2V2ZXJp
-        dHkiOiAiIiwgInRpdGxlIjogIk9uZSBwYWNrYWdlIGVycmF0YSIsICJjaGls
-        ZHJlbiI6IHt9LCAidmVyc2lvbiI6ICIxIiwgInJlYm9vdF9zdWdnZXN0ZWQi
-        OiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFt7Il9w
-        dWxwX3JlcG9faWQiOiAiRmVkb3JhXzE3IiwgInBhY2thZ2VzIjogW3sic3Jj
-        IjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJl
-        bGVwaGFudCIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQt
-        MC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogbnVsbCwgInZlcnNpb24i
-        OiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIn1d
-        LCAibmFtZSI6ICIxIiwgInNob3J0IjogIiJ9XSwgInN0YXR1cyI6ICJzdGFi
-        bGUiLCAidXBkYXRlZCI6ICIiLCAiZGVzY3JpcHRpb24iOiAiT25lIHBhY2th
-        Z2UgZXJyYXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAiMjAxNi0wNy0yOVQxODo1
-        ODo0NFoiLCAicHVzaGNvdW50IjogIiIsICJyaWdodHMiOiAiIiwgInNvbHV0
-        aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxlYXNlIjogIjEiLCAiX2lk
-        IjogIjg5NDM0MGUyLTRiNmItNGEyYi04N2MwLWM3NDMwM2M3NmU4YiJ9LCB7
-        InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBbIkZlZG9yYV8xNyJdLCAiX2hy
-        ZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvZXJyYXR1bS9iYjZk
-        ZTZmOC01NTk3LTQ4YzItODE5Yy0wMjgwZmYwYWMyN2EvIiwgImlzc3VlZCI6
-        ICIyMDEwLTAxLTAxIDAxOjAxOjAxIiwgInJlZmVyZW5jZXMiOiBbXSwgInB1
-        bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJl
-        cnJhdHVtIiwgImlkIjogIlJIRUEtMjAxMDowMDAxIiwgImZyb20iOiAibHph
-        cCtwdWJAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6ICIiLCAidGl0bGUiOiAi
-        RW1wdHkgZXJyYXRhIiwgImNoaWxkcmVuIjoge30sICJ2ZXJzaW9uIjogIjEi
-        LCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0
-        eSIsICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2Ny
-        aXB0aW9uIjogIkVtcHR5IGVycmF0YSIsICJfbGFzdF91cGRhdGVkIjogIjIw
-        MTYtMDctMjlUMTg6NTg6NDRaIiwgInB1c2hjb3VudCI6ICIiLCAicmlnaHRz
-        IjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIiLCAicmVsZWFz
-        ZSI6ICIxIiwgIl9pZCI6ICJiYjZkZTZmOC01NTk3LTQ4YzItODE5Yy0wMjgw
-        ZmYwYWMyN2EifV0=
+        Yy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJzIiwgInN1bSI6IFsic2hhMjU2
+        IiwgIjgwMmY0Mzk5ZGJkZDAxNDc2ZTI1NGMzYjMyYzQwYWZmNTljZjVkMjNh
+        NDVmYTQ4OGM2OTE3Y2U4OTA0ZDZiNGQiXSwgImZpbGVuYW1lIjogImJ6aXAy
+        LWxpYnMtMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjogIjAi
+        LCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAi
+        YXJjaCI6ICJ4ODZfNjQifV0sICJuYW1lIjogIlJlZCBIYXQgRW50ZXJwcmlz
+        ZSBMaW51eCBTZXJ2ZXIgKHYuIDYgZm9yIDY0LWJpdCB4ODZfNjQpIiwgInNo
+        b3J0IjogInJoZWwteDg2XzY0LXNlcnZlci02In1dLCAic3RhdHVzIjogImZp
+        bmFsIiwgInVwZGF0ZWQiOiAiMjAxMC0xMS0xMCAwMDowMDowMCIsICJkZXNj
+        cmlwdGlvbiI6ICJiemlwMiBpcyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gt
+        cXVhbGl0eSBkYXRhIGNvbXByZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxp
+        YmJ6MiBsaWJyYXJ5IG11c3QgYmUgcmVzdGFydGVkIGZvciB0aGUgdXBkYXRl
+        IHRvIHRha2UgZWZmZWN0LiIsICJfbGFzdF91cGRhdGVkIjogIjIwMTYtMTEt
+        MjlUMTk6NDM6MTVaIiwgInB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjogIkNv
+        cHlyaWdodCAyMDEwIFJlZCBIYXQgSW5jIiwgInNvbHV0aW9uIjogIkJlZm9y
+        ZSBhcHBseWluZyB0aGlzIHVwZGF0ZSwgbWFrZSBzdXJlIGFsbCBwcmV2aW91
+        c2x5LXJlbGVhc2VkIGVycmF0YVxucmVsZXZhbnQgdG8geW91ciBzeXN0ZW0g
+        aGF2ZSBiZWVuIGFwcGxpZWQuXG5cblRoaXMgdXBkYXRlIGlzIGF2YWlsYWJs
+        ZSB2aWEgdGhlIFJlZCBIYXQgTmV0d29yay4gRGV0YWlscyBvbiBob3cgdG9c
+        bnVzZSB0aGUgUmVkIEhhdCBOZXR3b3JrIHRvIGFwcGx5IHRoaXMgdXBkYXRl
+        IGFyZSBhdmFpbGFibGUgYXRcbmh0dHA6Ly9rYmFzZS5yZWRoYXQuY29tL2Zh
+        cS9kb2NzL0RPQy0xMTI1OSIsICJzdW1tYXJ5IjogIlVwZGF0ZWQgYnppcDIg
+        cGFja2FnZXMgdGhhdCBmaXggb25lIHNlY3VyaXR5IGlzc3VlIiwgInJlbGVh
+        c2UiOiAiIiwgIl9pZCI6ICJlMTViZDhkMC02MGExLTQzZDktYTY3NC1mOTRm
+        Y2E5OGM5NjQifV0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:45 GMT
+  recorded_at: Tue, 29 Nov 2016 19:43:16 GMT
 - request:
     method: post
-    uri: https://obelix.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://robot.example.com/pulp/api/v2/content/units/erratum/search/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJlcnJhdHVtIl0sImZpZWxkcyI6
-        eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '84'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jul 2016 18:58:45 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '651'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIzYWQ3ZmY4OS02NDg5LTQ2ZjEtYjI1
-        MC1hMmQ1MmZjMjk4MTIiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
-        In0sICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3NjQ3YmMyNWFhZjA5NTYyZTI2
-        In0sICJ1bml0X2lkIjogIjNhZDdmZjg5LTY0ODktNDZmMS1iMjUwLWEyZDUy
-        ZmMyOTgxMiIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
-        YXRhIjogeyJfaWQiOiAiODk0MzQwZTItNGI2Yi00YTJiLTg3YzAtYzc0MzAz
-        Yzc2ZThiIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
-        IjogeyIkb2lkIjogIjU3OWJhNzY0N2JjMjVhYWYwOTU2MmUyNyJ9LCAidW5p
-        dF9pZCI6ICI4OTQzNDBlMi00YjZiLTRhMmItODdjMC1jNzQzMDNjNzZlOGIi
-        LCAidW5pdF90eXBlX2lkIjogImVycmF0dW0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogImJiNmRlNmY4LTU1OTctNDhjMi04MTljLTAyODBmZjBhYzI3YSIs
-        ICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0ifSwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NzliYTc2NDdiYzI1YWFmMDk1NjJlMjUifSwgInVuaXRfaWQiOiAi
-        YmI2ZGU2ZjgtNTU5Ny00OGMyLTgxOWMtMDI4MGZmMGFjMjdhIiwgInVuaXRf
-        dHlwZV9pZCI6ICJlcnJhdHVtIn1d
-    http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:45 GMT
-- request:
-    method: post
-    uri: https://obelix.example.com/pulp/api/v2/content/units/erratum/search/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiM2FkN2Zm
-        ODktNjQ4OS00NmYxLWIyNTAtYTJkNTJmYzI5ODEyIl19fX0sImluY2x1ZGVf
+        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiZTE1YmQ4
+        ZDAtNjBhMS00M2Q5LWE2NzQtZjk0ZmNhOThjOTY0Il19fX0sImluY2x1ZGVf
         cmVwb3MiOnRydWV9
     headers:
       Accept:
@@ -1773,7 +2103,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:45 GMT
+      - Tue, 29 Nov 2016 19:43:16 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -1786,8 +2116,8 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJf
-        aHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9lcnJhdHVtLzNh
-        ZDdmZjg5LTY0ODktNDZmMS1iMjUwLWEyZDUyZmMyOTgxMi8iLCAiaXNzdWVk
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9lcnJhdHVtL2Ux
+        NWJkOGQwLTYwYTEtNDNkOS1hNjc0LWY5NGZjYTk4Yzk2NC8iLCAiaXNzdWVk
         IjogIjIwMTAtMTEtMTAgMDA6MDA6MDAiLCAicmVmZXJlbmNlcyI6IFt7Imhy
         ZWYiOiAiaHR0cHM6Ly9yaG4ucmVkaGF0LmNvbS9lcnJhdGEvUkhTQS0yMDEw
         LTA4NTguaHRtbCIsICJ0eXBlIjogInNlbGYiLCAiaWQiOiBudWxsLCAidGl0
@@ -1846,7 +2176,7 @@ http_interactions:
         IGhpZ2gtcXVhbGl0eSBkYXRhIGNvbXByZXNzb3IuIEl0IHByb3ZpZGVzIGJv
         dGhcbmxpYmJ6MiBsaWJyYXJ5IG11c3QgYmUgcmVzdGFydGVkIGZvciB0aGUg
         dXBkYXRlIHRvIHRha2UgZWZmZWN0LiIsICJfbGFzdF91cGRhdGVkIjogIjIw
-        MTYtMDctMjlUMTg6NTg6NDRaIiwgInB1c2hjb3VudCI6ICIiLCAicmlnaHRz
+        MTYtMTEtMjlUMTk6NDM6MTVaIiwgInB1c2hjb3VudCI6ICIiLCAicmlnaHRz
         IjogIkNvcHlyaWdodCAyMDEwIFJlZCBIYXQgSW5jIiwgInNvbHV0aW9uIjog
         IkJlZm9yZSBhcHBseWluZyB0aGlzIHVwZGF0ZSwgbWFrZSBzdXJlIGFsbCBw
         cmV2aW91c2x5LXJlbGVhc2VkIGVycmF0YVxucmVsZXZhbnQgdG8geW91ciBz
@@ -1856,13 +2186,13 @@ http_interactions:
         dXBkYXRlIGFyZSBhdmFpbGFibGUgYXRcbmh0dHA6Ly9rYmFzZS5yZWRoYXQu
         Y29tL2ZhcS9kb2NzL0RPQy0xMTI1OSIsICJzdW1tYXJ5IjogIlVwZGF0ZWQg
         YnppcDIgcGFja2FnZXMgdGhhdCBmaXggb25lIHNlY3VyaXR5IGlzc3VlIiwg
-        InJlbGVhc2UiOiAiIiwgIl9pZCI6ICIzYWQ3ZmY4OS02NDg5LTQ2ZjEtYjI1
-        MC1hMmQ1MmZjMjk4MTIifV0=
+        InJlbGVhc2UiOiAiIiwgIl9pZCI6ICJlMTViZDhkMC02MGExLTQzZDktYTY3
+        NC1mOTRmY2E5OGM5NjQifV0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:45 GMT
+  recorded_at: Tue, 29 Nov 2016 19:43:16 GMT
 - request:
     method: delete
-    uri: https://obelix.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://robot.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1881,7 +2211,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:45 GMT
+      - Tue, 29 Nov 2016 19:43:16 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -1892,14 +2222,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2ExNzJmYmVjLWY1ZDktNGRlMS05NDVkLWRkN2NhODQyOGU2ZS8iLCAi
-        dGFza19pZCI6ICJhMTcyZmJlYy1mNWQ5LTRkZTEtOTQ1ZC1kZDdjYTg0Mjhl
-        NmUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzJkNTRlNTYyLWM1NDktNGIzMi1iOTExLTQ4MWYzN2I2YWQ5My8iLCAi
+        dGFza19pZCI6ICIyZDU0ZTU2Mi1jNTQ5LTRiMzItYjkxMS00ODFmMzdiNmFk
+        OTMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:45 GMT
+  recorded_at: Tue, 29 Nov 2016 19:43:16 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/a172fbec-f5d9-4de1-945d-dd7ca8428e6e/
+    uri: https://robot.example.com/pulp/api/v2/tasks/2d54e562-c549-4b32-b911-481f37b6ad93/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1918,7 +2248,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:45 GMT
+      - Tue, 29 Nov 2016 19:43:16 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -1932,22 +2262,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hMTcyZmJlYy1mNWQ5LTRkZTEtOTQ1ZC1kZDdjYTg0Mjhl
-        NmUvIiwgInRhc2tfaWQiOiAiYTE3MmZiZWMtZjVkOS00ZGUxLTk0NWQtZGQ3
-        Y2E4NDI4ZTZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8yZDU0ZTU2Mi1jNTQ5LTRiMzItYjkxMS00ODFmMzdiNmFk
+        OTMvIiwgInRhc2tfaWQiOiAiMmQ1NGU1NjItYzU0OS00YjMyLWI5MTEtNDgx
+        ZjM3YjZhZDkzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
         bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
         ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
         Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
         IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NzliYTc2
-        NTdiYzI1YWFmMDk1NjJlMmMifSwgImlkIjogIjU3OWJhNzY1N2JjMjVhYWYw
-        OTU2MmUyYyJ9
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ODNkZGE1
+        NDY3MWUwOGVhYTZkMjU3OWIifSwgImlkIjogIjU4M2RkYTU0NjcxZTA4ZWFh
+        NmQyNTc5YiJ9
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:45 GMT
+  recorded_at: Tue, 29 Nov 2016 19:43:16 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/a172fbec-f5d9-4de1-945d-dd7ca8428e6e/
+    uri: https://robot.example.com/pulp/api/v2/tasks/2d54e562-c549-4b32-b911-481f37b6ad93/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1966,13 +2296,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:46 GMT
+      - Tue, 29 Nov 2016 19:43:17 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '670'
+      - '668'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1980,19 +2310,19 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hMTcyZmJlYy1mNWQ5LTRkZTEtOTQ1ZC1kZDdjYTg0Mjhl
-        NmUvIiwgInRhc2tfaWQiOiAiYTE3MmZiZWMtZjVkOS00ZGUxLTk0NWQtZGQ3
-        Y2E4NDI4ZTZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8yZDU0ZTU2Mi1jNTQ5LTRiMzItYjkxMS00ODFmMzdiNmFk
+        OTMvIiwgInRhc2tfaWQiOiAiMmQ1NGU1NjItYzU0OS00YjMyLWI5MTEtNDgx
+        ZjM3YjZhZDkzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTA3LTI5VDE4OjU4OjQ1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTA3LTI5VDE4OjU4OjQ1WiIsICJ0cmFjZWJh
+        MDE2LTExLTI5VDE5OjQzOjE2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTExLTI5VDE5OjQzOjE2WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBvYmVsaXguZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQi
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        b2JlbGl4LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3NjU3YmMyNWFhZjA5NTYy
-        ZTJjIn0sICJpZCI6ICI1NzliYTc2NTdiYzI1YWFmMDk1NjJlMmMifQ==
+        MUByb2JvdC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBy
+        b2JvdC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU4M2RkYTU0NjcxZTA4ZWFhNmQyNTc5
+        YiJ9LCAiaWQiOiAiNTgzZGRhNTQ2NzFlMDhlYWE2ZDI1NzliIn0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:46 GMT
+  recorded_at: Tue, 29 Nov 2016 19:43:17 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/services/pulp/package_group.yml
+++ b/test/fixtures/vcr_cassettes/services/pulp/package_group.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/5724e984-7a74-474d-9457-0c2a95ed321a/
+    uri: https://robot.example.com/pulp/api/v2/tasks/06dc69cf-ce61-4180-bfe7-2076d46424ee/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -21,13 +21,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:47 GMT
+      - Tue, 29 Nov 2016 19:44:28 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1121'
+      - '629'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -35,34 +35,23 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81NzI0ZTk4NC03YTc0LTQ3NGQtOTQ1Ny0wYzJhOTVlZDMy
-        MWEvIiwgInRhc2tfaWQiOiAiNTcyNGU5ODQtN2E3NC00NzRkLTk0NTctMGMy
-        YTk1ZWQzMjFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8wNmRjNjljZi1jZTYxLTQxODAtYmZlNy0yMDc2ZDQ2NDI0
+        ZWUvIiwgInRhc2tfaWQiOiAiMDZkYzY5Y2YtY2U2MS00MTgwLWJmZTctMjA3
+        NmQ0NjQyNGVlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Ny0yOVQxODo1ODo0N1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
-        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
-        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
-        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
-        T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQG9iZWxpeC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5n
-        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
-        QG9iZWxpeC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3Ii
-        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU3OWJhNzY3N2JjMjVhYWYwOTU2
-        MmUyZCJ9LCAiaWQiOiAiNTc5YmE3Njc3YmMyNWFhZjA5NTYyZTJkIn0=
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAcm9ib3QuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAid2Fp
+        dGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMUByb2JvdC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU4M2RkYTljNjcxZTA4ZWFh
+        NmQyNTc5YyJ9LCAiaWQiOiAiNTgzZGRhOWM2NzFlMDhlYWE2ZDI1NzljIn0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:47 GMT
+  recorded_at: Tue, 29 Nov 2016 19:44:28 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/5724e984-7a74-474d-9457-0c2a95ed321a/
+    uri: https://robot.example.com/pulp/api/v2/tasks/06dc69cf-ce61-4180-bfe7-2076d46424ee/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -81,13 +70,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:47 GMT
+      - Tue, 29 Nov 2016 19:44:29 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2284'
+      - '2282'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -95,16 +84,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81NzI0ZTk4NC03YTc0LTQ3NGQtOTQ1Ny0wYzJhOTVlZDMy
-        MWEvIiwgInRhc2tfaWQiOiAiNTcyNGU5ODQtN2E3NC00NzRkLTk0NTctMGMy
-        YTk1ZWQzMjFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8wNmRjNjljZi1jZTYxLTQxODAtYmZlNy0yMDc2ZDQ2NDI0
+        ZWUvIiwgInRhc2tfaWQiOiAiMDZkYzY5Y2YtY2U2MS00MTgwLWJmZTctMjA3
+        NmQ0NjQyNGVlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wNy0yOVQxODo1ODo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wNy0yOVQxODo1ODo0N1oiLCAidHJhY2ViYWNr
+        Ni0xMS0yOVQxOTo0NDoyOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0NDoyOFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMjRkM2Q0MGMtNDhjZS00OTJkLTg0ZjUtMWYxYjdkNmZj
-        MjEyLyIsICJ0YXNrX2lkIjogIjI0ZDNkNDBjLTQ4Y2UtNDkyZC04NGY1LTFm
-        MWI3ZDZmYzIxMiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNDg4YTFlNTItOTE1Ny00ZTQzLWI4NjktZTE3YjM2N2Zm
+        ZDkxLyIsICJ0YXNrX2lkIjogIjQ4OGExZTUyLTkxNTctNGU0My1iODY5LWUx
+        N2IzNjdmZmQ5MSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -115,40 +104,40 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQG9iZWxpeC5leGFt
-        cGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFt
-        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBs
-        ZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBv
-        cnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwg
-        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJz
-        dGFydGVkIjogIjIwMTYtMDctMjlUMTg6NTg6NDdaIiwgIl9ucyI6ICJyZXBv
-        X3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wNy0yOVQxODo1
-        ODo0N1oiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
-        ZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50Ijog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAxNSwg
-        InJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6
-        ICI1NzliYTc2NzcwYmU2ZjczOGVkZDlkY2MiLCAiZGV0YWlscyI6IHsiY29u
-        dGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVm
-        dCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUi
-        OiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9y
-        X2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3Njc3YmMyNWFhZjA5NTYyZTJkIn0s
-        ICJpZCI6ICI1NzliYTc2NzdiYzI1YWFmMDk1NjJlMmQifQ==
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0
+        ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTExLTI5VDE5OjQ0OjI4WiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMTEtMjlUMTk6NDQ6
+        MjhaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTgzZGRhOWNiMGVhZjIwOTliNjgxODhiIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU4M2RkYTljNjcxZTA4ZWFhNmQyNTc5YyJ9LCAi
+        aWQiOiAiNTgzZGRhOWM2NzFlMDhlYWE2ZDI1NzljIn0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:47 GMT
+  recorded_at: Tue, 29 Nov 2016 19:44:29 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/24d3d40c-48ce-492d-84f5-1f1b7d6fc212/
+    uri: https://robot.example.com/pulp/api/v2/tasks/488a1e52-9157-4e43-b869-e17b367ffd91/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -167,13 +156,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:47 GMT
+      - Tue, 29 Nov 2016 19:44:29 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '6911'
+      - '3503'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -181,163 +170,87 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8yNGQzZDQwYy00OGNlLTQ5MmQtODRmNS0xZjFi
-        N2Q2ZmMyMTIvIiwgInRhc2tfaWQiOiAiMjRkM2Q0MGMtNDhjZS00OTJkLTg0
-        ZjUtMWYxYjdkNmZjMjEyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy80ODhhMWU1Mi05MTU3LTRlNDMtYjg2OS1lMTdi
+        MzY3ZmZkOTEvIiwgInRhc2tfaWQiOiAiNDg4YTFlNTItOTE1Ny00ZTQzLWI4
+        NjktZTE3YjM2N2ZmZDkxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wNy0yOVQxODo1ODo0N1oiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wNy0yOVQxODo1ODo0N1oiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJmMGEyMDA1Ni00MTkyLTQ2YTAtYTQ3NS05ZGIxMDI2
-        YzViMjAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxNi0xMS0yOVQxOTo0NDoyOVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyNGMy
+        MzVmZC1iNTZmLTQyMzItYTk2Ni0yNWU0MWFhMWM0OTAiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWZiN2FmMjItY2Rj
+        Ni00MjEzLWE3YzUtMzQxODU2NGJlZGVhIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDQsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiOGYwMzVmZTQtN2ZjYi00NDViLWIzYjItODBhMzM1YTBiYThmIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiYTcyNjEzNWEtNjFhOS00Yzk0LTlmOTkt
-        NTZhMThkMTVkMzRmIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzg5
-        MzgxNmEtNDIwOS00MWNkLWFmNDUtOTE3NDk0ZGQzOThjIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjY1Yjc5ZjNmLTkxMTItNDViZC1iYjM5LTlkYTNi
-        NmE3NDRhOCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyMDEzNGJj
-        ZS1iZWEyLTQ1Y2ItODlkYi0xMjJjMDYzNjY5MzEiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJlMjc3MmEyNi00NWFjLTRiYmMtOWVkZC1iYTI4
-        ZmNlMGVhNTgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        aWQiOiAiOGRlM2NkM2QtNWFjNi00NDQ5LWEyMzAtYTA5NjI0ZDlmNTBiIiwg
+        Im51bV9wcm9jZXNzZWQiOiA0fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
+        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ3MDYxOWNlLWNiYzYt
+        NGU4MS1hNDk5LTU4YWE4OTc4NjVmMCIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIwMmVmNDkxMi1kYWMwLTQzZWQtYjQyZC1kOTEwNTQ2NzYzYTUi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhODJi
-        YzZkZS1hYjA1LTRkMDEtYjljYi1lNmJiYzU2OWE4Y2QiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNDY5NDU4YS1mODc4
-        LTRmNTAtYjBjOS04ZmM5OGI0ODBlMGMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdmNzllMzBmLWIxMjUtNDkx
-        Yi1iNmI1LTNjOTczNWY0ZmE4MiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQG9iZWxpeC5l
-        eGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhh
-        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJl
-        eGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3Rh
-        cnRlZCI6ICIyMDE2LTA3LTI5VDE4OjU4OjQ3WiIsICJfbnMiOiAicmVwb19w
-        dWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDctMjlUMTg6
-        NTg6NDdaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBl
-        X2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0
-        ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9y
-        ZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQi
-        LCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklT
-        SEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0
-        YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFf
-        MTciLCAiaWQiOiAiNTc5YmE3Njc3MGJlNmY3MzhlZGQ5ZGNkIiwgImRldGFp
-        bHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0
-        aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
-        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImYwYTIwMDU2
-        LTQxOTItNDZhMC1hNDc1LTlkYjEwMjZjNWIyMCIsICJudW1fcHJvY2Vzc2Vk
-        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRp
-        c3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4ZjAzNWZlNC03ZmNiLTQ0
-        NWItYjNiMi04MGEzMzVhMGJhOGYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
-        Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        UlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJh
-        NzI2MTM1YS02MWE5LTRjOTQtOWY5OS01NmExOGQxNWQzNGYiLCAibnVtX3By
-        b2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJjODkzODE2YS00MjA5LTQxY2QtYWY0NS05
-        MTc0OTRkZDM5OGMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
-        ZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwg
-        InN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjViNzlm
-        M2YtOTExMi00NWJkLWJiMzktOWRhM2I2YTc0NGE4IiwgIm51bV9wcm9jZXNz
-        ZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjIwMTM0YmNlLWJlYTItNDVjYi04OWRiLTEyMmMw
-        NjM2NjkzMSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAi
-        c3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUyNzcy
-        YTI2LTQ1YWMtNGJiYy05ZWRkLWJhMjhmY2UwZWE1OCIsICJudW1fcHJvY2Vz
-        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        Q2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9y
-        ZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
-        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjAyZWY0OTEyLWRhYzAt
-        NDNlZC1iNDJkLWQ5MTA1NDY3NjNhNSIsICJudW1fcHJvY2Vzc2VkIjogMX0s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
-        ZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0
-        ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogImE4MmJjNmRlLWFiMDUtNGQwMS1iOWNiLWU2
-        YmJjNTY5YThjZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
-        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3
-        ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImE0Njk0NThhLWY4NzgtNGY1MC1iMGM5LThmYzk4YjQ4MGUw
-        YyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBf
-        dHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiN2Y3OWUzMGYtYjEyNS00OTFiLWI2YjUtM2M5NzM1ZjRmYTgyIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjU3OWJhNzY3N2JjMjVhYWYwOTU2MmUzZCJ9LCAiaWQiOiAi
-        NTc5YmE3Njc3YmMyNWFhZjA5NTYyZTNkIn0=
+        cF9pZCI6ICI2YjZmYTNmZS0zZTQxLTQ2MWYtOWQ4My05ZWYzYjIzYzU2MGMi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5
+        cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmExMmRjOTktZGQ3
+        ZC00YThlLWIyM2QtZTJmZmI1OTk2ZjY5IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiZTdkYWRlZTctY2JjNC00NDkwLTg4OWMtNzdmMDJh
+        NzBhNmIzIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAi
+        c3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiZGViZjBhOGEtZDA5Zi00ZTgzLWFkZjktZDEyNTE5MjcwZDFh
+        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
+        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        ImU3MDY0MTc4LTg2YjgtNDUyMS05ODUxLWE1MTUxMjUxMjQ1MSIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjog
+        InB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImY3MmQw
+        ZWNhLWQ2MjItNDgwNi1hZGEzLWY3YjdkMDg3NTE5ZCIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
+        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZWNmMTVi
+        YjItNWNjZC00NWNmLWFhZGUtNDgxOTZjNDY5MWVkIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTFAcm9ib3QuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBy
+        b2JvdC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU4M2RkYTljNjcxZTA4ZWFhNmQyNTdh
+        YyJ9LCAiaWQiOiAiNTgzZGRhOWM2NzFlMDhlYWE2ZDI1N2FjIn0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:47 GMT
+  recorded_at: Tue, 29 Nov 2016 19:44:29 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/c5bdd455-4ef4-40c4-be73-7cfd1169be95/
+    uri: https://robot.example.com/pulp/api/v2/tasks/06dc69cf-ce61-4180-bfe7-2076d46424ee/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -356,113 +269,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:48 GMT
+      - Tue, 29 Nov 2016 19:44:29 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '651'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jNWJkZDQ1NS00ZWY0LTQwYzQtYmU3My03Y2ZkMTE2OWJl
-        OTUvIiwgInRhc2tfaWQiOiAiYzViZGQ0NTUtNGVmNC00MGM0LWJlNzMtN2Nm
-        ZDExNjliZTk1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
-        LTA3LTI5VDE4OjU4OjQ4WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
-        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJy
-        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBsZS5jb20i
-        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NzliYTc2ODdiYzI1YWFmMDk1NjJlM2UifSwgImlkIjogIjU3OWJh
-        NzY4N2JjMjVhYWYwOTU2MmUzZSJ9
-    http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:48 GMT
-- request:
-    method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/c5bdd455-4ef4-40c4-be73-7cfd1169be95/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jul 2016 18:58:48 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '670'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jNWJkZDQ1NS00ZWY0LTQwYzQtYmU3My03Y2ZkMTE2OWJl
-        OTUvIiwgInRhc2tfaWQiOiAiYzViZGQ0NTUtNGVmNC00MGM0LWJlNzMtN2Nm
-        ZDExNjliZTk1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTA3LTI5VDE4OjU4OjQ4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTA3LTI5VDE4OjU4OjQ4WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBvYmVsaXguZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQi
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        b2JlbGl4LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3Njg3YmMyNWFhZjA5NTYy
-        ZTNlIn0sICJpZCI6ICI1NzliYTc2ODdiYzI1YWFmMDk1NjJlM2UifQ==
-    http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:48 GMT
-- request:
-    method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/c04081c2-f114-4c53-ad72-f317119012a7/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jul 2016 18:58:49 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1121'
+      - '2282'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -470,76 +283,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jMDQwODFjMi1mMTE0LTRjNTMtYWQ3Mi1mMzE3MTE5MDEy
-        YTcvIiwgInRhc2tfaWQiOiAiYzA0MDgxYzItZjExNC00YzUzLWFkNzItZjMx
-        NzExOTAxMmE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Ny0yOVQxODo1ODo0OVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
-        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
-        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
-        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
-        T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQG9iZWxpeC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5n
-        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
-        QG9iZWxpeC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3Ii
-        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU3OWJhNzY5N2JjMjVhYWYwOTU2
-        MmUzZiJ9LCAiaWQiOiAiNTc5YmE3Njk3YmMyNWFhZjA5NTYyZTNmIn0=
-    http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:49 GMT
-- request:
-    method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/c04081c2-f114-4c53-ad72-f317119012a7/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jul 2016 18:58:50 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2284'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jMDQwODFjMi1mMTE0LTRjNTMtYWQ3Mi1mMzE3MTE5MDEy
-        YTcvIiwgInRhc2tfaWQiOiAiYzA0MDgxYzItZjExNC00YzUzLWFkNzItZjMx
-        NzExOTAxMmE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8wNmRjNjljZi1jZTYxLTQxODAtYmZlNy0yMDc2ZDQ2NDI0
+        ZWUvIiwgInRhc2tfaWQiOiAiMDZkYzY5Y2YtY2U2MS00MTgwLWJmZTctMjA3
+        NmQ0NjQyNGVlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wNy0yOVQxODo1ODo0OVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wNy0yOVQxODo1ODo0OVoiLCAidHJhY2ViYWNr
+        Ni0xMS0yOVQxOTo0NDoyOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0NDoyOFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvNzQxYTRiODktZmJiNi00M2UyLTliMTItMWFlMjAzYWI0
-        ZjFjLyIsICJ0YXNrX2lkIjogIjc0MWE0Yjg5LWZiYjYtNDNlMi05YjEyLTFh
-        ZTIwM2FiNGYxYyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNDg4YTFlNTItOTE1Ny00ZTQzLWI4NjktZTE3YjM2N2Zm
+        ZDkxLyIsICJ0YXNrX2lkIjogIjQ4OGExZTUyLTkxNTctNGU0My1iODY5LWUx
+        N2IzNjdmZmQ5MSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -550,40 +303,40 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQG9iZWxpeC5leGFt
-        cGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFt
-        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBs
-        ZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBv
-        cnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwg
-        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJz
-        dGFydGVkIjogIjIwMTYtMDctMjlUMTg6NTg6NDlaIiwgIl9ucyI6ICJyZXBv
-        X3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wNy0yOVQxODo1
-        ODo0OVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
-        ZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50Ijog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAxNSwg
-        InJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6
-        ICI1NzliYTc2OTcwYmU2ZjczOGVkZDlkZDkiLCAiZGV0YWlscyI6IHsiY29u
-        dGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVm
-        dCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUi
-        OiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9y
-        X2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3Njk3YmMyNWFhZjA5NTYyZTNmIn0s
-        ICJpZCI6ICI1NzliYTc2OTdiYzI1YWFmMDk1NjJlM2YifQ==
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0
+        ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTExLTI5VDE5OjQ0OjI4WiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMTEtMjlUMTk6NDQ6
+        MjhaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTgzZGRhOWNiMGVhZjIwOTliNjgxODhiIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU4M2RkYTljNjcxZTA4ZWFhNmQyNTc5YyJ9LCAi
+        aWQiOiAiNTgzZGRhOWM2NzFlMDhlYWE2ZDI1NzljIn0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:50 GMT
+  recorded_at: Tue, 29 Nov 2016 19:44:29 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/741a4b89-fbb6-43e2-9b12-1ae203ab4f1c/
+    uri: https://robot.example.com/pulp/api/v2/tasks/488a1e52-9157-4e43-b869-e17b367ffd91/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -602,13 +355,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:50 GMT
+      - Tue, 29 Nov 2016 19:44:29 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '6911'
+      - '6909'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -616,163 +369,163 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy83NDFhNGI4OS1mYmI2LTQzZTItOWIxMi0xYWUy
-        MDNhYjRmMWMvIiwgInRhc2tfaWQiOiAiNzQxYTRiODktZmJiNi00M2UyLTli
-        MTItMWFlMjAzYWI0ZjFjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy80ODhhMWU1Mi05MTU3LTRlNDMtYjg2OS1lMTdi
+        MzY3ZmZkOTEvIiwgInRhc2tfaWQiOiAiNDg4YTFlNTItOTE1Ny00ZTQzLWI4
+        NjktZTE3YjM2N2ZmZDkxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wNy0yOVQxODo1ODo0OVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wNy0yOVQxODo1ODo0OVoiLCAi
+        bWUiOiAiMjAxNi0xMS0yOVQxOTo0NDoyOVoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0NDoyOVoiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI5ODBmZGZlZS04NDgyLTRmMGYtOGM2OC0zYmViODIy
-        MDc2OWYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICIyNGMyMzVmZC1iNTZmLTQyMzItYTk2Ni0yNWU0MWFh
+        MWM0OTAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZGViOGE4NmQtOTQwNS00OTk2LTk0MzItYTMxNDZiYTMwZjYwIiwg
+        aWQiOiAiYWZiN2FmMjItY2RjNi00MjEzLWE3YzUtMzQxODU2NGJlZGVhIiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
         bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMzE1MTIyZDQtN2QyOC00MDBhLWIwNDEt
-        YmI3ODdjNmE0MGQ4IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiOGRlM2NkM2QtNWFjNi00NDQ5LWEyMzAt
+        YTA5NjI0ZDlmNTBiIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
         TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjkx
-        MGQzMGEtYmViYi00YjhlLWE0M2MtY2JmM2ZlMTE0MWY0IiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDcw
+        NjE5Y2UtY2JjNi00ZTgxLWE0OTktNThhYTg5Nzg2NWYwIiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImI2NjZlMDFjLTczZWUtNDVlOC05OGQxLWY4MDEy
-        Yzc4Yjc1MiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        IDAsICJzdGVwX2lkIjogIjZiNmZhM2ZlLTNlNDEtNDYxZi05ZDgzLTllZjNi
+        MjNjNTYwYyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
         OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
         InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2ZWI1ZDEw
-        ZS01NzQyLTQ4ZDItYjdiYS0zYjlhZGJhMDA5MDQiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyYTEyZGM5
+        OS1kZDdkLTRhOGUtYjIzZC1lMmZmYjU5OTZmNjkiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
         Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI3M2IwYjQ3MS1lMGExLTRmYzktYTc4Ny0yM2My
-        ZDAyNGY1ZjAiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICJlN2RhZGVlNy1jYmM0LTQ0OTAtODg5Yy03N2Yw
+        MmE3MGE2YjMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
         ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJkYjg3ZjE1Mi1hYjFkLTQxNDAtYWRjYy03NDVhNzdlNzExYjci
+        cF9pZCI6ICJkZWJmMGE4YS1kMDlmLTRlODMtYWRmOS1kMTI1MTkyNzBkMWEi
         LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
         dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
         c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwMTc1
-        ZWJlMy1hYmFiLTQwZDgtYjcwZi0wMjRhN2QzZmM4YTMiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlNzA2
+        NDE3OC04NmI4LTQ1MjEtOTg1MS1hNTE1MTI1MTI0NTEiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
         aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwM2UyZmI0ZS00Yjc3
-        LTQyMWItYTM0OS1mMjQyMWExZWQwYTgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmNzJkMGVjYS1kNjIy
+        LTQ4MDYtYWRhMy1mN2I3ZDA4NzUxOWQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
         TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
         X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImU3ZTMyMzgxLTM0YzctNDI4
-        My04YjQyLTU1OTVkZmE2NTFlYiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQG9iZWxpeC5l
-        eGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhh
-        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJl
-        eGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3Rh
-        cnRlZCI6ICIyMDE2LTA3LTI5VDE4OjU4OjQ5WiIsICJfbnMiOiAicmVwb19w
-        dWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDctMjlUMTg6
-        NTg6NDlaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBl
-        X2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0
-        ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9y
-        ZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQi
-        LCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklT
-        SEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0
-        YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFf
-        MTciLCAiaWQiOiAiNTc5YmE3Njk3MGJlNmY3MzhlZGQ5ZGRhIiwgImRldGFp
-        bHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0
-        aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
-        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVjZjE1YmIyLTVjY2QtNDVj
+        Zi1hYWRlLTQ4MTk2YzQ2OTFlZCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4
+        YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9u
+        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhj
+        ZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInN0YXJ0
+        ZWQiOiAiMjAxNi0xMS0yOVQxOTo0NDoyOVoiLCAiX25zIjogInJlcG9fcHVi
+        bGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTExLTI5VDE5OjQ0
+        OjI5WiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9p
+        ZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAic3VtbWFyeSI6IHsiZ2VuZXJhdGUg
+        c3FsaXRlIjogIlNLSVBQRUQiLCAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRh
+        IjogIkZJTklTSEVEIiwgInJwbXMiOiAiRklOSVNIRUQiLCAiY2xvc2VfcmVw
+        b19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJkcnBtcyI6ICJTS0lQUEVEIiwg
+        ImNvbXBzIjogIkZJTklTSEVEIiwgImRpc3RyaWJ1dGlvbiI6ICJGSU5JU0hF
+        RCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6ICJGSU5JU0hFRCIsICJlcnJhdGEi
+        OiAiRklOSVNIRUQiLCAibWV0YWRhdGEiOiAiRklOSVNIRUQifSwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3JfaWQiOiAiRmVkb3JhXzE3
+        IiwgImlkIjogIjU4M2RkYTlkYjBlYWYyMDk5YjY4MTg4YyIsICJkZXRhaWxz
+        IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiSW5pdGlh
+        bGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImluaXRpYWxp
+        emVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyNGMyMzVmZC1i
+        NTZmLTQyMzItYTk2Ni0yNWU0MWFhMWM0OTAiLCAibnVtX3Byb2Nlc3NlZCI6
+        IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
+        c2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0
+        cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWZiN2FmMjItY2RjNi00MjEz
+        LWE3YzUtMzQxODU2NGJlZGVhIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJu
+        dW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQ
+        TXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiA4LCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOGRl
+        M2NkM2QtNWFjNi00NDQ5LWEyMzAtYTA5NjI0ZDlmNTBiIiwgIm51bV9wcm9j
+        ZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjogImRycG1z
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiZDcwNjE5Y2UtY2JjNi00ZTgxLWE0OTktNThh
+        YTg5Nzg2NWYwIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJz
+        dGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRl
         IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjk4MGZkZmVl
-        LTg0ODItNGYwZi04YzY4LTNiZWI4MjIwNzY5ZiIsICJudW1fcHJvY2Vzc2Vk
-        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRp
-        c3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjZiNmZhM2Zl
+        LTNlNDEtNDYxZi05ZDgzLTllZjNiMjNjNTYwYyIsICJudW1fcHJvY2Vzc2Vk
+        IjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJp
+        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICIyYTEyZGM5OS1kZDdkLTRhOGUtYjIzZC1lMmZmYjU5
+        OTZmNjkiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0
+        ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlN2RhZGVl
+        Ny1jYmM0LTQ0OTAtODg5Yy03N2YwMmE3MGE2YjMiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNs
+        b3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVw
+        b19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
         U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkZWI4YTg2ZC05NDA1LTQ5
-        OTYtOTQzMi1hMzE0NmJhMzBmNjAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
-        Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        UlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIz
-        MTUxMjJkNC03ZDI4LTQwMGEtYjA0MS1iYjc4N2M2YTQwZDgiLCAibnVtX3By
-        b2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI2OTEwZDMwYS1iZWJiLTRiOGUtYTQzYy1j
-        YmYzZmUxMTQxZjQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
-        ZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwg
-        InN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjY2NmUw
-        MWMtNzNlZS00NWU4LTk4ZDEtZjgwMTJjNzhiNzUyIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjZlYjVkMTBlLTU3NDItNDhkMi1iN2JhLTNiOWFk
-        YmEwMDkwNCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAi
-        c3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjczYjBi
-        NDcxLWUwYTEtNGZjOS1hNzg3LTIzYzJkMDI0ZjVmMCIsICJudW1fcHJvY2Vz
-        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        Q2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9y
-        ZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
-        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImRiODdmMTUyLWFiMWQt
-        NDE0MC1hZGNjLTc0NWE3N2U3MTFiNyIsICJudW1fcHJvY2Vzc2VkIjogMX0s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
-        ZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0
-        ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjAxNzVlYmUzLWFiYWItNDBkOC1iNzBmLTAy
-        NGE3ZDNmYzhhMyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
-        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3
-        ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjAzZTJmYjRlLTRiNzctNDIxYi1hMzQ5LWYyNDIxYTFlZDBh
-        OCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBf
-        dHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZTdlMzIzODEtMzRjNy00MjgzLThiNDItNTU5NWRmYTY1MWViIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjU3OWJhNzY5N2JjMjVhYWYwOTU2MmU0ZiJ9LCAiaWQiOiAi
-        NTc5YmE3Njk3YmMyNWFhZjA5NTYyZTRmIn0=
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkZWJmMGE4YS1kMDlmLTRl
+        ODMtYWRmOS1kMTI1MTkyNzBkMWEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
+        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcg
+        c3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJlNzA2NDE3OC04NmI4LTQ1MjEtOTg1MS1hNTE1
+        MTI1MTI0NTEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2Vi
+        IiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICJmNzJkMGVjYS1kNjIyLTQ4MDYtYWRhMy1mN2I3ZDA4NzUxOWQi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImVjZjE1YmIyLTVjY2QtNDVjZi1hYWRlLTQ4MTk2YzQ2OTFlZCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1ODNkZGE5YzY3MWUwOGVhYTZkMjU3YWMifSwgImlkIjogIjU4
+        M2RkYTljNjcxZTA4ZWFhNmQyNTdhYyJ9
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:50 GMT
+  recorded_at: Tue, 29 Nov 2016 19:44:29 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/e838066b-f764-4166-9090-a77d4889e821/
+    uri: https://robot.example.com/pulp/api/v2/tasks/fae0daa7-1b2e-48e6-9d36-5230dbf93079/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -791,13 +544,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:50 GMT
+      - Tue, 29 Nov 2016 19:44:30 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '651'
+      - '631'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -805,24 +558,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lODM4MDY2Yi1mNzY0LTQxNjYtOTA5MC1hNzdkNDg4OWU4
-        MjEvIiwgInRhc2tfaWQiOiAiZTgzODA2NmItZjc2NC00MTY2LTkwOTAtYTc3
-        ZDQ4ODllODIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9mYWUwZGFhNy0xYjJlLTQ4ZTYtOWQzNi01MjMwZGJmOTMw
+        NzkvIiwgInRhc2tfaWQiOiAiZmFlMGRhYTctMWIyZS00OGU2LTlkMzYtNTIz
+        MGRiZjkzMDc5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
-        LTA3LTI5VDE4OjU4OjUwWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
-        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJy
-        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBsZS5jb20i
-        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NzliYTc2YTdiYzI1YWFmMDk1NjJlNTAifSwgImlkIjogIjU3OWJh
-        NzZhN2JjMjVhYWYwOTU2MmU1MCJ9
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUByb2JvdC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJ3
+        YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQHJvYm90LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTgzZGRhOWU2NzFlMDhl
+        YWE2ZDI1N2FkIn0sICJpZCI6ICI1ODNkZGE5ZTY3MWUwOGVhYTZkMjU3YWQi
+        fQ==
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:50 GMT
+  recorded_at: Tue, 29 Nov 2016 19:44:30 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/e838066b-f764-4166-9090-a77d4889e821/
+    uri: https://robot.example.com/pulp/api/v2/tasks/fae0daa7-1b2e-48e6-9d36-5230dbf93079/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -841,13 +594,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:50 GMT
+      - Tue, 29 Nov 2016 19:44:30 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '670'
+      - '668'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -855,24 +608,645 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lODM4MDY2Yi1mNzY0LTQxNjYtOTA5MC1hNzdkNDg4OWU4
-        MjEvIiwgInRhc2tfaWQiOiAiZTgzODA2NmItZjc2NC00MTY2LTkwOTAtYTc3
-        ZDQ4ODllODIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9mYWUwZGFhNy0xYjJlLTQ4ZTYtOWQzNi01MjMwZGJmOTMw
+        NzkvIiwgInRhc2tfaWQiOiAiZmFlMGRhYTctMWIyZS00OGU2LTlkMzYtNTIz
+        MGRiZjkzMDc5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTA3LTI5VDE4OjU4OjUwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTA3LTI5VDE4OjU4OjUwWiIsICJ0cmFjZWJh
+        MDE2LTExLTI5VDE5OjQ0OjMwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTExLTI5VDE5OjQ0OjMwWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBvYmVsaXguZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQi
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        b2JlbGl4LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3NmE3YmMyNWFhZjA5NTYy
-        ZTUwIn0sICJpZCI6ICI1NzliYTc2YTdiYzI1YWFmMDk1NjJlNTAifQ==
+        MUByb2JvdC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBy
+        b2JvdC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU4M2RkYTllNjcxZTA4ZWFhNmQyNTdh
+        ZCJ9LCAiaWQiOiAiNTgzZGRhOWU2NzFlMDhlYWE2ZDI1N2FkIn0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:51 GMT
+  recorded_at: Tue, 29 Nov 2016 19:44:30 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/0476ab8e-2880-4bff-87d7-092ad01b2048/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:44:31 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '629'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wNDc2YWI4ZS0yODgwLTRiZmYtODdkNy0wOTJhZDAxYjIw
+        NDgvIiwgInRhc2tfaWQiOiAiMDQ3NmFiOGUtMjg4MC00YmZmLTg3ZDctMDky
+        YWQwMWIyMDQ4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAcm9ib3QuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAid2Fp
+        dGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMUByb2JvdC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU4M2RkYTlmNjcxZTA4ZWFh
+        NmQyNTdhZSJ9LCAiaWQiOiAiNTgzZGRhOWY2NzFlMDhlYWE2ZDI1N2FlIn0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:44:31 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/0476ab8e-2880-4bff-87d7-092ad01b2048/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:44:32 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2282'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wNDc2YWI4ZS0yODgwLTRiZmYtODdkNy0wOTJhZDAxYjIw
+        NDgvIiwgInRhc2tfaWQiOiAiMDQ3NmFiOGUtMjg4MC00YmZmLTg3ZDctMDky
+        YWQwMWIyMDQ4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0xMS0yOVQxOTo0NDozMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0NDozMVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNzcxMjBhYzUtYzA1Zi00MjNlLWE4MDctOWFmMzI5ZTYy
+        YzA3LyIsICJ0YXNrX2lkIjogIjc3MTIwYWM1LWMwNWYtNDIzZS1hODA3LTlh
+        ZjMyOWU2MmMwNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0
+        ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTExLTI5VDE5OjQ0OjMxWiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMTEtMjlUMTk6NDQ6
+        MzJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTgzZGRhYTBiMGVhZjIwOTliNjgxODk4IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU4M2RkYTlmNjcxZTA4ZWFhNmQyNTdhZSJ9LCAi
+        aWQiOiAiNTgzZGRhOWY2NzFlMDhlYWE2ZDI1N2FlIn0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:44:32 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/77120ac5-c05f-423e-a807-9af329e62c07/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:44:32 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '3503'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy83NzEyMGFjNS1jMDVmLTQyM2UtYTgwNy05YWYz
+        MjllNjJjMDcvIiwgInRhc2tfaWQiOiAiNzcxMjBhYzUtYzA1Zi00MjNlLWE4
+        MDctOWFmMzI5ZTYyYzA3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxNi0xMS0yOVQxOTo0NDozMloiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiNzA0
+        NDkyYi1hYzc3LTQ5MGQtYTYxYS0zYTRjZTkwZDlmOWIiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzZjMTBhNTYtYjk4
+        ZS00M2IyLWEwYzgtZDVmNWUyN2NjMmVmIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDIsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiZWY0NWE0NDUtMGVkMS00YmM5LWJmNjUtZDE1NTdlMzkyNjRiIiwg
+        Im51bV9wcm9jZXNzZWQiOiAyfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
+        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNmYWM1Nzk5LWI3NTgt
+        NDEyZS1iMDYwLTQ0NmFhODFmNzFmNSIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICJiOTU5YTk4OC03MmJjLTQ4MTUtYWE5My02YjVhOTNlNjI4Njci
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5
+        cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGQ0NGQ1N2UtMjQw
+        Ny00YWIwLTk3YzgtNTliMTRhNTE3NTIzIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiNTQ3NTBjODktYzAzZC00ZDRlLWJiOTQtMWM5Y2Iz
+        ZjUyMGM0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAi
+        c3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiMjNjY2JiMzctMjVkMy00ZjFlLWJjZGQtNTdiYTBhOTJiYjk3
+        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
+        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjA1ZjBmNDc5LTA1OTktNGVmMi1hMTE0LWQyOWI5ODUzYmQ0OSIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjog
+        InB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNhYjBl
+        ZTQ5LTliNTctNDhiMS1hZmI5LWM4NzBiODI5YzFjOSIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
+        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzFkNmRi
+        N2UtOTRhNS00OTQ5LWIwOGItNTM4MTlkYTZmY2M1IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTFAcm9ib3QuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBy
+        b2JvdC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU4M2RkYWEwNjcxZTA4ZWFhNmQyNTdi
+        ZSJ9LCAiaWQiOiAiNTgzZGRhYTA2NzFlMDhlYWE2ZDI1N2JlIn0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:44:32 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/0476ab8e-2880-4bff-87d7-092ad01b2048/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:44:32 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2282'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wNDc2YWI4ZS0yODgwLTRiZmYtODdkNy0wOTJhZDAxYjIw
+        NDgvIiwgInRhc2tfaWQiOiAiMDQ3NmFiOGUtMjg4MC00YmZmLTg3ZDctMDky
+        YWQwMWIyMDQ4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0xMS0yOVQxOTo0NDozMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0NDozMVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNzcxMjBhYzUtYzA1Zi00MjNlLWE4MDctOWFmMzI5ZTYy
+        YzA3LyIsICJ0YXNrX2lkIjogIjc3MTIwYWM1LWMwNWYtNDIzZS1hODA3LTlh
+        ZjMyOWU2MmMwNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0
+        ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTExLTI5VDE5OjQ0OjMxWiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMTEtMjlUMTk6NDQ6
+        MzJaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTgzZGRhYTBiMGVhZjIwOTliNjgxODk4IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU4M2RkYTlmNjcxZTA4ZWFhNmQyNTdhZSJ9LCAi
+        aWQiOiAiNTgzZGRhOWY2NzFlMDhlYWE2ZDI1N2FlIn0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:44:32 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/77120ac5-c05f-423e-a807-9af329e62c07/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:44:32 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '6909'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy83NzEyMGFjNS1jMDVmLTQyM2UtYTgwNy05YWYz
+        MjllNjJjMDcvIiwgInRhc2tfaWQiOiAiNzcxMjBhYzUtYzA1Zi00MjNlLWE4
+        MDctOWFmMzI5ZTYyYzA3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0xMS0yOVQxOTo0NDozMloiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0NDozMloiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICJiNzA0NDkyYi1hYzc3LTQ5MGQtYTYxYS0zYTRjZTkw
+        ZDlmOWIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiNzZjMTBhNTYtYjk4ZS00M2IyLWEwYzgtZDVmNWUyN2NjMmVmIiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
+        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZWY0NWE0NDUtMGVkMS00YmM5LWJmNjUt
+        ZDE1NTdlMzkyNjRiIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
+        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiM2Zh
+        YzU3OTktYjc1OC00MTJlLWIwNjAtNDQ2YWE4MWY3MWY1IiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogImI5NTlhOTg4LTcyYmMtNDgxNS1hYTkzLTZiNWE5
+        M2U2Mjg2NyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
+        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0ZDQ0ZDU3
+        ZS0yNDA3LTRhYjAtOTdjOC01OWIxNGE1MTc1MjMiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI1NDc1MGM4OS1jMDNkLTRkNGUtYmI5NC0xYzlj
+        YjNmNTIwYzQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
+        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICIyM2NjYmIzNy0yNWQzLTRmMWUtYmNkZC01N2JhMGE5MmJiOTci
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
+        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNWYw
+        ZjQ3OS0wNTk5LTRlZjItYTExNC1kMjliOTg1M2JkNDkiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
+        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzYWIwZWU0OS05YjU3
+        LTQ4YjEtYWZiOS1jODcwYjgyOWMxYzkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
+        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImMxZDZkYjdlLTk0YTUtNDk0
+        OS1iMDhiLTUzODE5ZGE2ZmNjNSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4
+        YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9u
+        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhj
+        ZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInN0YXJ0
+        ZWQiOiAiMjAxNi0xMS0yOVQxOTo0NDozMloiLCAiX25zIjogInJlcG9fcHVi
+        bGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTExLTI5VDE5OjQ0
+        OjMyWiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9p
+        ZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAic3VtbWFyeSI6IHsiZ2VuZXJhdGUg
+        c3FsaXRlIjogIlNLSVBQRUQiLCAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRh
+        IjogIkZJTklTSEVEIiwgInJwbXMiOiAiRklOSVNIRUQiLCAiY2xvc2VfcmVw
+        b19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJkcnBtcyI6ICJTS0lQUEVEIiwg
+        ImNvbXBzIjogIkZJTklTSEVEIiwgImRpc3RyaWJ1dGlvbiI6ICJGSU5JU0hF
+        RCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6ICJGSU5JU0hFRCIsICJlcnJhdGEi
+        OiAiRklOSVNIRUQiLCAibWV0YWRhdGEiOiAiRklOSVNIRUQifSwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3JfaWQiOiAiRmVkb3JhXzE3
+        IiwgImlkIjogIjU4M2RkYWEwYjBlYWYyMDk5YjY4MTg5OSIsICJkZXRhaWxz
+        IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiSW5pdGlh
+        bGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImluaXRpYWxp
+        emVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiNzA0NDkyYi1h
+        Yzc3LTQ5MGQtYTYxYS0zYTRjZTkwZDlmOWIiLCAibnVtX3Byb2Nlc3NlZCI6
+        IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
+        c2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0
+        cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzZjMTBhNTYtYjk4ZS00M2Iy
+        LWEwYzgtZDVmNWUyN2NjMmVmIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJu
+        dW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQ
+        TXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiA4LCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZWY0
+        NWE0NDUtMGVkMS00YmM5LWJmNjUtZDE1NTdlMzkyNjRiIiwgIm51bV9wcm9j
+        ZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjogImRycG1z
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiM2ZhYzU3OTktYjc1OC00MTJlLWIwNjAtNDQ2
+        YWE4MWY3MWY1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJz
+        dGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI5NTlhOTg4
+        LTcyYmMtNDgxNS1hYTkzLTZiNWE5M2U2Mjg2NyIsICJudW1fcHJvY2Vzc2Vk
+        IjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJp
+        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICI0ZDQ0ZDU3ZS0yNDA3LTRhYjAtOTdjOC01OWIxNGE1
+        MTc1MjMiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0
+        ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1NDc1MGM4
+        OS1jMDNkLTRkNGUtYmI5NC0xYzljYjNmNTIwYzQiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNs
+        b3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVw
+        b19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyM2NjYmIzNy0yNWQzLTRm
+        MWUtYmNkZC01N2JhMGE5MmJiOTciLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
+        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcg
+        c3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICIwNWYwZjQ3OS0wNTk5LTRlZjItYTExNC1kMjli
+        OTg1M2JkNDkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2Vi
+        IiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICIzYWIwZWU0OS05YjU3LTQ4YjEtYWZiOS1jODcwYjgyOWMxYzki
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImMxZDZkYjdlLTk0YTUtNDk0OS1iMDhiLTUzODE5ZGE2ZmNjNSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1ODNkZGFhMDY3MWUwOGVhYTZkMjU3YmUifSwgImlkIjogIjU4
+        M2RkYWEwNjcxZTA4ZWFhNmQyNTdiZSJ9
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:44:32 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/9adc1f0c-f9bc-4c68-91b8-d1038c20c157/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:44:33 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '549'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85YWRjMWYwYy1mOWJjLTRjNjgtOTFiOC1kMTAzOGMyMGMx
+        NTcvIiwgInRhc2tfaWQiOiAiOWFkYzFmMGMtZjliYy00YzY4LTkxYjgtZDEw
+        MzhjMjBjMTU3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ODNkZGFh
+        MTY3MWUwOGVhYTZkMjU3YmYifSwgImlkIjogIjU4M2RkYWExNjcxZTA4ZWFh
+        NmQyNTdiZiJ9
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:44:33 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/9adc1f0c-f9bc-4c68-91b8-d1038c20c157/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:44:33 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '668'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85YWRjMWYwYy1mOWJjLTRjNjgtOTFiOC1kMTAzOGMyMGMx
+        NTcvIiwgInRhc2tfaWQiOiAiOWFkYzFmMGMtZjliYy00YzY4LTkxYjgtZDEw
+        MzhjMjBjMTU3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTExLTI5VDE5OjQ0OjMzWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTExLTI5VDE5OjQ0OjMzWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUByb2JvdC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBy
+        b2JvdC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU4M2RkYWExNjcxZTA4ZWFhNmQyNTdi
+        ZiJ9LCAiaWQiOiAiNTgzZGRhYTE2NzFlMDhlYWE2ZDI1N2JmIn0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:44:33 GMT
 - request:
     method: post
-    uri: https://obelix.example.com/pulp/api/v2/repositories/
+    uri: https://robot.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -913,13 +1287,13 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:51 GMT
+      - Tue, 29 Nov 2016 19:44:34 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
       - '320'
       Location:
-      - https://obelix.example.com/pulp/api/v2/repositories/Fedora_17/
+      - https://robot.example.com/pulp/api/v2/repositories/Fedora_17/
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -930,14 +1304,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTc5YmE3NmI3MGJlNmYwZGIyYjMzMmJkIn0sICJpZCI6ICJGZWRvcmFfMTci
+        NTgzZGRhYTJiMGVhZjI1ZjQ2OGQ0ODg0In0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:51 GMT
+  recorded_at: Tue, 29 Nov 2016 19:44:34 GMT
 - request:
     method: post
-    uri: https://obelix.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    uri: https://robot.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -960,7 +1334,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:51 GMT
+      - Tue, 29 Nov 2016 19:44:34 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -971,14 +1345,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzk0NGVmNjQxLWUxN2ItNGYzNi1iYzc0LTlhZGUyOWQyZjI1Ni8iLCAi
-        dGFza19pZCI6ICI5NDRlZjY0MS1lMTdiLTRmMzYtYmM3NC05YWRlMjlkMmYy
-        NTYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzM1MDIzZTBjLTNjZWUtNGIyMC1iYjNiLTY0MjRlOTYxZDM2Yi8iLCAi
+        dGFza19pZCI6ICIzNTAyM2UwYy0zY2VlLTRiMjAtYmIzYi02NDI0ZTk2MWQz
+        NmIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:51 GMT
+  recorded_at: Tue, 29 Nov 2016 19:44:34 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/944ef641-e17b-4f36-bc74-9ade29d2f256/
+    uri: https://robot.example.com/pulp/api/v2/tasks/35023e0c-3cee-4b20-bb3b-6424e961d36b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -997,13 +1371,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:51 GMT
+      - Tue, 29 Nov 2016 19:44:34 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '649'
+      - '629'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1011,24 +1385,23 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85NDRlZjY0MS1lMTdiLTRmMzYtYmM3NC05YWRlMjlkMmYy
-        NTYvIiwgInRhc2tfaWQiOiAiOTQ0ZWY2NDEtZTE3Yi00ZjM2LWJjNzQtOWFk
-        ZTI5ZDJmMjU2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8zNTAyM2UwYy0zY2VlLTRiMjAtYmIzYi02NDI0ZTk2MWQz
+        NmIvIiwgInRhc2tfaWQiOiAiMzUwMjNlMGMtM2NlZS00YjIwLWJiM2ItNjQy
+        NGU5NjFkMzZiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Ny0yOVQxODo1ODo1MVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAb2JlbGl4LmV4YW1wbGUuY29t
-        LmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVz
-        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAb2JlbGl4LmV4YW1wbGUuY29tIiwg
-        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNTc5YmE3NmI3YmMyNWFhZjA5NTYyZTUxIn0sICJpZCI6ICI1NzliYTc2
-        YjdiYzI1YWFmMDk1NjJlNTEifQ==
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAcm9ib3QuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAid2Fp
+        dGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMUByb2JvdC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU4M2RkYWEyNjcxZTA4ZWFh
+        NmQyNTdjMCJ9LCAiaWQiOiAiNTgzZGRhYTI2NzFlMDhlYWE2ZDI1N2MwIn0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:51 GMT
+  recorded_at: Tue, 29 Nov 2016 19:44:34 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/944ef641-e17b-4f36-bc74-9ade29d2f256/
+    uri: https://robot.example.com/pulp/api/v2/tasks/35023e0c-3cee-4b20-bb3b-6424e961d36b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1047,13 +1420,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:52 GMT
+      - Tue, 29 Nov 2016 19:44:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2284'
+      - '2282'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1061,16 +1434,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85NDRlZjY0MS1lMTdiLTRmMzYtYmM3NC05YWRlMjlkMmYy
-        NTYvIiwgInRhc2tfaWQiOiAiOTQ0ZWY2NDEtZTE3Yi00ZjM2LWJjNzQtOWFk
-        ZTI5ZDJmMjU2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8zNTAyM2UwYy0zY2VlLTRiMjAtYmIzYi02NDI0ZTk2MWQz
+        NmIvIiwgInRhc2tfaWQiOiAiMzUwMjNlMGMtM2NlZS00YjIwLWJiM2ItNjQy
+        NGU5NjFkMzZiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wNy0yOVQxODo1ODo1MloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wNy0yOVQxODo1ODo1MVoiLCAidHJhY2ViYWNr
+        Ni0xMS0yOVQxOTo0NDozNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0NDozNFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZTgxOTQ0MzMtYTVmZi00NTQzLWE3YjEtYTIzODQ3NGJm
-        MmY1LyIsICJ0YXNrX2lkIjogImU4MTk0NDMzLWE1ZmYtNDU0My1hN2IxLWEy
-        Mzg0NzRiZjJmNSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvMGQyNDU5YWItZjIzNC00MWU1LWI1YjUtM2U3MDVhMzI1
+        ZWRjLyIsICJ0YXNrX2lkIjogIjBkMjQ1OWFiLWYyMzQtNDFlNS1iNWI1LTNl
+        NzA1YTMyNWVkYyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -1081,40 +1454,40 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQG9iZWxpeC5leGFt
-        cGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFt
-        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBs
-        ZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBv
-        cnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwg
-        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJz
-        dGFydGVkIjogIjIwMTYtMDctMjlUMTg6NTg6NTFaIiwgIl9ucyI6ICJyZXBv
-        X3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wNy0yOVQxODo1
-        ODo1MloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
-        ZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50Ijog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAxNSwg
-        InJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6
-        ICI1NzliYTc2YzcwYmU2ZjczOGVkZDlkZTYiLCAiZGV0YWlscyI6IHsiY29u
-        dGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVm
-        dCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUi
-        OiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9y
-        X2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3NmI3YmMyNWFhZjA5NTYyZTUxIn0s
-        ICJpZCI6ICI1NzliYTc2YjdiYzI1YWFmMDk1NjJlNTEifQ==
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0
+        ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTExLTI5VDE5OjQ0OjM0WiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMTEtMjlUMTk6NDQ6
+        MzRaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTgzZGRhYTJiMGVhZjIwOTliNjgxOGE1IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU4M2RkYWEyNjcxZTA4ZWFhNmQyNTdjMCJ9LCAi
+        aWQiOiAiNTgzZGRhYTI2NzFlMDhlYWE2ZDI1N2MwIn0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:52 GMT
+  recorded_at: Tue, 29 Nov 2016 19:44:35 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/e8194433-a5ff-4543-a7b1-a238474bf2f5/
+    uri: https://robot.example.com/pulp/api/v2/tasks/0d2459ab-f234-41e5-b5b5-3e705a325edc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1133,13 +1506,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:52 GMT
+      - Tue, 29 Nov 2016 19:44:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '6911'
+      - '3503'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1147,167 +1520,367 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9lODE5NDQzMy1hNWZmLTQ1NDMtYTdiMS1hMjM4
-        NDc0YmYyZjUvIiwgInRhc2tfaWQiOiAiZTgxOTQ0MzMtYTVmZi00NTQzLWE3
-        YjEtYTIzODQ3NGJmMmY1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy8wZDI0NTlhYi1mMjM0LTQxZTUtYjViNS0zZTcw
+        NWEzMjVlZGMvIiwgInRhc2tfaWQiOiAiMGQyNDU5YWItZjIzNC00MWU1LWI1
+        YjUtM2U3MDVhMzI1ZWRjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wNy0yOVQxODo1ODo1MloiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wNy0yOVQxODo1ODo1MloiLCAi
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxNi0xMS0yOVQxOTo0NDozNVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1MGY4
+        MWVmNC0xMWNiLTQ2Y2UtYTIzMi1kNmM0NjhjMWVhN2QiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGM0NWE5NGYtZmYx
+        Mi00MjA2LWJmMjUtYWViNDdkZDMxMThiIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDcsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiZTc4MDZmNDAtOGVmMC00YTYzLWE5OTctYTc3YzJmZGJhNThjIiwg
+        Im51bV9wcm9jZXNzZWQiOiA3fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
+        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjgzMzVmMmY4LTQ3OGQt
+        NDljNC1hOTA5LTVkNTU5MDVlNmVkMyIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICJkOTBmNzI5OC0wNzViLTQyMDEtYWUzMi00OWY3ZTljZTE1YWYi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5
+        cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTA4N2VmN2MtNDFj
+        MS00MzAzLTkxYjYtNWJiNzMyYzg5YzNjIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiZmM3ZjhiM2QtYWVhOS00MGE1LWJhYTktOGNjYmZi
+        MWViNTgwIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAi
+        c3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiOTM2YzI5YmQtOTU5Yi00ZDk3LTlmMGQtNDI0ZGIzNzAwODFk
+        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
+        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        ImQxMzQyYzM4LTgyZGYtNDZlMy04MmIwLWE0M2VjYTVjYjNjZSIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjog
+        InB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjIwNTBi
+        YWJhLWUzNTQtNDZkMC1iNjdjLTQ1YjgyOWFlNzJhYSIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
+        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiM2Q2NWIy
+        MDgtNTZlMC00MTc4LWFiZGYtNDRiYjMwNzg2NWNlIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTFAcm9ib3QuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBy
+        b2JvdC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU4M2RkYWEyNjcxZTA4ZWFhNmQyNTdk
+        MCJ9LCAiaWQiOiAiNTgzZGRhYTI2NzFlMDhlYWE2ZDI1N2QwIn0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:44:35 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/35023e0c-3cee-4b20-bb3b-6424e961d36b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:44:35 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2282'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNTAyM2UwYy0zY2VlLTRiMjAtYmIzYi02NDI0ZTk2MWQz
+        NmIvIiwgInRhc2tfaWQiOiAiMzUwMjNlMGMtM2NlZS00YjIwLWJiM2ItNjQy
+        NGU5NjFkMzZiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0xMS0yOVQxOTo0NDozNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0NDozNFoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMGQyNDU5YWItZjIzNC00MWU1LWI1YjUtM2U3MDVhMzI1
+        ZWRjLyIsICJ0YXNrX2lkIjogIjBkMjQ1OWFiLWYyMzQtNDFlNS1iNWI1LTNl
+        NzA1YTMyNWVkYyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0
+        ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTExLTI5VDE5OjQ0OjM0WiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMTEtMjlUMTk6NDQ6
+        MzRaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTgzZGRhYTJiMGVhZjIwOTliNjgxOGE1IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU4M2RkYWEyNjcxZTA4ZWFhNmQyNTdjMCJ9LCAi
+        aWQiOiAiNTgzZGRhYTI2NzFlMDhlYWE2ZDI1N2MwIn0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:44:35 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/0d2459ab-f234-41e5-b5b5-3e705a325edc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:44:35 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '6909'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8wZDI0NTlhYi1mMjM0LTQxZTUtYjViNS0zZTcw
+        NWEzMjVlZGMvIiwgInRhc2tfaWQiOiAiMGQyNDU5YWItZjIzNC00MWU1LWI1
+        YjUtM2U3MDVhMzI1ZWRjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0xMS0yOVQxOTo0NDozNVoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0NDozNVoiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI5YzQwNWJjZi1jOWFkLTRkNDAtYTA0Yy1kMWQ3ODU0
-        MTMwZjUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICI1MGY4MWVmNC0xMWNiLTQ2Y2UtYTIzMi1kNmM0Njhj
+        MWVhN2QiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYWQwNjA0NjQtZWRkNC00NTBhLTllZjctZjlkMjI1ZmY1YjJjIiwg
+        aWQiOiAiMGM0NWE5NGYtZmYxMi00MjA2LWJmMjUtYWViNDdkZDMxMThiIiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
         bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMDA2NjM3MmQtYjkwOC00ZDg1LWFkODct
-        ZWZjNmZjMWMwZGZhIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZTc4MDZmNDAtOGVmMC00YTYzLWE5OTct
+        YTc3YzJmZGJhNThjIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
         TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjU1
-        NTc2Y2MtYzNlOC00N2NkLWFiMzItOTc2ZmJkMjJiMGNjIiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODMz
+        NWYyZjgtNDc4ZC00OWM0LWE5MDktNWQ1NTkwNWU2ZWQzIiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjAxZWI3MGVkLWFmNTQtNDNkYi05ZjA3LWNmZjU5
-        NDY2ZWRhMCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        IDAsICJzdGVwX2lkIjogImQ5MGY3Mjk4LTA3NWItNDIwMS1hZTMyLTQ5Zjdl
+        OWNlMTVhZiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
         OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
         InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2YmFiMzMy
-        OC1mZDk2LTRjOTQtYjQ2OC1hNDM3OGJjNGQwOGIiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhMDg3ZWY3
+        Yy00MWMxLTQzMDMtOTFiNi01YmI3MzJjODljM2MiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
         Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIwM2ZiMjczNy1hMzFiLTQzMWUtODY3Ni05Njlh
-        Y2EyNzU5ZWYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICJmYzdmOGIzZC1hZWE5LTQwYTUtYmFhOS04Y2Ni
+        ZmIxZWI1ODAiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
         ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJmYzRkMDM1Ni02YTUxLTQxYmUtYTg4OS00ZGQ1MDdkMGJhZjMi
+        cF9pZCI6ICI5MzZjMjliZC05NTliLTRkOTctOWYwZC00MjRkYjM3MDA4MWQi
         LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
         dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
         c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzM2Ux
-        YWUyMi03ZmMwLTQxYTAtYjhhYi1lNzYyMTczMmRkYzEiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkMTM0
+        MmMzOC04MmRmLTQ2ZTMtODJiMC1hNDNlY2E1Y2IzY2UiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
         aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhOGRiNTEyNS0zNjQz
-        LTQyN2YtYWQ4OC00ODE4YTU3MjljMGQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyMDUwYmFiYS1lMzU0
+        LTQ2ZDAtYjY3Yy00NWI4MjlhZTcyYWEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
         TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
         X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImIyMWQwZDQ2LWZkZTItNDgw
-        Ny05NzFhLTZiY2UyOWYxNTc2MyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQG9iZWxpeC5l
-        eGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhh
-        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJl
-        eGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3Rh
-        cnRlZCI6ICIyMDE2LTA3LTI5VDE4OjU4OjUyWiIsICJfbnMiOiAicmVwb19w
-        dWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDctMjlUMTg6
-        NTg6NTJaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBl
-        X2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0
-        ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9y
-        ZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQi
-        LCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklT
-        SEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0
-        YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFf
-        MTciLCAiaWQiOiAiNTc5YmE3NmM3MGJlNmY3MzhlZGQ5ZGU3IiwgImRldGFp
-        bHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0
-        aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
-        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNkNjViMjA4LTU2ZTAtNDE3
+        OC1hYmRmLTQ0YmIzMDc4NjVjZSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4
+        YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9u
+        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhj
+        ZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInN0YXJ0
+        ZWQiOiAiMjAxNi0xMS0yOVQxOTo0NDozNVoiLCAiX25zIjogInJlcG9fcHVi
+        bGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTExLTI5VDE5OjQ0
+        OjM1WiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9p
+        ZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAic3VtbWFyeSI6IHsiZ2VuZXJhdGUg
+        c3FsaXRlIjogIlNLSVBQRUQiLCAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRh
+        IjogIkZJTklTSEVEIiwgInJwbXMiOiAiRklOSVNIRUQiLCAiY2xvc2VfcmVw
+        b19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJkcnBtcyI6ICJTS0lQUEVEIiwg
+        ImNvbXBzIjogIkZJTklTSEVEIiwgImRpc3RyaWJ1dGlvbiI6ICJGSU5JU0hF
+        RCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6ICJGSU5JU0hFRCIsICJlcnJhdGEi
+        OiAiRklOSVNIRUQiLCAibWV0YWRhdGEiOiAiRklOSVNIRUQifSwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3JfaWQiOiAiRmVkb3JhXzE3
+        IiwgImlkIjogIjU4M2RkYWEzYjBlYWYyMDk5YjY4MThhNiIsICJkZXRhaWxz
+        IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiSW5pdGlh
+        bGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImluaXRpYWxp
+        emVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1MGY4MWVmNC0x
+        MWNiLTQ2Y2UtYTIzMi1kNmM0NjhjMWVhN2QiLCAibnVtX3Byb2Nlc3NlZCI6
+        IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
+        c2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0
+        cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGM0NWE5NGYtZmYxMi00MjA2
+        LWJmMjUtYWViNDdkZDMxMThiIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJu
+        dW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQ
+        TXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiA4LCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTc4
+        MDZmNDAtOGVmMC00YTYzLWE5OTctYTc3YzJmZGJhNThjIiwgIm51bV9wcm9j
+        ZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjogImRycG1z
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiODMzNWYyZjgtNDc4ZC00OWM0LWE5MDktNWQ1
+        NTkwNWU2ZWQzIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJz
+        dGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRl
         IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjljNDA1YmNm
-        LWM5YWQtNGQ0MC1hMDRjLWQxZDc4NTQxMzBmNSIsICJudW1fcHJvY2Vzc2Vk
-        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRp
-        c3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ5MGY3Mjk4
+        LTA3NWItNDIwMS1hZTMyLTQ5ZjdlOWNlMTVhZiIsICJudW1fcHJvY2Vzc2Vk
+        IjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJp
+        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICJhMDg3ZWY3Yy00MWMxLTQzMDMtOTFiNi01YmI3MzJj
+        ODljM2MiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0
+        ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmYzdmOGIz
+        ZC1hZWE5LTQwYTUtYmFhOS04Y2NiZmIxZWI1ODAiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNs
+        b3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVw
+        b19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
         U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZDA2MDQ2NC1lZGQ0LTQ1
-        MGEtOWVmNy1mOWQyMjVmZjViMmMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
-        Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        UlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIw
-        MDY2MzcyZC1iOTA4LTRkODUtYWQ4Ny1lZmM2ZmMxYzBkZmEiLCAibnVtX3By
-        b2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI2NTU1NzZjYy1jM2U4LTQ3Y2QtYWIzMi05
-        NzZmYmQyMmIwY2MiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
-        ZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwg
-        InN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDFlYjcw
-        ZWQtYWY1NC00M2RiLTlmMDctY2ZmNTk0NjZlZGEwIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjZiYWIzMzI4LWZkOTYtNGM5NC1iNDY4LWE0Mzc4
-        YmM0ZDA4YiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAi
-        c3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjAzZmIy
-        NzM3LWEzMWItNDMxZS04Njc2LTk2OWFjYTI3NTllZiIsICJudW1fcHJvY2Vz
-        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        Q2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9y
-        ZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
-        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZjNGQwMzU2LTZhNTEt
-        NDFiZS1hODg5LTRkZDUwN2QwYmFmMyIsICJudW1fcHJvY2Vzc2VkIjogMX0s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
-        ZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0
-        ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjMzZTFhZTIyLTdmYzAtNDFhMC1iOGFiLWU3
-        NjIxNzMyZGRjMSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
-        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3
-        ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImE4ZGI1MTI1LTM2NDMtNDI3Zi1hZDg4LTQ4MThhNTcyOWMw
-        ZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBf
-        dHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYjIxZDBkNDYtZmRlMi00ODA3LTk3MWEtNmJjZTI5ZjE1NzYzIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjU3OWJhNzZjN2JjMjVhYWYwOTU2MmU2MSJ9LCAiaWQiOiAi
-        NTc5YmE3NmM3YmMyNWFhZjA5NTYyZTYxIn0=
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5MzZjMjliZC05NTliLTRk
+        OTctOWYwZC00MjRkYjM3MDA4MWQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
+        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcg
+        c3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJkMTM0MmMzOC04MmRmLTQ2ZTMtODJiMC1hNDNl
+        Y2E1Y2IzY2UiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2Vi
+        IiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICIyMDUwYmFiYS1lMzU0LTQ2ZDAtYjY3Yy00NWI4MjlhZTcyYWEi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjNkNjViMjA4LTU2ZTAtNDE3OC1hYmRmLTQ0YmIzMDc4NjVjZSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1ODNkZGFhMjY3MWUwOGVhYTZkMjU3ZDAifSwgImlkIjogIjU4
+        M2RkYWEyNjcxZTA4ZWFhNmQyNTdkMCJ9
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:52 GMT
+  recorded_at: Tue, 29 Nov 2016 19:44:35 GMT
 - request:
     method: post
-    uri: https://obelix.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://robot.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwYWNrYWdlX2dyb3VwIl19fQ==
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwYWNrYWdlX2dyb3VwIl0sImZp
+        ZWxkcyI6eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
     headers:
       Accept:
       - application/json
@@ -1316,7 +1889,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '43'
+      - '90'
       User-Agent:
       - Ruby
   response:
@@ -1325,61 +1898,41 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:52 GMT
+      - Tue, 29 Nov 2016 19:44:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1486'
+      - '458'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Im1hbmRhdG9yeV9wYWNrYWdlX25hbWVzIjogWyJw
-        ZW5ndWluIl0sICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogImJp
-        cmQiLCAidXNlcl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVlLCAi
-        X25zIjogInVuaXRzX3BhY2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRlZCI6
-        IDE0Njk4MTg2NjEsICJvcHRpb25hbF9wYWNrYWdlX25hbWVzIjogW10sICJ0
-        cmFuc2xhdGVkX25hbWUiOiB7fSwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24i
-        OiB7fSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNr
-        YWdlX25hbWVzIjogW10sICJfY29udGVudF90eXBlX2lkIjogInBhY2thZ2Vf
-        Z3JvdXAiLCAiaWQiOiAiYmlyZCIsICJfaWQiOiAiNTNkODIzMTYtNjQyNS00
-        ODE3LThkNjEtMTM1ZTQ0MTlkYmJhIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0
-        LCAiY29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQi
-        OiAiMjAxNi0wNy0yOVQxODo1ODo1MloiLCAicmVwb19pZCI6ICJGZWRvcmFf
-        MTciLCAiY3JlYXRlZCI6ICIyMDE2LTA3LTI5VDE4OjU4OjUyWiIsICJ1bml0
-        X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0X2lkIjogIjUzZDgy
-        MzE2LTY0MjUtNDgxNy04ZDYxLTEzNWU0NDE5ZGJiYSIsICJfaWQiOiB7IiRv
-        aWQiOiAiNTc5YmE3NmM3YmMyNWFhZjA5NTYyZTVlIn19LCB7Im1ldGFkYXRh
-        IjogeyJtYW5kYXRvcnlfcGFja2FnZV9uYW1lcyI6IFsiZWxlcGhhbnQsZ2ly
-        YWZmZSxjaGVldGFoLGxpb24sbW9ua2V5LHBlbmd1aW4sc3F1aXJyZWwsd2Fs
-        cnVzIiwgInBlbmd1aW4iXSwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5h
-        bWUiOiAibWFtbWFsIiwgInVzZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0
-        IjogdHJ1ZSwgIl9ucyI6ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0
-        X3VwZGF0ZWQiOiAxNDY5ODE4NjYxLCAib3B0aW9uYWxfcGFja2FnZV9uYW1l
-        cyI6IFtdLCAidHJhbnNsYXRlZF9uYW1lIjoge30sICJ0cmFuc2xhdGVkX2Rl
-        c2NyaXB0aW9uIjoge30sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImRl
-        ZmF1bHRfcGFja2FnZV9uYW1lcyI6IFtdLCAiX2NvbnRlbnRfdHlwZV9pZCI6
-        ICJwYWNrYWdlX2dyb3VwIiwgImlkIjogIm1hbW1hbCIsICJfaWQiOiAiOTkz
-        MTNjYzktNWU5Yy00YzhhLTljY2MtNTE5MDJhOGRkZDM2IiwgImRpc3BsYXlf
-        b3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtd
-        fSwgInVwZGF0ZWQiOiAiMjAxNi0wNy0yOVQxODo1ODo1MloiLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE2LTA3LTI5VDE4OjU4
-        OjUyWiIsICJ1bml0X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0
-        X2lkIjogIjk5MzEzY2M5LTVlOWMtNGM4YS05Y2NjLTUxOTAyYThkZGQzNiIs
-        ICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3NmM3YmMyNWFhZjA5NTYyZTVmIn19
-        XQ==
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICI3ODVlNTNmMi0wMWQyLTQ4ODctOTg5
+        ZS1iYTE3ZDY0MzcyYzIiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwYWNrYWdl
+        X2dyb3VwIn0sICJfaWQiOiB7IiRvaWQiOiAiNTgzZGRhYTI2NzFlMDhlYWE2
+        ZDI1N2NkIn0sICJ1bml0X2lkIjogIjc4NWU1M2YyLTAxZDItNDg4Ny05ODll
+        LWJhMTdkNjQzNzJjMiIsICJ1bml0X3R5cGVfaWQiOiAicGFja2FnZV9ncm91
+        cCJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiYzBmZjZmZTEtM2I3Yy00ZTQx
+        LWFjMDctYmI0ODAxYjUwNTkzIiwgIl9jb250ZW50X3R5cGVfaWQiOiAicGFj
+        a2FnZV9ncm91cCJ9LCAiX2lkIjogeyIkb2lkIjogIjU4M2RkYWEyNjcxZTA4
+        ZWFhNmQyNTdjZSJ9LCAidW5pdF9pZCI6ICJjMGZmNmZlMS0zYjdjLTRlNDEt
+        YWMwNy1iYjQ4MDFiNTA1OTMiLCAidW5pdF90eXBlX2lkIjogInBhY2thZ2Vf
+        Z3JvdXAifV0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:52 GMT
+  recorded_at: Tue, 29 Nov 2016 19:44:35 GMT
 - request:
     method: post
-    uri: https://obelix.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://robot.example.com/pulp/api/v2/content/units/package_group/search/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwYWNrYWdlX2dyb3VwIl19fQ==
+        eyJjcml0ZXJpYSI6eyJsaW1pdCI6Miwic2tpcCI6MCwiZmlsdGVycyI6eyJf
+        aWQiOnsiJGluIjpbIjc4NWU1M2YyLTAxZDItNDg4Ny05ODllLWJhMTdkNjQz
+        NzJjMiIsImMwZmY2ZmUxLTNiN2MtNGU0MS1hYzA3LWJiNDgwMWI1MDU5MyJd
+        fX19LCJpbmNsdWRlX3JlcG9zIjp0cnVlfQ==
     headers:
       Accept:
       - application/json
@@ -1388,7 +1941,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '43'
+      - '160'
       User-Agent:
       - Ruby
   response:
@@ -1397,62 +1950,57 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:52 GMT
+      - Tue, 29 Nov 2016 19:44:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1486'
+      - '1272'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Im1hbmRhdG9yeV9wYWNrYWdlX25hbWVzIjogWyJw
-        ZW5ndWluIl0sICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogImJp
-        cmQiLCAidXNlcl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVlLCAi
-        X25zIjogInVuaXRzX3BhY2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRlZCI6
-        IDE0Njk4MTg2NjEsICJvcHRpb25hbF9wYWNrYWdlX25hbWVzIjogW10sICJ0
-        cmFuc2xhdGVkX25hbWUiOiB7fSwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24i
-        OiB7fSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNr
-        YWdlX25hbWVzIjogW10sICJfY29udGVudF90eXBlX2lkIjogInBhY2thZ2Vf
-        Z3JvdXAiLCAiaWQiOiAiYmlyZCIsICJfaWQiOiAiNTNkODIzMTYtNjQyNS00
-        ODE3LThkNjEtMTM1ZTQ0MTlkYmJhIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0
-        LCAiY29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQi
-        OiAiMjAxNi0wNy0yOVQxODo1ODo1MloiLCAicmVwb19pZCI6ICJGZWRvcmFf
-        MTciLCAiY3JlYXRlZCI6ICIyMDE2LTA3LTI5VDE4OjU4OjUyWiIsICJ1bml0
-        X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0X2lkIjogIjUzZDgy
-        MzE2LTY0MjUtNDgxNy04ZDYxLTEzNWU0NDE5ZGJiYSIsICJfaWQiOiB7IiRv
-        aWQiOiAiNTc5YmE3NmM3YmMyNWFhZjA5NTYyZTVlIn19LCB7Im1ldGFkYXRh
-        IjogeyJtYW5kYXRvcnlfcGFja2FnZV9uYW1lcyI6IFsiZWxlcGhhbnQsZ2ly
-        YWZmZSxjaGVldGFoLGxpb24sbW9ua2V5LHBlbmd1aW4sc3F1aXJyZWwsd2Fs
-        cnVzIiwgInBlbmd1aW4iXSwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5h
-        bWUiOiAibWFtbWFsIiwgInVzZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0
-        IjogdHJ1ZSwgIl9ucyI6ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0
-        X3VwZGF0ZWQiOiAxNDY5ODE4NjYxLCAib3B0aW9uYWxfcGFja2FnZV9uYW1l
-        cyI6IFtdLCAidHJhbnNsYXRlZF9uYW1lIjoge30sICJ0cmFuc2xhdGVkX2Rl
-        c2NyaXB0aW9uIjoge30sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImRl
-        ZmF1bHRfcGFja2FnZV9uYW1lcyI6IFtdLCAiX2NvbnRlbnRfdHlwZV9pZCI6
-        ICJwYWNrYWdlX2dyb3VwIiwgImlkIjogIm1hbW1hbCIsICJfaWQiOiAiOTkz
-        MTNjYzktNWU5Yy00YzhhLTljY2MtNTE5MDJhOGRkZDM2IiwgImRpc3BsYXlf
-        b3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtd
-        fSwgInVwZGF0ZWQiOiAiMjAxNi0wNy0yOVQxODo1ODo1MloiLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE2LTA3LTI5VDE4OjU4
-        OjUyWiIsICJ1bml0X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0
-        X2lkIjogIjk5MzEzY2M5LTVlOWMtNGM4YS05Y2NjLTUxOTAyYThkZGQzNiIs
-        ICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3NmM3YmMyNWFhZjA5NTYyZTVmIn19
-        XQ==
+        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJt
+        YW5kYXRvcnlfcGFja2FnZV9uYW1lcyI6IFsicGVuZ3VpbiJdLCAicmVwb19p
+        ZCI6ICJGZWRvcmFfMTciLCAibmFtZSI6ICJiaXJkIiwgInVzZXJfdmlzaWJs
+        ZSI6IHRydWUsICJkZWZhdWx0IjogdHJ1ZSwgIl9sYXN0X3VwZGF0ZWQiOiAi
+        MjAxNi0xMS0yOVQxMzo1OTozMVoiLCAiY2hpbGRyZW4iOiB7fSwgIm9wdGlv
+        bmFsX3BhY2thZ2VfbmFtZXMiOiBbXSwgInRyYW5zbGF0ZWRfbmFtZSI6IHt9
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcGFja2Fn
+        ZV9ncm91cC83ODVlNTNmMi0wMWQyLTQ4ODctOTg5ZS1iYTE3ZDY0MzcyYzIv
+        IiwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24iOiB7fSwgInB1bHBfdXNlcl9t
+        ZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNrYWdlX25hbWVzIjogW10sICJf
+        Y29udGVudF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAiaWQiOiAiYmly
+        ZCIsICJfaWQiOiAiNzg1ZTUzZjItMDFkMi00ODg3LTk4OWUtYmExN2Q2NDM3
+        MmMyIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxfcGFj
+        a2FnZV9uYW1lcyI6IFtdfSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjog
+        WyJGZWRvcmFfMTciXSwgIm1hbmRhdG9yeV9wYWNrYWdlX25hbWVzIjogWyJl
+        bGVwaGFudCxnaXJhZmZlLGNoZWV0YWgsbGlvbixtb25rZXkscGVuZ3Vpbixz
+        cXVpcnJlbCx3YWxydXMiLCAicGVuZ3VpbiJdLCAicmVwb19pZCI6ICJGZWRv
+        cmFfMTciLCAibmFtZSI6ICJtYW1tYWwiLCAidXNlcl92aXNpYmxlIjogdHJ1
+        ZSwgImRlZmF1bHQiOiB0cnVlLCAiX2xhc3RfdXBkYXRlZCI6ICIyMDE2LTEx
+        LTI5VDEzOjU5OjMxWiIsICJjaGlsZHJlbiI6IHt9LCAib3B0aW9uYWxfcGFj
+        a2FnZV9uYW1lcyI6IFtdLCAidHJhbnNsYXRlZF9uYW1lIjoge30sICJfaHJl
+        ZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9wYWNrYWdlX2dyb3Vw
+        L2MwZmY2ZmUxLTNiN2MtNGU0MS1hYzA3LWJiNDgwMWI1MDU5My8iLCAidHJh
+        bnNsYXRlZF9kZXNjcmlwdGlvbiI6IHt9LCAicHVscF91c2VyX21ldGFkYXRh
+        Ijoge30sICJkZWZhdWx0X3BhY2thZ2VfbmFtZXMiOiBbXSwgIl9jb250ZW50
+        X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJpZCI6ICJtYW1tYWwiLCAi
+        X2lkIjogImMwZmY2ZmUxLTNiN2MtNGU0MS1hYzA3LWJiNDgwMWI1MDU5MyIs
+        ICJkaXNwbGF5X29yZGVyIjogMTAyNCwgImNvbmRpdGlvbmFsX3BhY2thZ2Vf
+        bmFtZXMiOiBbXX1d
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:52 GMT
+  recorded_at: Tue, 29 Nov 2016 19:44:35 GMT
 - request:
     method: post
-    uri: https://obelix.example.com/pulp/api/v2/content/units/package_group/search/
+    uri: https://robot.example.com/pulp/api/v2/content/units/package_group/search/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiNTNkODIz
-        MTYtNjQyNS00ODE3LThkNjEtMTM1ZTQ0MTlkYmJhIl19fX0sImluY2x1ZGVf
+        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiNzg1ZTUz
+        ZjItMDFkMi00ODg3LTk4OWUtYmExN2Q2NDM3MmMyIl19fX0sImluY2x1ZGVf
         cmVwb3MiOnRydWV9
     headers:
       Accept:
@@ -1471,7 +2019,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:52 GMT
+      - Tue, 29 Nov 2016 19:44:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -1487,21 +2035,21 @@ http_interactions:
         YW5kYXRvcnlfcGFja2FnZV9uYW1lcyI6IFsicGVuZ3VpbiJdLCAicmVwb19p
         ZCI6ICJGZWRvcmFfMTciLCAibmFtZSI6ICJiaXJkIiwgInVzZXJfdmlzaWJs
         ZSI6IHRydWUsICJkZWZhdWx0IjogdHJ1ZSwgIl9sYXN0X3VwZGF0ZWQiOiAi
-        MjAxNi0wNy0yOVQxODo1Nzo0MVoiLCAiY2hpbGRyZW4iOiB7fSwgIm9wdGlv
+        MjAxNi0xMS0yOVQxMzo1OTozMVoiLCAiY2hpbGRyZW4iOiB7fSwgIm9wdGlv
         bmFsX3BhY2thZ2VfbmFtZXMiOiBbXSwgInRyYW5zbGF0ZWRfbmFtZSI6IHt9
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcGFja2Fn
-        ZV9ncm91cC81M2Q4MjMxNi02NDI1LTQ4MTctOGQ2MS0xMzVlNDQxOWRiYmEv
+        ZV9ncm91cC83ODVlNTNmMi0wMWQyLTQ4ODctOTg5ZS1iYTE3ZDY0MzcyYzIv
         IiwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24iOiB7fSwgInB1bHBfdXNlcl9t
         ZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNrYWdlX25hbWVzIjogW10sICJf
         Y29udGVudF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAiaWQiOiAiYmly
-        ZCIsICJfaWQiOiAiNTNkODIzMTYtNjQyNS00ODE3LThkNjEtMTM1ZTQ0MTlk
-        YmJhIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxfcGFj
+        ZCIsICJfaWQiOiAiNzg1ZTUzZjItMDFkMi00ODg3LTk4OWUtYmExN2Q2NDM3
+        MmMyIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxfcGFj
         a2FnZV9uYW1lcyI6IFtdfV0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:52 GMT
+  recorded_at: Tue, 29 Nov 2016 19:44:35 GMT
 - request:
     method: delete
-    uri: https://obelix.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://robot.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1520,7 +2068,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:52 GMT
+      - Tue, 29 Nov 2016 19:44:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -1531,14 +2079,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2Y4YmVlMDJlLTdkZmMtNGIwYy1hZWM1LTM4MDNiYzZiMmIyNy8iLCAi
-        dGFza19pZCI6ICJmOGJlZTAyZS03ZGZjLTRiMGMtYWVjNS0zODAzYmM2YjJi
-        MjcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2EyN2QyYzAyLTU5ZGItNGNmNy1iODA0LWMwMGI5NWRhMmUxZC8iLCAi
+        dGFza19pZCI6ICJhMjdkMmMwMi01OWRiLTRjZjctYjgwNC1jMDBiOTVkYTJl
+        MWQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:52 GMT
+  recorded_at: Tue, 29 Nov 2016 19:44:35 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/f8bee02e-7dfc-4b0c-aec5-3803bc6b2b27/
+    uri: https://robot.example.com/pulp/api/v2/tasks/a27d2c02-59db-4cf7-b804-c00b95da2e1d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1557,13 +2105,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:52 GMT
+      - Tue, 29 Nov 2016 19:44:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '651'
+      - '549'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1571,24 +2119,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mOGJlZTAyZS03ZGZjLTRiMGMtYWVjNS0zODAzYmM2YjJi
-        MjcvIiwgInRhc2tfaWQiOiAiZjhiZWUwMmUtN2RmYy00YjBjLWFlYzUtMzgw
-        M2JjNmIyYjI3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hMjdkMmMwMi01OWRiLTRjZjctYjgwNC1jMDBiOTVkYTJl
+        MWQvIiwgInRhc2tfaWQiOiAiYTI3ZDJjMDItNTlkYi00Y2Y3LWI4MDQtYzAw
+        Yjk1ZGEyZTFkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
-        LTA3LTI5VDE4OjU4OjUyWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
-        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJy
-        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBsZS5jb20i
-        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NzliYTc2YzdiYzI1YWFmMDk1NjJlNjIifSwgImlkIjogIjU3OWJh
-        NzZjN2JjMjVhYWYwOTU2MmU2MiJ9
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ODNkZGFh
+        MzY3MWUwOGVhYTZkMjU3ZDEifSwgImlkIjogIjU4M2RkYWEzNjcxZTA4ZWFh
+        NmQyNTdkMSJ9
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:52 GMT
+  recorded_at: Tue, 29 Nov 2016 19:44:35 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/f8bee02e-7dfc-4b0c-aec5-3803bc6b2b27/
+    uri: https://robot.example.com/pulp/api/v2/tasks/a27d2c02-59db-4cf7-b804-c00b95da2e1d/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1607,13 +2153,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:53 GMT
+      - Tue, 29 Nov 2016 19:44:36 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '670'
+      - '668'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1621,19 +2167,19 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mOGJlZTAyZS03ZGZjLTRiMGMtYWVjNS0zODAzYmM2YjJi
-        MjcvIiwgInRhc2tfaWQiOiAiZjhiZWUwMmUtN2RmYy00YjBjLWFlYzUtMzgw
-        M2JjNmIyYjI3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9hMjdkMmMwMi01OWRiLTRjZjctYjgwNC1jMDBiOTVkYTJl
+        MWQvIiwgInRhc2tfaWQiOiAiYTI3ZDJjMDItNTlkYi00Y2Y3LWI4MDQtYzAw
+        Yjk1ZGEyZTFkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTA3LTI5VDE4OjU4OjUyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTA3LTI5VDE4OjU4OjUyWiIsICJ0cmFjZWJh
+        MDE2LTExLTI5VDE5OjQ0OjM2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTExLTI5VDE5OjQ0OjM1WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBvYmVsaXguZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQi
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        b2JlbGl4LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3NmM3YmMyNWFhZjA5NTYy
-        ZTYyIn0sICJpZCI6ICI1NzliYTc2YzdiYzI1YWFmMDk1NjJlNjIifQ==
+        MUByb2JvdC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBy
+        b2JvdC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU4M2RkYWEzNjcxZTA4ZWFhNmQyNTdk
+        MSJ9LCAiaWQiOiAiNTgzZGRhYTM2NzFlMDhlYWE2ZDI1N2QxIn0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:53 GMT
+  recorded_at: Tue, 29 Nov 2016 19:44:36 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/services/pulp/puppet_module.yml
+++ b/test/fixtures/vcr_cassettes/services/pulp/puppet_module.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://obelix.example.com/pulp/api/v2/repositories/
+    uri: https://robot.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -38,13 +38,13 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:53 GMT
+      - Tue, 29 Nov 2016 19:42:20 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
       - '298'
       Location:
-      - https://obelix.example.com/pulp/api/v2/repositories/4/
+      - https://robot.example.com/pulp/api/v2/repositories/4/
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -54,14 +54,14 @@ http_interactions:
         ICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRkZWQiOiBudWxs
         LCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicHVwcGV0LXJlcG8ifSwgImxh
         c3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3VudHMi
-        OiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3
-        NmQ3MGJlNmYwZGIyYjMzMmMyIn0sICJpZCI6ICI0IiwgIl9ocmVmIjogIi9w
+        OiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNTgzZGRh
+        MWNiMGVhZjI1ZjQ1ODE5MmUzIn0sICJpZCI6ICI0IiwgIl9ocmVmIjogIi9w
         dWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvNC8ifQ==
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:53 GMT
+  recorded_at: Tue, 29 Nov 2016 19:42:20 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/repositories/4/?details=true
+    uri: https://robot.example.com/pulp/api/v2/repositories/4/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -80,7 +80,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:54 GMT
+      - Tue, 29 Nov 2016 19:42:20 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -99,14 +99,14 @@ http_interactions:
         dHJpYnV0b3JzIiwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRv
         cl90eXBlX2lkIjogInB1cHBldF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxp
         c2giOiB0cnVlLCAic2NyYXRjaHBhZCI6IHt9LCAiX2lkIjogeyIkb2lkIjog
-        IjU3OWJhNzZkNzBiZTZmMGRiMmIzMzJjNSJ9LCAiY29uZmlnIjogeyJzZXJ2
+        IjU4M2RkYTFjYjBlYWYyNWY0NTgxOTJlNiJ9LCAiY29uZmlnIjogeyJzZXJ2
         ZV9odHRwcyI6IHRydWUsICJzZXJ2ZV9odHRwIjogZmFsc2V9LCAiaWQiOiAi
         NF9wdXBwZXQifSwgeyJyZXBvX2lkIjogIjQiLCAiX2hyZWYiOiAiL3B1bHAv
         YXBpL3YyL3JlcG9zaXRvcmllcy80L2Rpc3RyaWJ1dG9ycy80LyIsICJfbnMi
         OiAicmVwb19kaXN0cmlidXRvcnMiLCAibGFzdF9wdWJsaXNoIjogbnVsbCwg
         ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAicHVwcGV0X2luc3RhbGxfZGlzdHJp
         YnV0b3IiLCAiYXV0b19wdWJsaXNoIjogdHJ1ZSwgInNjcmF0Y2hwYWQiOiB7
-        fSwgIl9pZCI6IHsiJG9pZCI6ICI1NzliYTc2ZDcwYmU2ZjBkYjJiMzMyYzQi
+        fSwgIl9pZCI6IHsiJG9pZCI6ICI1ODNkZGExY2IwZWFmMjVmNDU4MTkyZTUi
         fSwgImNvbmZpZyI6IHsiaW5zdGFsbF9wYXRoIjogIi92YXIvbGliL3B1bHAv
         cHVibGlzaGVkL3B1cHBldF9rYXRlbGxvX3Rlc3QiLCAiYXV0b19wdWJsaXNo
         IjogdHJ1ZX0sICJpZCI6ICI0In1dLCAibGFzdF91bml0X2FkZGVkIjogbnVs
@@ -117,18 +117,18 @@ http_interactions:
         aWVzLzQvaW1wb3J0ZXJzL3B1cHBldF9pbXBvcnRlci8iLCAiX25zIjogInJl
         cG9faW1wb3J0ZXJzIiwgImltcG9ydGVyX3R5cGVfaWQiOiAicHVwcGV0X2lt
         cG9ydGVyIiwgImxhc3Rfc3luYyI6IG51bGwsICJyZXBvX2lkIjogIjQiLCAi
-        X2lkIjogeyIkb2lkIjogIjU3OWJhNzZkNzBiZTZmMGRiMmIzMzJjMyJ9LCAi
+        X2lkIjogeyIkb2lkIjogIjU4M2RkYTFjYjBlYWYyNWY0NTgxOTJlNCJ9LCAi
         Y29uZmlnIjogeyJmZWVkIjogImh0dHA6Ly9kYXZpZGQuZmVkb3JhcGVvcGxl
         Lm9yZy9yZXBvcy9yYW5kb21fcHVwcGV0LyJ9LCAiaWQiOiAicHVwcGV0X2lt
         cG9ydGVyIn1dLCAibG9jYWxseV9zdG9yZWRfdW5pdHMiOiAwLCAiX2lkIjog
-        eyIkb2lkIjogIjU3OWJhNzZkNzBiZTZmMGRiMmIzMzJjMiJ9LCAidG90YWxf
+        eyIkb2lkIjogIjU4M2RkYTFjYjBlYWYyNWY0NTgxOTJlMyJ9LCAidG90YWxf
         cmVwb3NpdG9yeV91bml0cyI6IDAsICJpZCI6ICI0IiwgIl9ocmVmIjogIi9w
         dWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvNC8ifQ==
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:54 GMT
+  recorded_at: Tue, 29 Nov 2016 19:42:20 GMT
 - request:
     method: post
-    uri: https://obelix.example.com/pulp/api/v2/repositories/4/actions/publish/
+    uri: https://robot.example.com/pulp/api/v2/repositories/4/actions/publish/
     body:
       encoding: UTF-8
       base64_string: |
@@ -150,7 +150,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:54 GMT
+      - Tue, 29 Nov 2016 19:42:20 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -161,14 +161,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzhhZTU0NDQ5LTg4OTQtNGNmYy1hMzgwLTQ4NTVjYTJmZTUxYi8iLCAi
-        dGFza19pZCI6ICI4YWU1NDQ0OS04ODk0LTRjZmMtYTM4MC00ODU1Y2EyZmU1
-        MWIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzg3NDc5MTk5LTZhZjctNGEwZS04NWY5LTdiNDc4NDliMmUyOS8iLCAi
+        dGFza19pZCI6ICI4NzQ3OTE5OS02YWY3LTRhMGUtODVmOS03YjQ3ODQ5YjJl
+        MjkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:54 GMT
+  recorded_at: Tue, 29 Nov 2016 19:42:20 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/8ae54449-8894-4cfc-a380-4855ca2fe51b/
+    uri: https://robot.example.com/pulp/api/v2/tasks/87479199-6af7-4a0e-85f9-7b47849b2e29/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -187,13 +187,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:54 GMT
+      - Tue, 29 Nov 2016 19:42:20 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '566'
+      - '648'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -201,22 +201,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84YWU1NDQ0OS04ODk0LTRjZmMtYTM4MC00ODU1
-        Y2EyZmU1MWIvIiwgInRhc2tfaWQiOiAiOGFlNTQ0NDktODg5NC00Y2ZjLWEz
-        ODAtNDg1NWNhMmZlNTFiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0
+        dWxwL2FwaS92Mi90YXNrcy84NzQ3OTE5OS02YWY3LTRhMGUtODVmOS03YjQ3
+        ODQ5YjJlMjkvIiwgInRhc2tfaWQiOiAiODc0NzkxOTktNmFmNy00YTBlLTg1
+        ZjktN2I0Nzg0OWIyZTI5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0
         IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogbnVs
         bCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYt
-        MDctMjlUMTg6NTg6NTRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
+        MTEtMjlUMTk6NDI6MjBaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
         X3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjog
-        Ik5vbmUuZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6
-        IG51bGwsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjU3OWJhNzZlN2JjMjVhYWYwOTU2MmU2MyJ9LCAiaWQiOiAi
-        NTc5YmE3NmU3YmMyNWFhZjA5NTYyZTYzIn0=
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUuY29t
+        LmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVz
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAcm9ib3QuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1ODNkZGExYzY3MWUwOGVhYTZkMjU3NWQifSwgImlkIjogIjU4M2RkYTFj
+        NjcxZTA4ZWFhNmQyNTc1ZCJ9
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:54 GMT
+  recorded_at: Tue, 29 Nov 2016 19:42:20 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/8ae54449-8894-4cfc-a380-4855ca2fe51b/
+    uri: https://robot.example.com/pulp/api/v2/tasks/87479199-6af7-4a0e-85f9-7b47849b2e29/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -235,13 +237,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:54 GMT
+      - Tue, 29 Nov 2016 19:42:21 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1050'
+      - '1048'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -249,33 +251,33 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84YWU1NDQ0OS04ODk0LTRjZmMtYTM4MC00ODU1
-        Y2EyZmU1MWIvIiwgInRhc2tfaWQiOiAiOGFlNTQ0NDktODg5NC00Y2ZjLWEz
-        ODAtNDg1NWNhMmZlNTFiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0
+        dWxwL2FwaS92Mi90YXNrcy84NzQ3OTE5OS02YWY3LTRhMGUtODVmOS03YjQ3
+        ODQ5YjJlMjkvIiwgInRhc2tfaWQiOiAiODc0NzkxOTktNmFmNy00YTBlLTg1
+        ZjktN2I0Nzg0OWIyZTI5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0
         IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogIjIw
-        MTYtMDctMjlUMTg6NTg6NTRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
-        dGFydF90aW1lIjogIjIwMTYtMDctMjlUMTg6NTg6NTRaIiwgInRyYWNlYmFj
+        MTYtMTEtMjlUMTk6NDI6MjBaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
+        dGFydF90aW1lIjogIjIwMTYtMTEtMjlUMTk6NDI6MjBaIiwgInRyYWNlYmFj
         ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBv
         cnQiOiB7fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
-        QG9iZWxpeC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBv
-        YmVsaXguZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
-        Y2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICI0IiwgInN0
-        YXJ0ZWQiOiAiMjAxNi0wNy0yOVQxODo1ODo1NFoiLCAiX25zIjogInJlcG9f
-        cHVibGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTA3LTI5VDE4
-        OjU4OjU0WiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlw
-        ZV9pZCI6ICJwdXBwZXRfaW5zdGFsbF9kaXN0cmlidXRvciIsICJzdW1tYXJ5
-        IjogInN1Y2Nlc3MiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICI0IiwgImlkIjogIjU3OWJhNzZlNzBiZTZmNzM4ZWRkOWRl
-        OCIsICJkZXRhaWxzIjogeyJlcnJvcnMiOiBbXSwgInN1Y2Nlc3NfdW5pdF9r
-        ZXlzIjogW119fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        NzliYTc2ZTdiYzI1YWFmMDk1NjJlNjMifSwgImlkIjogIjU3OWJhNzZlN2Jj
-        MjVhYWYwOTU2MmU2MyJ9
+        QHJvYm90LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJv
+        Ym90LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
+        c3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiNCIsICJzdGFy
+        dGVkIjogIjIwMTYtMTEtMjlUMTk6NDI6MjBaIiwgIl9ucyI6ICJyZXBvX3B1
+        Ymxpc2hfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0xMS0yOVQxOTo0
+        MjoyMFoiLCAidHJhY2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVf
+        aWQiOiAicHVwcGV0X2luc3RhbGxfZGlzdHJpYnV0b3IiLCAic3VtbWFyeSI6
+        ICJzdWNjZXNzIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0
+        b3JfaWQiOiAiNCIsICJpZCI6ICI1ODNkZGExY2IwZWFmMjA5OWI2ODE4NTUi
+        LCAiZGV0YWlscyI6IHsiZXJyb3JzIjogW10sICJzdWNjZXNzX3VuaXRfa2V5
+        cyI6IFtdfX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTgz
+        ZGRhMWM2NzFlMDhlYWE2ZDI1NzVkIn0sICJpZCI6ICI1ODNkZGExYzY3MWUw
+        OGVhYTZkMjU3NWQifQ==
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:54 GMT
+  recorded_at: Tue, 29 Nov 2016 19:42:21 GMT
 - request:
     method: post
-    uri: https://obelix.example.com/pulp/api/v2/repositories/4/actions/sync/
+    uri: https://robot.example.com/pulp/api/v2/repositories/4/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -298,7 +300,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:55 GMT
+      - Tue, 29 Nov 2016 19:42:21 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -309,14 +311,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzg0YWQ3MmIyLWNmZmMtNDRjNS04MWI3LTc2ZDgxZWQ5NmU5ZS8iLCAi
-        dGFza19pZCI6ICI4NGFkNzJiMi1jZmZjLTQ0YzUtODFiNy03NmQ4MWVkOTZl
-        OWUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2E3MTM3NDIyLTg3MjYtNDUwZS1hNDEzLTAwZDk1YTRkMDZmMy8iLCAi
+        dGFza19pZCI6ICJhNzEzNzQyMi04NzI2LTQ1MGUtYTQxMy0wMGQ5NWE0ZDA2
+        ZjMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:55 GMT
+  recorded_at: Tue, 29 Nov 2016 19:42:21 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/84ad72b2-cffc-44c5-81b7-76d81ed96e9e/
+    uri: https://robot.example.com/pulp/api/v2/tasks/a7137422-8726-450e-a413-00d95a4d06f3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -335,13 +337,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:55 GMT
+      - Tue, 29 Nov 2016 19:42:21 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '641'
+      - '621'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -349,24 +351,23 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84NGFkNzJiMi1jZmZjLTQ0YzUtODFiNy03NmQ4MWVkOTZl
-        OWUvIiwgInRhc2tfaWQiOiAiODRhZDcyYjItY2ZmYy00NGM1LTgxYjctNzZk
-        ODFlZDk2ZTllIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        aS92Mi90YXNrcy9hNzEzNzQyMi04NzI2LTQ1MGUtYTQxMy0wMGQ5NWE0ZDA2
+        ZjMvIiwgInRhc2tfaWQiOiAiYTcxMzc0MjItODcyNi00NTBlLWE0MTMtMDBk
+        OTVhNGQwNmYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
         bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
-        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDctMjlUMTg6
-        NTg6NTVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
-        W10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogInJlc2VydmVk
-        X3Jlc291cmNlX3dvcmtlci0xQG9iZWxpeC5leGFtcGxlLmNvbS5kcSIsICJz
-        dGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
-        c291cmNlX3dvcmtlci0xQG9iZWxpeC5leGFtcGxlLmNvbSIsICJyZXN1bHQi
-        OiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU3OWJh
-        NzZmN2JjMjVhYWYwOTU2MmU2NCJ9LCAiaWQiOiAiNTc5YmE3NmY3YmMyNWFh
-        ZjA5NTYyZTY0In0=
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogbnVsbCwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBv
+        cnQiOiB7fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
+        QHJvYm90LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogIndhaXRpbmciLCAi
+        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAcm9i
+        b3QuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1ODNkZGExZDY3MWUwOGVhYTZkMjU3NWUi
+        fSwgImlkIjogIjU4M2RkYTFkNjcxZTA4ZWFhNmQyNTc1ZSJ9
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:55 GMT
+  recorded_at: Tue, 29 Nov 2016 19:42:21 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/84ad72b2-cffc-44c5-81b7-76d81ed96e9e/
+    uri: https://robot.example.com/pulp/api/v2/tasks/a7137422-8726-450e-a413-00d95a4d06f3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -385,13 +386,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:55 GMT
+      - Tue, 29 Nov 2016 19:42:22 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1062'
+      - '1060'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -399,12 +400,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84NGFkNzJiMi1jZmZjLTQ0YzUtODFiNy03NmQ4MWVkOTZl
-        OWUvIiwgInRhc2tfaWQiOiAiODRhZDcyYjItY2ZmYy00NGM1LTgxYjctNzZk
-        ODFlZDk2ZTllIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        aS92Mi90YXNrcy9hNzEzNzQyMi04NzI2LTQ1MGUtYTQxMy0wMGQ5NWE0ZDA2
+        ZjMvIiwgInRhc2tfaWQiOiAiYTcxMzc0MjItODcyNi00NTBlLWE0MTMtMDBk
+        OTVhNGQwNmYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
         bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
-        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDctMjlUMTg6
-        NTg6NTVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMTEtMjlUMTk6
+        NDI6MjFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
         W10sICJwcm9ncmVzc19yZXBvcnQiOiB7InB1cHBldF9pbXBvcnRlciI6IHsi
         bW9kdWxlcyI6IHsiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJleGVjdXRpb25f
         dGltZSI6IG51bGwsICJ0b3RhbF9jb3VudCI6IG51bGwsICJ0cmFjZWJhY2si
@@ -415,17 +416,17 @@ http_interactions:
         ZXhlY3V0aW9uX3RpbWUiOiBudWxsLCAicXVlcnlfdG90YWxfY291bnQiOiAx
         LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdGF0ZSI6ICJydW5uaW5nIiwg
         ImVycm9yIjogIk5vbmUiLCAiY3VycmVudF9xdWVyeSI6IG51bGx9fX0sICJx
-        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhh
-        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
-        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBs
-        ZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NzliYTc2ZjdiYzI1YWFmMDk1NjJlNjQifSwgImlkIjog
-        IjU3OWJhNzZmN2JjMjVhYWYwOTU2MmU2NCJ9
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUByb2JvdC5leGFt
+        cGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNTgzZGRhMWQ2NzFlMDhlYWE2ZDI1NzVlIn0sICJpZCI6ICI1
+        ODNkZGExZDY3MWUwOGVhYTZkMjU3NWUifQ==
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:55 GMT
+  recorded_at: Tue, 29 Nov 2016 19:42:22 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/84ad72b2-cffc-44c5-81b7-76d81ed96e9e/
+    uri: https://robot.example.com/pulp/api/v2/tasks/a7137422-8726-450e-a413-00d95a4d06f3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -444,13 +445,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:56 GMT
+      - Tue, 29 Nov 2016 19:42:22 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1123'
+      - '1121'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -458,12 +459,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84NGFkNzJiMi1jZmZjLTQ0YzUtODFiNy03NmQ4MWVkOTZl
-        OWUvIiwgInRhc2tfaWQiOiAiODRhZDcyYjItY2ZmYy00NGM1LTgxYjctNzZk
-        ODFlZDk2ZTllIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        aS92Mi90YXNrcy9hNzEzNzQyMi04NzI2LTQ1MGUtYTQxMy0wMGQ5NWE0ZDA2
+        ZjMvIiwgInRhc2tfaWQiOiAiYTcxMzc0MjItODcyNi00NTBlLWE0MTMtMDBk
+        OTVhNGQwNmYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
         bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
-        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDctMjlUMTg6
-        NTg6NTVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMTEtMjlUMTk6
+        NDI6MjFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
         W10sICJwcm9ncmVzc19yZXBvcnQiOiB7InB1cHBldF9pbXBvcnRlciI6IHsi
         bW9kdWxlcyI6IHsiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJleGVjdXRpb25f
         dGltZSI6IG51bGwsICJ0b3RhbF9jb3VudCI6IG51bGwsICJ0cmFjZWJhY2si
@@ -476,16 +477,16 @@ http_interactions:
         ImVycm9yIjogIk5vbmUiLCAiY3VycmVudF9xdWVyeSI6ICJodHRwOi8vZGF2
         aWRkLmZlZG9yYXBlb3BsZS5vcmcvcmVwb3MvcmFuZG9tX3B1cHBldC9tb2R1
         bGVzLmpzb24ifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAb2JlbGl4LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5p
-        bmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTFAb2JlbGl4LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJv
-        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3NmY3YmMyNWFhZjA5
-        NTYyZTY0In0sICJpZCI6ICI1NzliYTc2ZjdiYzI1YWFmMDk1NjJlNjQifQ==
+        a2VyLTFAcm9ib3QuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmlu
+        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUByb2JvdC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3Ii
+        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU4M2RkYTFkNjcxZTA4ZWFhNmQy
+        NTc1ZSJ9LCAiaWQiOiAiNTgzZGRhMWQ2NzFlMDhlYWE2ZDI1NzVlIn0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:56 GMT
+  recorded_at: Tue, 29 Nov 2016 19:42:22 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/84ad72b2-cffc-44c5-81b7-76d81ed96e9e/
+    uri: https://robot.example.com/pulp/api/v2/tasks/a7137422-8726-450e-a413-00d95a4d06f3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -504,13 +505,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:56 GMT
+      - Tue, 29 Nov 2016 19:42:23 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1123'
+      - '1121'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -518,12 +519,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84NGFkNzJiMi1jZmZjLTQ0YzUtODFiNy03NmQ4MWVkOTZl
-        OWUvIiwgInRhc2tfaWQiOiAiODRhZDcyYjItY2ZmYy00NGM1LTgxYjctNzZk
-        ODFlZDk2ZTllIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        aS92Mi90YXNrcy9hNzEzNzQyMi04NzI2LTQ1MGUtYTQxMy0wMGQ5NWE0ZDA2
+        ZjMvIiwgInRhc2tfaWQiOiAiYTcxMzc0MjItODcyNi00NTBlLWE0MTMtMDBk
+        OTVhNGQwNmYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
         bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
-        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDctMjlUMTg6
-        NTg6NTVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMTEtMjlUMTk6
+        NDI6MjFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
         W10sICJwcm9ncmVzc19yZXBvcnQiOiB7InB1cHBldF9pbXBvcnRlciI6IHsi
         bW9kdWxlcyI6IHsiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJleGVjdXRpb25f
         dGltZSI6IG51bGwsICJ0b3RhbF9jb3VudCI6IG51bGwsICJ0cmFjZWJhY2si
@@ -536,16 +537,16 @@ http_interactions:
         ImVycm9yIjogIk5vbmUiLCAiY3VycmVudF9xdWVyeSI6ICJodHRwOi8vZGF2
         aWRkLmZlZG9yYXBlb3BsZS5vcmcvcmVwb3MvcmFuZG9tX3B1cHBldC9tb2R1
         bGVzLmpzb24ifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAb2JlbGl4LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5p
-        bmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTFAb2JlbGl4LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJv
-        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3NmY3YmMyNWFhZjA5
-        NTYyZTY0In0sICJpZCI6ICI1NzliYTc2ZjdiYzI1YWFmMDk1NjJlNjQifQ==
+        a2VyLTFAcm9ib3QuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmlu
+        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUByb2JvdC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3Ii
+        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU4M2RkYTFkNjcxZTA4ZWFhNmQy
+        NTc1ZSJ9LCAiaWQiOiAiNTgzZGRhMWQ2NzFlMDhlYWE2ZDI1NzVlIn0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:56 GMT
+  recorded_at: Tue, 29 Nov 2016 19:42:23 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/84ad72b2-cffc-44c5-81b7-76d81ed96e9e/
+    uri: https://robot.example.com/pulp/api/v2/tasks/a7137422-8726-450e-a413-00d95a4d06f3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -564,13 +565,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:57 GMT
+      - Tue, 29 Nov 2016 19:42:23 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1107'
+      - '1105'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -578,12 +579,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84NGFkNzJiMi1jZmZjLTQ0YzUtODFiNy03NmQ4MWVkOTZl
-        OWUvIiwgInRhc2tfaWQiOiAiODRhZDcyYjItY2ZmYy00NGM1LTgxYjctNzZk
-        ODFlZDk2ZTllIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        aS92Mi90YXNrcy9hNzEzNzQyMi04NzI2LTQ1MGUtYTQxMy0wMGQ5NWE0ZDA2
+        ZjMvIiwgInRhc2tfaWQiOiAiYTcxMzc0MjItODcyNi00NTBlLWE0MTMtMDBk
+        OTVhNGQwNmYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
         bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
-        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDctMjlUMTg6
-        NTg6NTVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMTEtMjlUMTk6
+        NDI6MjFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
         W10sICJwcm9ncmVzc19yZXBvcnQiOiB7InB1cHBldF9pbXBvcnRlciI6IHsi
         bW9kdWxlcyI6IHsiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJleGVjdXRpb25f
         dGltZSI6IG51bGwsICJ0b3RhbF9jb3VudCI6IDQsICJ0cmFjZWJhY2siOiBu
@@ -595,17 +596,17 @@ http_interactions:
         IjogbnVsbCwgInN0YXRlIjogInN1Y2Nlc3MiLCAiZXJyb3IiOiAiTm9uZSIs
         ICJjdXJyZW50X3F1ZXJ5IjogImh0dHA6Ly9kYXZpZGQuZmVkb3JhcGVvcGxl
         Lm9yZy9yZXBvcy9yYW5kb21fcHVwcGV0L21vZHVsZXMuanNvbiJ9fX0sICJx
-        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhh
-        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
-        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBs
-        ZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NzliYTc2ZjdiYzI1YWFmMDk1NjJlNjQifSwgImlkIjog
-        IjU3OWJhNzZmN2JjMjVhYWYwOTU2MmU2NCJ9
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUByb2JvdC5leGFt
+        cGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNTgzZGRhMWQ2NzFlMDhlYWE2ZDI1NzVlIn0sICJpZCI6ICI1
+        ODNkZGExZDY3MWUwOGVhYTZkMjU3NWUifQ==
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:57 GMT
+  recorded_at: Tue, 29 Nov 2016 19:42:23 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/84ad72b2-cffc-44c5-81b7-76d81ed96e9e/
+    uri: https://robot.example.com/pulp/api/v2/tasks/a7137422-8726-450e-a413-00d95a4d06f3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -624,13 +625,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:57 GMT
+      - Tue, 29 Nov 2016 19:42:24 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1107'
+      - '1105'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -638,12 +639,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84NGFkNzJiMi1jZmZjLTQ0YzUtODFiNy03NmQ4MWVkOTZl
-        OWUvIiwgInRhc2tfaWQiOiAiODRhZDcyYjItY2ZmYy00NGM1LTgxYjctNzZk
-        ODFlZDk2ZTllIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        aS92Mi90YXNrcy9hNzEzNzQyMi04NzI2LTQ1MGUtYTQxMy0wMGQ5NWE0ZDA2
+        ZjMvIiwgInRhc2tfaWQiOiAiYTcxMzc0MjItODcyNi00NTBlLWE0MTMtMDBk
+        OTVhNGQwNmYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
         bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
-        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDctMjlUMTg6
-        NTg6NTVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMTEtMjlUMTk6
+        NDI6MjFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
         W10sICJwcm9ncmVzc19yZXBvcnQiOiB7InB1cHBldF9pbXBvcnRlciI6IHsi
         bW9kdWxlcyI6IHsiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJleGVjdXRpb25f
         dGltZSI6IG51bGwsICJ0b3RhbF9jb3VudCI6IDQsICJ0cmFjZWJhY2siOiBu
@@ -655,17 +656,17 @@ http_interactions:
         IjogbnVsbCwgInN0YXRlIjogInN1Y2Nlc3MiLCAiZXJyb3IiOiAiTm9uZSIs
         ICJjdXJyZW50X3F1ZXJ5IjogImh0dHA6Ly9kYXZpZGQuZmVkb3JhcGVvcGxl
         Lm9yZy9yZXBvcy9yYW5kb21fcHVwcGV0L21vZHVsZXMuanNvbiJ9fX0sICJx
-        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhh
-        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
-        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBs
-        ZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NzliYTc2ZjdiYzI1YWFmMDk1NjJlNjQifSwgImlkIjog
-        IjU3OWJhNzZmN2JjMjVhYWYwOTU2MmU2NCJ9
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUByb2JvdC5leGFt
+        cGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNTgzZGRhMWQ2NzFlMDhlYWE2ZDI1NzVlIn0sICJpZCI6ICI1
+        ODNkZGExZDY3MWUwOGVhYTZkMjU3NWUifQ==
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:57 GMT
+  recorded_at: Tue, 29 Nov 2016 19:42:24 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/84ad72b2-cffc-44c5-81b7-76d81ed96e9e/
+    uri: https://robot.example.com/pulp/api/v2/tasks/a7137422-8726-450e-a413-00d95a4d06f3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -684,13 +685,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:58 GMT
+      - Tue, 29 Nov 2016 19:42:25 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1107'
+      - '1105'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -698,12 +699,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84NGFkNzJiMi1jZmZjLTQ0YzUtODFiNy03NmQ4MWVkOTZl
-        OWUvIiwgInRhc2tfaWQiOiAiODRhZDcyYjItY2ZmYy00NGM1LTgxYjctNzZk
-        ODFlZDk2ZTllIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        aS92Mi90YXNrcy9hNzEzNzQyMi04NzI2LTQ1MGUtYTQxMy0wMGQ5NWE0ZDA2
+        ZjMvIiwgInRhc2tfaWQiOiAiYTcxMzc0MjItODcyNi00NTBlLWE0MTMtMDBk
+        OTVhNGQwNmYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
         bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
-        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDctMjlUMTg6
-        NTg6NTVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMTEtMjlUMTk6
+        NDI6MjFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
         W10sICJwcm9ncmVzc19yZXBvcnQiOiB7InB1cHBldF9pbXBvcnRlciI6IHsi
         bW9kdWxlcyI6IHsiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJleGVjdXRpb25f
         dGltZSI6IG51bGwsICJ0b3RhbF9jb3VudCI6IDQsICJ0cmFjZWJhY2siOiBu
@@ -715,17 +716,17 @@ http_interactions:
         IjogbnVsbCwgInN0YXRlIjogInN1Y2Nlc3MiLCAiZXJyb3IiOiAiTm9uZSIs
         ICJjdXJyZW50X3F1ZXJ5IjogImh0dHA6Ly9kYXZpZGQuZmVkb3JhcGVvcGxl
         Lm9yZy9yZXBvcy9yYW5kb21fcHVwcGV0L21vZHVsZXMuanNvbiJ9fX0sICJx
-        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhh
-        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
-        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBs
-        ZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NzliYTc2ZjdiYzI1YWFmMDk1NjJlNjQifSwgImlkIjog
-        IjU3OWJhNzZmN2JjMjVhYWYwOTU2MmU2NCJ9
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUByb2JvdC5leGFt
+        cGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNTgzZGRhMWQ2NzFlMDhlYWE2ZDI1NzVlIn0sICJpZCI6ICI1
+        ODNkZGExZDY3MWUwOGVhYTZkMjU3NWUifQ==
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:58 GMT
+  recorded_at: Tue, 29 Nov 2016 19:42:25 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/84ad72b2-cffc-44c5-81b7-76d81ed96e9e/
+    uri: https://robot.example.com/pulp/api/v2/tasks/a7137422-8726-450e-a413-00d95a4d06f3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -744,13 +745,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:58:59 GMT
+      - Tue, 29 Nov 2016 19:42:26 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1107'
+      - '1105'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -758,12 +759,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84NGFkNzJiMi1jZmZjLTQ0YzUtODFiNy03NmQ4MWVkOTZl
-        OWUvIiwgInRhc2tfaWQiOiAiODRhZDcyYjItY2ZmYy00NGM1LTgxYjctNzZk
-        ODFlZDk2ZTllIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        aS92Mi90YXNrcy9hNzEzNzQyMi04NzI2LTQ1MGUtYTQxMy0wMGQ5NWE0ZDA2
+        ZjMvIiwgInRhc2tfaWQiOiAiYTcxMzc0MjItODcyNi00NTBlLWE0MTMtMDBk
+        OTVhNGQwNmYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
         bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
-        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDctMjlUMTg6
-        NTg6NTVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMTEtMjlUMTk6
+        NDI6MjFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
         W10sICJwcm9ncmVzc19yZXBvcnQiOiB7InB1cHBldF9pbXBvcnRlciI6IHsi
         bW9kdWxlcyI6IHsiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJleGVjdXRpb25f
         dGltZSI6IG51bGwsICJ0b3RhbF9jb3VudCI6IDQsICJ0cmFjZWJhY2siOiBu
@@ -775,17 +776,17 @@ http_interactions:
         IjogbnVsbCwgInN0YXRlIjogInN1Y2Nlc3MiLCAiZXJyb3IiOiAiTm9uZSIs
         ICJjdXJyZW50X3F1ZXJ5IjogImh0dHA6Ly9kYXZpZGQuZmVkb3JhcGVvcGxl
         Lm9yZy9yZXBvcy9yYW5kb21fcHVwcGV0L21vZHVsZXMuanNvbiJ9fX0sICJx
-        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhh
-        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
-        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBs
-        ZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NzliYTc2ZjdiYzI1YWFmMDk1NjJlNjQifSwgImlkIjog
-        IjU3OWJhNzZmN2JjMjVhYWYwOTU2MmU2NCJ9
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUByb2JvdC5leGFt
+        cGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNTgzZGRhMWQ2NzFlMDhlYWE2ZDI1NzVlIn0sICJpZCI6ICI1
+        ODNkZGExZDY3MWUwOGVhYTZkMjU3NWUifQ==
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:58:59 GMT
+  recorded_at: Tue, 29 Nov 2016 19:42:26 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/84ad72b2-cffc-44c5-81b7-76d81ed96e9e/
+    uri: https://robot.example.com/pulp/api/v2/tasks/a7137422-8726-450e-a413-00d95a4d06f3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -804,13 +805,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:59:00 GMT
+      - Tue, 29 Nov 2016 19:42:27 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1107'
+      - '1105'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -818,34 +819,34 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84NGFkNzJiMi1jZmZjLTQ0YzUtODFiNy03NmQ4MWVkOTZl
-        OWUvIiwgInRhc2tfaWQiOiAiODRhZDcyYjItY2ZmYy00NGM1LTgxYjctNzZk
-        ODFlZDk2ZTllIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        aS92Mi90YXNrcy9hNzEzNzQyMi04NzI2LTQ1MGUtYTQxMy0wMGQ5NWE0ZDA2
+        ZjMvIiwgInRhc2tfaWQiOiAiYTcxMzc0MjItODcyNi00NTBlLWE0MTMtMDBk
+        OTVhNGQwNmYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
         bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
-        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMDctMjlUMTg6
-        NTg6NTVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMTEtMjlUMTk6
+        NDI6MjFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
         W10sICJwcm9ncmVzc19yZXBvcnQiOiB7InB1cHBldF9pbXBvcnRlciI6IHsi
         bW9kdWxlcyI6IHsiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJleGVjdXRpb25f
         dGltZSI6IG51bGwsICJ0b3RhbF9jb3VudCI6IDQsICJ0cmFjZWJhY2siOiBu
         dWxsLCAiaW5kaXZpZHVhbF9lcnJvcnMiOiBbXSwgInN0YXRlIjogInJ1bm5p
         bmciLCAiZXJyb3JfY291bnQiOiAwLCAiZXJyb3IiOiAiTm9uZSIsICJmaW5p
-        c2hlZF9jb3VudCI6IDN9LCAibWV0YWRhdGEiOiB7InF1ZXJ5X2ZpbmlzaGVk
+        c2hlZF9jb3VudCI6IDJ9LCAibWV0YWRhdGEiOiB7InF1ZXJ5X2ZpbmlzaGVk
         X2NvdW50IjogMSwgInRyYWNlYmFjayI6IG51bGwsICJleGVjdXRpb25fdGlt
         ZSI6IDEsICJxdWVyeV90b3RhbF9jb3VudCI6IDEsICJlcnJvcl9tZXNzYWdl
         IjogbnVsbCwgInN0YXRlIjogInN1Y2Nlc3MiLCAiZXJyb3IiOiAiTm9uZSIs
         ICJjdXJyZW50X3F1ZXJ5IjogImh0dHA6Ly9kYXZpZGQuZmVkb3JhcGVvcGxl
         Lm9yZy9yZXBvcy9yYW5kb21fcHVwcGV0L21vZHVsZXMuanNvbiJ9fX0sICJx
-        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhh
-        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
-        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBs
-        ZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NzliYTc2ZjdiYzI1YWFmMDk1NjJlNjQifSwgImlkIjog
-        IjU3OWJhNzZmN2JjMjVhYWYwOTU2MmU2NCJ9
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUByb2JvdC5leGFt
+        cGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNTgzZGRhMWQ2NzFlMDhlYWE2ZDI1NzVlIn0sICJpZCI6ICI1
+        ODNkZGExZDY3MWUwOGVhYTZkMjU3NWUifQ==
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:00 GMT
+  recorded_at: Tue, 29 Nov 2016 19:42:27 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/84ad72b2-cffc-44c5-81b7-76d81ed96e9e/
+    uri: https://robot.example.com/pulp/api/v2/tasks/a7137422-8726-450e-a413-00d95a4d06f3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -864,13 +865,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:59:02 GMT
+      - Tue, 29 Nov 2016 19:42:28 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1834'
+      - '1105'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -878,20 +879,140 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84NGFkNzJiMi1jZmZjLTQ0YzUtODFiNy03NmQ4MWVkOTZl
-        OWUvIiwgInRhc2tfaWQiOiAiODRhZDcyYjItY2ZmYy00NGM1LTgxYjctNzZk
-        ODFlZDk2ZTllIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
-        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMDctMjlU
-        MTg6NTk6MDFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
-        IjogIjIwMTYtMDctMjlUMTg6NTg6NTVaIiwgInRyYWNlYmFjayI6IG51bGws
+        aS92Mi90YXNrcy9hNzEzNzQyMi04NzI2LTQ1MGUtYTQxMy0wMGQ5NWE0ZDA2
+        ZjMvIiwgInRhc2tfaWQiOiAiYTcxMzc0MjItODcyNi00NTBlLWE0MTMtMDBk
+        OTVhNGQwNmYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMTEtMjlUMTk6
+        NDI6MjFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        W10sICJwcm9ncmVzc19yZXBvcnQiOiB7InB1cHBldF9pbXBvcnRlciI6IHsi
+        bW9kdWxlcyI6IHsiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJleGVjdXRpb25f
+        dGltZSI6IG51bGwsICJ0b3RhbF9jb3VudCI6IDQsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAiaW5kaXZpZHVhbF9lcnJvcnMiOiBbXSwgInN0YXRlIjogInJ1bm5p
+        bmciLCAiZXJyb3JfY291bnQiOiAwLCAiZXJyb3IiOiAiTm9uZSIsICJmaW5p
+        c2hlZF9jb3VudCI6IDJ9LCAibWV0YWRhdGEiOiB7InF1ZXJ5X2ZpbmlzaGVk
+        X2NvdW50IjogMSwgInRyYWNlYmFjayI6IG51bGwsICJleGVjdXRpb25fdGlt
+        ZSI6IDEsICJxdWVyeV90b3RhbF9jb3VudCI6IDEsICJlcnJvcl9tZXNzYWdl
+        IjogbnVsbCwgInN0YXRlIjogInN1Y2Nlc3MiLCAiZXJyb3IiOiAiTm9uZSIs
+        ICJjdXJyZW50X3F1ZXJ5IjogImh0dHA6Ly9kYXZpZGQuZmVkb3JhcGVvcGxl
+        Lm9yZy9yZXBvcy9yYW5kb21fcHVwcGV0L21vZHVsZXMuanNvbiJ9fX0sICJx
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUByb2JvdC5leGFt
+        cGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNTgzZGRhMWQ2NzFlMDhlYWE2ZDI1NzVlIn0sICJpZCI6ICI1
+        ODNkZGExZDY3MWUwOGVhYTZkMjU3NWUifQ==
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:42:28 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/a7137422-8726-450e-a413-00d95a4d06f3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:42:29 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1105'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hNzEzNzQyMi04NzI2LTQ1MGUtYTQxMy0wMGQ5NWE0ZDA2
+        ZjMvIiwgInRhc2tfaWQiOiAiYTcxMzc0MjItODcyNi00NTBlLWE0MTMtMDBk
+        OTVhNGQwNmYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6
+        ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTYtMTEtMjlUMTk6
+        NDI6MjFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjog
+        W10sICJwcm9ncmVzc19yZXBvcnQiOiB7InB1cHBldF9pbXBvcnRlciI6IHsi
+        bW9kdWxlcyI6IHsiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJleGVjdXRpb25f
+        dGltZSI6IG51bGwsICJ0b3RhbF9jb3VudCI6IDQsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAiaW5kaXZpZHVhbF9lcnJvcnMiOiBbXSwgInN0YXRlIjogInJ1bm5p
+        bmciLCAiZXJyb3JfY291bnQiOiAwLCAiZXJyb3IiOiAiTm9uZSIsICJmaW5p
+        c2hlZF9jb3VudCI6IDJ9LCAibWV0YWRhdGEiOiB7InF1ZXJ5X2ZpbmlzaGVk
+        X2NvdW50IjogMSwgInRyYWNlYmFjayI6IG51bGwsICJleGVjdXRpb25fdGlt
+        ZSI6IDEsICJxdWVyeV90b3RhbF9jb3VudCI6IDEsICJlcnJvcl9tZXNzYWdl
+        IjogbnVsbCwgInN0YXRlIjogInN1Y2Nlc3MiLCAiZXJyb3IiOiAiTm9uZSIs
+        ICJjdXJyZW50X3F1ZXJ5IjogImh0dHA6Ly9kYXZpZGQuZmVkb3JhcGVvcGxl
+        Lm9yZy9yZXBvcy9yYW5kb21fcHVwcGV0L21vZHVsZXMuanNvbiJ9fX0sICJx
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUByb2JvdC5leGFt
+        cGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNTgzZGRhMWQ2NzFlMDhlYWE2ZDI1NzVlIn0sICJpZCI6ICI1
+        ODNkZGExZDY3MWUwOGVhYTZkMjU3NWUifQ==
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:42:29 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/a7137422-8726-450e-a413-00d95a4d06f3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:42:31 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1832'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9hNzEzNzQyMi04NzI2LTQ1MGUtYTQxMy0wMGQ5NWE0ZDA2
+        ZjMvIiwgInRhc2tfaWQiOiAiYTcxMzc0MjItODcyNi00NTBlLWE0MTMtMDBk
+        OTVhNGQwNmYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTYtMTEtMjlU
+        MTk6NDI6MzBaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
+        IjogIjIwMTYtMTEtMjlUMTk6NDI6MjFaIiwgInRyYWNlYmFjayI6IG51bGws
         ICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzZjZjExN2NiLTIwN2ItNDkwMC04ZDEzLWUyNTNmY2RjNGM2Zi8iLCAi
-        dGFza19pZCI6ICI2Y2YxMTdjYi0yMDdiLTQ5MDAtOGQxMy1lMjUzZmNkYzRj
-        NmYifSwgeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMDU2YTg3M2Yt
-        M2Q4My00YjhmLThmNjQtYWRiOTBlNjcyYzI2LyIsICJ0YXNrX2lkIjogIjA1
-        NmE4NzNmLTNkODMtNGI4Zi04ZjY0LWFkYjkwZTY3MmMyNiJ9XSwgInByb2dy
+        c2tzL2JlNTVhYWRhLTRkODItNGY0NS1hMzMwLTFlMTE0MTVkMGM4NS8iLCAi
+        dGFza19pZCI6ICJiZTU1YWFkYS00ZDgyLTRmNDUtYTMzMC0xZTExNDE1ZDBj
+        ODUifSwgeyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNDNiM2ExZmUt
+        NmU3NS00ZWY3LWI5NmUtNzI2NGExNzZjYzNlLyIsICJ0YXNrX2lkIjogIjQz
+        YjNhMWZlLTZlNzUtNGVmNy1iOTZlLTcyNjRhMTc2Y2MzZSJ9XSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsicHVwcGV0X2ltcG9ydGVyIjogeyJtb2R1bGVzIjog
-        eyJlcnJvcl9tZXNzYWdlIjogbnVsbCwgImV4ZWN1dGlvbl90aW1lIjogNCwg
+        eyJlcnJvcl9tZXNzYWdlIjogbnVsbCwgImV4ZWN1dGlvbl90aW1lIjogNywg
         InRvdGFsX2NvdW50IjogNCwgInRyYWNlYmFjayI6IG51bGwsICJpbmRpdmlk
         dWFsX2Vycm9ycyI6IFtdLCAic3RhdGUiOiAic3VjY2VzcyIsICJlcnJvcl9j
         b3VudCI6IDAsICJlcnJvciI6ICJOb25lIiwgImZpbmlzaGVkX2NvdW50Ijog
@@ -901,27 +1022,27 @@ http_interactions:
         dGUiOiAic3VjY2VzcyIsICJlcnJvciI6ICJOb25lIiwgImN1cnJlbnRfcXVl
         cnkiOiAiaHR0cDovL2RhdmlkZC5mZWRvcmFwZW9wbGUub3JnL3JlcG9zL3Jh
         bmRvbV9wdXBwZXQvbW9kdWxlcy5qc29uIn19fSwgInF1ZXVlIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0xQG9iZWxpeC5leGFtcGxlLmNvbS5kcSIs
-        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
-        ZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJw
-        dXBwZXRfaW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQi
-        OiAiNCIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE2LTA3
-        LTI5VDE4OjU4OjU1WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAi
-        Y29tcGxldGVkIjogIjIwMTYtMDctMjlUMTg6NTk6MDFaIiwgImltcG9ydGVy
-        X3R5cGVfaWQiOiAicHVwcGV0X2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2Ui
-        OiBudWxsLCAic3VtbWFyeSI6IHsidG90YWxfZXhlY3V0aW9uX3RpbWUiOiA1
-        fSwgImFkZGVkX2NvdW50IjogNCwgInJlbW92ZWRfY291bnQiOiAwLCAidXBk
-        YXRlZF9jb3VudCI6IDAsICJpZCI6ICI1NzliYTc3NTcwYmU2ZjczOGVkZDlk
-        ZTkiLCAiZGV0YWlscyI6IHsiZmluaXNoZWRfY291bnQiOiA0LCAidG90YWxf
-        Y291bnQiOiA0LCAiZXJyb3JfY291bnQiOiAwfX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3NmY3YmMyNWFhZjA5NTYyZTY0In0s
-        ICJpZCI6ICI1NzliYTc2ZjdiYzI1YWFmMDk1NjJlNjQifQ==
+        dmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUuY29tLmRxIiwg
+        InN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVk
+        X3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAicHVw
+        cGV0X2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjog
+        IjQiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxNi0xMS0y
+        OVQxOTo0MjoyMVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE2LTExLTI5VDE5OjQyOjMwWiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInB1cHBldF9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjog
+        bnVsbCwgInN1bW1hcnkiOiB7InRvdGFsX2V4ZWN1dGlvbl90aW1lIjogOH0s
+        ICJhZGRlZF9jb3VudCI6IDQsICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0
+        ZWRfY291bnQiOiAwLCAiaWQiOiAiNTgzZGRhMjZiMGVhZjIwOTliNjgxODU2
+        IiwgImRldGFpbHMiOiB7ImZpbmlzaGVkX2NvdW50IjogNCwgInRvdGFsX2Nv
+        dW50IjogNCwgImVycm9yX2NvdW50IjogMH19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU4M2RkYTFkNjcxZTA4ZWFhNmQyNTc1ZSJ9LCAi
+        aWQiOiAiNTgzZGRhMWQ2NzFlMDhlYWE2ZDI1NzVlIn0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:02 GMT
+  recorded_at: Tue, 29 Nov 2016 19:42:31 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/6cf117cb-207b-4900-8d13-e253fcdc4c6f/
+    uri: https://robot.example.com/pulp/api/v2/tasks/be55aada-4d82-4f45-a330-1e11415d0c85/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -940,13 +1061,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:59:02 GMT
+      - Tue, 29 Nov 2016 19:42:31 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1408'
+      - '1406'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -954,12 +1075,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82Y2YxMTdjYi0yMDdiLTQ5MDAtOGQxMy1lMjUz
-        ZmNkYzRjNmYvIiwgInRhc2tfaWQiOiAiNmNmMTE3Y2ItMjA3Yi00OTAwLThk
-        MTMtZTI1M2ZjZGM0YzZmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0
+        dWxwL2FwaS92Mi90YXNrcy9iZTU1YWFkYS00ZDgyLTRmNDUtYTMzMC0xZTEx
+        NDE1ZDBjODUvIiwgInRhc2tfaWQiOiAiYmU1NWFhZGEtNGQ4Mi00ZjQ1LWEz
+        MzAtMWUxMTQxNWQwYzg1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0
         IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogIjIw
-        MTYtMDctMjlUMTg6NTk6MDFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
-        dGFydF90aW1lIjogIjIwMTYtMDctMjlUMTg6NTk6MDFaIiwgInRyYWNlYmFj
+        MTYtMTEtMjlUMTk6NDI6MzBaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
+        dGFydF90aW1lIjogIjIwMTYtMTEtMjlUMTk6NDI6MzBaIiwgInRyYWNlYmFj
         ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBv
         cnQiOiB7IjRfcHVwcGV0IjogeyJtb2R1bGVzIjogeyJlcnJvcl9tZXNzYWdl
         IjogbnVsbCwgImV4ZWN1dGlvbl90aW1lIjogMCwgInRvdGFsX2NvdW50Ijog
@@ -970,25 +1091,25 @@ http_interactions:
         ICJtZXRhZGF0YSI6IHsiZXhlY3V0aW9uX3RpbWUiOiAwLCAic3RhdGUiOiAi
         c3VjY2VzcyIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgImVycm9yIjogIk5v
         bmUiLCAidHJhY2ViYWNrIjogbnVsbH19fSwgInF1ZXVlIjogInJlc2VydmVk
-        X3Jlc291cmNlX3dvcmtlci0xQG9iZWxpeC5leGFtcGxlLmNvbS5kcSIsICJz
-        dGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
-        ZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBsZS5jb20iLCAicmVzdWx0
-        IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAi
-        cmVwb19pZCI6ICI0IiwgInN0YXJ0ZWQiOiAiMjAxNi0wNy0yOVQxODo1OTow
-        MVoiLCAiX25zIjogInJlcG9fcHVibGlzaF9yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDE2LTA3LTI5VDE4OjU5OjAxWiIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJwdXBwZXRfZGlzdHJpYnV0b3Ii
-        LCAic3VtbWFyeSI6IHsidG90YWxfZXhlY3V0aW9uX3RpbWUiOiAwfSwgImVy
-        cm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3JfaWQiOiAiNF9wdXBw
-        ZXQiLCAiaWQiOiAiNTc5YmE3NzU3MGJlNmY3MzhlZGQ5ZGVhIiwgImRldGFp
-        bHMiOiB7fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTc5
-        YmE3NzU3YmMyNWFhZjA5NTYyZTY5In0sICJpZCI6ICI1NzliYTc3NTdiYzI1
-        YWFmMDk1NjJlNjkifQ==
+        X3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUuY29tLmRxIiwgInN0
+        YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
+        IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiNCIsICJzdGFydGVkIjogIjIwMTYtMTEtMjlUMTk6NDI6MzBa
+        IiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0cyIsICJjb21wbGV0ZWQi
+        OiAiMjAxNi0xMS0yOVQxOTo0MjozMFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAicHVwcGV0X2Rpc3RyaWJ1dG9yIiwg
+        InN1bW1hcnkiOiB7InRvdGFsX2V4ZWN1dGlvbl90aW1lIjogMH0sICJlcnJv
+        cl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogIjRfcHVwcGV0
+        IiwgImlkIjogIjU4M2RkYTI2YjBlYWYyMDk5YjY4MTg1NyIsICJkZXRhaWxz
+        Ijoge319LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU4M2Rk
+        YTI2NjcxZTA4ZWFhNmQyNTc2MyJ9LCAiaWQiOiAiNTgzZGRhMjY2NzFlMDhl
+        YWE2ZDI1NzYzIn0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:02 GMT
+  recorded_at: Tue, 29 Nov 2016 19:42:31 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/056a873f-3d83-4b8f-8f64-adb90e672c26/
+    uri: https://robot.example.com/pulp/api/v2/tasks/43b3a1fe-6e75-4ef7-b96e-7264a176cc3e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1007,13 +1128,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:59:02 GMT
+      - Tue, 29 Nov 2016 19:42:31 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1284'
+      - '1282'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1021,38 +1142,38 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8wNTZhODczZi0zZDgzLTRiOGYtOGY2NC1hZGI5
-        MGU2NzJjMjYvIiwgInRhc2tfaWQiOiAiMDU2YTg3M2YtM2Q4My00YjhmLThm
-        NjQtYWRiOTBlNjcyYzI2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0
+        dWxwL2FwaS92Mi90YXNrcy80M2IzYTFmZS02ZTc1LTRlZjctYjk2ZS03MjY0
+        YTE3NmNjM2UvIiwgInRhc2tfaWQiOiAiNDNiM2ExZmUtNmU3NS00ZWY3LWI5
+        NmUtNzI2NGExNzZjYzNlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0
         IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogIjIw
-        MTYtMDctMjlUMTg6NTk6MDFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
-        dGFydF90aW1lIjogIjIwMTYtMDctMjlUMTg6NTk6MDFaIiwgInRyYWNlYmFj
+        MTYtMTEtMjlUMTk6NDI6MzFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJz
+        dGFydF90aW1lIjogIjIwMTYtMTEtMjlUMTk6NDI6MzBaIiwgInRyYWNlYmFj
         ayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBv
         cnQiOiB7fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
-        QG9iZWxpeC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBv
-        YmVsaXguZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3Vj
-        Y2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICI0IiwgInN0
-        YXJ0ZWQiOiAiMjAxNi0wNy0yOVQxODo1OTowMVoiLCAiX25zIjogInJlcG9f
-        cHVibGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTA3LTI5VDE4
-        OjU5OjAxWiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlw
-        ZV9pZCI6ICJwdXBwZXRfaW5zdGFsbF9kaXN0cmlidXRvciIsICJzdW1tYXJ5
-        IjogInN1Y2Nlc3MiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmli
-        dXRvcl9pZCI6ICI0IiwgImlkIjogIjU3OWJhNzc1NzBiZTZmNzM4ZWRkOWRl
-        YiIsICJkZXRhaWxzIjogeyJlcnJvcnMiOiBbXSwgInN1Y2Nlc3NfdW5pdF9r
-        ZXlzIjogW3sidmVyc2lvbiI6ICIwLjIuMCIsICJuYW1lIjogInNhbWJhIiwg
-        ImF1dGhvciI6ICJwdXBwZXQifSwgeyJ2ZXJzaW9uIjogIjAuMC4xIiwgIm5h
-        bWUiOiAiY3JvbiIsICJhdXRob3IiOiAicHVwcGV0In0sIHsidmVyc2lvbiI6
-        ICIwLjIuMCIsICJuYW1lIjogImh0dHBkIiwgImF1dGhvciI6ICI1dWJaM3Iw
-        In0sIHsidmVyc2lvbiI6ICIxLjAuMiIsICJuYW1lIjogInB1cmVmdHBkIiwg
-        ImF1dGhvciI6ICJzYXoifV19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
-        JG9pZCI6ICI1NzliYTc3NTdiYzI1YWFmMDk1NjJlNmEifSwgImlkIjogIjU3
-        OWJhNzc1N2JjMjVhYWYwOTU2MmU2YSJ9
+        QHJvYm90LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJv
+        Ym90LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
+        c3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiNCIsICJzdGFy
+        dGVkIjogIjIwMTYtMTEtMjlUMTk6NDI6MzBaIiwgIl9ucyI6ICJyZXBvX3B1
+        Ymxpc2hfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0xMS0yOVQxOTo0
+        MjozMVoiLCAidHJhY2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVf
+        aWQiOiAicHVwcGV0X2luc3RhbGxfZGlzdHJpYnV0b3IiLCAic3VtbWFyeSI6
+        ICJzdWNjZXNzIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0
+        b3JfaWQiOiAiNCIsICJpZCI6ICI1ODNkZGEyN2IwZWFmMjA5OWI2ODE4NTgi
+        LCAiZGV0YWlscyI6IHsiZXJyb3JzIjogW10sICJzdWNjZXNzX3VuaXRfa2V5
+        cyI6IFt7InZlcnNpb24iOiAiMS4wLjIiLCAibmFtZSI6ICJwdXJlZnRwZCIs
+        ICJhdXRob3IiOiAic2F6In0sIHsidmVyc2lvbiI6ICIwLjIuMCIsICJuYW1l
+        IjogImh0dHBkIiwgImF1dGhvciI6ICI1dWJaM3IwIn0sIHsidmVyc2lvbiI6
+        ICIwLjIuMCIsICJuYW1lIjogInNhbWJhIiwgImF1dGhvciI6ICJwdXBwZXQi
+        fSwgeyJ2ZXJzaW9uIjogIjAuMC4xIiwgIm5hbWUiOiAiY3JvbiIsICJhdXRo
+        b3IiOiAicHVwcGV0In1dfX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRv
+        aWQiOiAiNTgzZGRhMjY2NzFlMDhlYWE2ZDI1NzY0In0sICJpZCI6ICI1ODNk
+        ZGEyNjY3MWUwOGVhYTZkMjU3NjQifQ==
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:02 GMT
+  recorded_at: Tue, 29 Nov 2016 19:42:31 GMT
 - request:
     method: post
-    uri: https://obelix.example.com/pulp/api/v2/repositories/4/search/units/
+    uri: https://robot.example.com/pulp/api/v2/repositories/4/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1075,7 +1196,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:59:02 GMT
+      - Tue, 29 Nov 2016 19:42:31 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -1087,40 +1208,41 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICI3NjllNjY1ZS0wYTU1LTQ2MGQtOGU0
-        My1jNzY5MjM1ZDY0ZGIiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwdXBwZXRf
-        bW9kdWxlIn0sICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3NzM3YmMyNWFhZjA5
-        NTYyZTY2In0sICJ1bml0X2lkIjogIjc2OWU2NjVlLTBhNTUtNDYwZC04ZTQz
-        LWM3NjkyMzVkNjRkYiIsICJ1bml0X3R5cGVfaWQiOiAicHVwcGV0X21vZHVs
-        ZSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiOGY3NjNiOWYtMzFhMS00MTRi
-        LThmNmEtYmY0OTI0YjczNzliIiwgIl9jb250ZW50X3R5cGVfaWQiOiAicHVw
-        cGV0X21vZHVsZSJ9LCAiX2lkIjogeyIkb2lkIjogIjU3OWJhNzc1N2JjMjVh
-        YWYwOTU2MmU2OCJ9LCAidW5pdF9pZCI6ICI4Zjc2M2I5Zi0zMWExLTQxNGIt
-        OGY2YS1iZjQ5MjRiNzM3OWIiLCAidW5pdF90eXBlX2lkIjogInB1cHBldF9t
-        b2R1bGUifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjogImI3M2NlZmZlLTcwZTQt
-        NDk1OC1iNmI0LTdkODg3OGI2Y2Q1NCIsICJfY29udGVudF90eXBlX2lkIjog
-        InB1cHBldF9tb2R1bGUifSwgIl9pZCI6IHsiJG9pZCI6ICI1NzliYTc3NDdi
-        YzI1YWFmMDk1NjJlNjcifSwgInVuaXRfaWQiOiAiYjczY2VmZmUtNzBlNC00
-        OTU4LWI2YjQtN2Q4ODc4YjZjZDU0IiwgInVuaXRfdHlwZV9pZCI6ICJwdXBw
-        ZXRfbW9kdWxlIn0sIHsibWV0YWRhdGEiOiB7Il9pZCI6ICJmZWYyMTdlMy01
-        YzNiLTQzMmEtYThkZC1mNmUzZmM2ZGQxMzkiLCAiX2NvbnRlbnRfdHlwZV9p
-        ZCI6ICJwdXBwZXRfbW9kdWxlIn0sICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3
-        NzI3YmMyNWFhZjA5NTYyZTY1In0sICJ1bml0X2lkIjogImZlZjIxN2UzLTVj
-        M2ItNDMyYS1hOGRkLWY2ZTNmYzZkZDEzOSIsICJ1bml0X3R5cGVfaWQiOiAi
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIxNDAzOGMyYy0wZmM0LTQ5YWYtYjQx
+        My1hMGJmMmZlYzc4NTMiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwdXBwZXRf
+        bW9kdWxlIn0sICJfaWQiOiB7IiRvaWQiOiAiNTgzZGRhMjA2NzFlMDhlYWE2
+        ZDI1NzVmIn0sICJ1bml0X2lkIjogIjE0MDM4YzJjLTBmYzQtNDlhZi1iNDEz
+        LWEwYmYyZmVjNzg1MyIsICJ1bml0X3R5cGVfaWQiOiAicHVwcGV0X21vZHVs
+        ZSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiMjJhYjNlMmMtYzVhNi00MmNl
+        LTk1NTQtMDBlNzEwMWQzNmM2IiwgIl9jb250ZW50X3R5cGVfaWQiOiAicHVw
+        cGV0X21vZHVsZSJ9LCAiX2lkIjogeyIkb2lkIjogIjU4M2RkYTI1NjcxZTA4
+        ZWFhNmQyNTc2MSJ9LCAidW5pdF9pZCI6ICIyMmFiM2UyYy1jNWE2LTQyY2Ut
+        OTU1NC0wMGU3MTAxZDM2YzYiLCAidW5pdF90eXBlX2lkIjogInB1cHBldF9t
+        b2R1bGUifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjogIjQ1MDA1MTkwLTdhNzQt
+        NGUzMS04MzA4LWZhNmRhODU2MjdmNSIsICJfY29udGVudF90eXBlX2lkIjog
+        InB1cHBldF9tb2R1bGUifSwgIl9pZCI6IHsiJG9pZCI6ICI1ODNkZGEyMTY3
+        MWUwOGVhYTZkMjU3NjAifSwgInVuaXRfaWQiOiAiNDUwMDUxOTAtN2E3NC00
+        ZTMxLTgzMDgtZmE2ZGE4NTYyN2Y1IiwgInVuaXRfdHlwZV9pZCI6ICJwdXBw
+        ZXRfbW9kdWxlIn0sIHsibWV0YWRhdGEiOiB7Il9pZCI6ICI4MGZhOGUzYy05
+        OGVkLTQyOWQtYjNmMC1kZTg4MDVjNDQ4MmIiLCAiX2NvbnRlbnRfdHlwZV9p
+        ZCI6ICJwdXBwZXRfbW9kdWxlIn0sICJfaWQiOiB7IiRvaWQiOiAiNTgzZGRh
+        MjY2NzFlMDhlYWE2ZDI1NzYyIn0sICJ1bml0X2lkIjogIjgwZmE4ZTNjLTk4
+        ZWQtNDI5ZC1iM2YwLWRlODgwNWM0NDgyYiIsICJ1bml0X3R5cGVfaWQiOiAi
         cHVwcGV0X21vZHVsZSJ9XQ==
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:02 GMT
+  recorded_at: Tue, 29 Nov 2016 19:42:31 GMT
 - request:
     method: post
-    uri: https://obelix.example.com/pulp/api/v2/content/units/puppet_module/search/
+    uri: https://robot.example.com/pulp/api/v2/content/units/puppet_module/search/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiNzY5ZTY2
-        NWUtMGE1NS00NjBkLThlNDMtYzc2OTIzNWQ2NGRiIiwiOGY3NjNiOWYtMzFh
-        MS00MTRiLThmNmEtYmY0OTI0YjczNzliIiwiYjczY2VmZmUtNzBlNC00OTU4
-        LWI2YjQtN2Q4ODc4YjZjZDU0IiwiZmVmMjE3ZTMtNWMzYi00MzJhLWE4ZGQt
-        ZjZlM2ZjNmRkMTM5Il19fX0sImluY2x1ZGVfcmVwb3MiOnRydWV9
+        eyJjcml0ZXJpYSI6eyJsaW1pdCI6NCwic2tpcCI6MCwiZmlsdGVycyI6eyJf
+        aWQiOnsiJGluIjpbIjE0MDM4YzJjLTBmYzQtNDlhZi1iNDEzLWEwYmYyZmVj
+        Nzg1MyIsIjIyYWIzZTJjLWM1YTYtNDJjZS05NTU0LTAwZTcxMDFkMzZjNiIs
+        IjQ1MDA1MTkwLTdhNzQtNGUzMS04MzA4LWZhNmRhODU2MjdmNSIsIjgwZmE4
+        ZTNjLTk4ZWQtNDI5ZC1iM2YwLWRlODgwNWM0NDgyYiJdfX19LCJpbmNsdWRl
+        X3JlcG9zIjp0cnVlfQ==
     headers:
       Accept:
       - application/json
@@ -1129,7 +1251,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '219'
+      - '238'
       User-Agent:
       - Ruby
   response:
@@ -1138,7 +1260,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:59:02 GMT
+      - Tue, 29 Nov 2016 19:42:31 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -1151,294 +1273,234 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         W3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcHVwcGV0
-        X21vZHVsZS83NjllNjY1ZS0wYTU1LTQ2MGQtOGU0My1jNzY5MjM1ZDY0ZGIv
+        X21vZHVsZS8xNDAzOGMyYy0wZmM0LTQ5YWYtYjQxMy1hMGJmMmZlYzc4NTMv
         IiwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9p
-        ZCI6ICJwdXBwZXRfbW9kdWxlIiwgImNoZWNrc3VtcyI6IFtbIm1hbmlmZXN0
-        cy9zZXJ2aWNlLnBwIiwgIjE5MmM4MTk3OTFlMjA0MjcwMzg5MWU1MWE2MWQz
-        MTRhIl0sIFsiTW9kdWxlZmlsZSIsICJkMzA5ZWUzMTUxNzZlYTNmOTIzNDgw
-        YzI4NmUzYTU1YiJdLCBbInNwZWMvc3BlYy5vcHRzIiwgImE2MDBkZWQ5OTVk
-        OTQ4ZTM5M2ZiZTIzMjBiYThlNTFjIl0sIFsidGVzdHMvaW5pdC5wcCIsICI0
-        ZGNjMjg2OGNiOTc0MGMzMmViNjhmMzQ1YTdiNzE5NCJdLCBbInNwZWMvc3Bl
-        Y19oZWxwZXIucmIiLCAiY2ExOWVjNGY0NTFlYmM3ZmRiMDM1YjUyZWFlNmU5
-        MDkiXSwgWyJtYW5pZmVzdHMvY29uZi5wcCIsICJhZDRiMjg1YTY3MzZhZWJl
-        YmI2ZmE1OWUzOGRkZGVkMSJdLCBbIm1hbmlmZXN0cy9wYXJhbXMucHAiLCAi
-        ZjQxZDExZTdkYmJkZTY3YTJjZjRkMjljZjY3ODNhNTUiXSwgWyJtYW5pZmVz
-        dHMvaW5zdGFsbC5wcCIsICJjOTI5ZTEzZjU0NmJjZGIzZjAyZWZlZGU5ZGIx
-        YWY5YiJdLCBbIm1hbmlmZXN0cy9pbml0LnBwIiwgImY2NThiNTk0YWM4OGRh
-        OTAyNmM2NzViZmUwMzEwZDU3Il0sIFsiUkVBRE1FIiwgIjYyN2ZiYjU3ZWI4
-        ZDk0MzA4ZjAxYTExNDMwNDE4ZmI2Il1dLCAiY2hpbGRyZW4iOiB7fSwgImF1
-        dGhvciI6ICJwdXBwZXQiLCAicHJvamVjdF9wYWdlIjogImh0dHBzOi8vZ2l0
-        aHViLmNvbS81VWItWjNyMC9wdXBwZXQtc2FtYmEiLCAic291cmNlIjogImh0
-        dHBzOi8vZ2l0aHViLmNvbS81VWItWjNyMC9wdXBwZXQtc2FtYmEiLCAidmVy
-        c2lvbiI6ICIwLjIuMCIsICJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyI0
-        Il0sICJkZXNjcmlwdGlvbiI6ICJUaGlzIHB1cHBldCBtb2R1bGUgbWFuYWdl
-        cyBzYW1iYSBjb25maWd1cmF0aW9uLlxuXG5JdCBoYXMgYmVlbiB0ZXN0ZWQg
-        b25seSBmb3Igc2FtYmEgbWFuYWdpbmcgc2hhcmVzLCB0b3VnaCBpdCBkb2Vz
-        IG5vdCBjYXJlIGFib3V0IHRoZSBjb250ZW50IG9mIHlvdXIgY29uZmlnIGZp
-        bGUuXG5cblRlc3RlZCBvbiBDZW50T1MgNi4yLCBSSEVMIDYuMiwgQ2VudE9T
-        IDUuOC4iLCAiX2xhc3RfdXBkYXRlZCI6ICIyMDE2LTA3LTI5VDE4OjU4OjU5
-        WiIsICJkb3dubG9hZGVkIjogdHJ1ZSwgImRlcGVuZGVuY2llcyI6IFtdLCAi
-        dHlwZXMiOiBbXSwgIl9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVscC9j
-        b250ZW50L3VuaXRzL3B1cHBldF9tb2R1bGUvZDUvNjFjZjdkYzFjMmI4N2Qy
-        YWNlMDRmNjM1OGEzMmUwMWMwYWZjNTYzZTYzNGU5YjE3MzQ1ZGExODVkM2M0
-        NzUvNVViWjNyMC1zYW1iYS0wLjIuMC50YXIuZ3oiLCAiX2lkIjogIjc2OWU2
-        NjVlLTBhNTUtNDYwZC04ZTQzLWM3NjkyMzVkNjRkYiIsICJuYW1lIjogInNh
-        bWJhIiwgImxpY2Vuc2UiOiAiR1BMIHYzIiwgImNoZWNrc3VtIjogImM3NzJk
-        ZWNmNzgzNmU0MmE3MjE1YzJhZWUzZjhiZDc0MmUxYzQ4MDM5NGE2NTBiNjU5
-        NDdiM2MwODMyODRjYWMiLCAic3VtbWFyeSI6ICJBIHB1cHBldCBtb2R1bGUg
-        dGhhdCBtYW5hZ2VzIHNhbWJhIiwgImNoZWNrc3VtX3R5cGUiOiAic2hhMjU2
-        IiwgInRhZ19saXN0IjogW119LCB7Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9j
-        b250ZW50L3VuaXRzL3B1cHBldF9tb2R1bGUvOGY3NjNiOWYtMzFhMS00MTRi
-        LThmNmEtYmY0OTI0YjczNzliLyIsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7
-        fSwgIl9jb250ZW50X3R5cGVfaWQiOiAicHVwcGV0X21vZHVsZSIsICJjaGVj
-        a3N1bXMiOiBbWyJtYW5pZmVzdHMvdGFzay5wcCIsICI0Y2I0YWE0OWRmOGM5
-        MDYxOWQ5MDM5OTkyYTUxNmMwNyJdLCBbInNwZWMvc3BlYy5vcHRzIiwgImE2
-        MDBkZWQ5OTVkOTQ4ZTM5M2ZiZTIzMjBiYThlNTFjIl0sIFsibWFuaWZlc3Rz
-        L21vbnRobHkucHAiLCAiYjk5MDBmNmUyZGIwODU0ZjM0YzY2OTMwMjg3ZGI3
-        MDAiXSwgWyJ0ZXN0cy9pbml0LnBwIiwgIjRiY2I3ZTAzYWNlZDhiYjQ2ODM1
-        MWE0NWU4ZTliYzc2Il0sIFsic3BlYy9zcGVjX2hlbHBlci5yYiIsICJjYTE5
-        ZWM0ZjQ1MWViYzdmZGIwMzViNTJlYWU2ZTkwOSJdLCBbIm1hbmlmZXN0cy93
-        ZWVrbHkucHAiLCAiN2QzNGEwMGQ2Mjk1NzVlZTJlNGY0YmQ1OGVhYjFkNDAi
-        XSwgWyJtYW5pZmVzdHMvZGFpbHkucHAiLCAiOTZmZmQwZTU5MmRlM2Y1ZGQw
-        NTRkZTM3NTVhOGJjZmYiXSwgWyJNb2R1bGVmaWxlIiwgIjE4YzkyMDhlNzdh
-        M2M0M2I0ZGY2NWFlOGJiM2JmODA0Il0sIFsibWFuaWZlc3RzL2luaXQucHAi
-        LCAiOGMzZTEwYmMzZTI0NjU5MDg0MzZmMWFhNzcxZjAzOWIiXSwgWyJtYW5p
-        ZmVzdHMvaG91cmx5LnBwIiwgIjdhMTc2MjFhNzMxNzUwYzQwYzg3MmU3YTVi
-        NmY0NDQyIl0sIFsiUkVBRE1FIiwgIjQ5MWU2M2E5Y2Y3NWY4MjUzNjk1Mjg5
-        ODNjYWFlODdhIl0sIFsibWFuaWZlc3RzL3BhcmFtcy5wcCIsICJkNTkyNDkx
-        OGZjMDU5ZGFhNDdhYTM1NTUzNGE0YjQzNCJdXSwgImNoaWxkcmVuIjoge30s
-        ICJhdXRob3IiOiAicHVwcGV0IiwgInByb2plY3RfcGFnZSI6ICJodHRwczov
-        L2dpdGh1Yi5jb20vNVViLVozcjAvcHVwcGV0LWNyb24iLCAic291cmNlIjog
-        Imh0dHBzOi8vZ2l0aHViLmNvbS81VWItWjNyMC9wdXBwZXQtY3Jvbi5naXQi
-        LCAidmVyc2lvbiI6ICIwLjAuMSIsICJyZXBvc2l0b3J5X21lbWJlcnNoaXBz
-        IjogWyI0Il0sICJkZXNjcmlwdGlvbiI6ICJUaGlzIHB1cHBldCBtb2R1bGUg
-        bWFuYWdlcyB0aGUgc2NoZWR1bGluZyBvZiB0YXNrIHRyb3VnaCBjcm9uLlxu
-        SXQgaGFzIHNob3J0Y3V0cyAgY2xhc3NlcyBmb3IgaG91cmx5ICgvZXRjL2Ny
-        b24uaG91cmx5KSwgZGFpbHkgKC9ldGMvY3Jvbi5kYWlseSksIHdlZWtseSAo
-        L2V0Yy9jcm9uLmRhaWx5KSBhbmQgbW9udGhseSAoL2V0Yy9jcm9uLm1vbnRo
-        bHkpIHNjaGVkdWxhdGlvbi5cblxuSXQgaGFzIGJlZW4gdGVzdGVkIG9ubHkg
-        Li4uXG5cblRlc3RlZCBvbiBDZW50T1MgNi4yLCBSSEVMIDYuMiwgQ2VudE9T
-        IDUuOC5cblxuUmVxdWlyZW1lbnRzOlxuXG4gKiBbRmFjdGVyXShodHRwOi8v
-        d3d3LnB1cHBldGxhYnMuY29tL3B1cHBldC9yZWxhdGVkLXByb2plY3RzL2Zh
-        Y3Rlci8pIDEuNi4xIG9yIGdyZWF0ZXIgKHZlcnNpb25zIHRoYXQgc3VwcG9y
-        dCB0aGUgb3NmYW1pbHkgZmFjdClcbiAqIFtwdXBwZXRsYWJzL3N0ZGxpYl0g
-        Zm9yIHRoZSB2YWxpZGF0ZV9hYnNvbHV0ZV9wYXRoIHN0YXRlbWVudFxuXG5U
-        b2RvOlxuLSBTZXQgdXAgYW5kIGluc3RhbGwgY3JvbiBpbiB0aGUgLSB2ZXJ5
-        IHVubGlrZWx5IC0gY2FzZSB0aGF0IGl0J3Mgbm90IGluc3RhbGxlZDtcbi0g
-        TWFrZSBjcm9uOjp0YXNrIHdvcmsgd2l0aCB3aW5kb3dzLiIsICJfbGFzdF91
-        cGRhdGVkIjogIjIwMTYtMDctMjlUMTg6NTk6MDFaIiwgImRvd25sb2FkZWQi
-        OiB0cnVlLCAiZGVwZW5kZW5jaWVzIjogW3sibmFtZSI6ICJwdXBwZXRsYWJz
-        L3N0ZGxpYiIsICJ2ZXJzaW9uX3JlcXVpcmVtZW50IjogIj49My4wLjAifV0s
-        ICJ0eXBlcyI6IFtdLCAiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxw
-        L2NvbnRlbnQvdW5pdHMvcHVwcGV0X21vZHVsZS83My85MTBiMjY2ZDZlMjBk
-        NjczOWQzZmIwYzY1OWIwYzQ4MDBmMjc5NDc1YWEzZGNmMWVmZmIzZWZmNmYw
-        YzhlYi81VWJaM3IwLWNyb24tMC4wLjEudGFyLmd6IiwgIl9pZCI6ICI4Zjc2
-        M2I5Zi0zMWExLTQxNGItOGY2YS1iZjQ5MjRiNzM3OWIiLCAibmFtZSI6ICJj
-        cm9uIiwgImxpY2Vuc2UiOiAiR1BMIHYzIiwgImNoZWNrc3VtIjogIjBlOTQ4
-        NWUwMDQyNjM2YzA5NTIyMDVjZDY3YWQ2NjkwNGQwYzRmNmIzN2VhMTkyZDE1
-        Yjc2NDI2ZTk2MTA0YTYiLCAic3VtbWFyeSI6ICJQdXBwZXQgbW9kdWxlIHRo
-        YXQgbWFuYWdlcyBzY2hlZHVsaW5nIG9mIHRhc2sgdHJvdWdoIGNyb24iLCAi
-        Y2hlY2tzdW1fdHlwZSI6ICJzaGEyNTYiLCAidGFnX2xpc3QiOiBbXX0sIHsi
-        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcHVwcGV0X21v
-        ZHVsZS9iNzNjZWZmZS03MGU0LTQ5NTgtYjZiNC03ZDg4NzhiNmNkNTQvIiwg
-        InB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6
-        ICJwdXBwZXRfbW9kdWxlIiwgImNoZWNrc3VtcyI6IFtbImZpbGVzL2RlZmxh
-        dGUuY29uZiIsICIxZmM2NzhhYTk2N2Y0ZmQzYzgyMzhjOTExMTAxOWExZCJd
-        LCBbInNwZWMvc3BlYy5vcHRzIiwgImE2MDBkZWQ5OTVkOTQ4ZTM5M2ZiZTIz
-        MjBiYThlNTFjIl0sIFsidGVtcGxhdGVzL2h0dHBkLmNvbmYuUkhFTC5lcmIi
-        LCAiNGNiY2MyOTc2NTM1NmFlYjlhMDFiZWVjZTY3MzhmZTgiXSwgWyJmaWxl
-        cy9zcGR5L21vZC1zcGR5LWJldGFfY3VycmVudF9pMzg2LnJwbSIsICI0YWJk
-        ZWUzNTM5MmMxYzZkMzI5ZGVmMjAxNzM5MzQwMyJdLCBbInRlbXBsYXRlcy9w
-        aHAuaW5pLlJIRUwuZXJiIiwgIjI1Y2JiNzYwZTVmY2Y4MTE2NWZiYzMzY2U5
-        OGZlNmQ5Il0sIFsibWFuaWZlc3RzL3BhcmFtcy5wcCIsICJkMDJlYjg3YTNl
-        ZDY5ZmY2MzhjYTAyOGI2NzAwMTYyMSJdLCBbImZpbGVzL2Vycm9yL2Vycm9y
-        Lmh0bWwiLCAiM2FmODQxMWM4MmEwNzI1YzBiYTZiYTBmYTY4MWJkMDgiXSwg
-        WyJmaWxlcy9zcGR5L21vZC1zcGR5LWJldGFfY3VycmVudF94ODZfNjQucnBt
-        IiwgIjZkMjVkMDNiZmI4MjQ5ZjdjNmRjZDk5MDY5MDljOTk1Il0sIFsibWFu
-        aWZlc3RzL3NzbC5wcCIsICI2ZDhhOWNhZjFhMTMxMzJiNmNkMjQ2NGRhNjA2
-        MjgxYiJdLCBbIm1hbmlmZXN0cy9pbml0LnBwIiwgImZjZDhjOGY5NzY3MTBl
-        YWM2NTMyYWRjMmYyOGJmYTQ0Il0sIFsibWFuaWZlc3RzL2Rldi5wcCIsICIx
-        M2UwNTY0ZDM2NmYyNzY5NGIxMTVmODExMjQwNjQyOSJdLCBbIm1hbmlmZXN0
-        cy92aG9zdC5wcCIsICI2ZWFjODQyMDFkMjM5NDM2YzM4NmZlMmFkZjRjNDI1
-        MiJdLCBbImZpbGVzL3NwZHkvbW9kLXNwZHktYmV0YV9jdXJyZW50X2kzODYu
-        ZGViIiwgIjdkNzI0NzRlMzk4M2YzOTBkYWY4OWYxMjg5ZTA4NTIxIl0sIFsi
-        dGVtcGxhdGVzL3NzbC5jb25mLlJIRUwuZXJiIiwgImYxMTY2MThmYjg1ZmZk
-        ZGEzY2VmMWZjZjVhODIxMGM4Il0sIFsibGliL3B1cHBldC9wcm92aWRlci9h
-        Mm1vZC9hMm1vZC5yYiIsICIwYWNmNDJkM2Q2NzBhOTkxNWM1YTNmNDZhZTcz
-        MzVmMSJdLCBbImxpYi9wdXBwZXQvcHJvdmlkZXIvYTJtb2QvbW9kZml4LnJi
-        IiwgImY0NTM2Y2RjYTY4ZDE1YTIzNWNiYjFlMGI2N2U0NDA2Il0sIFsidGVt
-        cGxhdGVzL2xvY2FsaXplZC1lcnJvci1wYWdlcy5EZWJpYW4uZXJiIiwgIjU3
-        OGRmZDUzNzkxMWE3YjhkZGNkNDg1NjQwNDUyYWMzIl0sIFsic3BlYy9zcGVj
-        X2hlbHBlci5yYiIsICJjYTE5ZWM0ZjQ1MWViYzdmZGIwMzViNTJlYWU2ZTkw
-        OSJdLCBbIm1hbmlmZXN0cy9zcGR5LnBwIiwgImVmNzkyYjQxNDA4MjM2YWVk
-        YTdmNTdhNDI3ZjU3NGViIl0sIFsiZmlsZXMvc3BkeS9tb2Qtc3BkeS1iZXRh
-        X2N1cnJlbnRfYW1kNjQuZGViIiwgIjgzNGM4NTAzOGFlNTAyNjBkYTNhMDcw
-        Y2ZhMGNkYmRmIl0sIFsiTW9kdWxlZmlsZSIsICJlYTMzZTJkN2ZlNGQ5N2Vh
-        ZmEwNzE3MmM5MmMxMzBkYiJdLCBbIm1hbmlmZXN0cy9waHAucHAiLCAiNTZl
-        YTdmMjk3YWFhY2RkZTAwMWQzNTI5MDUxYjNjMGUiXSwgWyJ0ZW1wbGF0ZXMv
-        dmhvc3QtZGVmYXVsdC5jb25mLmVyYiIsICJlZDY0YTUzYWYwZDdiYWQ3NjIx
-        NzZhOThjOWVhM2U2MiJdLCBbIlJFQURNRSIsICI0YzliNDM2ZTQ4YTQ0N2Q2
-        MzRlYjgyMWMwNmZmZjZmYyJdLCBbInRlbXBsYXRlcy9waHAuaW5pLkRlYmlh
-        bi5lcmIiLCAiMTgwYTM5Y2EyNjJlMTMyYzZkNDMxOTczOTg2ZDdlMzkiXSwg
-        WyJsaWIvcHVwcGV0L3R5cGUvYTJtb2QucmIiLCAiYWRjZjc1NGEwNzYxNTM0
-        NDJlYWMyYmViNDI3MzY1NDciXV0sICJjaGlsZHJlbiI6IHt9LCAiYXV0aG9y
-        IjogIjV1YlozcjAiLCAicHJvamVjdF9wYWdlIjogIiIsICJzb3VyY2UiOiAi
-        IiwgInZlcnNpb24iOiAiMC4yLjAiLCAicmVwb3NpdG9yeV9tZW1iZXJzaGlw
-        cyI6IFsiNCJdLCAiZGVzY3JpcHRpb24iOiAiVGhpcyBtb2R1bGUgaGFuZGxl
-        cyBhIHN0YW5kYXJkIGh0dHBkIGluc3RhbGxhdGlvbi5cblxuSXQgaGFzIG9w
-        dGlvbmFsIGNsYXNzZXMgaWYgeW91IHdhbnQgdG8gaW5zdGFsbCBhbmQgY29u
-        ZmlndXJlIG1vZF9zc2wsIHBocCwgbW9kX3NwZHkgb3IgaHR0cGQtZGV2Llxu
-        XG5JdCBoYXMgYmVlbiB0ZXN0ZWQgb24gQ2VudE9TIDYuMiBhbmQgQ2VudE9T
-        IDUuOC5cbkl0IGNvdWxkIHdvcmsgYWxzbyBvbiBkZWJpYW4sIGJ1dCB0aGF0
-        IG5lZWRzIHRvIGJlIHRlc3RlZC4iLCAiX2xhc3RfdXBkYXRlZCI6ICIyMDE2
-        LTA3LTI5VDE4OjU5OjAwWiIsICJkb3dubG9hZGVkIjogdHJ1ZSwgImRlcGVu
-        ZGVuY2llcyI6IFtdLCAidHlwZXMiOiBbeyJkb2MiOiAiTWFuYWdlIEFwYWNo
-        ZSAyIG1vZHVsZXMgb24gRGViaWFuIGFuZCBVYnVudHUiLCAibmFtZSI6ICJh
-        Mm1vZCIsICJwYXJhbWV0ZXJzIjogW3siZG9jIjogIlRoZSBuYW1lIG9mIHRo
-        ZSBtb2R1bGUgdG8gYmUgbWFuYWdlZCIsICJuYW1lIjogIm5hbWUifV0sICJw
-        cm92aWRlcnMiOiBbeyJkb2MiOiAiTWFuYWdlIEFwYWNoZSAyIG1vZHVsZXMg
-        b24gRGViaWFuIGFuZCBVYnVudHUiLCAibmFtZSI6ICJhMm1vZCJ9LCB7ImRv
-        YyI6ICJEdW1teSBwcm92aWRlciBmb3IgQTJtb2QuXG5cbiAgICBGYWtlIG5p
-        bCByZXNvdXJjZXMgd2hlbiB0aGVyZSBpcyBubyBjcm9udGFiIGJpbmFyeSBh
-        dmFpbGFibGUuIEFsbG93c1xuICAgIHB1cHBldGQgdG8gcnVuIG9uIGEgYm9v
-        dHN0cmFwcGVkIG1hY2hpbmUgYmVmb3JlIGEgQ3JvbiBwYWNrYWdlIGhhcyBi
-        ZWVuXG4gICAgaW5zdGFsbGVkLiBXb3JrYXJvdW5kIGZvcjogaHR0cDovL3By
-        b2plY3RzLnB1cHBldGxhYnMuY29tL2lzc3Vlcy8yMzg0XG4gICAgIiwgIm5h
-        bWUiOiAibW9kZml4In1dfV0sICJfc3RvcmFnZV9wYXRoIjogIi92YXIvbGli
-        L3B1bHAvY29udGVudC91bml0cy9wdXBwZXRfbW9kdWxlLzg2L2JkM2Q1ODI2
-        OTg0OTEwNWRmMjAwNzgzMWY4NzI0YTVhYjE4NTM5ZTc0Y2ZjODMxNmQwNWRm
-        Mzk5ZGNiOGYwLzVVYlozcjAtaHR0cGQtMC4yLjAudGFyLmd6IiwgIl9pZCI6
-        ICJiNzNjZWZmZS03MGU0LTQ5NTgtYjZiNC03ZDg4NzhiNmNkNTQiLCAibmFt
-        ZSI6ICJodHRwZCIsICJsaWNlbnNlIjogIkdQTCB2MyIsICJjaGVja3N1bSI6
-        ICIwMDQzMGRlYmI5OWU5NDE2YTBmNzNlMTgxMjljNjNlZWU2NzkwMjNiY2Rm
-        MGQyNjc3NDJlYmU4ZmYxMGU5Yzk5IiwgInN1bW1hcnkiOiAiVGhpcyBtb2R1
-        bGUgaGFuZGxlcyBhIHN0YW5kYXJkIGh0dHBkIGluc3RhbGxhdGlvbi4iLCAi
-        Y2hlY2tzdW1fdHlwZSI6ICJzaGEyNTYiLCAidGFnX2xpc3QiOiBbXX0sIHsi
-        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcHVwcGV0X21v
-        ZHVsZS9mZWYyMTdlMy01YzNiLTQzMmEtYThkZC1mNmUzZmM2ZGQxMzkvIiwg
-        InB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6
-        ICJwdXBwZXRfbW9kdWxlIiwgImNoZWNrc3VtcyI6IFtbImZpbGVzXFxkZWJp
-        YW5cXE1heENsaWVudHNOdW1iZXIiLCAiMmE1MmE1ZTY1ZmMzYzQzZjQwOTU1
-        MGRmYWQxZjkwNGYiXSwgWyJzcGVjXFx1bml0XFxwdXBwZXRcXHR5cGVcXFJF
-        QURNRS5tYXJrZG93biIsICJkZTI2YTc2NDM4MTNhYmQ2YzJlN2UyODA3MWIx
-        ZWY5NCJdLCBbInNwZWNcXHVuaXRcXHB1cHBldFxccHJvdmlkZXJcXFJFQURN
-        RS5tYXJrZG93biIsICJlNTI2Njg5NDRlZTZhZjJmYjVkNWI5ZTc5ODM0MjY0
-        NSJdLCBbImZpbGVzXFxkZWJpYW5cXERvbnRSZXNvbHZlIiwgImViNDU4NWFk
-        OWZlMDQyNjc4MWVkN2M0OTI1MmY4MjI1Il0sIFsidGVzdHNcXGluaXQucHAi
-        LCAiNWQ2ZTg0YmQwNmUyM2M0ZDU2NTc4MmRiNjdlMzMzZWMiXSwgWyJ0ZW1w
-        bGF0ZXNcXGRlZmF1bHRfY29uZmlnLmVyYiIsICIyMjI5NDUxODljNWI4ZDRl
-        ZmE5ZmUyYzNjYzAxZjQzNSJdLCBbInNwZWNcXFJFQURNRS5tYXJrZG93biIs
-        ICIzMmExZmMwMTIxYzI4YWZmNTU0ZWY1ZDQyMmI4YjUxZSJdLCBbImZpbGVz
-        XFxkZWJpYW5cXEFsdExvZyIsICJhM2Q3Zjg5ZGM5MTYwNjIyMzQyMzdhY2Y3
-        NWJkZTk3ZCJdLCBbIlJFQURNRS5tZCIsICI5Y2JiOTQ1YzZjZTczMDMxYjAw
-        YjFjNTI2OWNiYjYzOCJdLCBbImZpbGVzXFxkZWJpYW5cXENocm9vdEV2ZXJ5
-        b25lIiwgImViNDU4NWFkOWZlMDQyNjc4MWVkN2M0OTI1MmY4MjI1Il0sIFsi
-        ZmlsZXNcXGRlYmlhblxcTm9Bbm9ueW1vdXMiLCAiZWI0NTg1YWQ5ZmUwNDI2
-        NzgxZWQ3YzQ5MjUyZjgyMjUiXSwgWyJmaWxlc1xcZGViaWFuXFxWZXJib3Nl
-        TG9nIiwgIjdmYTNiNzY3YzQ2MGI1NGEyYmU0ZDQ5MDMwYjM0OWM3Il0sIFsi
-        ZmlsZXNcXGRlYmlhblxcUEFNQXV0aGVudGljYXRpb24iLCAiZWI0NTg1YWQ5
-        ZmUwNDI2NzgxZWQ3YzQ5MjUyZjgyMjUiXSwgWyJtYW5pZmVzdHNcXHBhcmFt
-        cy5wcCIsICJlN2IzY2YzYTYxMTVlOTZhNmY3NmQzZmYyYzU0NTYyNSJdLCBb
-        ImZpbGVzXFxkZWJpYW5cXFB1cmVEQiIsICI2ZGI1OTY1Njk4NTI3ZTFmMTQw
-        ZGZjNzNlZDQwZDQ3YyJdLCBbIm1hbmlmZXN0c1xcY29uZmlnLnBwIiwgImIx
-        MmQ2MzMxMzQ5ZDIxN2JiYmE2ODRhMGM1NjUyNjIwIl0sIFsiZmlsZXNcXGRl
-        YmlhblxcVW5peEF1dGhlbnRpY2F0aW9uIiwgImViNDU4NWFkOWZlMDQyNjc4
-        MWVkN2M0OTI1MmY4MjI1Il0sIFsibWFuaWZlc3RzXFxpbml0LnBwIiwgIjYx
-        Njc1YTkwNWM0MDY0MWU3MGQ2Zjc0OTg1ZmRhOGM4Il0sIFsiTW9kdWxlZmls
-        ZSIsICJkZWNhYWFiMzJhOTkzMWMzNTY1YTZmYzQ3ZjI2YTc0MCJdLCBbImZp
-        bGVzXFxkZWJpYW5cXE1pblVJRCIsICI0ZmJhZmQ2OTQ4YjY1MjljYWEyYjc4
-        ZTQ3NjM1OTg3NSJdLCBbIm1hbmlmZXN0c1xcc2VydmljZS5wcCIsICI3MjJk
-        NjI2NTFlNmM2MWRhNDMzMDMzMmI2MzgyZjVhOSJdLCBbInNwZWNcXHNwZWMu
-        b3B0cyIsICJhNjAwZGVkOTk1ZDk0OGUzOTNmYmUyMzIwYmE4ZTUxYyJdLCBb
-        InNwZWNcXHNwZWNfaGVscGVyLnJiIiwgImNhMTllYzRmNDUxZWJjN2ZkYjAz
-        NWI1MmVhZTZlOTA5Il0sIFsibWFuaWZlc3RzXFxpbnN0YWxsLnBwIiwgIjUx
-        Y2FhMjVmOTBhNDc5Y2Q1MDE4MjQzNjJiOWJkYmExIl1dLCAiY2hpbGRyZW4i
-        OiB7fSwgImF1dGhvciI6ICJzYXoiLCAicHJvamVjdF9wYWdlIjogImh0dHBz
-        Oi8vZ2l0aHViLmNvbS9zYXovcHVwcGV0LXB1cmVmdHBkIiwgInNvdXJjZSI6
-        ICIiLCAidmVyc2lvbiI6ICIxLjAuMiIsICJyZXBvc2l0b3J5X21lbWJlcnNo
-        aXBzIjogWyI0Il0sICJkZXNjcmlwdGlvbiI6ICJNYW5hZ2UgUHVyZS1GVFBk
-        IHZpYSBQdXBwZXQiLCAiX2xhc3RfdXBkYXRlZCI6ICIyMDE2LTA3LTI5VDE4
-        OjU4OjU4WiIsICJkb3dubG9hZGVkIjogdHJ1ZSwgImRlcGVuZGVuY2llcyI6
-        IFtdLCAidHlwZXMiOiBbXSwgIl9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIv
-        cHVscC9jb250ZW50L3VuaXRzL3B1cHBldF9tb2R1bGUvYTUvYzRjZjViZmM3
-        M2QyY2I0YTg0YmMxMzQ5YmQyNjk5ZGJiOTRiZTY5ZTJhYTU0ZjA1Mjc1NDIw
-        NTY0NjFhZmYvNVViWjNyMC1wdXJlZnRwZC0xLjAuMi50YXIuZ3oiLCAiX2lk
-        IjogImZlZjIxN2UzLTVjM2ItNDMyYS1hOGRkLWY2ZTNmYzZkZDEzOSIsICJu
-        YW1lIjogInB1cmVmdHBkIiwgImxpY2Vuc2UiOiAiQXBhY2hlIExpY2Vuc2Us
-        IFZlcnNpb24gMi4wIiwgImNoZWNrc3VtIjogImVlZjE4ZThiZDUxNjJhMDFk
-        ODA1Yzc2MzM1YjhhOTRjNDgwNjdlYTg0YTBlNmY5NGVkMWJlZWY1NWZhZWU4
-        MDkiLCAic3VtbWFyeSI6ICIiLCAiY2hlY2tzdW1fdHlwZSI6ICJzaGEyNTYi
+        ZCI6ICJwdXBwZXRfbW9kdWxlIiwgImNoZWNrc3VtcyI6IFtbImZpbGVzXFxk
+        ZWJpYW5cXE1heENsaWVudHNOdW1iZXIiLCAiMmE1MmE1ZTY1ZmMzYzQzZjQw
+        OTU1MGRmYWQxZjkwNGYiXSwgWyJzcGVjXFx1bml0XFxwdXBwZXRcXHR5cGVc
+        XFJFQURNRS5tYXJrZG93biIsICJkZTI2YTc2NDM4MTNhYmQ2YzJlN2UyODA3
+        MWIxZWY5NCJdLCBbInNwZWNcXHVuaXRcXHB1cHBldFxccHJvdmlkZXJcXFJF
+        QURNRS5tYXJrZG93biIsICJlNTI2Njg5NDRlZTZhZjJmYjVkNWI5ZTc5ODM0
+        MjY0NSJdLCBbImZpbGVzXFxkZWJpYW5cXERvbnRSZXNvbHZlIiwgImViNDU4
+        NWFkOWZlMDQyNjc4MWVkN2M0OTI1MmY4MjI1Il0sIFsidGVzdHNcXGluaXQu
+        cHAiLCAiNWQ2ZTg0YmQwNmUyM2M0ZDU2NTc4MmRiNjdlMzMzZWMiXSwgWyJ0
+        ZW1wbGF0ZXNcXGRlZmF1bHRfY29uZmlnLmVyYiIsICIyMjI5NDUxODljNWI4
+        ZDRlZmE5ZmUyYzNjYzAxZjQzNSJdLCBbInNwZWNcXFJFQURNRS5tYXJrZG93
+        biIsICIzMmExZmMwMTIxYzI4YWZmNTU0ZWY1ZDQyMmI4YjUxZSJdLCBbImZp
+        bGVzXFxkZWJpYW5cXEFsdExvZyIsICJhM2Q3Zjg5ZGM5MTYwNjIyMzQyMzdh
+        Y2Y3NWJkZTk3ZCJdLCBbIlJFQURNRS5tZCIsICI5Y2JiOTQ1YzZjZTczMDMx
+        YjAwYjFjNTI2OWNiYjYzOCJdLCBbImZpbGVzXFxkZWJpYW5cXENocm9vdEV2
+        ZXJ5b25lIiwgImViNDU4NWFkOWZlMDQyNjc4MWVkN2M0OTI1MmY4MjI1Il0s
+        IFsiZmlsZXNcXGRlYmlhblxcTm9Bbm9ueW1vdXMiLCAiZWI0NTg1YWQ5ZmUw
+        NDI2NzgxZWQ3YzQ5MjUyZjgyMjUiXSwgWyJmaWxlc1xcZGViaWFuXFxWZXJi
+        b3NlTG9nIiwgIjdmYTNiNzY3YzQ2MGI1NGEyYmU0ZDQ5MDMwYjM0OWM3Il0s
+        IFsiZmlsZXNcXGRlYmlhblxcUEFNQXV0aGVudGljYXRpb24iLCAiZWI0NTg1
+        YWQ5ZmUwNDI2NzgxZWQ3YzQ5MjUyZjgyMjUiXSwgWyJtYW5pZmVzdHNcXHBh
+        cmFtcy5wcCIsICJlN2IzY2YzYTYxMTVlOTZhNmY3NmQzZmYyYzU0NTYyNSJd
+        LCBbImZpbGVzXFxkZWJpYW5cXFB1cmVEQiIsICI2ZGI1OTY1Njk4NTI3ZTFm
+        MTQwZGZjNzNlZDQwZDQ3YyJdLCBbIm1hbmlmZXN0c1xcY29uZmlnLnBwIiwg
+        ImIxMmQ2MzMxMzQ5ZDIxN2JiYmE2ODRhMGM1NjUyNjIwIl0sIFsiZmlsZXNc
+        XGRlYmlhblxcVW5peEF1dGhlbnRpY2F0aW9uIiwgImViNDU4NWFkOWZlMDQy
+        Njc4MWVkN2M0OTI1MmY4MjI1Il0sIFsibWFuaWZlc3RzXFxpbml0LnBwIiwg
+        IjYxNjc1YTkwNWM0MDY0MWU3MGQ2Zjc0OTg1ZmRhOGM4Il0sIFsiTW9kdWxl
+        ZmlsZSIsICJkZWNhYWFiMzJhOTkzMWMzNTY1YTZmYzQ3ZjI2YTc0MCJdLCBb
+        ImZpbGVzXFxkZWJpYW5cXE1pblVJRCIsICI0ZmJhZmQ2OTQ4YjY1MjljYWEy
+        Yjc4ZTQ3NjM1OTg3NSJdLCBbIm1hbmlmZXN0c1xcc2VydmljZS5wcCIsICI3
+        MjJkNjI2NTFlNmM2MWRhNDMzMDMzMmI2MzgyZjVhOSJdLCBbInNwZWNcXHNw
+        ZWMub3B0cyIsICJhNjAwZGVkOTk1ZDk0OGUzOTNmYmUyMzIwYmE4ZTUxYyJd
+        LCBbInNwZWNcXHNwZWNfaGVscGVyLnJiIiwgImNhMTllYzRmNDUxZWJjN2Zk
+        YjAzNWI1MmVhZTZlOTA5Il0sIFsibWFuaWZlc3RzXFxpbnN0YWxsLnBwIiwg
+        IjUxY2FhMjVmOTBhNDc5Y2Q1MDE4MjQzNjJiOWJkYmExIl1dLCAiY2hpbGRy
+        ZW4iOiB7fSwgImF1dGhvciI6ICJzYXoiLCAicHJvamVjdF9wYWdlIjogImh0
+        dHBzOi8vZ2l0aHViLmNvbS9zYXovcHVwcGV0LXB1cmVmdHBkIiwgInNvdXJj
+        ZSI6ICIiLCAidmVyc2lvbiI6ICIxLjAuMiIsICJyZXBvc2l0b3J5X21lbWJl
+        cnNoaXBzIjogWyI0Il0sICJkZXNjcmlwdGlvbiI6ICJNYW5hZ2UgUHVyZS1G
+        VFBkIHZpYSBQdXBwZXQiLCAiX2xhc3RfdXBkYXRlZCI6ICIyMDE2LTExLTI5
+        VDE1OjMzOjAyWiIsICJkb3dubG9hZGVkIjogdHJ1ZSwgImRlcGVuZGVuY2ll
+        cyI6IFtdLCAidHlwZXMiOiBbXSwgIl9zdG9yYWdlX3BhdGgiOiAiL3Zhci9s
+        aWIvcHVscC9jb250ZW50L3VuaXRzL3B1cHBldF9tb2R1bGUvYTUvYzRjZjVi
+        ZmM3M2QyY2I0YTg0YmMxMzQ5YmQyNjk5ZGJiOTRiZTY5ZTJhYTU0ZjA1Mjc1
+        NDIwNTY0NjFhZmYvNVViWjNyMC1wdXJlZnRwZC0xLjAuMi50YXIuZ3oiLCAi
+        X2lkIjogIjE0MDM4YzJjLTBmYzQtNDlhZi1iNDEzLWEwYmYyZmVjNzg1MyIs
+        ICJuYW1lIjogInB1cmVmdHBkIiwgImxpY2Vuc2UiOiAiQXBhY2hlIExpY2Vu
+        c2UsIFZlcnNpb24gMi4wIiwgImNoZWNrc3VtIjogImVlZjE4ZThiZDUxNjJh
+        MDFkODA1Yzc2MzM1YjhhOTRjNDgwNjdlYTg0YTBlNmY5NGVkMWJlZWY1NWZh
+        ZWU4MDkiLCAic3VtbWFyeSI6ICIiLCAiY2hlY2tzdW1fdHlwZSI6ICJzaGEy
+        NTYiLCAidGFnX2xpc3QiOiBbXX0sIHsiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L2NvbnRlbnQvdW5pdHMvcHVwcGV0X21vZHVsZS8yMmFiM2UyYy1jNWE2LTQy
+        Y2UtOTU1NC0wMGU3MTAxZDM2YzYvIiwgInB1bHBfdXNlcl9tZXRhZGF0YSI6
+        IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwdXBwZXRfbW9kdWxlIiwgImNo
+        ZWNrc3VtcyI6IFtbImZpbGVzL2RlZmxhdGUuY29uZiIsICIxZmM2NzhhYTk2
+        N2Y0ZmQzYzgyMzhjOTExMTAxOWExZCJdLCBbInNwZWMvc3BlYy5vcHRzIiwg
+        ImE2MDBkZWQ5OTVkOTQ4ZTM5M2ZiZTIzMjBiYThlNTFjIl0sIFsidGVtcGxh
+        dGVzL2h0dHBkLmNvbmYuUkhFTC5lcmIiLCAiNGNiY2MyOTc2NTM1NmFlYjlh
+        MDFiZWVjZTY3MzhmZTgiXSwgWyJmaWxlcy9zcGR5L21vZC1zcGR5LWJldGFf
+        Y3VycmVudF9pMzg2LnJwbSIsICI0YWJkZWUzNTM5MmMxYzZkMzI5ZGVmMjAx
+        NzM5MzQwMyJdLCBbInRlbXBsYXRlcy9waHAuaW5pLlJIRUwuZXJiIiwgIjI1
+        Y2JiNzYwZTVmY2Y4MTE2NWZiYzMzY2U5OGZlNmQ5Il0sIFsibWFuaWZlc3Rz
+        L3BhcmFtcy5wcCIsICJkMDJlYjg3YTNlZDY5ZmY2MzhjYTAyOGI2NzAwMTYy
+        MSJdLCBbImZpbGVzL2Vycm9yL2Vycm9yLmh0bWwiLCAiM2FmODQxMWM4MmEw
+        NzI1YzBiYTZiYTBmYTY4MWJkMDgiXSwgWyJmaWxlcy9zcGR5L21vZC1zcGR5
+        LWJldGFfY3VycmVudF94ODZfNjQucnBtIiwgIjZkMjVkMDNiZmI4MjQ5Zjdj
+        NmRjZDk5MDY5MDljOTk1Il0sIFsibWFuaWZlc3RzL3NzbC5wcCIsICI2ZDhh
+        OWNhZjFhMTMxMzJiNmNkMjQ2NGRhNjA2MjgxYiJdLCBbIm1hbmlmZXN0cy9p
+        bml0LnBwIiwgImZjZDhjOGY5NzY3MTBlYWM2NTMyYWRjMmYyOGJmYTQ0Il0s
+        IFsibWFuaWZlc3RzL2Rldi5wcCIsICIxM2UwNTY0ZDM2NmYyNzY5NGIxMTVm
+        ODExMjQwNjQyOSJdLCBbIm1hbmlmZXN0cy92aG9zdC5wcCIsICI2ZWFjODQy
+        MDFkMjM5NDM2YzM4NmZlMmFkZjRjNDI1MiJdLCBbImZpbGVzL3NwZHkvbW9k
+        LXNwZHktYmV0YV9jdXJyZW50X2kzODYuZGViIiwgIjdkNzI0NzRlMzk4M2Yz
+        OTBkYWY4OWYxMjg5ZTA4NTIxIl0sIFsidGVtcGxhdGVzL3NzbC5jb25mLlJI
+        RUwuZXJiIiwgImYxMTY2MThmYjg1ZmZkZGEzY2VmMWZjZjVhODIxMGM4Il0s
+        IFsibGliL3B1cHBldC9wcm92aWRlci9hMm1vZC9hMm1vZC5yYiIsICIwYWNm
+        NDJkM2Q2NzBhOTkxNWM1YTNmNDZhZTczMzVmMSJdLCBbImxpYi9wdXBwZXQv
+        cHJvdmlkZXIvYTJtb2QvbW9kZml4LnJiIiwgImY0NTM2Y2RjYTY4ZDE1YTIz
+        NWNiYjFlMGI2N2U0NDA2Il0sIFsidGVtcGxhdGVzL2xvY2FsaXplZC1lcnJv
+        ci1wYWdlcy5EZWJpYW4uZXJiIiwgIjU3OGRmZDUzNzkxMWE3YjhkZGNkNDg1
+        NjQwNDUyYWMzIl0sIFsic3BlYy9zcGVjX2hlbHBlci5yYiIsICJjYTE5ZWM0
+        ZjQ1MWViYzdmZGIwMzViNTJlYWU2ZTkwOSJdLCBbIm1hbmlmZXN0cy9zcGR5
+        LnBwIiwgImVmNzkyYjQxNDA4MjM2YWVkYTdmNTdhNDI3ZjU3NGViIl0sIFsi
+        ZmlsZXMvc3BkeS9tb2Qtc3BkeS1iZXRhX2N1cnJlbnRfYW1kNjQuZGViIiwg
+        IjgzNGM4NTAzOGFlNTAyNjBkYTNhMDcwY2ZhMGNkYmRmIl0sIFsiTW9kdWxl
+        ZmlsZSIsICJlYTMzZTJkN2ZlNGQ5N2VhZmEwNzE3MmM5MmMxMzBkYiJdLCBb
+        Im1hbmlmZXN0cy9waHAucHAiLCAiNTZlYTdmMjk3YWFhY2RkZTAwMWQzNTI5
+        MDUxYjNjMGUiXSwgWyJ0ZW1wbGF0ZXMvdmhvc3QtZGVmYXVsdC5jb25mLmVy
+        YiIsICJlZDY0YTUzYWYwZDdiYWQ3NjIxNzZhOThjOWVhM2U2MiJdLCBbIlJF
+        QURNRSIsICI0YzliNDM2ZTQ4YTQ0N2Q2MzRlYjgyMWMwNmZmZjZmYyJdLCBb
+        InRlbXBsYXRlcy9waHAuaW5pLkRlYmlhbi5lcmIiLCAiMTgwYTM5Y2EyNjJl
+        MTMyYzZkNDMxOTczOTg2ZDdlMzkiXSwgWyJsaWIvcHVwcGV0L3R5cGUvYTJt
+        b2QucmIiLCAiYWRjZjc1NGEwNzYxNTM0NDJlYWMyYmViNDI3MzY1NDciXV0s
+        ICJjaGlsZHJlbiI6IHt9LCAiYXV0aG9yIjogIjV1YlozcjAiLCAicHJvamVj
+        dF9wYWdlIjogIiIsICJzb3VyY2UiOiAiIiwgInZlcnNpb24iOiAiMC4yLjAi
+        LCAicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiNCJdLCAiZGVzY3JpcHRp
+        b24iOiAiVGhpcyBtb2R1bGUgaGFuZGxlcyBhIHN0YW5kYXJkIGh0dHBkIGlu
+        c3RhbGxhdGlvbi5cblxuSXQgaGFzIG9wdGlvbmFsIGNsYXNzZXMgaWYgeW91
+        IHdhbnQgdG8gaW5zdGFsbCBhbmQgY29uZmlndXJlIG1vZF9zc2wsIHBocCwg
+        bW9kX3NwZHkgb3IgaHR0cGQtZGV2LlxuXG5JdCBoYXMgYmVlbiB0ZXN0ZWQg
+        b24gQ2VudE9TIDYuMiBhbmQgQ2VudE9TIDUuOC5cbkl0IGNvdWxkIHdvcmsg
+        YWxzbyBvbiBkZWJpYW4sIGJ1dCB0aGF0IG5lZWRzIHRvIGJlIHRlc3RlZC4i
+        LCAiX2xhc3RfdXBkYXRlZCI6ICIyMDE2LTExLTI5VDE1OjMzOjA2WiIsICJk
+        b3dubG9hZGVkIjogdHJ1ZSwgImRlcGVuZGVuY2llcyI6IFtdLCAidHlwZXMi
+        OiBbeyJkb2MiOiAiTWFuYWdlIEFwYWNoZSAyIG1vZHVsZXMgb24gRGViaWFu
+        IGFuZCBVYnVudHUiLCAibmFtZSI6ICJhMm1vZCIsICJwYXJhbWV0ZXJzIjog
+        W3siZG9jIjogIlRoZSBuYW1lIG9mIHRoZSBtb2R1bGUgdG8gYmUgbWFuYWdl
+        ZCIsICJuYW1lIjogIm5hbWUifV0sICJwcm92aWRlcnMiOiBbeyJkb2MiOiAi
+        TWFuYWdlIEFwYWNoZSAyIG1vZHVsZXMgb24gRGViaWFuIGFuZCBVYnVudHUi
+        LCAibmFtZSI6ICJhMm1vZCJ9LCB7ImRvYyI6ICJEdW1teSBwcm92aWRlciBm
+        b3IgQTJtb2QuXG5cbiAgICBGYWtlIG5pbCByZXNvdXJjZXMgd2hlbiB0aGVy
+        ZSBpcyBubyBjcm9udGFiIGJpbmFyeSBhdmFpbGFibGUuIEFsbG93c1xuICAg
+        IHB1cHBldGQgdG8gcnVuIG9uIGEgYm9vdHN0cmFwcGVkIG1hY2hpbmUgYmVm
+        b3JlIGEgQ3JvbiBwYWNrYWdlIGhhcyBiZWVuXG4gICAgaW5zdGFsbGVkLiBX
+        b3JrYXJvdW5kIGZvcjogaHR0cDovL3Byb2plY3RzLnB1cHBldGxhYnMuY29t
+        L2lzc3Vlcy8yMzg0XG4gICAgIiwgIm5hbWUiOiAibW9kZml4In1dfV0sICJf
+        c3RvcmFnZV9wYXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0cy9w
+        dXBwZXRfbW9kdWxlLzg2L2JkM2Q1ODI2OTg0OTEwNWRmMjAwNzgzMWY4NzI0
+        YTVhYjE4NTM5ZTc0Y2ZjODMxNmQwNWRmMzk5ZGNiOGYwLzVVYlozcjAtaHR0
+        cGQtMC4yLjAudGFyLmd6IiwgIl9pZCI6ICIyMmFiM2UyYy1jNWE2LTQyY2Ut
+        OTU1NC0wMGU3MTAxZDM2YzYiLCAibmFtZSI6ICJodHRwZCIsICJsaWNlbnNl
+        IjogIkdQTCB2MyIsICJjaGVja3N1bSI6ICIwMDQzMGRlYmI5OWU5NDE2YTBm
+        NzNlMTgxMjljNjNlZWU2NzkwMjNiY2RmMGQyNjc3NDJlYmU4ZmYxMGU5Yzk5
+        IiwgInN1bW1hcnkiOiAiVGhpcyBtb2R1bGUgaGFuZGxlcyBhIHN0YW5kYXJk
+        IGh0dHBkIGluc3RhbGxhdGlvbi4iLCAiY2hlY2tzdW1fdHlwZSI6ICJzaGEy
+        NTYiLCAidGFnX2xpc3QiOiBbXX0sIHsiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L2NvbnRlbnQvdW5pdHMvcHVwcGV0X21vZHVsZS80NTAwNTE5MC03YTc0LTRl
+        MzEtODMwOC1mYTZkYTg1NjI3ZjUvIiwgInB1bHBfdXNlcl9tZXRhZGF0YSI6
+        IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwdXBwZXRfbW9kdWxlIiwgImNo
+        ZWNrc3VtcyI6IFtbIm1hbmlmZXN0cy9zZXJ2aWNlLnBwIiwgIjE5MmM4MTk3
+        OTFlMjA0MjcwMzg5MWU1MWE2MWQzMTRhIl0sIFsiTW9kdWxlZmlsZSIsICJk
+        MzA5ZWUzMTUxNzZlYTNmOTIzNDgwYzI4NmUzYTU1YiJdLCBbInNwZWMvc3Bl
+        Yy5vcHRzIiwgImE2MDBkZWQ5OTVkOTQ4ZTM5M2ZiZTIzMjBiYThlNTFjIl0s
+        IFsidGVzdHMvaW5pdC5wcCIsICI0ZGNjMjg2OGNiOTc0MGMzMmViNjhmMzQ1
+        YTdiNzE5NCJdLCBbInNwZWMvc3BlY19oZWxwZXIucmIiLCAiY2ExOWVjNGY0
+        NTFlYmM3ZmRiMDM1YjUyZWFlNmU5MDkiXSwgWyJtYW5pZmVzdHMvY29uZi5w
+        cCIsICJhZDRiMjg1YTY3MzZhZWJlYmI2ZmE1OWUzOGRkZGVkMSJdLCBbIm1h
+        bmlmZXN0cy9wYXJhbXMucHAiLCAiZjQxZDExZTdkYmJkZTY3YTJjZjRkMjlj
+        ZjY3ODNhNTUiXSwgWyJtYW5pZmVzdHMvaW5zdGFsbC5wcCIsICJjOTI5ZTEz
+        ZjU0NmJjZGIzZjAyZWZlZGU5ZGIxYWY5YiJdLCBbIm1hbmlmZXN0cy9pbml0
+        LnBwIiwgImY2NThiNTk0YWM4OGRhOTAyNmM2NzViZmUwMzEwZDU3Il0sIFsi
+        UkVBRE1FIiwgIjYyN2ZiYjU3ZWI4ZDk0MzA4ZjAxYTExNDMwNDE4ZmI2Il1d
+        LCAiY2hpbGRyZW4iOiB7fSwgImF1dGhvciI6ICJwdXBwZXQiLCAicHJvamVj
+        dF9wYWdlIjogImh0dHBzOi8vZ2l0aHViLmNvbS81VWItWjNyMC9wdXBwZXQt
+        c2FtYmEiLCAic291cmNlIjogImh0dHBzOi8vZ2l0aHViLmNvbS81VWItWjNy
+        MC9wdXBwZXQtc2FtYmEiLCAidmVyc2lvbiI6ICIwLjIuMCIsICJyZXBvc2l0
+        b3J5X21lbWJlcnNoaXBzIjogWyI0Il0sICJkZXNjcmlwdGlvbiI6ICJUaGlz
+        IHB1cHBldCBtb2R1bGUgbWFuYWdlcyBzYW1iYSBjb25maWd1cmF0aW9uLlxu
+        XG5JdCBoYXMgYmVlbiB0ZXN0ZWQgb25seSBmb3Igc2FtYmEgbWFuYWdpbmcg
+        c2hhcmVzLCB0b3VnaCBpdCBkb2VzIG5vdCBjYXJlIGFib3V0IHRoZSBjb250
+        ZW50IG9mIHlvdXIgY29uZmlnIGZpbGUuXG5cblRlc3RlZCBvbiBDZW50T1Mg
+        Ni4yLCBSSEVMIDYuMiwgQ2VudE9TIDUuOC4iLCAiX2xhc3RfdXBkYXRlZCI6
+        ICIyMDE2LTExLTI5VDE1OjMzOjAzWiIsICJkb3dubG9hZGVkIjogdHJ1ZSwg
+        ImRlcGVuZGVuY2llcyI6IFtdLCAidHlwZXMiOiBbXSwgIl9zdG9yYWdlX3Bh
+        dGgiOiAiL3Zhci9saWIvcHVscC9jb250ZW50L3VuaXRzL3B1cHBldF9tb2R1
+        bGUvZDUvNjFjZjdkYzFjMmI4N2QyYWNlMDRmNjM1OGEzMmUwMWMwYWZjNTYz
+        ZTYzNGU5YjE3MzQ1ZGExODVkM2M0NzUvNVViWjNyMC1zYW1iYS0wLjIuMC50
+        YXIuZ3oiLCAiX2lkIjogIjQ1MDA1MTkwLTdhNzQtNGUzMS04MzA4LWZhNmRh
+        ODU2MjdmNSIsICJuYW1lIjogInNhbWJhIiwgImxpY2Vuc2UiOiAiR1BMIHYz
+        IiwgImNoZWNrc3VtIjogImM3NzJkZWNmNzgzNmU0MmE3MjE1YzJhZWUzZjhi
+        ZDc0MmUxYzQ4MDM5NGE2NTBiNjU5NDdiM2MwODMyODRjYWMiLCAic3VtbWFy
+        eSI6ICJBIHB1cHBldCBtb2R1bGUgdGhhdCBtYW5hZ2VzIHNhbWJhIiwgImNo
+        ZWNrc3VtX3R5cGUiOiAic2hhMjU2IiwgInRhZ19saXN0IjogW119LCB7Il9o
+        cmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3B1cHBldF9tb2R1
+        bGUvODBmYThlM2MtOThlZC00MjlkLWIzZjAtZGU4ODA1YzQ0ODJiLyIsICJw
+        dWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAi
+        cHVwcGV0X21vZHVsZSIsICJjaGVja3N1bXMiOiBbWyJtYW5pZmVzdHMvdGFz
+        ay5wcCIsICI0Y2I0YWE0OWRmOGM5MDYxOWQ5MDM5OTkyYTUxNmMwNyJdLCBb
+        InNwZWMvc3BlYy5vcHRzIiwgImE2MDBkZWQ5OTVkOTQ4ZTM5M2ZiZTIzMjBi
+        YThlNTFjIl0sIFsibWFuaWZlc3RzL21vbnRobHkucHAiLCAiYjk5MDBmNmUy
+        ZGIwODU0ZjM0YzY2OTMwMjg3ZGI3MDAiXSwgWyJ0ZXN0cy9pbml0LnBwIiwg
+        IjRiY2I3ZTAzYWNlZDhiYjQ2ODM1MWE0NWU4ZTliYzc2Il0sIFsic3BlYy9z
+        cGVjX2hlbHBlci5yYiIsICJjYTE5ZWM0ZjQ1MWViYzdmZGIwMzViNTJlYWU2
+        ZTkwOSJdLCBbIm1hbmlmZXN0cy93ZWVrbHkucHAiLCAiN2QzNGEwMGQ2Mjk1
+        NzVlZTJlNGY0YmQ1OGVhYjFkNDAiXSwgWyJtYW5pZmVzdHMvZGFpbHkucHAi
+        LCAiOTZmZmQwZTU5MmRlM2Y1ZGQwNTRkZTM3NTVhOGJjZmYiXSwgWyJNb2R1
+        bGVmaWxlIiwgIjE4YzkyMDhlNzdhM2M0M2I0ZGY2NWFlOGJiM2JmODA0Il0s
+        IFsibWFuaWZlc3RzL2luaXQucHAiLCAiOGMzZTEwYmMzZTI0NjU5MDg0MzZm
+        MWFhNzcxZjAzOWIiXSwgWyJtYW5pZmVzdHMvaG91cmx5LnBwIiwgIjdhMTc2
+        MjFhNzMxNzUwYzQwYzg3MmU3YTViNmY0NDQyIl0sIFsiUkVBRE1FIiwgIjQ5
+        MWU2M2E5Y2Y3NWY4MjUzNjk1Mjg5ODNjYWFlODdhIl0sIFsibWFuaWZlc3Rz
+        L3BhcmFtcy5wcCIsICJkNTkyNDkxOGZjMDU5ZGFhNDdhYTM1NTUzNGE0YjQz
+        NCJdXSwgImNoaWxkcmVuIjoge30sICJhdXRob3IiOiAicHVwcGV0IiwgInBy
+        b2plY3RfcGFnZSI6ICJodHRwczovL2dpdGh1Yi5jb20vNVViLVozcjAvcHVw
+        cGV0LWNyb24iLCAic291cmNlIjogImh0dHBzOi8vZ2l0aHViLmNvbS81VWIt
+        WjNyMC9wdXBwZXQtY3Jvbi5naXQiLCAidmVyc2lvbiI6ICIwLjAuMSIsICJy
+        ZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyI0Il0sICJkZXNjcmlwdGlvbiI6
+        ICJUaGlzIHB1cHBldCBtb2R1bGUgbWFuYWdlcyB0aGUgc2NoZWR1bGluZyBv
+        ZiB0YXNrIHRyb3VnaCBjcm9uLlxuSXQgaGFzIHNob3J0Y3V0cyAgY2xhc3Nl
+        cyBmb3IgaG91cmx5ICgvZXRjL2Nyb24uaG91cmx5KSwgZGFpbHkgKC9ldGMv
+        Y3Jvbi5kYWlseSksIHdlZWtseSAoL2V0Yy9jcm9uLmRhaWx5KSBhbmQgbW9u
+        dGhseSAoL2V0Yy9jcm9uLm1vbnRobHkpIHNjaGVkdWxhdGlvbi5cblxuSXQg
+        aGFzIGJlZW4gdGVzdGVkIG9ubHkgLi4uXG5cblRlc3RlZCBvbiBDZW50T1Mg
+        Ni4yLCBSSEVMIDYuMiwgQ2VudE9TIDUuOC5cblxuUmVxdWlyZW1lbnRzOlxu
+        XG4gKiBbRmFjdGVyXShodHRwOi8vd3d3LnB1cHBldGxhYnMuY29tL3B1cHBl
+        dC9yZWxhdGVkLXByb2plY3RzL2ZhY3Rlci8pIDEuNi4xIG9yIGdyZWF0ZXIg
+        KHZlcnNpb25zIHRoYXQgc3VwcG9ydCB0aGUgb3NmYW1pbHkgZmFjdClcbiAq
+        IFtwdXBwZXRsYWJzL3N0ZGxpYl0gZm9yIHRoZSB2YWxpZGF0ZV9hYnNvbHV0
+        ZV9wYXRoIHN0YXRlbWVudFxuXG5Ub2RvOlxuLSBTZXQgdXAgYW5kIGluc3Rh
+        bGwgY3JvbiBpbiB0aGUgLSB2ZXJ5IHVubGlrZWx5IC0gY2FzZSB0aGF0IGl0
+        J3Mgbm90IGluc3RhbGxlZDtcbi0gTWFrZSBjcm9uOjp0YXNrIHdvcmsgd2l0
+        aCB3aW5kb3dzLiIsICJfbGFzdF91cGRhdGVkIjogIjIwMTYtMTEtMjlUMTU6
+        MzM6MDdaIiwgImRvd25sb2FkZWQiOiB0cnVlLCAiZGVwZW5kZW5jaWVzIjog
+        W3sibmFtZSI6ICJwdXBwZXRsYWJzL3N0ZGxpYiIsICJ2ZXJzaW9uX3JlcXVp
+        cmVtZW50IjogIj49My4wLjAifV0sICJ0eXBlcyI6IFtdLCAiX3N0b3JhZ2Vf
+        cGF0aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQvdW5pdHMvcHVwcGV0X21v
+        ZHVsZS83My85MTBiMjY2ZDZlMjBkNjczOWQzZmIwYzY1OWIwYzQ4MDBmMjc5
+        NDc1YWEzZGNmMWVmZmIzZWZmNmYwYzhlYi81VWJaM3IwLWNyb24tMC4wLjEu
+        dGFyLmd6IiwgIl9pZCI6ICI4MGZhOGUzYy05OGVkLTQyOWQtYjNmMC1kZTg4
+        MDVjNDQ4MmIiLCAibmFtZSI6ICJjcm9uIiwgImxpY2Vuc2UiOiAiR1BMIHYz
+        IiwgImNoZWNrc3VtIjogIjBlOTQ4NWUwMDQyNjM2YzA5NTIyMDVjZDY3YWQ2
+        NjkwNGQwYzRmNmIzN2VhMTkyZDE1Yjc2NDI2ZTk2MTA0YTYiLCAic3VtbWFy
+        eSI6ICJQdXBwZXQgbW9kdWxlIHRoYXQgbWFuYWdlcyBzY2hlZHVsaW5nIG9m
+        IHRhc2sgdHJvdWdoIGNyb24iLCAiY2hlY2tzdW1fdHlwZSI6ICJzaGEyNTYi
         LCAidGFnX2xpc3QiOiBbXX1d
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:02 GMT
+  recorded_at: Tue, 29 Nov 2016 19:42:31 GMT
 - request:
     method: post
-    uri: https://obelix.example.com/pulp/api/v2/repositories/4/search/units/
+    uri: https://robot.example.com/pulp/api/v2/content/units/puppet_module/search/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwdXBwZXRfbW9kdWxlIl0sImZp
-        ZWxkcyI6eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '90'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jul 2016 18:59:02 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '916'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICI3NjllNjY1ZS0wYTU1LTQ2MGQtOGU0
-        My1jNzY5MjM1ZDY0ZGIiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwdXBwZXRf
-        bW9kdWxlIn0sICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3NzM3YmMyNWFhZjA5
-        NTYyZTY2In0sICJ1bml0X2lkIjogIjc2OWU2NjVlLTBhNTUtNDYwZC04ZTQz
-        LWM3NjkyMzVkNjRkYiIsICJ1bml0X3R5cGVfaWQiOiAicHVwcGV0X21vZHVs
-        ZSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiOGY3NjNiOWYtMzFhMS00MTRi
-        LThmNmEtYmY0OTI0YjczNzliIiwgIl9jb250ZW50X3R5cGVfaWQiOiAicHVw
-        cGV0X21vZHVsZSJ9LCAiX2lkIjogeyIkb2lkIjogIjU3OWJhNzc1N2JjMjVh
-        YWYwOTU2MmU2OCJ9LCAidW5pdF9pZCI6ICI4Zjc2M2I5Zi0zMWExLTQxNGIt
-        OGY2YS1iZjQ5MjRiNzM3OWIiLCAidW5pdF90eXBlX2lkIjogInB1cHBldF9t
-        b2R1bGUifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjogImI3M2NlZmZlLTcwZTQt
-        NDk1OC1iNmI0LTdkODg3OGI2Y2Q1NCIsICJfY29udGVudF90eXBlX2lkIjog
-        InB1cHBldF9tb2R1bGUifSwgIl9pZCI6IHsiJG9pZCI6ICI1NzliYTc3NDdi
-        YzI1YWFmMDk1NjJlNjcifSwgInVuaXRfaWQiOiAiYjczY2VmZmUtNzBlNC00
-        OTU4LWI2YjQtN2Q4ODc4YjZjZDU0IiwgInVuaXRfdHlwZV9pZCI6ICJwdXBw
-        ZXRfbW9kdWxlIn0sIHsibWV0YWRhdGEiOiB7Il9pZCI6ICJmZWYyMTdlMy01
-        YzNiLTQzMmEtYThkZC1mNmUzZmM2ZGQxMzkiLCAiX2NvbnRlbnRfdHlwZV9p
-        ZCI6ICJwdXBwZXRfbW9kdWxlIn0sICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3
-        NzI3YmMyNWFhZjA5NTYyZTY1In0sICJ1bml0X2lkIjogImZlZjIxN2UzLTVj
-        M2ItNDMyYS1hOGRkLWY2ZTNmYzZkZDEzOSIsICJ1bml0X3R5cGVfaWQiOiAi
-        cHVwcGV0X21vZHVsZSJ9XQ==
-    http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:02 GMT
-- request:
-    method: post
-    uri: https://obelix.example.com/pulp/api/v2/content/units/puppet_module/search/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiNzY5ZTY2
-        NWUtMGE1NS00NjBkLThlNDMtYzc2OTIzNWQ2NGRiIl19fX0sImluY2x1ZGVf
+        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMTQwMzhj
+        MmMtMGZjNC00OWFmLWI0MTMtYTBiZjJmZWM3ODUzIl19fX0sImluY2x1ZGVf
         cmVwb3MiOnRydWV9
     headers:
       Accept:
@@ -1457,61 +1519,78 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:59:02 GMT
+      - Tue, 29 Nov 2016 19:42:31 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1684'
+      - '2451'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
         W3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcHVwcGV0
-        X21vZHVsZS83NjllNjY1ZS0wYTU1LTQ2MGQtOGU0My1jNzY5MjM1ZDY0ZGIv
+        X21vZHVsZS8xNDAzOGMyYy0wZmM0LTQ5YWYtYjQxMy1hMGJmMmZlYzc4NTMv
         IiwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9p
-        ZCI6ICJwdXBwZXRfbW9kdWxlIiwgImNoZWNrc3VtcyI6IFtbIm1hbmlmZXN0
-        cy9zZXJ2aWNlLnBwIiwgIjE5MmM4MTk3OTFlMjA0MjcwMzg5MWU1MWE2MWQz
-        MTRhIl0sIFsiTW9kdWxlZmlsZSIsICJkMzA5ZWUzMTUxNzZlYTNmOTIzNDgw
-        YzI4NmUzYTU1YiJdLCBbInNwZWMvc3BlYy5vcHRzIiwgImE2MDBkZWQ5OTVk
-        OTQ4ZTM5M2ZiZTIzMjBiYThlNTFjIl0sIFsidGVzdHMvaW5pdC5wcCIsICI0
-        ZGNjMjg2OGNiOTc0MGMzMmViNjhmMzQ1YTdiNzE5NCJdLCBbInNwZWMvc3Bl
-        Y19oZWxwZXIucmIiLCAiY2ExOWVjNGY0NTFlYmM3ZmRiMDM1YjUyZWFlNmU5
-        MDkiXSwgWyJtYW5pZmVzdHMvY29uZi5wcCIsICJhZDRiMjg1YTY3MzZhZWJl
-        YmI2ZmE1OWUzOGRkZGVkMSJdLCBbIm1hbmlmZXN0cy9wYXJhbXMucHAiLCAi
-        ZjQxZDExZTdkYmJkZTY3YTJjZjRkMjljZjY3ODNhNTUiXSwgWyJtYW5pZmVz
-        dHMvaW5zdGFsbC5wcCIsICJjOTI5ZTEzZjU0NmJjZGIzZjAyZWZlZGU5ZGIx
-        YWY5YiJdLCBbIm1hbmlmZXN0cy9pbml0LnBwIiwgImY2NThiNTk0YWM4OGRh
-        OTAyNmM2NzViZmUwMzEwZDU3Il0sIFsiUkVBRE1FIiwgIjYyN2ZiYjU3ZWI4
-        ZDk0MzA4ZjAxYTExNDMwNDE4ZmI2Il1dLCAiY2hpbGRyZW4iOiB7fSwgImF1
-        dGhvciI6ICJwdXBwZXQiLCAicHJvamVjdF9wYWdlIjogImh0dHBzOi8vZ2l0
-        aHViLmNvbS81VWItWjNyMC9wdXBwZXQtc2FtYmEiLCAic291cmNlIjogImh0
-        dHBzOi8vZ2l0aHViLmNvbS81VWItWjNyMC9wdXBwZXQtc2FtYmEiLCAidmVy
-        c2lvbiI6ICIwLjIuMCIsICJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyI0
-        Il0sICJkZXNjcmlwdGlvbiI6ICJUaGlzIHB1cHBldCBtb2R1bGUgbWFuYWdl
-        cyBzYW1iYSBjb25maWd1cmF0aW9uLlxuXG5JdCBoYXMgYmVlbiB0ZXN0ZWQg
-        b25seSBmb3Igc2FtYmEgbWFuYWdpbmcgc2hhcmVzLCB0b3VnaCBpdCBkb2Vz
-        IG5vdCBjYXJlIGFib3V0IHRoZSBjb250ZW50IG9mIHlvdXIgY29uZmlnIGZp
-        bGUuXG5cblRlc3RlZCBvbiBDZW50T1MgNi4yLCBSSEVMIDYuMiwgQ2VudE9T
-        IDUuOC4iLCAiX2xhc3RfdXBkYXRlZCI6ICIyMDE2LTA3LTI5VDE4OjU4OjU5
-        WiIsICJkb3dubG9hZGVkIjogdHJ1ZSwgImRlcGVuZGVuY2llcyI6IFtdLCAi
-        dHlwZXMiOiBbXSwgIl9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVscC9j
-        b250ZW50L3VuaXRzL3B1cHBldF9tb2R1bGUvZDUvNjFjZjdkYzFjMmI4N2Qy
-        YWNlMDRmNjM1OGEzMmUwMWMwYWZjNTYzZTYzNGU5YjE3MzQ1ZGExODVkM2M0
-        NzUvNVViWjNyMC1zYW1iYS0wLjIuMC50YXIuZ3oiLCAiX2lkIjogIjc2OWU2
-        NjVlLTBhNTUtNDYwZC04ZTQzLWM3NjkyMzVkNjRkYiIsICJuYW1lIjogInNh
-        bWJhIiwgImxpY2Vuc2UiOiAiR1BMIHYzIiwgImNoZWNrc3VtIjogImM3NzJk
-        ZWNmNzgzNmU0MmE3MjE1YzJhZWUzZjhiZDc0MmUxYzQ4MDM5NGE2NTBiNjU5
-        NDdiM2MwODMyODRjYWMiLCAic3VtbWFyeSI6ICJBIHB1cHBldCBtb2R1bGUg
-        dGhhdCBtYW5hZ2VzIHNhbWJhIiwgImNoZWNrc3VtX3R5cGUiOiAic2hhMjU2
-        IiwgInRhZ19saXN0IjogW119XQ==
+        ZCI6ICJwdXBwZXRfbW9kdWxlIiwgImNoZWNrc3VtcyI6IFtbImZpbGVzXFxk
+        ZWJpYW5cXE1heENsaWVudHNOdW1iZXIiLCAiMmE1MmE1ZTY1ZmMzYzQzZjQw
+        OTU1MGRmYWQxZjkwNGYiXSwgWyJzcGVjXFx1bml0XFxwdXBwZXRcXHR5cGVc
+        XFJFQURNRS5tYXJrZG93biIsICJkZTI2YTc2NDM4MTNhYmQ2YzJlN2UyODA3
+        MWIxZWY5NCJdLCBbInNwZWNcXHVuaXRcXHB1cHBldFxccHJvdmlkZXJcXFJF
+        QURNRS5tYXJrZG93biIsICJlNTI2Njg5NDRlZTZhZjJmYjVkNWI5ZTc5ODM0
+        MjY0NSJdLCBbImZpbGVzXFxkZWJpYW5cXERvbnRSZXNvbHZlIiwgImViNDU4
+        NWFkOWZlMDQyNjc4MWVkN2M0OTI1MmY4MjI1Il0sIFsidGVzdHNcXGluaXQu
+        cHAiLCAiNWQ2ZTg0YmQwNmUyM2M0ZDU2NTc4MmRiNjdlMzMzZWMiXSwgWyJ0
+        ZW1wbGF0ZXNcXGRlZmF1bHRfY29uZmlnLmVyYiIsICIyMjI5NDUxODljNWI4
+        ZDRlZmE5ZmUyYzNjYzAxZjQzNSJdLCBbInNwZWNcXFJFQURNRS5tYXJrZG93
+        biIsICIzMmExZmMwMTIxYzI4YWZmNTU0ZWY1ZDQyMmI4YjUxZSJdLCBbImZp
+        bGVzXFxkZWJpYW5cXEFsdExvZyIsICJhM2Q3Zjg5ZGM5MTYwNjIyMzQyMzdh
+        Y2Y3NWJkZTk3ZCJdLCBbIlJFQURNRS5tZCIsICI5Y2JiOTQ1YzZjZTczMDMx
+        YjAwYjFjNTI2OWNiYjYzOCJdLCBbImZpbGVzXFxkZWJpYW5cXENocm9vdEV2
+        ZXJ5b25lIiwgImViNDU4NWFkOWZlMDQyNjc4MWVkN2M0OTI1MmY4MjI1Il0s
+        IFsiZmlsZXNcXGRlYmlhblxcTm9Bbm9ueW1vdXMiLCAiZWI0NTg1YWQ5ZmUw
+        NDI2NzgxZWQ3YzQ5MjUyZjgyMjUiXSwgWyJmaWxlc1xcZGViaWFuXFxWZXJi
+        b3NlTG9nIiwgIjdmYTNiNzY3YzQ2MGI1NGEyYmU0ZDQ5MDMwYjM0OWM3Il0s
+        IFsiZmlsZXNcXGRlYmlhblxcUEFNQXV0aGVudGljYXRpb24iLCAiZWI0NTg1
+        YWQ5ZmUwNDI2NzgxZWQ3YzQ5MjUyZjgyMjUiXSwgWyJtYW5pZmVzdHNcXHBh
+        cmFtcy5wcCIsICJlN2IzY2YzYTYxMTVlOTZhNmY3NmQzZmYyYzU0NTYyNSJd
+        LCBbImZpbGVzXFxkZWJpYW5cXFB1cmVEQiIsICI2ZGI1OTY1Njk4NTI3ZTFm
+        MTQwZGZjNzNlZDQwZDQ3YyJdLCBbIm1hbmlmZXN0c1xcY29uZmlnLnBwIiwg
+        ImIxMmQ2MzMxMzQ5ZDIxN2JiYmE2ODRhMGM1NjUyNjIwIl0sIFsiZmlsZXNc
+        XGRlYmlhblxcVW5peEF1dGhlbnRpY2F0aW9uIiwgImViNDU4NWFkOWZlMDQy
+        Njc4MWVkN2M0OTI1MmY4MjI1Il0sIFsibWFuaWZlc3RzXFxpbml0LnBwIiwg
+        IjYxNjc1YTkwNWM0MDY0MWU3MGQ2Zjc0OTg1ZmRhOGM4Il0sIFsiTW9kdWxl
+        ZmlsZSIsICJkZWNhYWFiMzJhOTkzMWMzNTY1YTZmYzQ3ZjI2YTc0MCJdLCBb
+        ImZpbGVzXFxkZWJpYW5cXE1pblVJRCIsICI0ZmJhZmQ2OTQ4YjY1MjljYWEy
+        Yjc4ZTQ3NjM1OTg3NSJdLCBbIm1hbmlmZXN0c1xcc2VydmljZS5wcCIsICI3
+        MjJkNjI2NTFlNmM2MWRhNDMzMDMzMmI2MzgyZjVhOSJdLCBbInNwZWNcXHNw
+        ZWMub3B0cyIsICJhNjAwZGVkOTk1ZDk0OGUzOTNmYmUyMzIwYmE4ZTUxYyJd
+        LCBbInNwZWNcXHNwZWNfaGVscGVyLnJiIiwgImNhMTllYzRmNDUxZWJjN2Zk
+        YjAzNWI1MmVhZTZlOTA5Il0sIFsibWFuaWZlc3RzXFxpbnN0YWxsLnBwIiwg
+        IjUxY2FhMjVmOTBhNDc5Y2Q1MDE4MjQzNjJiOWJkYmExIl1dLCAiY2hpbGRy
+        ZW4iOiB7fSwgImF1dGhvciI6ICJzYXoiLCAicHJvamVjdF9wYWdlIjogImh0
+        dHBzOi8vZ2l0aHViLmNvbS9zYXovcHVwcGV0LXB1cmVmdHBkIiwgInNvdXJj
+        ZSI6ICIiLCAidmVyc2lvbiI6ICIxLjAuMiIsICJyZXBvc2l0b3J5X21lbWJl
+        cnNoaXBzIjogWyI0Il0sICJkZXNjcmlwdGlvbiI6ICJNYW5hZ2UgUHVyZS1G
+        VFBkIHZpYSBQdXBwZXQiLCAiX2xhc3RfdXBkYXRlZCI6ICIyMDE2LTExLTI5
+        VDE1OjMzOjAyWiIsICJkb3dubG9hZGVkIjogdHJ1ZSwgImRlcGVuZGVuY2ll
+        cyI6IFtdLCAidHlwZXMiOiBbXSwgIl9zdG9yYWdlX3BhdGgiOiAiL3Zhci9s
+        aWIvcHVscC9jb250ZW50L3VuaXRzL3B1cHBldF9tb2R1bGUvYTUvYzRjZjVi
+        ZmM3M2QyY2I0YTg0YmMxMzQ5YmQyNjk5ZGJiOTRiZTY5ZTJhYTU0ZjA1Mjc1
+        NDIwNTY0NjFhZmYvNVViWjNyMC1wdXJlZnRwZC0xLjAuMi50YXIuZ3oiLCAi
+        X2lkIjogIjE0MDM4YzJjLTBmYzQtNDlhZi1iNDEzLWEwYmYyZmVjNzg1MyIs
+        ICJuYW1lIjogInB1cmVmdHBkIiwgImxpY2Vuc2UiOiAiQXBhY2hlIExpY2Vu
+        c2UsIFZlcnNpb24gMi4wIiwgImNoZWNrc3VtIjogImVlZjE4ZThiZDUxNjJh
+        MDFkODA1Yzc2MzM1YjhhOTRjNDgwNjdlYTg0YTBlNmY5NGVkMWJlZWY1NWZh
+        ZWU4MDkiLCAic3VtbWFyeSI6ICIiLCAiY2hlY2tzdW1fdHlwZSI6ICJzaGEy
+        NTYiLCAidGFnX2xpc3QiOiBbXX1d
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:02 GMT
+  recorded_at: Tue, 29 Nov 2016 19:42:31 GMT
 - request:
     method: delete
-    uri: https://obelix.example.com/pulp/api/v2/repositories/4/
+    uri: https://robot.example.com/pulp/api/v2/repositories/4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1530,7 +1609,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:59:02 GMT
+      - Tue, 29 Nov 2016 19:42:32 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -1541,14 +1620,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2NmZWE0NTBhLTBhY2EtNDU4YS05MDA0LTUxMGQyNDEzNDMxMi8iLCAi
-        dGFza19pZCI6ICJjZmVhNDUwYS0wYWNhLTQ1OGEtOTAwNC01MTBkMjQxMzQz
-        MTIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2I0ZDE3M2VlLTllMWUtNDQwZC1hMjI4LWMwZjEyY2VlNzE0ZS8iLCAi
+        dGFza19pZCI6ICJiNGQxNzNlZS05ZTFlLTQ0MGQtYTIyOC1jMGYxMmNlZTcx
+        NGUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:02 GMT
+  recorded_at: Tue, 29 Nov 2016 19:42:32 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/cfea450a-0aca-458a-9004-510d24134312/
+    uri: https://robot.example.com/pulp/api/v2/tasks/b4d173ee-9e1e-440d-a228-c0f12cee714e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1567,13 +1646,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:59:02 GMT
+      - Tue, 29 Nov 2016 19:42:32 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '625'
+      - '541'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1581,23 +1660,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jZmVhNDUwYS0wYWNhLTQ1OGEtOTAwNC01MTBkMjQxMzQz
-        MTIvIiwgInRhc2tfaWQiOiAiY2ZlYTQ1MGEtMGFjYS00NThhLTkwMDQtNTEw
-        ZDI0MTM0MzEyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        aS92Mi90YXNrcy9iNGQxNzNlZS05ZTFlLTQ0MGQtYTIyOC1jMGYxMmNlZTcx
+        NGUvIiwgInRhc2tfaWQiOiAiYjRkMTczZWUtOWUxZS00NDBkLWEyMjgtYzBm
+        MTJjZWU3MTRlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
         bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiBudWxsLCAiX25z
         IjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAidHJhY2Vi
         YWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3Jl
-        cG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTFAb2JlbGl4LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogIndhaXRpbmci
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        b2JlbGl4LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3NzY3YmMyNWFhZjA5NTYy
-        ZTZiIn0sICJpZCI6ICI1NzliYTc3NjdiYzI1YWFmMDk1NjJlNmIifQ==
+        cG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6ICJ3YWl0
+        aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51bGwsICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTgzZGRhMjg2NzFlMDhl
+        YWE2ZDI1NzY1In0sICJpZCI6ICI1ODNkZGEyODY3MWUwOGVhYTZkMjU3NjUi
+        fQ==
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:02 GMT
+  recorded_at: Tue, 29 Nov 2016 19:42:32 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/cfea450a-0aca-458a-9004-510d24134312/
+    uri: https://robot.example.com/pulp/api/v2/tasks/b4d173ee-9e1e-440d-a228-c0f12cee714e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1616,13 +1694,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:59:03 GMT
+      - Tue, 29 Nov 2016 19:42:32 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '662'
+      - '660'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1630,19 +1708,19 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jZmVhNDUwYS0wYWNhLTQ1OGEtOTAwNC01MTBkMjQxMzQz
-        MTIvIiwgInRhc2tfaWQiOiAiY2ZlYTQ1MGEtMGFjYS00NThhLTkwMDQtNTEw
-        ZDI0MTM0MzEyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
-        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0wNy0y
-        OVQxODo1OTowMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3Rp
-        bWUiOiAiMjAxNi0wNy0yOVQxODo1OTowMloiLCAidHJhY2ViYWNrIjogbnVs
+        aS92Mi90YXNrcy9iNGQxNzNlZS05ZTFlLTQ0MGQtYTIyOC1jMGYxMmNlZTcx
+        NGUvIiwgInRhc2tfaWQiOiAiYjRkMTczZWUtOWUxZS00NDBkLWEyMjgtYzBm
+        MTJjZWU3MTRlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTo0IiwgInB1
+        bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAxNi0xMS0y
+        OVQxOTo0MjozMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3Rp
+        bWUiOiAiMjAxNi0xMS0yOVQxOTo0MjozMloiLCAidHJhY2ViYWNrIjogbnVs
         bCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9
-        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAb2JlbGl4
-        LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQG9iZWxpeC5l
-        eGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjU3OWJhNzc2N2JjMjVhYWYwOTU2MmU2YiJ9LCAi
-        aWQiOiAiNTc5YmE3NzY3YmMyNWFhZjA5NTYyZTZiIn0=
+        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAcm9ib3Qu
+        ZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2Vy
+        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAcm9ib3QuZXhh
+        bXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1ODNkZGEyODY3MWUwOGVhYTZkMjU3NjUifSwgImlk
+        IjogIjU4M2RkYTI4NjcxZTA4ZWFhNmQyNTc2NSJ9
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:03 GMT
+  recorded_at: Tue, 29 Nov 2016 19:42:32 GMT
 recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/services/pulp/rpm.yml
+++ b/test/fixtures/vcr_cassettes/services/pulp/rpm.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/526ffb19-fd8a-40f6-8aad-15b9b1f7c2fe/
+    uri: https://robot.example.com/pulp/api/v2/tasks/e8c0dfbe-6c1e-47c4-905d-96cd33d26c80/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -21,13 +21,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:59:04 GMT
+      - Tue, 29 Nov 2016 19:40:22 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1121'
+      - '547'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -35,34 +35,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81MjZmZmIxOS1mZDhhLTQwZjYtOGFhZC0xNWI5YjFmN2My
-        ZmUvIiwgInRhc2tfaWQiOiAiNTI2ZmZiMTktZmQ4YS00MGY2LThhYWQtMTVi
-        OWIxZjdjMmZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9lOGMwZGZiZS02YzFlLTQ3YzQtOTA1ZC05NmNkMzNkMjZj
+        ODAvIiwgInRhc2tfaWQiOiAiZThjMGRmYmUtNmMxZS00N2M0LTkwNWQtOTZj
+        ZDMzZDI2YzgwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Ny0yOVQxODo1OTowNFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
-        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
-        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
-        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
-        T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQG9iZWxpeC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5n
-        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
-        QG9iZWxpeC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3Ii
-        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU3OWJhNzc4N2JjMjVhYWYwOTU2
-        MmU2YyJ9LCAiaWQiOiAiNTc5YmE3Nzg3YmMyNWFhZjA5NTYyZTZjIn0=
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6
+        ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTgzZGQ5YTY2
+        NzFlMDhlYWE2ZDI1NzI3In0sICJpZCI6ICI1ODNkZDlhNjY3MWUwOGVhYTZk
+        MjU3MjcifQ==
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:04 GMT
+  recorded_at: Tue, 29 Nov 2016 19:40:23 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/526ffb19-fd8a-40f6-8aad-15b9b1f7c2fe/
+    uri: https://robot.example.com/pulp/api/v2/tasks/e8c0dfbe-6c1e-47c4-905d-96cd33d26c80/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -81,13 +69,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:59:04 GMT
+      - Tue, 29 Nov 2016 19:40:23 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2284'
+      - '2282'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -95,16 +83,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81MjZmZmIxOS1mZDhhLTQwZjYtOGFhZC0xNWI5YjFmN2My
-        ZmUvIiwgInRhc2tfaWQiOiAiNTI2ZmZiMTktZmQ4YS00MGY2LThhYWQtMTVi
-        OWIxZjdjMmZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9lOGMwZGZiZS02YzFlLTQ3YzQtOTA1ZC05NmNkMzNkMjZj
+        ODAvIiwgInRhc2tfaWQiOiAiZThjMGRmYmUtNmMxZS00N2M0LTkwNWQtOTZj
+        ZDMzZDI2YzgwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wNy0yOVQxODo1OTowNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wNy0yOVQxODo1OTowNFoiLCAidHJhY2ViYWNr
+        Ni0xMS0yOVQxOTo0MDoyM1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0MDoyM1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZDlkMzk1YzQtYjJiZi00NzhhLWE1YTYtZTFlNjU3NWUw
-        MTYzLyIsICJ0YXNrX2lkIjogImQ5ZDM5NWM0LWIyYmYtNDc4YS1hNWE2LWUx
-        ZTY1NzVlMDE2MyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvZTFkMTkwYzAtNWQyNy00ZWY2LWI1YTgtYWNiYTJhMjk5
+        ZjI3LyIsICJ0YXNrX2lkIjogImUxZDE5MGMwLTVkMjctNGVmNi1iNWE4LWFj
+        YmEyYTI5OWYyNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -115,40 +103,40 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQG9iZWxpeC5leGFt
-        cGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFt
-        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBs
-        ZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBv
-        cnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwg
-        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJz
-        dGFydGVkIjogIjIwMTYtMDctMjlUMTg6NTk6MDRaIiwgIl9ucyI6ICJyZXBv
-        X3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wNy0yOVQxODo1
-        OTowNFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
-        ZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50Ijog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAxNSwg
-        InJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6
-        ICI1NzliYTc3ODcwYmU2ZjczOGVkZDlkZjciLCAiZGV0YWlscyI6IHsiY29u
-        dGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVm
-        dCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUi
-        OiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9y
-        X2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3Nzg3YmMyNWFhZjA5NTYyZTZjIn0s
-        ICJpZCI6ICI1NzliYTc3ODdiYzI1YWFmMDk1NjJlNmMifQ==
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0
+        ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTExLTI5VDE5OjQwOjIzWiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMTEtMjlUMTk6NDA6
+        MjNaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTgzZGQ5YTdiMGVhZjIwOTliNjgxODM5IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU4M2RkOWE2NjcxZTA4ZWFhNmQyNTcyNyJ9LCAi
+        aWQiOiAiNTgzZGQ5YTY2NzFlMDhlYWE2ZDI1NzI3In0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:04 GMT
+  recorded_at: Tue, 29 Nov 2016 19:40:23 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/d9d395c4-b2bf-478a-a5a6-e1e6575e0163/
+    uri: https://robot.example.com/pulp/api/v2/tasks/e1d190c0-5d27-4ef6-b5a8-acba2a299f27/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -167,13 +155,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:59:04 GMT
+      - Tue, 29 Nov 2016 19:40:23 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '6911'
+      - '638'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -181,163 +169,299 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9kOWQzOTVjNC1iMmJmLTQ3OGEtYTVhNi1lMWU2
-        NTc1ZTAxNjMvIiwgInRhc2tfaWQiOiAiZDlkMzk1YzQtYjJiZi00NzhhLWE1
-        YTYtZTFlNjU3NWUwMTYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy9lMWQxOTBjMC01ZDI3LTRlZjYtYjVhOC1hY2Jh
+        MmEyOTlmMjcvIiwgInRhc2tfaWQiOiAiZTFkMTkwYzAtNWQyNy00ZWY2LWI1
+        YTgtYWNiYTJhMjk5ZjI3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wNy0yOVQxODo1OTowNFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wNy0yOVQxODo1OTowNFoiLCAi
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiBudWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBb
+        XSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRf
+        cmVzb3VyY2Vfd29ya2VyLTFAcm9ib3QuZXhhbXBsZS5jb20uZHEiLCAic3Rh
+        dGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMUByb2JvdC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU4M2RkOWE3
+        NjcxZTA4ZWFhNmQyNTczNyJ9LCAiaWQiOiAiNTgzZGQ5YTc2NzFlMDhlYWE2
+        ZDI1NzM3In0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:40:23 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/e8c0dfbe-6c1e-47c4-905d-96cd33d26c80/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:40:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2282'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9lOGMwZGZiZS02YzFlLTQ3YzQtOTA1ZC05NmNkMzNkMjZj
+        ODAvIiwgInRhc2tfaWQiOiAiZThjMGRmYmUtNmMxZS00N2M0LTkwNWQtOTZj
+        ZDMzZDI2YzgwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0xMS0yOVQxOTo0MDoyM1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0MDoyM1oiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvZTFkMTkwYzAtNWQyNy00ZWY2LWI1YTgtYWNiYTJhMjk5
+        ZjI3LyIsICJ0YXNrX2lkIjogImUxZDE5MGMwLTVkMjctNGVmNi1iNWE4LWFj
+        YmEyYTI5OWYyNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0
+        ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTExLTI5VDE5OjQwOjIzWiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMTEtMjlUMTk6NDA6
+        MjNaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTgzZGQ5YTdiMGVhZjIwOTliNjgxODM5IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU4M2RkOWE2NjcxZTA4ZWFhNmQyNTcyNyJ9LCAi
+        aWQiOiAiNTgzZGQ5YTY2NzFlMDhlYWE2ZDI1NzI3In0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:40:24 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/e1d190c0-5d27-4ef6-b5a8-acba2a299f27/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:40:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '6909'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9lMWQxOTBjMC01ZDI3LTRlZjYtYjVhOC1hY2Jh
+        MmEyOTlmMjcvIiwgInRhc2tfaWQiOiAiZTFkMTkwYzAtNWQyNy00ZWY2LWI1
+        YTgtYWNiYTJhMjk5ZjI3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0xMS0yOVQxOTo0MDoyM1oiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0MDoyM1oiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI3NzNhMzBkZC04MTYwLTQzYTAtOTVmOS1iNDU1MjEw
-        NzZiN2IiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICIzOTRlNzNmMi0xMzI0LTQ3MzMtODE4My04ZmZiZTU2
+        NzFhNDMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZTg0YTQyNjAtYjNkYy00ZjBjLWFmZTUtNWNmMmEzMmZkMTUwIiwg
+        aWQiOiAiNjkyYTA3ZGEtNGNhOS00YjhjLWIwN2EtZjdlZDRhM2EzZDkzIiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
         bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiYjBjNDk2OGQtYzFlMi00NjFmLTljYTYt
-        YTdkMjUyOWI0MzVmIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNDMzYjRjMjctOGRkMS00NGM0LWE5NDMt
+        ZGNjNWY2NWEzM2I1IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
         TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZWZi
-        ODBiNzAtYzA2Ny00NWM1LWEwZWEtYjJjN2MxZGJlNmUxIiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDgy
+        NjliMmEtNGRmOC00N2RiLTkzNDItZWUzMDgwNGJlYThiIiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImNiZGQzZmFlLWU4MDctNDI1My05MjE1LWJlZTY4
-        OWMwNGM3ZiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        IDAsICJzdGVwX2lkIjogIjUyM2FjMmNmLTRkMTktNDgzNi04YWE1LTgwYmJk
+        YTM3Yjc1MCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
         OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
         InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2NDA3Njk2
-        NC0wMjI3LTRkZjItOGFhMi1kZWQ1NTZlMjcxODYiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmY2FlODhk
+        Yi0xMWRhLTQyZWEtOTYwMy03NTU0ZTc1OGNlMzYiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
         Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJiYjlkZDQyYi03MGFiLTQ4ODUtYjllOC0wYWU5
-        YzMyYmY0MjkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICJkZGYxNjk5OS1lOWVjLTRiZTMtOWU2OC04N2I3
+        YjNhMjc4OTIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
         ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIwM2U0NmZjYS04NjVkLTQ1NjQtYWYwZC02NzRmMDQxNGVkMzki
+        cF9pZCI6ICJmZDgxMWQ2NS02YjZlLTQyZjMtYmQ5Ny00NjcxYzMyNDVkNjAi
         LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
         dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
         c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZTM4
-        YzU3ZC1jZWY1LTQwMzctYThlOC1hOTcwYTdjM2MyZmIiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzZGEx
+        NWNjYy0zYTk3LTQ2NTAtOWM1Yy03YTdmMzAwZDQyOGUiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
         aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1ZGRlNTVkZC1lNmFh
-        LTRkMGMtYmQ0NS1jMzFkMWVmMmQ3NmQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxM2FjYjNjMi01MDU4
+        LTQwNGMtYTA2Yy00NjdiNjg4ZWJlOTYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
         TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
         X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZkNDljZDljLTFmMmUtNDVj
-        OS1hNWYzLTliNjMxMDI5MzY3YiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQG9iZWxpeC5l
-        eGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhh
-        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJl
-        eGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3Rh
-        cnRlZCI6ICIyMDE2LTA3LTI5VDE4OjU5OjA0WiIsICJfbnMiOiAicmVwb19w
-        dWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDctMjlUMTg6
-        NTk6MDRaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBl
-        X2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0
-        ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9y
-        ZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQi
-        LCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklT
-        SEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0
-        YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFf
-        MTciLCAiaWQiOiAiNTc5YmE3Nzg3MGJlNmY3MzhlZGQ5ZGY4IiwgImRldGFp
-        bHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0
-        aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
-        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdmMjY2OGYyLWJjZTEtNGNi
+        NC1iMjI5LTRiZGU1ZDU1NTYzYiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4
+        YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9u
+        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhj
+        ZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInN0YXJ0
+        ZWQiOiAiMjAxNi0xMS0yOVQxOTo0MDoyM1oiLCAiX25zIjogInJlcG9fcHVi
+        bGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTExLTI5VDE5OjQw
+        OjIzWiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9p
+        ZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAic3VtbWFyeSI6IHsiZ2VuZXJhdGUg
+        c3FsaXRlIjogIlNLSVBQRUQiLCAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRh
+        IjogIkZJTklTSEVEIiwgInJwbXMiOiAiRklOSVNIRUQiLCAiY2xvc2VfcmVw
+        b19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJkcnBtcyI6ICJTS0lQUEVEIiwg
+        ImNvbXBzIjogIkZJTklTSEVEIiwgImRpc3RyaWJ1dGlvbiI6ICJGSU5JU0hF
+        RCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6ICJGSU5JU0hFRCIsICJlcnJhdGEi
+        OiAiRklOSVNIRUQiLCAibWV0YWRhdGEiOiAiRklOSVNIRUQifSwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3JfaWQiOiAiRmVkb3JhXzE3
+        IiwgImlkIjogIjU4M2RkOWE3YjBlYWYyMDk5YjY4MTgzYSIsICJkZXRhaWxz
+        IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiSW5pdGlh
+        bGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImluaXRpYWxp
+        emVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzOTRlNzNmMi0x
+        MzI0LTQ3MzMtODE4My04ZmZiZTU2NzFhNDMiLCAibnVtX3Byb2Nlc3NlZCI6
+        IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
+        c2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0
+        cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjkyYTA3ZGEtNGNhOS00Yjhj
+        LWIwN2EtZjdlZDRhM2EzZDkzIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJu
+        dW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQ
+        TXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiA4LCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDMz
+        YjRjMjctOGRkMS00NGM0LWE5NDMtZGNjNWY2NWEzM2I1IiwgIm51bV9wcm9j
+        ZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjogImRycG1z
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiMDgyNjliMmEtNGRmOC00N2RiLTkzNDItZWUz
+        MDgwNGJlYThiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJz
+        dGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRl
         IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc3M2EzMGRk
-        LTgxNjAtNDNhMC05NWY5LWI0NTUyMTA3NmI3YiIsICJudW1fcHJvY2Vzc2Vk
-        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRp
-        c3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjUyM2FjMmNm
+        LTRkMTktNDgzNi04YWE1LTgwYmJkYTM3Yjc1MCIsICJudW1fcHJvY2Vzc2Vk
+        IjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJp
+        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICJmY2FlODhkYi0xMWRhLTQyZWEtOTYwMy03NTU0ZTc1
+        OGNlMzYiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0
+        ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkZGYxNjk5
+        OS1lOWVjLTRiZTMtOWU2OC04N2I3YjNhMjc4OTIiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNs
+        b3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVw
+        b19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
         U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlODRhNDI2MC1iM2RjLTRm
-        MGMtYWZlNS01Y2YyYTMyZmQxNTAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
-        Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        UlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJi
-        MGM0OTY4ZC1jMWUyLTQ2MWYtOWNhNi1hN2QyNTI5YjQzNWYiLCAibnVtX3By
-        b2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJlZmI4MGI3MC1jMDY3LTQ1YzUtYTBlYS1i
-        MmM3YzFkYmU2ZTEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
-        ZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwg
-        InN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiY2JkZDNm
-        YWUtZTgwNy00MjUzLTkyMTUtYmVlNjg5YzA0YzdmIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjY0MDc2OTY0LTAyMjctNGRmMi04YWEyLWRlZDU1
-        NmUyNzE4NiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAi
-        c3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJiOWRk
-        NDJiLTcwYWItNDg4NS1iOWU4LTBhZTljMzJiZjQyOSIsICJudW1fcHJvY2Vz
-        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        Q2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9y
-        ZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
-        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjAzZTQ2ZmNhLTg2NWQt
-        NDU2NC1hZjBkLTY3NGYwNDE0ZWQzOSIsICJudW1fcHJvY2Vzc2VkIjogMX0s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
-        ZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0
-        ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogImFlMzhjNTdkLWNlZjUtNDAzNy1hOGU4LWE5
-        NzBhN2MzYzJmYiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
-        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3
-        ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjVkZGU1NWRkLWU2YWEtNGQwYy1iZDQ1LWMzMWQxZWYyZDc2
-        ZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBf
-        dHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZmQ0OWNkOWMtMWYyZS00NWM5LWE1ZjMtOWI2MzEwMjkzNjdiIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjU3OWJhNzc4N2JjMjVhYWYwOTU2MmU3YyJ9LCAiaWQiOiAi
-        NTc5YmE3Nzg3YmMyNWFhZjA5NTYyZTdjIn0=
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmZDgxMWQ2NS02YjZlLTQy
+        ZjMtYmQ5Ny00NjcxYzMyNDVkNjAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
+        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcg
+        c3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICIzZGExNWNjYy0zYTk3LTQ2NTAtOWM1Yy03YTdm
+        MzAwZDQyOGUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2Vi
+        IiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICIxM2FjYjNjMi01MDU4LTQwNGMtYTA2Yy00NjdiNjg4ZWJlOTYi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjdmMjY2OGYyLWJjZTEtNGNiNC1iMjI5LTRiZGU1ZDU1NTYzYiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1ODNkZDlhNzY3MWUwOGVhYTZkMjU3MzcifSwgImlkIjogIjU4
+        M2RkOWE3NjcxZTA4ZWFhNmQyNTczNyJ9
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:04 GMT
+  recorded_at: Tue, 29 Nov 2016 19:40:24 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/a072e41a-8920-4cc2-bbe9-b4978802e1fa/
+    uri: https://robot.example.com/pulp/api/v2/tasks/86b9ce71-4f46-4a3e-8231-6b93922eb69a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -356,107 +480,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:59:05 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '633'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hMDcyZTQxYS04OTIwLTRjYzItYmJlOS1iNDk3ODgwMmUx
-        ZmEvIiwgInRhc2tfaWQiOiAiYTA3MmU0MWEtODkyMC00Y2MyLWJiZTktYjQ5
-        Nzg4MDJlMWZhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
-        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMUBvYmVsaXguZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
-        d2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
-        b3JrZXItMUBvYmVsaXguZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwg
-        ImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1NzliYTc3OTdiYzI1
-        YWFmMDk1NjJlN2QifSwgImlkIjogIjU3OWJhNzc5N2JjMjVhYWYwOTU2MmU3
-        ZCJ9
-    http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:05 GMT
-- request:
-    method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/a072e41a-8920-4cc2-bbe9-b4978802e1fa/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jul 2016 18:59:05 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '670'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hMDcyZTQxYS04OTIwLTRjYzItYmJlOS1iNDk3ODgwMmUx
-        ZmEvIiwgInRhc2tfaWQiOiAiYTA3MmU0MWEtODkyMC00Y2MyLWJiZTktYjQ5
-        Nzg4MDJlMWZhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTA3LTI5VDE4OjU5OjA1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTA3LTI5VDE4OjU5OjA1WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBvYmVsaXguZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQi
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        b2JlbGl4LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3Nzk3YmMyNWFhZjA5NTYy
-        ZTdkIn0sICJpZCI6ICI1NzliYTc3OTdiYzI1YWFmMDk1NjJlN2QifQ==
-    http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:05 GMT
-- request:
-    method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/9f8908a0-d1a1-4cb6-98d0-c37204582521/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jul 2016 18:59:06 GMT
+      - Tue, 29 Nov 2016 19:40:24 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -469,25 +493,25 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85Zjg5MDhhMC1kMWExLTRjYjYtOThkMC1jMzcyMDQ1ODI1
-        MjEvIiwgInRhc2tfaWQiOiAiOWY4OTA4YTAtZDFhMS00Y2I2LTk4ZDAtYzM3
-        MjA0NTgyNTIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Ny0yOVQxODo1OTowNloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAb2JlbGl4LmV4YW1wbGUuY29t
-        LmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVz
-        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAb2JlbGl4LmV4YW1wbGUuY29tIiwg
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84NmI5Y2U3MS00ZjQ2LTRhM2UtODIzMS02YjkzOTIyZWI2
+        OWEvIiwgInRhc2tfaWQiOiAiODZiOWNlNzEtNGY0Ni00YTNlLTgyMzEtNmI5
+        MzkyMmViNjlhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
+        LTExLTI5VDE5OjQwOjI0WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUByb2JvdC5leGFtcGxlLmNv
+        bS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUuY29tIiwg
         InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNTc5YmE3N2E3YmMyNWFhZjA5NTYyZTdlIn0sICJpZCI6ICI1NzliYTc3
-        YTdiYzI1YWFmMDk1NjJlN2UifQ==
+        OiAiNTgzZGQ5YTg2NzFlMDhlYWE2ZDI1NzM4In0sICJpZCI6ICI1ODNkZDlh
+        ODY3MWUwOGVhYTZkMjU3MzgifQ==
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:06 GMT
+  recorded_at: Tue, 29 Nov 2016 19:40:24 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/9f8908a0-d1a1-4cb6-98d0-c37204582521/
+    uri: https://robot.example.com/pulp/api/v2/tasks/86b9ce71-4f46-4a3e-8231-6b93922eb69a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -506,13 +530,63 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:59:07 GMT
+      - Tue, 29 Nov 2016 19:40:25 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2284'
+      - '668'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84NmI5Y2U3MS00ZjQ2LTRhM2UtODIzMS02YjkzOTIyZWI2
+        OWEvIiwgInRhc2tfaWQiOiAiODZiOWNlNzEtNGY0Ni00YTNlLTgyMzEtNmI5
+        MzkyMmViNjlhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTExLTI5VDE5OjQwOjI0WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTExLTI5VDE5OjQwOjI0WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUByb2JvdC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBy
+        b2JvdC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU4M2RkOWE4NjcxZTA4ZWFhNmQyNTcz
+        OCJ9LCAiaWQiOiAiNTgzZGQ5YTg2NzFlMDhlYWE2ZDI1NzM4In0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:40:25 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/5af83ec2-96b6-45e9-9815-89629c5b8ea5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:40:26 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '629'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -520,16 +594,65 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85Zjg5MDhhMC1kMWExLTRjYjYtOThkMC1jMzcyMDQ1ODI1
-        MjEvIiwgInRhc2tfaWQiOiAiOWY4OTA4YTAtZDFhMS00Y2I2LTk4ZDAtYzM3
-        MjA0NTgyNTIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy81YWY4M2VjMi05NmI2LTQ1ZTktOTgxNS04OTYyOWM1Yjhl
+        YTUvIiwgInRhc2tfaWQiOiAiNWFmODNlYzItOTZiNi00NWU5LTk4MTUtODk2
+        MjljNWI4ZWE1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAcm9ib3QuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAid2Fp
+        dGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMUByb2JvdC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU4M2RkOWFhNjcxZTA4ZWFh
+        NmQyNTczOSJ9LCAiaWQiOiAiNTgzZGQ5YWE2NzFlMDhlYWE2ZDI1NzM5In0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:40:26 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/5af83ec2-96b6-45e9-9815-89629c5b8ea5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:40:26 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2282'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81YWY4M2VjMi05NmI2LTQ1ZTktOTgxNS04OTYyOWM1Yjhl
+        YTUvIiwgInRhc2tfaWQiOiAiNWFmODNlYzItOTZiNi00NWU5LTk4MTUtODk2
+        MjljNWI4ZWE1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wNy0yOVQxODo1OTowNloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wNy0yOVQxODo1OTowNloiLCAidHJhY2ViYWNr
+        Ni0xMS0yOVQxOTo0MDoyNloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0MDoyNloiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYjY4MjMyNWItMjIzNy00NmYwLWJhNTctNzNiMDkzY2M2
-        ZDNhLyIsICJ0YXNrX2lkIjogImI2ODIzMjViLTIyMzctNDZmMC1iYTU3LTcz
-        YjA5M2NjNmQzYSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvNDg0ZDAzMGMtNjQwZC00YjcxLTg1ZmUtZTliNDM0MDEy
+        NDI1LyIsICJ0YXNrX2lkIjogIjQ4NGQwMzBjLTY0MGQtNGI3MS04NWZlLWU5
+        YjQzNDAxMjQyNSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -540,40 +663,40 @@ http_interactions:
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
         RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQG9iZWxpeC5leGFt
-        cGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFt
-        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBs
-        ZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBv
-        cnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwg
-        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJz
-        dGFydGVkIjogIjIwMTYtMDctMjlUMTg6NTk6MDZaIiwgIl9ucyI6ICJyZXBv
-        X3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wNy0yOVQxODo1
-        OTowNloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
-        ZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50Ijog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAxNSwg
-        InJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6
-        ICI1NzliYTc3YTcwYmU2ZjczOGVkZDllMDQiLCAiZGV0YWlscyI6IHsiY29u
-        dGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVm
-        dCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUi
-        OiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9y
-        X2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3N2E3YmMyNWFhZjA5NTYyZTdlIn0s
-        ICJpZCI6ICI1NzliYTc3YTdiYzI1YWFmMDk1NjJlN2UifQ==
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0
+        ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTExLTI5VDE5OjQwOjI2WiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMTEtMjlUMTk6NDA6
+        MjZaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTgzZGQ5YWFiMGVhZjIwOTliNjgxODQ2IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU4M2RkOWFhNjcxZTA4ZWFhNmQyNTczOSJ9LCAi
+        aWQiOiAiNTgzZGQ5YWE2NzFlMDhlYWE2ZDI1NzM5In0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:07 GMT
+  recorded_at: Tue, 29 Nov 2016 19:40:26 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/b682325b-2237-46f0-ba57-73b093cc6d3a/
+    uri: https://robot.example.com/pulp/api/v2/tasks/484d030c-640d-4b71-85fe-e9b434012425/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -592,13 +715,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:59:07 GMT
+      - Tue, 29 Nov 2016 19:40:26 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '6911'
+      - '656'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -606,168 +729,1244 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9iNjgyMzI1Yi0yMjM3LTQ2ZjAtYmE1Ny03M2Iw
-        OTNjYzZkM2EvIiwgInRhc2tfaWQiOiAiYjY4MjMyNWItMjIzNy00NmYwLWJh
-        NTctNzNiMDkzY2M2ZDNhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy80ODRkMDMwYy02NDBkLTRiNzEtODVmZS1lOWI0
+        MzQwMTI0MjUvIiwgInRhc2tfaWQiOiAiNDg0ZDAzMGMtNjQwZC00YjcxLTg1
+        ZmUtZTliNDM0MDEyNDI1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wNy0yOVQxODo1OTowN1oiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wNy0yOVQxODo1OTowNloiLCAi
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxNi0xMS0yOVQxOTo0MDoyNloiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAcm9ib3QuZXhh
+        bXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUByb2JvdC5leGFtcGxl
+        LmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
+        eyIkb2lkIjogIjU4M2RkOWFhNjcxZTA4ZWFhNmQyNTc0OSJ9LCAiaWQiOiAi
+        NTgzZGQ5YWE2NzFlMDhlYWE2ZDI1NzQ5In0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:40:26 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/5af83ec2-96b6-45e9-9815-89629c5b8ea5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:40:27 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2282'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81YWY4M2VjMi05NmI2LTQ1ZTktOTgxNS04OTYyOWM1Yjhl
+        YTUvIiwgInRhc2tfaWQiOiAiNWFmODNlYzItOTZiNi00NWU5LTk4MTUtODk2
+        MjljNWI4ZWE1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0xMS0yOVQxOTo0MDoyNloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0MDoyNloiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNDg0ZDAzMGMtNjQwZC00YjcxLTg1ZmUtZTliNDM0MDEy
+        NDI1LyIsICJ0YXNrX2lkIjogIjQ4NGQwMzBjLTY0MGQtNGI3MS04NWZlLWU5
+        YjQzNDAxMjQyNSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0
+        ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTExLTI5VDE5OjQwOjI2WiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMTEtMjlUMTk6NDA6
+        MjZaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTgzZGQ5YWFiMGVhZjIwOTliNjgxODQ2IiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU4M2RkOWFhNjcxZTA4ZWFhNmQyNTczOSJ9LCAi
+        aWQiOiAiNTgzZGQ5YWE2NzFlMDhlYWE2ZDI1NzM5In0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:40:27 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/484d030c-640d-4b71-85fe-e9b434012425/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:40:27 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '6909'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy80ODRkMDMwYy02NDBkLTRiNzEtODVmZS1lOWI0
+        MzQwMTI0MjUvIiwgInRhc2tfaWQiOiAiNDg0ZDAzMGMtNjQwZC00YjcxLTg1
+        ZmUtZTliNDM0MDEyNDI1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0xMS0yOVQxOTo0MDoyNloiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0MDoyNloiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI3N2UwNGYxMS00Njk2LTQ3YzMtODIyYy0zYzI4MGM2
-        ZTdhMmMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICI4NzlkYTRlZC01MzQ1LTQ1YzktYTFlZC0yZWFhYjI1
+        OWI2NGIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZWY4YzhjNjAtN2Q0Yi00YTg0LTk4NzctN2U4NGVmMjZjMzZkIiwg
+        aWQiOiAiMjA2MDAwMjEtZjQzYi00NGEzLTlkODctMjExN2NjNDJhZWVlIiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
         bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNTQ4MjE2YTctN2RjZi00NWM4LWFiNDQt
-        MjY5NTY5ZTcwZDFjIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiYWRlMjQ0NzQtOGQ2ZC00ZDEwLTk2OGEt
+        YzE2MzNiNWVhMmU1IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
         TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODEz
-        MWEyNTktMmJjMC00YTE4LThiODAtZDBiOTg1YWQ4ZDI1IiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiN2Yz
+        MjVlYzQtNGJmYi00MTFmLWEyOTEtZWNjOTkxOWVhMTY0IiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjBkYTg4NThhLTk0NzktNGE3Ni1hMDM0LTI3ODVm
-        ZTQxY2JhZSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        IDAsICJzdGVwX2lkIjogIjZkNmM4NjE4LTk1NWEtNDJhNy1iYmI3LWJhMDNj
+        ZTlkYzUyZCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
         OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
         InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxYThkMjg1
-        ZC1lNzBjLTQ1NTktODdlYy01YjdmOTMyOGYxN2QiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3MDA3MDk0
+        Zi00ZTVhLTQ4OWUtYTEyMy0yMDZiNzk3NjJhZTMiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
         Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIzNTFjOTM2Ny04NDExLTRkNDgtOTgyYS1hNzYy
-        MDc0ODEzZjQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICIxNTM3NTJhMy1kOTRmLTRlMjItODEyMi1mNTVi
+        ZjdlMmE4NDkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
         ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIzMzE4MjY1YS1mZjZmLTQ4MjMtYjY4My1iYTY2MDgxNmY3NWYi
+        cF9pZCI6ICIwNTNiZDJkYi1kZjRjLTRjOTAtODgwZi05ZGE1NmJkZWRlYzUi
         LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
         dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
         c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNzkw
-        NzgxZC1kNTFmLTQzMDItOTkyOC0xNjY4MzBmZDQwMDIiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5Y2Q2
+        ZTUwZC05NTQ4LTRhNjEtOWJmZC04YjQ1ODFhODY0ZWEiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
         aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3ODM5ZjhmZS1jYTRj
-        LTQzN2EtOTQ0MS03MGU0MjZmMWIzZDkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZWQ1ZDM1ZC03ODQ1
+        LTRlNWQtOGZhMS1jMmJiM2VlMWZlNWQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
         TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
         X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImY0MDVmMzA2LTc4NTEtNGM0
-        NC1hY2FhLTU2NWU1ZDcwMDdmMyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQG9iZWxpeC5l
-        eGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhh
-        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJl
-        eGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3Rh
-        cnRlZCI6ICIyMDE2LTA3LTI5VDE4OjU5OjA2WiIsICJfbnMiOiAicmVwb19w
-        dWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDctMjlUMTg6
-        NTk6MDdaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBl
-        X2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0
-        ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9y
-        ZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQi
-        LCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklT
-        SEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0
-        YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFf
-        MTciLCAiaWQiOiAiNTc5YmE3N2I3MGJlNmY3MzhlZGQ5ZTA1IiwgImRldGFp
-        bHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0
-        aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
-        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE0MjcwNzY0LWEzNDgtNDcz
+        Yy05Y2UxLTBjYWFmYjRkN2Q2YiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4
+        YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9u
+        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhj
+        ZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInN0YXJ0
+        ZWQiOiAiMjAxNi0xMS0yOVQxOTo0MDoyNloiLCAiX25zIjogInJlcG9fcHVi
+        bGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTExLTI5VDE5OjQw
+        OjI2WiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9p
+        ZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAic3VtbWFyeSI6IHsiZ2VuZXJhdGUg
+        c3FsaXRlIjogIlNLSVBQRUQiLCAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRh
+        IjogIkZJTklTSEVEIiwgInJwbXMiOiAiRklOSVNIRUQiLCAiY2xvc2VfcmVw
+        b19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJkcnBtcyI6ICJTS0lQUEVEIiwg
+        ImNvbXBzIjogIkZJTklTSEVEIiwgImRpc3RyaWJ1dGlvbiI6ICJGSU5JU0hF
+        RCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6ICJGSU5JU0hFRCIsICJlcnJhdGEi
+        OiAiRklOSVNIRUQiLCAibWV0YWRhdGEiOiAiRklOSVNIRUQifSwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3JfaWQiOiAiRmVkb3JhXzE3
+        IiwgImlkIjogIjU4M2RkOWFhYjBlYWYyMDk5YjY4MTg0NyIsICJkZXRhaWxz
+        IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiSW5pdGlh
+        bGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImluaXRpYWxp
+        emVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4NzlkYTRlZC01
+        MzQ1LTQ1YzktYTFlZC0yZWFhYjI1OWI2NGIiLCAibnVtX3Byb2Nlc3NlZCI6
+        IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
+        c2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0
+        cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjA2MDAwMjEtZjQzYi00NGEz
+        LTlkODctMjExN2NjNDJhZWVlIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJu
+        dW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQ
+        TXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiA4LCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWRl
+        MjQ0NzQtOGQ2ZC00ZDEwLTk2OGEtYzE2MzNiNWVhMmU1IiwgIm51bV9wcm9j
+        ZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjogImRycG1z
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiN2YzMjVlYzQtNGJmYi00MTFmLWEyOTEtZWNj
+        OTkxOWVhMTY0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJz
+        dGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRl
         IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc3ZTA0ZjEx
-        LTQ2OTYtNDdjMy04MjJjLTNjMjgwYzZlN2EyYyIsICJudW1fcHJvY2Vzc2Vk
-        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRp
-        c3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjZkNmM4NjE4
+        LTk1NWEtNDJhNy1iYmI3LWJhMDNjZTlkYzUyZCIsICJudW1fcHJvY2Vzc2Vk
+        IjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJp
+        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICI3MDA3MDk0Zi00ZTVhLTQ4OWUtYTEyMy0yMDZiNzk3
+        NjJhZTMiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0
+        ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNTM3NTJh
+        My1kOTRmLTRlMjItODEyMi1mNTViZjdlMmE4NDkiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNs
+        b3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVw
+        b19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
         U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlZjhjOGM2MC03ZDRiLTRh
-        ODQtOTg3Ny03ZTg0ZWYyNmMzNmQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
-        Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        UlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1
-        NDgyMTZhNy03ZGNmLTQ1YzgtYWI0NC0yNjk1NjllNzBkMWMiLCAibnVtX3By
-        b2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI4MTMxYTI1OS0yYmMwLTRhMTgtOGI4MC1k
-        MGI5ODVhZDhkMjUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
-        ZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwg
-        InN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGRhODg1
-        OGEtOTQ3OS00YTc2LWEwMzQtMjc4NWZlNDFjYmFlIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjFhOGQyODVkLWU3MGMtNDU1OS04N2VjLTViN2Y5
-        MzI4ZjE3ZCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAi
-        c3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM1MWM5
-        MzY3LTg0MTEtNGQ0OC05ODJhLWE3NjIwNzQ4MTNmNCIsICJudW1fcHJvY2Vz
-        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        Q2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9y
-        ZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
-        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjMzMTgyNjVhLWZmNmYt
-        NDgyMy1iNjgzLWJhNjYwODE2Zjc1ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
-        ZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0
-        ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjA3OTA3ODFkLWQ1MWYtNDMwMi05OTI4LTE2
-        NjgzMGZkNDAwMiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
-        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3
-        ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjc4MzlmOGZlLWNhNGMtNDM3YS05NDQxLTcwZTQyNmYxYjNk
-        OSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBf
-        dHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZjQwNWYzMDYtNzg1MS00YzQ0LWFjYWEtNTY1ZTVkNzAwN2YzIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjU3OWJhNzdhN2JjMjVhYWYwOTU2MmU4ZSJ9LCAiaWQiOiAi
-        NTc5YmE3N2E3YmMyNWFhZjA5NTYyZThlIn0=
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNTNiZDJkYi1kZjRjLTRj
+        OTAtODgwZi05ZGE1NmJkZWRlYzUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
+        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcg
+        c3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI5Y2Q2ZTUwZC05NTQ4LTRhNjEtOWJmZC04YjQ1
+        ODFhODY0ZWEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2Vi
+        IiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICJhZWQ1ZDM1ZC03ODQ1LTRlNWQtOGZhMS1jMmJiM2VlMWZlNWQi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImE0MjcwNzY0LWEzNDgtNDczYy05Y2UxLTBjYWFmYjRkN2Q2YiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1ODNkZDlhYTY3MWUwOGVhYTZkMjU3NDkifSwgImlkIjogIjU4
+        M2RkOWFhNjcxZTA4ZWFhNmQyNTc0OSJ9
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:07 GMT
+  recorded_at: Tue, 29 Nov 2016 19:40:27 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/33371fc1-5b0a-4bce-ab66-ac4241ec730c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:40:27 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '631'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zMzM3MWZjMS01YjBhLTRiY2UtYWI2Ni1hYzQyNDFlYzcz
+        MGMvIiwgInRhc2tfaWQiOiAiMzMzNzFmYzEtNWIwYS00YmNlLWFiNjYtYWM0
+        MjQxZWM3MzBjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUByb2JvdC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJ3
+        YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0xQHJvYm90LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTgzZGQ5YWI2NzFlMDhl
+        YWE2ZDI1NzRhIn0sICJpZCI6ICI1ODNkZDlhYjY3MWUwOGVhYTZkMjU3NGEi
+        fQ==
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:40:27 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/33371fc1-5b0a-4bce-ab66-ac4241ec730c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:40:28 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '668'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zMzM3MWZjMS01YjBhLTRiY2UtYWI2Ni1hYzQyNDFlYzcz
+        MGMvIiwgInRhc2tfaWQiOiAiMzMzNzFmYzEtNWIwYS00YmNlLWFiNjYtYWM0
+        MjQxZWM3MzBjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE2LTExLTI5VDE5OjQwOjI3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTExLTI5VDE5OjQwOjI3WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MUByb2JvdC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBy
+        b2JvdC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU4M2RkOWFiNjcxZTA4ZWFhNmQyNTc0
+        YSJ9LCAiaWQiOiAiNTgzZGQ5YWI2NzFlMDhlYWE2ZDI1NzRhIn0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:40:28 GMT
 - request:
     method: post
-    uri: https://obelix.example.com/pulp/api/v2/content/units/rpm/search/
+    uri: https://robot.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiNDdlNTlj
-        ZWMtZGQ2Yi00OWRmLThhMzQtMGQyMzE1ZmY4NTMwIl19fX0sImluY2x1ZGVf
+        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
+        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
+        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
+        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
+        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwic3NsX3ZhbGlkYXRpb24i
+        Om51bGwsImRvd25sb2FkX3BvbGljeSI6bnVsbCwicmVtb3ZlX21pc3Npbmci
+        Om51bGx9LCJub3RlcyI6eyJfcmVwby10eXBlIjoicnBtLXJlcG8ifSwiZGlz
+        dHJpYnV0b3JzIjpbeyJkaXN0cmlidXRvcl90eXBlX2lkIjoieXVtX2Rpc3Ry
+        aWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7InJlbGF0aXZlX3VybCI6
+        InRlc3RfcGF0aCIsImh0dHAiOmZhbHNlLCJodHRwcyI6dHJ1ZSwicHJvdGVj
+        dGVkIjp0cnVlfSwiYXV0b19wdWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9p
+        ZCI6IkZlZG9yYV8xNyJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ImV4cG9y
+        dF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJodHRwIjpm
+        YWxzZSwiaHR0cHMiOmZhbHNlLCJyZWxhdGl2ZV91cmwiOiJ0ZXN0X3BhdGgi
+        fSwiYXV0b19wdWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJleHBv
+        cnRfZGlzdHJpYnV0b3IifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
+        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
+        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
+        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
+        bmUifV19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '861'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:40:28 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '320'
+      Location:
+      - https://robot.example.com/pulp/api/v2/repositories/Fedora_17/
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
+        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
+        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NTgzZGQ5YWNiMGVhZjI1ZjQ1ODE5MmRiIn0sICJpZCI6ICJGZWRvcmFfMTci
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
+        MTcvIn0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:40:29 GMT
+- request:
+    method: post
+    uri: https://robot.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
+        Ijp0cnVlfX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '53'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:40:29 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzI2ODY5MDhlLWNlZjctNDdjMC05ZTc5LWJiOWFiYjNlM2JmNi8iLCAi
+        dGFza19pZCI6ICIyNjg2OTA4ZS1jZWY3LTQ3YzAtOWU3OS1iYjlhYmIzZTNi
+        ZjYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:40:29 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/2686908e-cef7-47c0-9e79-bb9abb3e3bf6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:40:29 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '629'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yNjg2OTA4ZS1jZWY3LTQ3YzAtOWU3OS1iYjlhYmIzZTNi
+        ZjYvIiwgInRhc2tfaWQiOiAiMjY4NjkwOGUtY2VmNy00N2MwLTllNzktYmI5
+        YWJiM2UzYmY2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAcm9ib3QuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAid2Fp
+        dGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMUByb2JvdC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU4M2RkOWFkNjcxZTA4ZWFh
+        NmQyNTc0YiJ9LCAiaWQiOiAiNTgzZGQ5YWQ2NzFlMDhlYWE2ZDI1NzRiIn0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:40:29 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/2686908e-cef7-47c0-9e79-bb9abb3e3bf6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:40:29 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2282'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yNjg2OTA4ZS1jZWY3LTQ3YzAtOWU3OS1iYjlhYmIzZTNi
+        ZjYvIiwgInRhc2tfaWQiOiAiMjY4NjkwOGUtY2VmNy00N2MwLTllNzktYmI5
+        YWJiM2UzYmY2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0xMS0yOVQxOTo0MDoyOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0MDoyOVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNDk4YWUzYTYtNTFiYy00MWQ5LWJmM2EtOTJkNDNiMmU1
+        MmJkLyIsICJ0YXNrX2lkIjogIjQ5OGFlM2E2LTUxYmMtNDFkOS1iZjNhLTky
+        ZDQzYjJlNTJiZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0
+        ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTExLTI5VDE5OjQwOjI5WiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMTEtMjlUMTk6NDA6
+        MjlaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTgzZGQ5YWRiMGVhZjIwOTliNjgxODUzIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU4M2RkOWFkNjcxZTA4ZWFhNmQyNTc0YiJ9LCAi
+        aWQiOiAiNTgzZGQ5YWQ2NzFlMDhlYWE2ZDI1NzRiIn0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:40:29 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/498ae3a6-51bc-41d9-bf3a-92d43b2e52bd/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:40:29 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '3503'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy80OThhZTNhNi01MWJjLTQxZDktYmYzYS05MmQ0
+        M2IyZTUyYmQvIiwgInRhc2tfaWQiOiAiNDk4YWUzYTYtNTFiYy00MWQ5LWJm
+        M2EtOTJkNDNiMmU1MmJkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxNi0xMS0yOVQxOTo0MDoyOVoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNTc0
+        ZGY0NS0wYjdiLTRlNWUtYWI5Zi04ZjBkYWE3NzViNWYiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjNkYTY3NmEtMzUw
+        MS00Nzg4LTgwMTgtZDE5OTE4ZmQ4NDU2IiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDIsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiYmRkNDU5OTItMjRjZC00OGI1LWJjZTAtNzQyMzE2ODk0YTQ2Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAyfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
+        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRiZDkyYmNjLTdhYmIt
+        NDBjYi1iZTBjLTQ1MWFmNmVjODFlZiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI1ZTYyMDk5NS02MTc0LTQ1YWQtODM1Ny1kMTIwMzZhMjcxNDMi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5
+        cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWRjYTQ5YWMtZDVh
+        OC00YmMzLTllYzEtZTNjMzljNWU2MmY4IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiM2YyNDEzYmUtNmFkMy00OGViLThmYmUtZDZkMjUy
+        MGY1YzI0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAi
+        c3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiZGI2MDhiNmUtY2ZjNS00MmVhLTgzN2MtMWIwMzRkZGU5Y2E1
+        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
+        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjZmNTU5MTJlLWEwNGQtNGRhZS1hMGQ2LTQ2ZTIzM2EwMGI4NyIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjog
+        InB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ0ODZj
+        YTJkLTI3ZmMtNDM3Zi1iNDVmLTU4YmZiMDgxYmI5OSIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
+        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDhkOWZl
+        ZTItM2ZjMy00NWVkLWI0MDEtYWMxMGY3M2JiMWMwIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTFAcm9ib3QuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBy
+        b2JvdC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU4M2RkOWFkNjcxZTA4ZWFhNmQyNTc1
+        YiJ9LCAiaWQiOiAiNTgzZGQ5YWQ2NzFlMDhlYWE2ZDI1NzViIn0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:40:29 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/2686908e-cef7-47c0-9e79-bb9abb3e3bf6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:40:30 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2282'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yNjg2OTA4ZS1jZWY3LTQ3YzAtOWU3OS1iYjlhYmIzZTNi
+        ZjYvIiwgInRhc2tfaWQiOiAiMjY4NjkwOGUtY2VmNy00N2MwLTllNzktYmI5
+        YWJiM2UzYmY2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        Ni0xMS0yOVQxOTo0MDoyOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0MDoyOVoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvNDk4YWUzYTYtNTFiYy00MWQ5LWJmM2EtOTJkNDNiMmU1
+        MmJkLyIsICJ0YXNrX2lkIjogIjQ5OGFlM2E2LTUxYmMtNDFkOS1iZjNhLTky
+        ZDQzYjJlNTJiZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
+        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0
+        ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJy
+        ZXBvX2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Rh
+        cnRlZCI6ICIyMDE2LTExLTI5VDE5OjQwOjI5WiIsICJfbnMiOiAicmVwb19z
+        eW5jX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMTEtMjlUMTk6NDA6
+        MjlaIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVy
+        cm9yX21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJy
+        ZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAi
+        NTgzZGQ5YWRiMGVhZjIwOTliNjgxODUzIiwgImRldGFpbHMiOiB7ImNvbnRl
+        bnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQi
+        OiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjog
+        MCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9k
+        ZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0Ijog
+        MH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0
+        YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjU4M2RkOWFkNjcxZTA4ZWFhNmQyNTc0YiJ9LCAi
+        aWQiOiAiNTgzZGQ5YWQ2NzFlMDhlYWE2ZDI1NzRiIn0=
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:40:30 GMT
+- request:
+    method: get
+    uri: https://robot.example.com/pulp/api/v2/tasks/498ae3a6-51bc-41d9-bf3a-92d43b2e52bd/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:40:30 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '6909'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy80OThhZTNhNi01MWJjLTQxZDktYmYzYS05MmQ0
+        M2IyZTUyYmQvIiwgInRhc2tfaWQiOiAiNDk4YWUzYTYtNTFiYy00MWQ5LWJm
+        M2EtOTJkNDNiMmU1MmJkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxNi0xMS0yOVQxOTo0MDoyOVoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0xMS0yOVQxOTo0MDoyOVoiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICIxNTc0ZGY0NS0wYjdiLTRlNWUtYWI5Zi04ZjBkYWE3
+        NzViNWYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiMjNkYTY3NmEtMzUwMS00Nzg4LTgwMTgtZDE5OTE4ZmQ4NDU2Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
+        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiYmRkNDU5OTItMjRjZC00OGI1LWJjZTAt
+        NzQyMzE2ODk0YTQ2IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
+        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGJk
+        OTJiY2MtN2FiYi00MGNiLWJlMGMtNDUxYWY2ZWM4MWVmIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjVlNjIwOTk1LTYxNzQtNDVhZC04MzU3LWQxMjAz
+        NmEyNzE0MyIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
+        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZGNhNDlh
+        Yy1kNWE4LTRiYzMtOWVjMS1lM2MzOWM1ZTYyZjgiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICIzZjI0MTNiZS02YWQzLTQ4ZWItOGZiZS1kNmQy
+        NTIwZjVjMjQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
+        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICJkYjYwOGI2ZS1jZmM1LTQyZWEtODM3Yy0xYjAzNGRkZTljYTUi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
+        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2ZjU1
+        OTEyZS1hMDRkLTRkYWUtYTBkNi00NmUyMzNhMDBiODciLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
+        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkNDg2Y2EyZC0yN2Zj
+        LTQzN2YtYjQ1Zi01OGJmYjA4MWJiOTkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
+        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ4ZDlmZWUyLTNmYzMtNDVl
+        ZC1iNDAxLWFjMTBmNzNiYjFjMCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4
+        YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9u
+        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQHJvYm90LmV4YW1w
+        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhj
+        ZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInN0YXJ0
+        ZWQiOiAiMjAxNi0xMS0yOVQxOTo0MDoyOVoiLCAiX25zIjogInJlcG9fcHVi
+        bGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE2LTExLTI5VDE5OjQw
+        OjI5WiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9p
+        ZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAic3VtbWFyeSI6IHsiZ2VuZXJhdGUg
+        c3FsaXRlIjogIlNLSVBQRUQiLCAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRh
+        IjogIkZJTklTSEVEIiwgInJwbXMiOiAiRklOSVNIRUQiLCAiY2xvc2VfcmVw
+        b19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJkcnBtcyI6ICJTS0lQUEVEIiwg
+        ImNvbXBzIjogIkZJTklTSEVEIiwgImRpc3RyaWJ1dGlvbiI6ICJGSU5JU0hF
+        RCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6ICJGSU5JU0hFRCIsICJlcnJhdGEi
+        OiAiRklOSVNIRUQiLCAibWV0YWRhdGEiOiAiRklOSVNIRUQifSwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3JfaWQiOiAiRmVkb3JhXzE3
+        IiwgImlkIjogIjU4M2RkOWFkYjBlYWYyMDk5YjY4MTg1NCIsICJkZXRhaWxz
+        IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiSW5pdGlh
+        bGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImluaXRpYWxp
+        emVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNTc0ZGY0NS0w
+        YjdiLTRlNWUtYWI5Zi04ZjBkYWE3NzViNWYiLCAibnVtX3Byb2Nlc3NlZCI6
+        IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
+        c2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0
+        cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjNkYTY3NmEtMzUwMS00Nzg4
+        LTgwMTgtZDE5OTE4ZmQ4NDU2IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJu
+        dW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQ
+        TXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiA4LCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYmRk
+        NDU5OTItMjRjZC00OGI1LWJjZTAtNzQyMzE2ODk0YTQ2IiwgIm51bV9wcm9j
+        ZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjogImRycG1z
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiNGJkOTJiY2MtN2FiYi00MGNiLWJlMGMtNDUx
+        YWY2ZWM4MWVmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJz
+        dGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjVlNjIwOTk1
+        LTYxNzQtNDVhZC04MzU3LWQxMjAzNmEyNzE0MyIsICJudW1fcHJvY2Vzc2Vk
+        IjogM30sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJp
+        dGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICJhZGNhNDlhYy1kNWE4LTRiYzMtOWVjMS1lM2MzOWM1
+        ZTYyZjgiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0
+        ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzZjI0MTNi
+        ZS02YWQzLTQ4ZWItOGZiZS1kNmQyNTIwZjVjMjQiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNs
+        b3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVw
+        b19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkYjYwOGI2ZS1jZmM1LTQy
+        ZWEtODM3Yy0xYjAzNGRkZTljYTUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
+        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcg
+        c3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI2ZjU1OTEyZS1hMDRkLTRkYWUtYTBkNi00NmUy
+        MzNhMDBiODciLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2Vi
+        IiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICJkNDg2Y2EyZC0yN2ZjLTQzN2YtYjQ1Zi01OGJmYjA4MWJiOTki
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImQ4ZDlmZWUyLTNmYzMtNDVlZC1iNDAxLWFjMTBmNzNiYjFjMCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1ODNkZDlhZDY3MWUwOGVhYTZkMjU3NWIifSwgImlkIjogIjU4
+        M2RkOWFkNjcxZTA4ZWFhNmQyNTc1YiJ9
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:40:30 GMT
+- request:
+    method: post
+    uri: https://robot.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwiZmllbGRzIjp7InVu
+        aXQiOltdLCJhc3NvY2lhdGlvbiI6WyJ1bml0X2lkIl19fX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '80'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:40:30 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1672'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIwMWMyNzZlYS04OTcxLTQ2MTEtYjE1
+        My1kYTU3MDk2NDgwZmMiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1ODNkZDlhZDY3MWUwOGVhYTZkMjU3NTAifSwg
+        InVuaXRfaWQiOiAiMDFjMjc2ZWEtODk3MS00NjExLWIxNTMtZGE1NzA5NjQ4
+        MGZjIiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
+        X2lkIjogIjFkNzAyMzlhLTdiODktNDliZC1iMTJhLTU4OTM5MWIwNDlhNCIs
+        ICJfY29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjog
+        IjU4M2RkOWFkNjcxZTA4ZWFhNmQyNTc1MSJ9LCAidW5pdF9pZCI6ICIxZDcw
+        MjM5YS03Yjg5LTQ5YmQtYjEyYS01ODkzOTFiMDQ5YTQiLCAidW5pdF90eXBl
+        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNjIxYWZjZWQt
+        NThmYy00M2U5LTllNDYtMDgxZWJjNmY0NGFkIiwgIl9jb250ZW50X3R5cGVf
+        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTgzZGQ5YWQ2NzFlMDhl
+        YWE2ZDI1NzRmIn0sICJ1bml0X2lkIjogIjYyMWFmY2VkLTU4ZmMtNDNlOS05
+        ZTQ2LTA4MWViYzZmNDRhZCIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
+        bWV0YWRhdGEiOiB7Il9pZCI6ICJhNzEzOTA4ZC1jNjIyLTRmODYtOWNmYy02
+        ZTMzOTliODA0ZTMiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1ODNkZDlhZDY3MWUwOGVhYTZkMjU3NGUifSwgInVu
+        aXRfaWQiOiAiYTcxMzkwOGQtYzYyMi00Zjg2LTljZmMtNmUzMzk5YjgwNGUz
+        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lk
+        IjogImI0ODI5OWE3LWQzNzUtNDg1MC1iODJjLTlhZTQxZDc2N2E2OSIsICJf
+        Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU4
+        M2RkOWFkNjcxZTA4ZWFhNmQyNTc0YyJ9LCAidW5pdF9pZCI6ICJiNDgyOTlh
+        Ny1kMzc1LTQ4NTAtYjgyYy05YWU0MWQ3NjdhNjkiLCAidW5pdF90eXBlX2lk
+        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiY2IzYWZjZWMtNmFj
+        OS00ZmVlLWEwYmEtMjJiNzBhYzlkYzBkIiwgIl9jb250ZW50X3R5cGVfaWQi
+        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTgzZGQ5YWQ2NzFlMDhlYWE2
+        ZDI1NzUyIn0sICJ1bml0X2lkIjogImNiM2FmY2VjLTZhYzktNGZlZS1hMGJh
+        LTIyYjcwYWM5ZGMwZCIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
+        YWRhdGEiOiB7Il9pZCI6ICJlMmIyNDJhMS1iNTBkLTQ2NjktOGFhNi01NDNi
+        ZGZkOTk2ZGYiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
+        IHsiJG9pZCI6ICI1ODNkZDlhZDY3MWUwOGVhYTZkMjU3NTMifSwgInVuaXRf
+        aWQiOiAiZTJiMjQyYTEtYjUwZC00NjY5LThhYTYtNTQzYmRmZDk5NmRmIiwg
+        InVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjog
+        ImZjZmFkMzQ0LTUxNzEtNDNlYi1iNDZhLTgyYTg1NjY2MTdiZCIsICJfY29u
+        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU4M2Rk
+        OWFkNjcxZTA4ZWFhNmQyNTc0ZCJ9LCAidW5pdF9pZCI6ICJmY2ZhZDM0NC01
+        MTcxLTQzZWItYjQ2YS04MmE4NTY2NjE3YmQiLCAidW5pdF90eXBlX2lkIjog
+        InJwbSJ9XQ==
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:40:30 GMT
+- request:
+    method: post
+    uri: https://robot.example.com/pulp/api/v2/content/units/rpm/search/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJsaW1pdCI6OCwic2tpcCI6MCwiZmllbGRzIjpbIm5h
+        bWUiLCJ2ZXJzaW9uIiwicmVsZWFzZSIsImFyY2giLCJlcG9jaCIsInN1bW1h
+        cnkiLCJzb3VyY2VycG0iLCJjaGVja3N1bSIsImZpbGVuYW1lIiwiX2lkIl0s
+        ImZpbHRlcnMiOnsiX2lkIjp7IiRpbiI6WyIwMWMyNzZlYS04OTcxLTQ2MTEt
+        YjE1My1kYTU3MDk2NDgwZmMiLCIxZDcwMjM5YS03Yjg5LTQ5YmQtYjEyYS01
+        ODkzOTFiMDQ5YTQiLCI2MjFhZmNlZC01OGZjLTQzZTktOWU0Ni0wODFlYmM2
+        ZjQ0YWQiLCJhNzEzOTA4ZC1jNjIyLTRmODYtOWNmYy02ZTMzOTliODA0ZTMi
+        LCJiNDgyOTlhNy1kMzc1LTQ4NTAtYjgyYy05YWU0MWQ3NjdhNjkiLCJjYjNh
+        ZmNlYy02YWM5LTRmZWUtYTBiYS0yMmI3MGFjOWRjMGQiLCJlMmIyNDJhMS1i
+        NTBkLTQ2NjktOGFhNi01NDNiZGZkOTk2ZGYiLCJmY2ZhZDM0NC01MTcxLTQz
+        ZWItYjQ2YS04MmE4NTY2NjE3YmQiXX19fSwiaW5jbHVkZV9yZXBvcyI6dHJ1
+        ZX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '497'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 29 Nov 2016 19:40:30 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '3804'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJz
+        b3VyY2VycG0iOiAicGVuZ3Vpbi0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6
+        ICJwZW5ndWluIiwgImNoZWNrc3VtIjogIjNmY2IyYzkyN2RlOWUxM2JmNjg0
+        NjkwMzJhMjhiMTM5ZDNlNWFkMmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQi
+        LCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsICJm
+        aWxlbmFtZSI6ICJwZW5ndWluLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9j
+        aCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44Iiwg
+        Il9pZCI6ICIwMWMyNzZlYS04OTcxLTQ2MTEtYjE1My1kYTU3MDk2NDgwZmMi
+        LCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjog
+        Ii9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS8wMWMyNzZlYS04OTcx
+        LTQ2MTEtYjE1My1kYTU3MDk2NDgwZmMvIn0sIHsicmVwb3NpdG9yeV9tZW1i
+        ZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJzb3VyY2VycG0iOiAiY2hlZXRh
+        aC0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJjaGVldGFoIiwgImNoZWNr
+        c3VtIjogIjQyMmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIzZTE3ZjU3OGY5
+        MjRmNzQ4ODBkZWJkYmI3ZDY1ZmIzNjhkYWUiLCAic3VtbWFyeSI6ICJBIGR1
+        bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsICJmaWxlbmFtZSI6ICJjaGVldGFo
+        LTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24i
+        OiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICIxZDcwMjM5YS03
+        Yjg5LTQ5YmQtYjEyYS01ODkzOTFiMDQ5YTQiLCAiYXJjaCI6ICJub2FyY2gi
+        LCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250
+        ZW50L3VuaXRzL3JwbS8xZDcwMjM5YS03Yjg5LTQ5YmQtYjEyYS01ODkzOTFi
+        MDQ5YTQvIn0sIHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3Jh
+        XzE3Il0sICJzb3VyY2VycG0iOiAibW9ua2V5LTAuMy0wLjguc3JjLnJwbSIs
+        ICJuYW1lIjogIm1vbmtleSIsICJjaGVja3N1bSI6ICIwZThmYTUwZDAxMjhm
+        YmFiYzdjY2M1NjMyZTNmYTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4
+        NTAxZGIxIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtl
+        eSIsICJmaWxlbmFtZSI6ICJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwg
+        ImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIw
+        LjgiLCAiX2lkIjogIjYyMWFmY2VkLTU4ZmMtNDNlOS05ZTQ2LTA4MWViYzZm
+        NDRhZCIsICJhcmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hy
+        ZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBtLzYyMWFmY2Vk
+        LTU4ZmMtNDNlOS05ZTQ2LTA4MWViYzZmNDRhZC8ifSwgeyJyZXBvc2l0b3J5
+        X21lbWJlcnNoaXBzIjogWyJGZWRvcmFfMTciXSwgInNvdXJjZXJwbSI6ICJs
+        aW9uLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogImxpb24iLCAiY2hlY2tz
+        dW0iOiAiMTI0MDBkYzk1YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5
+        ODE1ODU0MzdhYjY0Y2Q2MmVmYTNlNGFlNCIsICJzdW1tYXJ5IjogIkEgZHVt
+        bXkgcGFja2FnZSBvZiBsaW9uIiwgImZpbGVuYW1lIjogImxpb24tMC4zLTAu
+        OC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMi
+        LCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogImE3MTM5MDhkLWM2MjItNGY4
+        Ni05Y2ZjLTZlMzM5OWI4MDRlMyIsICJhcmNoIjogIm5vYXJjaCIsICJjaGls
+        ZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5p
+        dHMvcnBtL2E3MTM5MDhkLWM2MjItNGY4Ni05Y2ZjLTZlMzM5OWI4MDRlMy8i
+        fSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJGZWRvcmFfMTciXSwg
+        InNvdXJjZXJwbSI6ICJnaXJhZmZlLTAuMy0wLjguc3JjLnJwbSIsICJuYW1l
+        IjogImdpcmFmZmUiLCAiY2hlY2tzdW0iOiAiZjI1ZDY3ZDFkOWRhMDRmMTJl
+        NTdjYTMyMzI0N2I0Mzg5MWFjNDY1MzNlMzU1YjgyZGU2ZDE5MjIwMDlmOWYx
+        NCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwg
+        ImZpbGVuYW1lIjogImdpcmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVw
+        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgi
+        LCAiX2lkIjogImI0ODI5OWE3LWQzNzUtNDg1MC1iODJjLTlhZTQxZDc2N2E2
+        OSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBtL2I0ODI5OWE3LWQz
+        NzUtNDg1MC1iODJjLTlhZTQxZDc2N2E2OS8ifSwgeyJyZXBvc2l0b3J5X21l
+        bWJlcnNoaXBzIjogWyJGZWRvcmFfMTciXSwgInNvdXJjZXJwbSI6ICJ3YWxy
+        dXMtMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAid2FscnVzIiwgImNoZWNr
+        c3VtIjogIjZlOGQ2ZGMwNTdlM2UyYzk4MTlmMGRjN2U2YzdiN2Y4NmJmMmU4
+        NTcxYmJhNDE0YWRlYzdmYjYyMWE0NjFkZmQiLCAic3VtbWFyeSI6ICJBIGR1
+        bW15IHBhY2thZ2Ugb2Ygd2FscnVzIiwgImZpbGVuYW1lIjogIndhbHJ1cy0w
+        LjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjog
+        IjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiY2IzYWZjZWMtNmFj
+        OS00ZmVlLWEwYmEtMjJiNzBhYzlkYzBkIiwgImFyY2giOiAibm9hcmNoIiwg
+        ImNoaWxkcmVuIjoge30sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVu
+        dC91bml0cy9ycG0vY2IzYWZjZWMtNmFjOS00ZmVlLWEwYmEtMjJiNzBhYzlk
+        YzBkLyJ9LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBbIkZlZG9yYV8x
+        NyJdLCAic291cmNlcnBtIjogInNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIs
+        ICJuYW1lIjogInNxdWlycmVsIiwgImNoZWNrc3VtIjogIjI1MTc2OGJkZDE1
+        ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFl
+        ODc4YTE3ZDIiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1
+        aXJyZWwiLCAiZmlsZW5hbWUiOiAic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gu
+        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFz
+        ZSI6ICIwLjgiLCAiX2lkIjogImUyYjI0MmExLWI1MGQtNDY2OS04YWE2LTU0
+        M2JkZmQ5OTZkZiIsICJhcmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6IHt9
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBtL2Uy
+        YjI0MmExLWI1MGQtNDY2OS04YWE2LTU0M2JkZmQ5OTZkZi8ifSwgeyJyZXBv
+        c2l0b3J5X21lbWJlcnNoaXBzIjogWyJGZWRvcmFfMTciXSwgInNvdXJjZXJw
+        bSI6ICJlbGVwaGFudC0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJlbGVw
+        aGFudCIsICJjaGVja3N1bSI6ICIzZTFjNzBjZDFiNDIxMzI4YWNhZjYzOTdj
+        YjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3MmEwYTcwMWYzIiwgInN1
+        bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBoYW50IiwgImZpbGVu
+        YW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6
+        ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgIl9p
+        ZCI6ICJmY2ZhZDM0NC01MTcxLTQzZWItYjQ2YS04MmE4NTY2NjE3YmQiLCAi
+        YXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS9mY2ZhZDM0NC01MTcxLTQz
+        ZWItYjQ2YS04MmE4NTY2NjE3YmQvIn1d
+    http_version: 
+  recorded_at: Tue, 29 Nov 2016 19:40:30 GMT
+- request:
+    method: post
+    uri: https://robot.example.com/pulp/api/v2/content/units/rpm/search/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMDFjMjc2
+        ZWEtODk3MS00NjExLWIxNTMtZGE1NzA5NjQ4MGZjIl19fX0sImluY2x1ZGVf
         cmVwb3MiOnRydWV9
     headers:
       Accept:
@@ -786,7 +1985,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:59:07 GMT
+      - Tue, 29 Nov 2016 19:40:30 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -799,8 +1998,8 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJf
-        aHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9ycG0vNDdlNTlj
-        ZWMtZGQ2Yi00OWRmLThhMzQtMGQyMzE1ZmY4NTMwLyIsICJidWlsZF90aW1l
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9ycG0vMDFjMjc2
+        ZWEtODk3MS00NjExLWIxNTMtZGE1NzA5NjQ4MGZjLyIsICJidWlsZF90aW1l
         IjogMTMwODI1NzQ2MCwgImJ1aWxkaG9zdCI6ICJkaGNwLTI2LTExOC5icnEu
         cmVkaGF0LmNvbSIsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250
         ZW50X3R5cGVfaWQiOiAicnBtIiwgImNoaWxkcmVuIjoge30sICJzaXplIjog
@@ -847,8 +2046,8 @@ http_interactions:
         biAgICAgIDxycG06ZW50cnkgbmFtZT1cIi9iaW4vc2hcIiBwcmU9XCIxXCIg
         Lz5cbiAgICA8L3JwbTpyZXF1aXJlcz5cbiAgPC9mb3JtYXQ+XG48L3BhY2th
         Z2U+XG4ifSwgImRlc2NyaXB0aW9uIjogIkEgZHVtbXkgcGFja2FnZSBvZiBw
-        ZW5ndWluIiwgIl9sYXN0X3VwZGF0ZWQiOiAiMjAxNi0wNy0yOVQxODo1ODoz
-        OVoiLCAidGltZSI6IDEzMjE4OTEwMjksICJkb3dubG9hZGVkIjogdHJ1ZSwg
+        ZW5ndWluIiwgIl9sYXN0X3VwZGF0ZWQiOiAiMjAxNi0xMS0yOVQxMzo1OToz
+        MFoiLCAidGltZSI6IDEzMjE4OTEwMjksICJkb3dubG9hZGVkIjogdHJ1ZSwg
         ImhlYWRlcl9yYW5nZSI6IHsic3RhcnQiOiAyODAsICJlbmQiOiAyMDE2fSwg
         ImFyY2giOiAibm9hcmNoIiwgIm5hbWUiOiAicGVuZ3VpbiIsICJfc3RvcmFn
         ZV9wYXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0cy9ycG0vZmEv
@@ -861,844 +2060,16 @@ http_interactions:
         Y2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFkMmU1ODU2NGZj
         MjEwZmQ2ZTQ4NjM1YmU2OTQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2th
         Z2Ugb2YgcGVuZ3VpbiIsICJyZWxhdGl2ZXBhdGgiOiAicGVuZ3Vpbi0wLjMt
-        MC44Lm5vYXJjaC5ycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjQ3
-        ZTU5Y2VjLWRkNmItNDlkZi04YTM0LTBkMjMxNWZmODUzMCIsICJyZXF1aXJl
+        MC44Lm5vYXJjaC5ycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjAx
+        YzI3NmVhLTg5NzEtNDYxMS1iMTUzLWRhNTcwOTY0ODBmYyIsICJyZXF1aXJl
         cyI6IFt7InJlbGVhc2UiOiBudWxsLCAiZXBvY2giOiBudWxsLCAidmVyc2lv
         biI6IG51bGwsICJmbGFncyI6IG51bGwsICJuYW1lIjogIi9iaW4vc2gifV19
         XQ==
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:07 GMT
-- request:
-    method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/b5011747-f00f-4df9-aaec-ba64fb3e54d6/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jul 2016 18:59:07 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '651'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iNTAxMTc0Ny1mMDBmLTRkZjktYWFlYy1iYTY0ZmIzZTU0
-        ZDYvIiwgInRhc2tfaWQiOiAiYjUwMTE3NDctZjAwZi00ZGY5LWFhZWMtYmE2
-        NGZiM2U1NGQ2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
-        LTA3LTI5VDE4OjU5OjA3WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
-        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJy
-        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBsZS5jb20i
-        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NzliYTc3YjdiYzI1YWFmMDk1NjJlOGYifSwgImlkIjogIjU3OWJh
-        NzdiN2JjMjVhYWYwOTU2MmU4ZiJ9
-    http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:07 GMT
-- request:
-    method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/b5011747-f00f-4df9-aaec-ba64fb3e54d6/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jul 2016 18:59:08 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '670'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9iNTAxMTc0Ny1mMDBmLTRkZjktYWFlYy1iYTY0ZmIzZTU0
-        ZDYvIiwgInRhc2tfaWQiOiAiYjUwMTE3NDctZjAwZi00ZGY5LWFhZWMtYmE2
-        NGZiM2U1NGQ2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTA3LTI5VDE4OjU5OjA3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTA3LTI5VDE4OjU5OjA3WiIsICJ0cmFjZWJh
-        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
-        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBvYmVsaXguZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQi
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        b2JlbGl4LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3N2I3YmMyNWFhZjA5NTYy
-        ZThmIn0sICJpZCI6ICI1NzliYTc3YjdiYzI1YWFmMDk1NjJlOGYifQ==
-    http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:08 GMT
-- request:
-    method: post
-    uri: https://obelix.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
-        ZXBvcy96b28iLCJzc2xfY2FfY2VydCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0
-        IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwic3NsX3ZhbGlkYXRpb24i
-        Om51bGwsImRvd25sb2FkX3BvbGljeSI6bnVsbCwicmVtb3ZlX21pc3Npbmci
-        Om51bGx9LCJub3RlcyI6eyJfcmVwby10eXBlIjoicnBtLXJlcG8ifSwiZGlz
-        dHJpYnV0b3JzIjpbeyJkaXN0cmlidXRvcl90eXBlX2lkIjoieXVtX2Rpc3Ry
-        aWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7InJlbGF0aXZlX3VybCI6
-        InRlc3RfcGF0aCIsImh0dHAiOmZhbHNlLCJodHRwcyI6dHJ1ZSwicHJvdGVj
-        dGVkIjp0cnVlfSwiYXV0b19wdWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9p
-        ZCI6IkZlZG9yYV8xNyJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ImV4cG9y
-        dF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJodHRwIjpm
-        YWxzZSwiaHR0cHMiOmZhbHNlLCJyZWxhdGl2ZV91cmwiOiJ0ZXN0X3BhdGgi
-        fSwiYXV0b19wdWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJleHBv
-        cnRfZGlzdHJpYnV0b3IifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19w
-        dWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xv
-        bmUifV19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '861'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Fri, 29 Jul 2016 18:59:08 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '320'
-      Location:
-      - https://obelix.example.com/pulp/api/v2/repositories/Fedora_17/
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NTc5YmE3N2M3MGJlNmYwZGIyYjMzMmQ2In0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:08 GMT
-- request:
-    method: post
-    uri: https://obelix.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
-        Ijp0cnVlfX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '53'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: ACCEPTED
-    headers:
-      Date:
-      - Fri, 29 Jul 2016 18:59:09 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2MxYTQxODZlLThhNTktNGQ1NS04NzcyLWQ2ZjUwYmMwYmVjNC8iLCAi
-        dGFza19pZCI6ICJjMWE0MTg2ZS04YTU5LTRkNTUtODc3Mi1kNmY1MGJjMGJl
-        YzQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:09 GMT
-- request:
-    method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/c1a4186e-8a59-4d55-8772-d6f50bc0bec4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jul 2016 18:59:09 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1121'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jMWE0MTg2ZS04YTU5LTRkNTUtODc3Mi1kNmY1MGJjMGJl
-        YzQvIiwgInRhc2tfaWQiOiAiYzFhNDE4NmUtOGE1OS00ZDU1LTg3NzItZDZm
-        NTBiYzBiZWM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0w
-        Ny0yOVQxODo1OTowOVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
-        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
-        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
-        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6
-        ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIklOX1BS
-        T0dSRVNTIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQG9iZWxpeC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5n
-        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
-        QG9iZWxpeC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3Ii
-        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU3OWJhNzdkN2JjMjVhYWYwOTU2
-        MmU5MCJ9LCAiaWQiOiAiNTc5YmE3N2Q3YmMyNWFhZjA5NTYyZTkwIn0=
-    http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:09 GMT
-- request:
-    method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/c1a4186e-8a59-4d55-8772-d6f50bc0bec4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jul 2016 18:59:09 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2284'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9jMWE0MTg2ZS04YTU5LTRkNTUtODc3Mi1kNmY1MGJjMGJl
-        YzQvIiwgInRhc2tfaWQiOiAiYzFhNDE4NmUtOGE1OS00ZDU1LTg3NzItZDZm
-        NTBiYzBiZWM0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        Ni0wNy0yOVQxODo1OTowOVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxNi0wNy0yOVQxODo1OTowOVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMGY1ZDc0NGEtODEyNS00MjI3LWIzYWItMDViZGRmYmUx
-        MTAyLyIsICJ0YXNrX2lkIjogIjBmNWQ3NDRhLTgxMjUtNDIyNy1iM2FiLTA1
-        YmRkZmJlMTEwMiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19fSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQG9iZWxpeC5leGFt
-        cGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFt
-        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBs
-        ZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBv
-        cnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwg
-        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51bGwsICJz
-        dGFydGVkIjogIjIwMTYtMDctMjlUMTg6NTk6MDlaIiwgIl9ucyI6ICJyZXBv
-        X3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNi0wNy0yOVQxODo1
-        OTowOVoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
-        ZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250ZW50Ijog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
-        LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAxNSwg
-        InJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6
-        ICI1NzliYTc3ZDcwYmU2ZjczOGVkZDllMTEiLCAiZGV0YWlscyI6IHsiY29u
-        dGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVtc19sZWZ0IjogMCwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVm
-        dCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUi
-        OiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgImVycm9y
-        X2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQi
-        OiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3N2Q3YmMyNWFhZjA5NTYyZTkwIn0s
-        ICJpZCI6ICI1NzliYTc3ZDdiYzI1YWFmMDk1NjJlOTAifQ==
-    http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:09 GMT
-- request:
-    method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/0f5d744a-8125-4227-b3ab-05bddfbe1102/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jul 2016 18:59:09 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6911'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8wZjVkNzQ0YS04MTI1LTQyMjctYjNhYi0wNWJk
-        ZGZiZTExMDIvIiwgInRhc2tfaWQiOiAiMGY1ZDc0NGEtODEyNS00MjI3LWIz
-        YWItMDViZGRmYmUxMTAyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxNi0wNy0yOVQxODo1OTowOVoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxNi0wNy0yOVQxODo1OTowOVoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
-        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJlOTAwMjZiOS0yZTgzLTQ5OWEtODllOS00MmJmNGEy
-        MzYxYjUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
-        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZWFmM2ZjYzctODNhOS00NDM3LTkxMWItZjBjZTMwMzQwMzc2Iiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNjg3ODE2MTktYWIxNC00YzcyLWIzODEt
-        NWJmMGRmMGU1ZTcxIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
-        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDZi
-        YWZmNWEtZjIxMC00MjI2LWFlMTctZGY1NmI0OTkxOTBlIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImFkZjE2MTg1LWJiYWQtNDZhZC1iNGY3LTY5Zjhh
-        MzBkMTM0NSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5ZTUyM2Fh
-        Yy05YjE4LTQxOWItODdmYi1lNGU4NDI2NmQ4ODAiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJmNzhlNjgxMy04N2UxLTQzMGUtODBlMy05NjI3
-        NDBkZDk4N2YiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI1YjY1NDQ4NC1iNzI2LTRhYzAtYTg4Ny1lNDBmYmIwMDIwOTgi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0Zjg4
-        MWRjMy05NTA2LTRjYzYtOTU5Ni1iN2Q4Yjg0OTZkOWMiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJs
-        aXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2ZDhlMzU1Mi1kOTQ0
-        LTQxZWEtOTg3Ni03MGM5Zjc0ZWE4NzgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImU0NDgxMmJhLWM0ZGUtNGRk
-        My1iODNlLWRlZmE0Y2IwNDNmMyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwg
-        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQG9iZWxpeC5l
-        eGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhh
-        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJl
-        eGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3Rh
-        cnRlZCI6ICIyMDE2LTA3LTI5VDE4OjU5OjA5WiIsICJfbnMiOiAicmVwb19w
-        dWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTYtMDctMjlUMTg6
-        NTk6MDlaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBl
-        X2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0
-        ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiOiAiRklOSVNIRUQiLCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9y
-        ZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQi
-        LCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklT
-        SEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0
-        YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJy
-        b3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFf
-        MTciLCAiaWQiOiAiNTc5YmE3N2Q3MGJlNmY3MzhlZGQ5ZTEyIiwgImRldGFp
-        bHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0
-        aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
-        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImU5MDAyNmI5
-        LTJlODMtNDk5YS04OWU5LTQyYmY0YTIzNjFiNSIsICJudW1fcHJvY2Vzc2Vk
-        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRp
-        c3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlYWYzZmNjNy04M2E5LTQ0
-        MzctOTExYi1mMGNlMzAzNDAzNzYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
-        Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        UlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2
-        ODc4MTYxOS1hYjE0LTRjNzItYjM4MS01YmYwZGYwZTVlNzEiLCAibnVtX3By
-        b2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJw
-        bXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIwNmJhZmY1YS1mMjEwLTQyMjYtYWUxNy1k
-        ZjU2YjQ5OTE5MGUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
-        ZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwg
-        InN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWRmMTYx
-        ODUtYmJhZC00NmFkLWI0ZjctNjlmOGEzMGQxMzQ1IiwgIm51bV9wcm9jZXNz
-        ZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwg
-        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjllNTIzYWFjLTliMTgtNDE5Yi04N2ZiLWU0ZTg0
-        MjY2ZDg4MCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAi
-        c3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImY3OGU2
-        ODEzLTg3ZTEtNDMwZS04MGUzLTk2Mjc0MGRkOTg3ZiIsICJudW1fcHJvY2Vz
-        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        Q2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9y
-        ZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
-        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjViNjU0NDg0LWI3MjYt
-        NGFjMC1hODg3LWU0MGZiYjAwMjA5OCIsICJudW1fcHJvY2Vzc2VkIjogMX0s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
-        ZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0
-        ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjRmODgxZGMzLTk1MDYtNGNjNi05NTk2LWI3
-        ZDhiODQ5NmQ5YyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
-        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3
-        ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjZkOGUzNTUyLWQ5NDQtNDFlYS05ODc2LTcwYzlmNzRlYTg3
-        OCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBf
-        dHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZTQ0ODEyYmEtYzRkZS00ZGQzLWI4M2UtZGVmYTRjYjA0M2YzIiwg
-        Im51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjU3OWJhNzdkN2JjMjVhYWYwOTU2MmVhMCJ9LCAiaWQiOiAi
-        NTc5YmE3N2Q3YmMyNWFhZjA5NTYyZWEwIn0=
-    http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:09 GMT
-- request:
-    method: post
-    uri: https://obelix.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwiZmllbGRzIjp7InVu
-        aXQiOltdLCJhc3NvY2lhdGlvbiI6WyJ1bml0X2lkIl19fX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '80'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jul 2016 18:59:09 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1672'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICI0N2U1OWNlYy1kZDZiLTQ5ZGYtOGEz
-        NC0wZDIzMTVmZjg1MzAiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
-        Il9pZCI6IHsiJG9pZCI6ICI1NzliYTc3ZDdiYzI1YWFmMDk1NjJlOTUifSwg
-        InVuaXRfaWQiOiAiNDdlNTljZWMtZGQ2Yi00OWRmLThhMzQtMGQyMzE1ZmY4
-        NTMwIiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogIjQ5M2U3OWI3LTU4OWQtNGMxOS05NTE5LTRhMjhlNGM3NDc1MCIs
-        ICJfY29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjog
-        IjU3OWJhNzdkN2JjMjVhYWYwOTU2MmU5MSJ9LCAidW5pdF9pZCI6ICI0OTNl
-        NzliNy01ODlkLTRjMTktOTUxOS00YTI4ZTRjNzQ3NTAiLCAidW5pdF90eXBl
-        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiYTk4Zjg0ZGQt
-        OGYwNy00MDQ3LWJmNDMtNWYwZGIzNjg0Yzg4IiwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3N2Q3YmMyNWFh
-        ZjA5NTYyZTk2In0sICJ1bml0X2lkIjogImE5OGY4NGRkLThmMDctNDA0Ny1i
-        ZjQzLTVmMGRiMzY4NGM4OCIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
-        bWV0YWRhdGEiOiB7Il9pZCI6ICJjNzAwNjI4OS0wZTI1LTRlNzItOTJhNS04
-        YTEwNzE4NTJhYmUiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1NzliYTc3ZDdiYzI1YWFmMDk1NjJlOTIifSwgInVu
-        aXRfaWQiOiAiYzcwMDYyODktMGUyNS00ZTcyLTkyYTUtOGExMDcxODUyYWJl
-        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lk
-        IjogImNjYjhhOWJjLTAxZTEtNDI2OS05ZmQyLWRmMWYyNmE2ODVkNiIsICJf
-        Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU3
-        OWJhNzdkN2JjMjVhYWYwOTU2MmU5NyJ9LCAidW5pdF9pZCI6ICJjY2I4YTli
-        Yy0wMWUxLTQyNjktOWZkMi1kZjFmMjZhNjg1ZDYiLCAidW5pdF90eXBlX2lk
-        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiY2UwYmU5MzgtYTBi
-        OS00OGUxLWFmMjUtYmQ3ZDExMzZjOTk0IiwgIl9jb250ZW50X3R5cGVfaWQi
-        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3N2Q3YmMyNWFhZjA5
-        NTYyZTk0In0sICJ1bml0X2lkIjogImNlMGJlOTM4LWEwYjktNDhlMS1hZjI1
-        LWJkN2QxMTM2Yzk5NCIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
-        YWRhdGEiOiB7Il9pZCI6ICJkNjU1NTRlOC1iOTA3LTQ0MzItYjg1OC02NzEx
-        OTFkZTlkYzIiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NzliYTc3ZDdiYzI1YWFmMDk1NjJlOTMifSwgInVuaXRf
-        aWQiOiAiZDY1NTU0ZTgtYjkwNy00NDMyLWI4NTgtNjcxMTkxZGU5ZGMyIiwg
-        InVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjog
-        ImY1MzljZGY4LWQ1NzYtNDE0Yi1hNDgyLTRiNWVjZmQ0YjQ3YSIsICJfY29u
-        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU3OWJh
-        NzdkN2JjMjVhYWYwOTU2MmU5OCJ9LCAidW5pdF9pZCI6ICJmNTM5Y2RmOC1k
-        NTc2LTQxNGItYTQ4Mi00YjVlY2ZkNGI0N2EiLCAidW5pdF90eXBlX2lkIjog
-        InJwbSJ9XQ==
-    http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:09 GMT
-- request:
-    method: post
-    uri: https://obelix.example.com/pulp/api/v2/content/units/rpm/search/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiNDdlNTlj
-        ZWMtZGQ2Yi00OWRmLThhMzQtMGQyMzE1ZmY4NTMwIiwiNDkzZTc5YjctNTg5
-        ZC00YzE5LTk1MTktNGEyOGU0Yzc0NzUwIiwiYTk4Zjg0ZGQtOGYwNy00MDQ3
-        LWJmNDMtNWYwZGIzNjg0Yzg4IiwiYzcwMDYyODktMGUyNS00ZTcyLTkyYTUt
-        OGExMDcxODUyYWJlIiwiY2NiOGE5YmMtMDFlMS00MjY5LTlmZDItZGYxZjI2
-        YTY4NWQ2IiwiY2UwYmU5MzgtYTBiOS00OGUxLWFmMjUtYmQ3ZDExMzZjOTk0
-        IiwiZDY1NTU0ZTgtYjkwNy00NDMyLWI4NTgtNjcxMTkxZGU5ZGMyIiwiZjUz
-        OWNkZjgtZDU3Ni00MTRiLWE0ODItNGI1ZWNmZDRiNDdhIl19fSwiZmllbGRz
-        IjpbIm5hbWUiLCJ2ZXJzaW9uIiwicmVsZWFzZSIsImFyY2giLCJlcG9jaCIs
-        InN1bW1hcnkiLCJzb3VyY2VycG0iLCJjaGVja3N1bSIsImZpbGVuYW1lIiwi
-        X2lkIl19LCJpbmNsdWRlX3JlcG9zIjp0cnVlfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '478'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jul 2016 18:59:09 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3804'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJz
-        b3VyY2VycG0iOiAicGVuZ3Vpbi0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6
-        ICJwZW5ndWluIiwgImNoZWNrc3VtIjogIjNmY2IyYzkyN2RlOWUxM2JmNjg0
-        NjkwMzJhMjhiMTM5ZDNlNWFkMmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQi
-        LCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgcGVuZ3VpbiIsICJm
-        aWxlbmFtZSI6ICJwZW5ndWluLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9j
-        aCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44Iiwg
-        Il9pZCI6ICI0N2U1OWNlYy1kZDZiLTQ5ZGYtOGEzNC0wZDIzMTVmZjg1MzAi
-        LCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjog
-        Ii9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS80N2U1OWNlYy1kZDZi
-        LTQ5ZGYtOGEzNC0wZDIzMTVmZjg1MzAvIn0sIHsicmVwb3NpdG9yeV9tZW1i
-        ZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJzb3VyY2VycG0iOiAiZ2lyYWZm
-        ZS0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJnaXJhZmZlIiwgImNoZWNr
-        c3VtIjogImYyNWQ2N2QxZDlkYTA0ZjEyZTU3Y2EzMjMyNDdiNDM4OTFhYzQ2
-        NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQiLCAic3VtbWFyeSI6ICJBIGR1
-        bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsICJmaWxlbmFtZSI6ICJnaXJhZmZl
-        LTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24i
-        OiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICI0OTNlNzliNy01
-        ODlkLTRjMTktOTUxOS00YTI4ZTRjNzQ3NTAiLCAiYXJjaCI6ICJub2FyY2gi
-        LCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250
-        ZW50L3VuaXRzL3JwbS80OTNlNzliNy01ODlkLTRjMTktOTUxOS00YTI4ZTRj
-        NzQ3NTAvIn0sIHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3Jh
-        XzE3Il0sICJzb3VyY2VycG0iOiAiY2hlZXRhaC0wLjMtMC44LnNyYy5ycG0i
-        LCAibmFtZSI6ICJjaGVldGFoIiwgImNoZWNrc3VtIjogIjQyMmQwYmFhMGNk
-        OWQ3NzEzYWU3OTZlODg2YTIzZTE3ZjU3OGY5MjRmNzQ4ODBkZWJkYmI3ZDY1
-        ZmIzNjhkYWUiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgY2hl
-        ZXRhaCIsICJmaWxlbmFtZSI6ICJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJw
-        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2Ui
-        OiAiMC44IiwgIl9pZCI6ICJhOThmODRkZC04ZjA3LTQwNDctYmY0My01ZjBk
-        YjM2ODRjODgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwg
-        Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS9hOThm
-        ODRkZC04ZjA3LTQwNDctYmY0My01ZjBkYjM2ODRjODgvIn0sIHsicmVwb3Np
-        dG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJzb3VyY2VycG0i
-        OiAiZWxlcGhhbnQtMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAiZWxlcGhh
-        bnQiLCAiY2hlY2tzdW0iOiAiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2Iz
-        ZDE2MTQ1MzA2YmI5NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsICJzdW1t
-        YXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBlbGVwaGFudCIsICJmaWxlbmFt
-        ZSI6ICJlbGVwaGFudC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAi
-        MCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQi
-        OiAiYzcwMDYyODktMGUyNS00ZTcyLTkyYTUtOGExMDcxODUyYWJlIiwgImFy
-        Y2giOiAibm9hcmNoIiwgImNoaWxkcmVuIjoge30sICJfaHJlZiI6ICIvcHVs
-        cC9hcGkvdjIvY29udGVudC91bml0cy9ycG0vYzcwMDYyODktMGUyNS00ZTcy
-        LTkyYTUtOGExMDcxODUyYWJlLyJ9LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hp
-        cHMiOiBbIkZlZG9yYV8xNyJdLCAic291cmNlcnBtIjogIndhbHJ1cy0wLjMt
-        MC44LnNyYy5ycG0iLCAibmFtZSI6ICJ3YWxydXMiLCAiY2hlY2tzdW0iOiAi
-        NmU4ZDZkYzA1N2UzZTJjOTgxOWYwZGM3ZTZjN2I3Zjg2YmYyZTg1NzFiYmE0
-        MTRhZGVjN2ZiNjIxYTQ2MWRmZCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFj
-        a2FnZSBvZiB3YWxydXMiLCAiZmlsZW5hbWUiOiAid2FscnVzLTAuMy0wLjgu
-        bm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwg
-        InJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICJjY2I4YTliYy0wMWUxLTQyNjkt
-        OWZkMi1kZjFmMjZhNjg1ZDYiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRy
-        ZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRz
-        L3JwbS9jY2I4YTliYy0wMWUxLTQyNjktOWZkMi1kZjFmMjZhNjg1ZDYvIn0s
-        IHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJz
-        b3VyY2VycG0iOiAibW9ua2V5LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjog
-        Im1vbmtleSIsICJjaGVja3N1bSI6ICIwZThmYTUwZDAxMjhmYmFiYzdjY2M1
-        NjMyZTNmYTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwg
-        InN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIsICJmaWxl
-        bmFtZSI6ICJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjog
-        IjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lk
-        IjogImNlMGJlOTM4LWEwYjktNDhlMS1hZjI1LWJkN2QxMTM2Yzk5NCIsICJh
-        cmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBtL2NlMGJlOTM4LWEwYjktNDhl
-        MS1hZjI1LWJkN2QxMTM2Yzk5NC8ifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNo
-        aXBzIjogWyJGZWRvcmFfMTciXSwgInNvdXJjZXJwbSI6ICJsaW9uLTAuMy0w
-        Ljguc3JjLnJwbSIsICJuYW1lIjogImxpb24iLCAiY2hlY2tzdW0iOiAiMTI0
-        MDBkYzk1YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0Mzdh
-        YjY0Y2Q2MmVmYTNlNGFlNCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2Fn
-        ZSBvZiBsaW9uIiwgImZpbGVuYW1lIjogImxpb24tMC4zLTAuOC5ub2FyY2gu
-        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFz
-        ZSI6ICIwLjgiLCAiX2lkIjogImQ2NTU1NGU4LWI5MDctNDQzMi1iODU4LTY3
-        MTE5MWRlOWRjMiIsICJhcmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6IHt9
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBtL2Q2
-        NTU1NGU4LWI5MDctNDQzMi1iODU4LTY3MTE5MWRlOWRjMi8ifSwgeyJyZXBv
-        c2l0b3J5X21lbWJlcnNoaXBzIjogWyJGZWRvcmFfMTciXSwgInNvdXJjZXJw
-        bSI6ICJzcXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJzcXVp
-        cnJlbCIsICJjaGVja3N1bSI6ICIyNTE3NjhiZGQxNWYxM2Q3ODQ4N2MyNzYz
-        OGFhNmFlY2QwMTU1MWUyNTM3NTYwOTNjZGUxYzBhZTg3OGExN2QyIiwgInN1
-        bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwgImZpbGVu
-        YW1lIjogInNxdWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6
-        ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgIl9p
-        ZCI6ICJmNTM5Y2RmOC1kNTc2LTQxNGItYTQ4Mi00YjVlY2ZkNGI0N2EiLCAi
-        YXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS9mNTM5Y2RmOC1kNTc2LTQx
-        NGItYTQ4Mi00YjVlY2ZkNGI0N2EvIn1d
-    http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:09 GMT
-- request:
-    method: post
-    uri: https://obelix.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwiZmllbGRzIjp7InVu
-        aXQiOltdLCJhc3NvY2lhdGlvbiI6WyJ1bml0X2lkIl19fX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '80'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 29 Jul 2016 18:59:09 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1672'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICI0N2U1OWNlYy1kZDZiLTQ5ZGYtOGEz
-        NC0wZDIzMTVmZjg1MzAiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
-        Il9pZCI6IHsiJG9pZCI6ICI1NzliYTc3ZDdiYzI1YWFmMDk1NjJlOTUifSwg
-        InVuaXRfaWQiOiAiNDdlNTljZWMtZGQ2Yi00OWRmLThhMzQtMGQyMzE1ZmY4
-        NTMwIiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogIjQ5M2U3OWI3LTU4OWQtNGMxOS05NTE5LTRhMjhlNGM3NDc1MCIs
-        ICJfY29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjog
-        IjU3OWJhNzdkN2JjMjVhYWYwOTU2MmU5MSJ9LCAidW5pdF9pZCI6ICI0OTNl
-        NzliNy01ODlkLTRjMTktOTUxOS00YTI4ZTRjNzQ3NTAiLCAidW5pdF90eXBl
-        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiYTk4Zjg0ZGQt
-        OGYwNy00MDQ3LWJmNDMtNWYwZGIzNjg0Yzg4IiwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3N2Q3YmMyNWFh
-        ZjA5NTYyZTk2In0sICJ1bml0X2lkIjogImE5OGY4NGRkLThmMDctNDA0Ny1i
-        ZjQzLTVmMGRiMzY4NGM4OCIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
-        bWV0YWRhdGEiOiB7Il9pZCI6ICJjNzAwNjI4OS0wZTI1LTRlNzItOTJhNS04
-        YTEwNzE4NTJhYmUiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1NzliYTc3ZDdiYzI1YWFmMDk1NjJlOTIifSwgInVu
-        aXRfaWQiOiAiYzcwMDYyODktMGUyNS00ZTcyLTkyYTUtOGExMDcxODUyYWJl
-        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lk
-        IjogImNjYjhhOWJjLTAxZTEtNDI2OS05ZmQyLWRmMWYyNmE2ODVkNiIsICJf
-        Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU3
-        OWJhNzdkN2JjMjVhYWYwOTU2MmU5NyJ9LCAidW5pdF9pZCI6ICJjY2I4YTli
-        Yy0wMWUxLTQyNjktOWZkMi1kZjFmMjZhNjg1ZDYiLCAidW5pdF90eXBlX2lk
-        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiY2UwYmU5MzgtYTBi
-        OS00OGUxLWFmMjUtYmQ3ZDExMzZjOTk0IiwgIl9jb250ZW50X3R5cGVfaWQi
-        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3N2Q3YmMyNWFhZjA5
-        NTYyZTk0In0sICJ1bml0X2lkIjogImNlMGJlOTM4LWEwYjktNDhlMS1hZjI1
-        LWJkN2QxMTM2Yzk5NCIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
-        YWRhdGEiOiB7Il9pZCI6ICJkNjU1NTRlOC1iOTA3LTQ0MzItYjg1OC02NzEx
-        OTFkZTlkYzIiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
-        IHsiJG9pZCI6ICI1NzliYTc3ZDdiYzI1YWFmMDk1NjJlOTMifSwgInVuaXRf
-        aWQiOiAiZDY1NTU0ZTgtYjkwNy00NDMyLWI4NTgtNjcxMTkxZGU5ZGMyIiwg
-        InVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjog
-        ImY1MzljZGY4LWQ1NzYtNDE0Yi1hNDgyLTRiNWVjZmQ0YjQ3YSIsICJfY29u
-        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU3OWJh
-        NzdkN2JjMjVhYWYwOTU2MmU5OCJ9LCAidW5pdF9pZCI6ICJmNTM5Y2RmOC1k
-        NTc2LTQxNGItYTQ4Mi00YjVlY2ZkNGI0N2EiLCAidW5pdF90eXBlX2lkIjog
-        InJwbSJ9XQ==
-    http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:09 GMT
+  recorded_at: Tue, 29 Nov 2016 19:40:30 GMT
 - request:
     method: delete
-    uri: https://obelix.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://robot.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1717,7 +2088,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:59:10 GMT
+      - Tue, 29 Nov 2016 19:40:30 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -1728,14 +2099,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzY2NDU4YTA3LWQxYzAtNDk2Zi1hNzNkLTg0Mjc5MDM4MGYwMy8iLCAi
-        dGFza19pZCI6ICI2NjQ1OGEwNy1kMWMwLTQ5NmYtYTczZC04NDI3OTAzODBm
-        MDMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2Q1ZWY5YzI2LTc4NjQtNDM0NS04MzVlLTA4YmNhZWFmODM2OS8iLCAi
+        dGFza19pZCI6ICJkNWVmOWMyNi03ODY0LTQzNDUtODM1ZS0wOGJjYWVhZjgz
+        NjkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:10 GMT
+  recorded_at: Tue, 29 Nov 2016 19:40:30 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/66458a07-d1c0-496f-a73d-842790380f03/
+    uri: https://robot.example.com/pulp/api/v2/tasks/d5ef9c26-7864-4345-835e-08bcaeaf8369/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1754,13 +2125,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:59:10 GMT
+      - Tue, 29 Nov 2016 19:40:30 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '651'
+      - '549'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1768,24 +2139,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NjQ1OGEwNy1kMWMwLTQ5NmYtYTczZC04NDI3OTAzODBm
-        MDMvIiwgInRhc2tfaWQiOiAiNjY0NThhMDctZDFjMC00OTZmLWE3M2QtODQy
-        NzkwMzgwZjAzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kNWVmOWMyNi03ODY0LTQzNDUtODM1ZS0wOGJjYWVhZjgz
+        NjkvIiwgInRhc2tfaWQiOiAiZDVlZjljMjYtNzg2NC00MzQ1LTgzNWUtMDhi
+        Y2FlYWY4MzY5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
-        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE2
-        LTA3LTI5VDE4OjU5OjEwWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
-        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBsZS5j
-        b20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJy
-        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBvYmVsaXguZXhhbXBsZS5jb20i
-        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1NzliYTc3ZTdiYzI1YWFmMDk1NjJlYTEifSwgImlkIjogIjU3OWJh
-        NzdlN2JjMjVhYWYwOTU2MmVhMSJ9
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJOb25lLmRxIiwgInN0YXRl
+        IjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ODNkZDlh
+        ZTY3MWUwOGVhYTZkMjU3NWMifSwgImlkIjogIjU4M2RkOWFlNjcxZTA4ZWFh
+        NmQyNTc1YyJ9
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:10 GMT
+  recorded_at: Tue, 29 Nov 2016 19:40:30 GMT
 - request:
     method: get
-    uri: https://obelix.example.com/pulp/api/v2/tasks/66458a07-d1c0-496f-a73d-842790380f03/
+    uri: https://robot.example.com/pulp/api/v2/tasks/d5ef9c26-7864-4345-835e-08bcaeaf8369/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1804,13 +2173,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 29 Jul 2016 18:59:10 GMT
+      - Tue, 29 Nov 2016 19:40:31 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '670'
+      - '668'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1818,19 +2187,19 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NjQ1OGEwNy1kMWMwLTQ5NmYtYTczZC04NDI3OTAzODBm
-        MDMvIiwgInRhc2tfaWQiOiAiNjY0NThhMDctZDFjMC00OTZmLWE3M2QtODQy
-        NzkwMzgwZjAzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kNWVmOWMyNi03ODY0LTQzNDUtODM1ZS0wOGJjYWVhZjgz
+        NjkvIiwgInRhc2tfaWQiOiAiZDVlZjljMjYtNzg2NC00MzQ1LTgzNWUtMDhi
+        Y2FlYWY4MzY5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE2LTA3LTI5VDE4OjU5OjEwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE2LTA3LTI5VDE4OjU5OjEwWiIsICJ0cmFjZWJh
+        MDE2LTExLTI5VDE5OjQwOjMwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE2LTExLTI5VDE5OjQwOjMwWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBvYmVsaXguZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQi
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        b2JlbGl4LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTc5YmE3N2U3YmMyNWFhZjA5NTYy
-        ZWExIn0sICJpZCI6ICI1NzliYTc3ZTdiYzI1YWFmMDk1NjJlYTEifQ==
+        MUByb2JvdC5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBy
+        b2JvdC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU4M2RkOWFlNjcxZTA4ZWFhNmQyNTc1
+        YyJ9LCAiaWQiOiAiNTgzZGQ5YWU2NzFlMDhlYWE2ZDI1NzVjIn0=
     http_version: 
-  recorded_at: Fri, 29 Jul 2016 18:59:10 GMT
+  recorded_at: Tue, 29 Nov 2016 19:40:31 GMT
 recorded_with: VCR 2.9.3

--- a/test/glue/pulp/repository_test.rb
+++ b/test/glue/pulp/repository_test.rb
@@ -58,28 +58,6 @@ module Katello
   end
 
   class GluePulpNonVcrTests < GluePulpRepoTestBase
-    def test_create_docker_new_tag
-      manifest = FactoryGirl.build(:docker_manifest, :name => 'manifest', :id => 1)
-
-      assert_nil ::Katello::DockerTag.find_by_name('asdf')
-
-      tag = @fedora_17_x86_64.create_docker_tag(manifest, :name => 'asdf', :_id => '1234')
-      assert_equal 'asdf', tag.name
-      assert_equal '1234', tag.uuid
-      assert_equal 'manifest', tag.docker_manifest.name
-    end
-
-    def test_create_docker_existing_tag
-      manifest = FactoryGirl.build(:docker_manifest, :name => 'manifest', :id => 1)
-
-      existing_tag = ::Katello::DockerTag.create!(:repository_id => @fedora_17_x86_64.id,
-                                                 :docker_manifest => manifest,
-                                                 :name => 'zxcv', :uuid => '5678')
-      tag = @fedora_17_x86_64.create_docker_tag(manifest, :name => 'zxcv', :_id => '5678')
-      assert_equal existing_tag, tag
-      assert_equal existing_tag.docker_manifest, tag.docker_manifest
-    end
-
     def test_importer_feed_url
       pulp_host = URI.parse(SETTINGS[:katello][:pulp][:url]).host
       repo = ::Katello::Repository.new(:url => 'http://zodiak.com/ted', :unprotected => false, :relative_path => '/elbow')
@@ -312,31 +290,6 @@ module Katello
       refute_nil @fedora_17_x86_64.sync_start
     end
 
-    def test_packages
-      @fedora_17_x86_64.index_db_rpms
-      refute_empty @fedora_17_x86_64.rpms.select { |package| package.name == 'elephant' }
-    end
-
-    def test_errata
-      refute_empty @fedora_17_x86_64.errata_json.select { |errata| errata['id'] == "RHEA-2010:0002" }
-    end
-
-    def test_index_db_errata
-      @fedora_17_x86_64.errata.destroy_all
-      assert_empty @fedora_17_x86_64.errata
-      @fedora_17_x86_64.index_db_errata
-      @fedora_17_x86_64.reload
-      refute_empty @fedora_17_x86_64.errata
-    end
-
-    def test_index_db_rpms
-      @fedora_17_x86_64.rpms.destroy_all
-      assert_empty @fedora_17_x86_64.rpms
-      @fedora_17_x86_64.index_db_rpms
-      @fedora_17_x86_64.reload
-      refute_empty @fedora_17_x86_64.rpms
-    end
-
     def test_import_distribution_data
       @fedora_17_x86_64.import_distribution_data
 
@@ -372,12 +325,6 @@ module Katello
       package_groups = @fedora_17_x86_64.package_groups
 
       refute_empty package_groups.select { |group| group.name == 'mammals' }
-    end
-
-    def test_package_group_categories
-      categories = @fedora_17_x86_64.package_group_categories
-
-      refute_empty categories.select { |category| category['name'] == 'all' }
     end
   end
 

--- a/test/lib/tasks/reimport_test.rb
+++ b/test/lib/tasks/reimport_test.rb
@@ -22,17 +22,11 @@ module Katello
       Dir.glob(Katello::Engine.root.to_s + '/app/models/katello/*.rb').each { |file| require file }
 
       importable_models = Katello::Model.subclasses.select { |model| model if model.respond_to?(:import_all) }
-      importable_models -= [Katello::DockerManifest]
-
       importable_models.each { |model| model.expects(:import_all) }
 
       key = katello_activation_keys(:simple_key)
       key.expects(:import_pools)
       Katello::ActivationKey.stubs(:all).returns([key])
-
-      docker_repo = katello_repositories(:redis)
-      docker_repo.expects(:index_db_docker_manifests)
-      Katello::Repository.stubs(:docker_type).returns([docker_repo])
 
       Rake.application.invoke_task('katello:reimport')
     end

--- a/test/models/docker_manifest_test.rb
+++ b/test/models/docker_manifest_test.rb
@@ -12,27 +12,17 @@ module Katello
       @repo = Repository.find(katello_repositories(:redis).id)
 
       ids = @manifests.map { |attrs| attrs[:_id] }
-      ::Katello::Repository.any_instance.stubs(:pulp_docker_manifest_ids).returns(ids)
-      Runcible::Extensions::DockerManifest.any_instance.stubs(:find_all_by_unit_ids).with(ids).returns(@manifests)
-
-      ids = @tags.map { |attrs| attrs[:_id] }
-      ::Katello::Repository.any_instance.stubs(:pulp_docker_tag_ids).returns(ids)
-      Runcible::Extensions::DockerTag.any_instance.stubs(:find_all_by_unit_ids).with(ids).returns(@tags)
-      Runcible::Extensions::Repository.any_instance.stubs(:unit_search).returns(@tags)
+      Katello::Pulp::DockerManifest.stubs(:ids_for_repository).returns(ids)
+      Katello::Pulp::DockerManifest.stubs(:fetch).returns(@manifests)
     end
 
-    def test_index_db_docker_manifests
-      @repo.index_db_docker_manifests
+    def test_import_for_repository
+      Katello::DockerManifest.import_for_repository(@repo)
+
       assert_equal 1, DockerManifest.count
       assert_equal 1, @repo.docker_manifests.count
       assert_equal ["manifest1"], DockerManifest.all.map(&:name).sort
-
       assert_equal "sha256:f52325afc9c353f58d65b24d8f9a5e61be83f0518aa222639cb77bc7b77d49a9", DockerManifest.all.first.digest
-
-      manifest = DockerManifest.find_by_digest("sha256:f52325afc9c353f58d65b24d8f9a5e61be83f0518aa222639cb77bc7b77d49a9")
-      assert_equal 1, manifest.docker_tags.count
-      assert_equal "latest", manifest.docker_tags[0].name
-      assert_equal @repo.id, manifest.docker_tags[0].repository_id
     end
   end
 end

--- a/test/models/ostree_branch_test.rb
+++ b/test/models/ostree_branch_test.rb
@@ -10,13 +10,12 @@ module Katello
       @repo = Repository.find(katello_repositories(:ostree_rhel7).id)
 
       ids = @branches.map { |attrs| attrs[:_id] }
-      ::Katello::Repository.any_instance.stubs(:pulp_ostree_branch_ids).returns(ids)
-      Runcible::Extensions::OstreeBranch.any_instance.stubs(:find_all_by_unit_ids).
-        with(ids).returns(@branches)
+      ::Katello::Pulp::OstreeBranch.stubs(:ids_for_repository).returns(ids)
+      ::Katello::Pulp::OstreeBranch.stubs(:fetch).returns(@branches)
     end
 
     def test_index_db_ostree_branches
-      @repo.index_db_ostree_branches
+      @repo.index_content
       assert_equal 1, OstreeBranch.count
       assert_equal 1, @repo.ostree_branches.count
       branch_names = @branches.map { |b| b[:branch] }

--- a/test/models/rpm_test.rb
+++ b/test/models/rpm_test.rb
@@ -117,9 +117,10 @@ module Katello
         package.merge!(:repoids => [@repo.pulp_id])
       end
 
-      @repo.stubs(:rpms_json).returns(@packages)
-      @repo.stubs(:pulp_rpm_ids).returns(@packages.map { |p| p['_id'] })
-      @repo.index_db_rpms
+      Katello::Pulp::Rpm.stubs(:ids_for_repository).returns(@packages.map { |p| p['_id'] })
+      Katello::Pulp::Rpm.stubs(:fetch).returns(@packages)
+      Katello::Rpm.import_for_repository(@repo)
+
       @all_ids = @repo.rpms.pluck(:uuid).sort
     end
 

--- a/test/services/katello/pulp/erratum_test.rb
+++ b/test/services/katello/pulp/erratum_test.rb
@@ -26,19 +26,19 @@ module Katello
 
     class ErratumTest < ErratumTestBase
       def test_backend_data
-        RepositorySupport.repo.index_db_errata
+        Katello::Erratum.import_for_repository(RepositorySupport.repo)
         erratum = Pulp::Erratum.new(Erratum.find_by_errata_id(@@full_errata_id).uuid)
         assert @@full_errata_id, erratum .backend_data['id']
       end
 
       def test_pulp_data
-        RepositorySupport.repo.index_db_errata
+        Katello::Erratum.import_for_repository(RepositorySupport.repo)
         uuid = Erratum.find_by_errata_id(@@full_errata_id).uuid
         assert @@full_errata_id, Pulp::Erratum.pulp_data(uuid)['id']
       end
 
       def test_update_from_json
-        uuid = RepositorySupport.repo.errata_json.detect { |e| e['id'] == @@full_errata_id }['_id']
+        uuid = Katello::Pulp::Erratum.fetch_for_repository(RepositorySupport.repo.pulp_id).detect { |e| e['id'] == @@full_errata_id }['_id']
         errata_data = Pulp::Erratum.pulp_data(uuid)
         erratum = Erratum.create!(:uuid => errata_data['_id'])
         erratum.update_from_json(errata_data)

--- a/test/services/katello/pulp/package_group_test.rb
+++ b/test/services/katello/pulp/package_group_test.rb
@@ -19,6 +19,8 @@ module Katello
         @@package_groups = RepositorySupport.repo.package_groups
 
         @@package_group_names = ['bird', 'mammal']
+
+        Katello::PackageGroup.import_for_repository(RepositorySupport.repo)
       end
 
       def teardown
@@ -29,18 +31,15 @@ module Katello
 
     class PackageGroupTest < PackageGroupTestBase
       def test_repo_package_groups
-        RepositorySupport.repo.index_db_package_groups
         assert_equal 2, @@package_groups.length
         assert_equal @@package_group_names, @@package_groups.map(&:name).sort
       end
 
       def test_pulp_data
-        RepositorySupport.repo.index_db_package_groups
         assert_equal @@package_group_names[0], Pulp::PackageGroup.pulp_data(@@package_groups.sort_by(&:name).first.uuid)['id']
       end
 
       def test_update_from_json
-        RepositorySupport.repo.index_db_package_groups
         uuid = @@package_groups.first.uuid
         PackageGroup.where(:uuid => uuid).first.destroy! if PackageGroup.exists?(:uuid => uuid)
         package_group = PackageGroup.create!(:uuid => uuid)

--- a/test/services/katello/pulp/puppet_module_test.rb
+++ b/test/services/katello/pulp/puppet_module_test.rb
@@ -11,7 +11,7 @@ module Katello
 
         @repository = Repository.find(katello_repositories(:p_forge).id)
         RepositorySupport.create_and_sync_repo(@repository)
-        @repository.index_db_puppet_modules
+        @repository.index_content
 
         @names = ["cron", "httpd", "pureftpd", "samba"]
       end

--- a/test/services/katello/pulp/rpm_test.rb
+++ b/test/services/katello/pulp/rpm_test.rb
@@ -13,7 +13,7 @@ module Katello
         VCR.insert_cassette('services/pulp/rpm')
         repo = Repository.find(@loaded_fixtures['katello_repositories']['fedora_17_x86_64']['id'])
         RepositorySupport.create_and_sync_repo(repo.id)
-        repo.index_db_rpms
+        Katello::Rpm.import_for_repository(RepositorySupport.repo)
         @package_id = RepositorySupport.repo.rpms.first.id
       end
 


### PR DESCRIPTION
This does two major things:
1) Centralizes fetching and indexing of content to central places (pulp_database_unit.rb & pulp_content_unit.rb).  This should help making content units pluggable in the future easier, as all the code is based around the unit DB class or service class. 

2) Change the indexing so that we only keep a page (default is 500) of units in memory.  Previously we would fetch all units in pages, but then take the entire list and index that.  With this change we actually index just the page while we have it, and then throw it away to fetch another page and process that.  