### PR TITLE
Fixes #17610 - Corrects multi repo cv publishes

### DIFF
--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -23,7 +23,7 @@ module Actions
           sequence do
             plan_action(ContentView::AddToEnvironment, version, library)
             concurrence do
-              content_view.repositories_to_publish_by_library_instance.each do |_library_instance, repositories|
+              content_view.publish_repositories do |repositories|
                 sequence do
                   clone_to_version = plan_action(Repository::CloneToVersion, repositories, version)
                   plan_action(Repository::CloneToEnvironment, clone_to_version.new_repository, library)

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -291,6 +291,17 @@ module Katello
       end
     end
 
+    def publish_repositories
+      repositories = composite? ? repositories_to_publish_by_library_instance.values : repositories_to_publish
+      repositories.each do |repos|
+        if repos.is_a? Array
+          yield repos
+        else
+          yield [repos]
+        end
+      end
+    end
+
     # Returns actual puppet modules associated with all components
     def component_modules_to_publish
       composite? ? components.flat_map { |version| version.puppet_modules } : nil


### PR DESCRIPTION
Commit e5586b7e6bfd07455997fdb1d7651650f9a83154 broke publishing of
non-composite content views with multiple repositories. This is because
the changes were meant more for composite cv's and assumed library
instances of repositories to be published to be non nil.
In short you could not add a yum repo and repo of another type and
publish em together.
This commit fixes that issue by treating repos with no library
instances differently from  ones with library instances (which tend to
be the component cv repos.)