### PR TITLE
Fixes #17550 - load test db when schema not present

### DIFF
--- a/engines/bastion_katello/lib/bastion_katello/engine.rb
+++ b/engines/bastion_katello/lib/bastion_katello/engine.rb
@@ -10,6 +10,8 @@ module BastionKatello
       consumer_cert_rpm = 'katello-ca-consumer-latest.noarch.rpm'
       consumer_cert_rpm = SETTINGS[:katello][:consumer_cert_rpm] if SETTINGS.key?(:katello)
 
+      db_migrated = ActiveRecord::Base.connection.table_exists?(Setting.table_name)
+
       Bastion.register_plugin(
         :name => 'bastion_katello',
         :javascript => 'bastion_katello/bastion_katello',
@@ -34,10 +36,10 @@ module BastionKatello
         ),
         :config => {
           'consumerCertRPM' => consumer_cert_rpm,
-          'defaultDownloadPolicy' => !Foreman.in_rake? && Setting['default_download_policy'],
+          'defaultDownloadPolicy' => !Foreman.in_rake? && db_migrated && Setting['default_download_policy'],
           'remoteExecutionPresent' => ::Katello.with_remote_execution?,
           'remoteExecutionByDefault' => ::Katello.with_remote_execution? && !Foreman.in_rake?('db:migrate') &&
-                                          Setting['remote_execution_by_default']
+                                        db_migrated && Setting['remote_execution_by_default']
         }
       )
     end


### PR DESCRIPTION
otherwise trying to run rake test or otherwise load the
test db would fail, because the settings table would not exist