### PR TITLE
Fixes #17584 - Set CVV description to CV history

### DIFF
--- a/app/lib/actions/katello/content_view_version/incremental_update.rb
+++ b/app/lib/actions/katello/content_view_version/incremental_update.rb
@@ -166,7 +166,16 @@ module Actions
             end
             humanized_lines << ''
           end
-          version.description = humanized_lines.join("\n")
+
+          version_history = version.history.publish.first
+          if version_history.notes
+            version_history.notes += "\n"
+          else
+            version_history.notes = ''
+          end
+
+          version_history.notes += humanized_lines.join("\n")
+          version_history.save!
           version.save!
         end
 

--- a/test/models/content_view_version_test.rb
+++ b/test/models/content_view_version_test.rb
@@ -29,7 +29,7 @@ module Katello
                                             :notes => "Failed description"
                                            )
 
-      assert 'Success description', @cvv.description
+      assert_equal 'Success description', @cvv.description
     end
 
     def test_promotable_in_sequence


### PR DESCRIPTION
Set the content view version description to the content view history,
related to #7612