### PR TITLE
Fixes #8455 - sort index api alphabetically by default

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -24,7 +24,7 @@ module Katello
     param_group :search, Api::V2::ApiController
     def index
       activation_key_includes = [:content_view, :environment, :host_collections, :organization]
-      respond(:collection => scoped_search(index_relation.uniq, :name, :desc, :includes => activation_key_includes))
+      respond(:collection => scoped_search(index_relation.uniq, :name, :asc, :includes => activation_key_includes))
     end
 
     api :POST, "/activation_keys", N_("Create an activation key")
@@ -115,7 +115,7 @@ module Katello
       scoped = scoped.where(:organization_id => @activation_key.organization)
       scoped = scoped.where(:name => params[:name]) if params[:name]
 
-      respond_for_index(:collection => scoped_search(scoped, :name, :desc, :resource_class => HostCollection))
+      respond_for_index(:collection => scoped_search(scoped, :name, :asc, :resource_class => HostCollection))
     end
 
     api :GET, "/activation_keys/:id/releases", N_("Show release versions available for an activation key")

--- a/app/controllers/katello/api/v2/content_view_puppet_modules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_puppet_modules_controller.rb
@@ -12,7 +12,7 @@ module Katello
     param :uuid, String, :desc => N_("the uuid of the puppet module to associate")
     param_group :search, ::Katello::Api::V2::ApiController
     def index
-      respond(:collection => scoped_search(index_relation.uniq, :name, :desc))
+      respond(:collection => scoped_search(index_relation.uniq, :name, :asc))
     end
 
     api :POST, "/content_views/:content_view_id/content_view_puppet_modules",

--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -34,7 +34,7 @@ module Katello
       content_view_includes = [:activation_keys, :content_view_puppet_modules, :content_view_versions,
                                :environments, :organization, :repositories, components: [:content_view, :environments]]
 
-      respond(:collection => scoped_search(index_relation.uniq, :name, :desc, :includes => content_view_includes))
+      respond(:collection => scoped_search(index_relation.uniq, :name, :asc, :includes => content_view_includes))
     end
 
     def index_relation

--- a/app/controllers/katello/api/v2/environments_controller.rb
+++ b/app/controllers/katello/api/v2/environments_controller.rb
@@ -48,7 +48,7 @@ module Katello
     param :library, [true, false], :desc => N_("set true if you want to see only library environments")
     param :name, String, :desc => N_("filter only environments containing this name")
     def index
-      respond(:collection => scoped_search(index_relation.uniq, :name, :desc, :resource_class => KTEnvironment))
+      respond(:collection => scoped_search(index_relation.uniq, :name, :asc, :resource_class => KTEnvironment))
     end
 
     def index_relation

--- a/app/controllers/katello/api/v2/gpg_keys_controller.rb
+++ b/app/controllers/katello/api/v2/gpg_keys_controller.rb
@@ -24,7 +24,7 @@ module Katello
     param :name, String, :desc => N_("name of the GPG key"), :required => false
     param_group :search, Api::V2::ApiController
     def index
-      respond(:collection => scoped_search(index_relation.uniq, :name, :desc))
+      respond(:collection => scoped_search(index_relation.uniq, :name, :asc))
     end
 
     def index_relation

--- a/app/controllers/katello/api/v2/host_collections_controller.rb
+++ b/app/controllers/katello/api/v2/host_collections_controller.rb
@@ -34,7 +34,7 @@ module Katello
     param :available_for, String, :required => false,
           :desc => N_("Interpret specified object to return only Host Collections that can be associated with specified object. The value 'host' is supported.")
     def index
-      respond(:collection => scoped_search(index_relation.uniq, :name, :desc))
+      respond(:collection => scoped_search(index_relation.uniq, :name, :asc))
     end
 
     def index_relation

--- a/app/controllers/katello/api/v2/products_controller.rb
+++ b/app/controllers/katello/api/v2/products_controller.rb
@@ -36,7 +36,7 @@ module Katello
     param_group :search, Api::V2::ApiController
     def index
       options = {:includes => [:sync_plan, :provider]}
-      respond(:collection => scoped_search(index_relation.uniq, :name, :desc, options))
+      respond(:collection => scoped_search(index_relation.uniq, :name, :asc, options))
     end
 
     def index_relation

--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -59,7 +59,7 @@ module Katello
     param_group :search, Api::V2::ApiController
     def index
       options = {:includes => [:gpg_key, :product, :environment]}
-      respond(:collection => scoped_search(index_relation.uniq, :name, :desc, options))
+      respond(:collection => scoped_search(index_relation.uniq, :name, :asc, options))
     end
 
     def index_relation

--- a/app/controllers/katello/api/v2/sync_plans_controller.rb
+++ b/app/controllers/katello/api/v2/sync_plans_controller.rb
@@ -22,7 +22,7 @@ module Katello
     param :sync_date, String, :desc => N_("filter by sync date")
     param :interval, SyncPlan::TYPES, :desc => N_("filter by interval")
     def index
-      respond_for_index(:collection => scoped_search(index_relation.uniq, :name, :desc))
+      respond_for_index(:collection => scoped_search(index_relation.uniq, :name, :asc))
     end
 
     def index_relation


### PR DESCRIPTION
instead of the reverse alphabetical sort that was
being done