### PR TITLE
fixes #17524 - capsule - update repo creation during repo sync

### DIFF
--- a/app/lib/actions/katello/capsule_content/configure_capsule.rb
+++ b/app/lib/actions/katello/capsule_content/configure_capsule.rb
@@ -2,10 +2,10 @@ module Actions
   module Katello
     module CapsuleContent
       class ConfigureCapsule < ::Actions::EntryAction
-        def plan(capsule, environment, content_view)
+        def plan(capsule, environment, content_view, repository)
           sequence do
             plan_action(RemoveUnneededRepos, capsule)
-            plan_action(CreateRepos, capsule, environment, content_view)
+            plan_action(CreateRepos, capsule, environment, content_view, repository)
           end
         end
       end


### PR DESCRIPTION
Currently, when a user syncs a repository (in library) that will
be synced to a capsule, the logic will create all missing
repositories on the capsule.  This means that syncing one
repository on a brand new capsule could result in tens or
hundreds of repositories being created.

This commit changes the behavior such that only the repository
being synced will be created.   That said, if a user performs
a full sync of the capsule (e.g. from cli or ui via
Infrastructure -> Capsule (or Smart Proxies)), all repositories
will be created.

Example test scenario 1:
- sync N repositories to a katello instance
- install a capsule (smart proxy w/ content)
- enable 'Library' for that capsule
- sync a repo (e.g. UI Content -> Sync Status)
- observe that with the change, only the repo being synced is created and synced on the capsule (and not all N repos)  - this can be observed from the katello task, but also by viewing the resultant repos on the capsule via pulp-admin

Example test scenario 2:
- confirm that a capsule sync still works as expected (e.g. if initiated via CLI (capsule content synchronize --id 4), all repos are created and synced)