### PR TITLE
Fixes #17622: Display need for virt-who in the UI

### DIFF
--- a/app/models/katello/glue/candlepin/owner.rb
+++ b/app/models/katello/glue/candlepin/owner.rb
@@ -21,7 +21,9 @@ module Katello
       end
 
       def owner_details
-        Resources::Candlepin::Owner.find self.label
+        details = Resources::Candlepin::Owner.find self.label
+        details['virt_who'] = self.subscriptions.using_virt_who.any?
+        details
       end
 
       def service_level

--- a/app/models/katello/glue/candlepin/pool.rb
+++ b/app/models/katello/glue/candlepin/pool.rb
@@ -94,7 +94,7 @@ module Katello
       end
 
       def import_data
-        pool_attributes = {}
+        pool_attributes = {}.with_indifferent_access
         pool_json = self.backend_data
         product_attributes = pool_json["productAttributes"] + pool_json["attributes"]
 
@@ -125,6 +125,8 @@ module Katello
         if pool_attributes.key?(:unmapped_guests_only) && pool_attributes[:unmapped_guests_only] == 'true'
           pool_attributes[:unmapped_guest] = true
         end
+
+        pool_attributes[:virt_who] = pool_attributes['virt_limit'] != "0" && !pool_attributes['virt_limit'].nil? && subscription.redhat?
 
         exceptions = pool_attributes.keys.map(&:to_sym) - self.attribute_names.map(&:to_sym)
         self.update_attributes(pool_attributes.except!(*exceptions))

--- a/app/models/katello/pool.rb
+++ b/app/models/katello/pool.rb
@@ -26,6 +26,7 @@ module Katello
     scoped_search :on => :consumed, :complete_value => true, :validator => ScopedSearch::Validators::INTEGER
     scoped_search :on => :account_number, :complete_value => true, :rename => :account, :validator => ScopedSearch::Validators::INTEGER
     scoped_search :on => :contract_number, :complete_value => true, :rename => :contract, :validator => ScopedSearch::Validators::INTEGER
+    scoped_search :on => :virt_who, :complete_value => true, :only_explicit => true
     scoped_search :on => :name, :relation => :subscription, :complete_value => true, :rename => :name
     scoped_search :on => :support_level, :relation => :subscription, :complete_value => true
     scoped_search :on => :sockets, :relation => :subscription, :complete_value => true, :validator => ScopedSearch::Validators::INTEGER

--- a/app/models/katello/subscription.rb
+++ b/app/models/katello/subscription.rb
@@ -17,6 +17,10 @@ module Katello
         where("#{Katello::Product.table_name}.id" => Product.with_subscribable_content)
     end
 
+    def self.using_virt_who
+      joins(:pools).where("#{Katello::Pool.table_name}.virt_who" => true)
+    end
+
     def redhat?
       self.products.any? { |product| product.redhat? }
     end
@@ -31,6 +35,14 @@ module Katello
 
     def recently_expired?
       pools.any?(&:recently_expired?)
+    end
+
+    def virt_who_pools
+      pools.where("#{Katello::Pool.table_name}.virt_who" => true)
+    end
+
+    def virt_who?
+      virt_who_pools.any?
     end
 
     def self.humanize_class_name(_name = nil)

--- a/app/views/katello/api/v2/subscriptions/base.json.rabl
+++ b/app/views/katello/api/v2/subscriptions/base.json.rabl
@@ -15,6 +15,7 @@ attributes :type
 attributes :name => :product_name
 attributes :unmapped_guest
 attributes :virt_only
+attributes :virt_who
 
 node :host, :if => lambda { |sub| sub && sub.hypervisor } do |subscription|
   {

--- a/db/migrate/20161209162947_add_virt_who_to_katello_pools.rb
+++ b/db/migrate/20161209162947_add_virt_who_to_katello_pools.rb
@@ -1,0 +1,9 @@
+class AddVirtWhoToKatelloPools < ActiveRecord::Migration
+  def up
+    add_column :katello_pools, :virt_who, :boolean, :default => false, :null => false
+  end
+
+  def down
+    remove_column :katello_pools, :virt_who
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/subscription-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/subscription-details.controller.js
@@ -51,5 +51,7 @@ angular.module('Bastion.subscriptions').controller('SubscriptionDetailsControlle
 
             return "";
         };
+
+        $scope.virtWhoToolTip = translate("If the virt-who field is Yes then the subscription requires the use of virt-who. Learn how to configure and use this tool in the <a href=\"https://access.redhat.com/documentation/en/red-hat-satellite/6.2/single/virtual-instances-guide/\">Virtual Instances Guide</a>.");
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/views/subscription-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/views/subscription-info.html
@@ -8,6 +8,19 @@
 
       <dt translate>Description</dt>
       <dd>{{ subscription.description }}</dd>
+      
+      <dt>
+        <span translate>Virt-Who Usage Required</span>
+        <i class="pf pficon-info"
+          tooltip-html-unsafe="{{ virtWhoToolTip }}"
+           tooltip-trigger="click"
+           tooltip-animation="false"
+           tooltip-placement="right"
+           tooltip-close-popup-delay="5"
+           tooltip-append-to-body="true">
+        </i>
+      </dt>
+      <dd>{{ subscription.virt_who | booleanToYesNo }}</dd>
 
       <dt translate>Consumed</dt>
       <dd>{{ subscription | subscriptionConsumedFilter }}</dd>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/views/manifest-import.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/views/manifest-import.html
@@ -72,7 +72,12 @@
     </div>
 
   </form>
-
+  
+  <div bst-alert="info" ng-if="details.virt_who">
+    <span translate>
+      The uploaded manifest contains subscriptions that require the use of virt-who. Learn how to configure and use this tool in the <a href="https://access.redhat.com/documentation/en/red-hat-satellite/6.2/single/virtual-instances-guide/">Virtual Instances Guide</a>.
+    </span>
+  </div>
 </section>
 
 <section>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/subscriptions.html
@@ -36,12 +36,13 @@
           <th bst-table-column="supportLevel"><span translate>Support Level</span></th>
           <th bst-table-column="contractNumber"><span translate>Contract</span></th>
           <th bst-table-column="accountNumber"><span translate>Account</span></th>
+          <th bst-table-column="virtLimit"><span translate>Requires Virt-Who Usage</span></th>
         </tr>
       </thead>
 
       <tbody>
         <tr bst-table-row ng-repeat-start="(name, subscriptions) in groupedSubscriptions">
-          <td bst-table-cell colspan="7">
+          <td bst-table-cell colspan="8">
             <b>{{ name }}</b>
           </td>
         </tr>
@@ -57,6 +58,7 @@
           <td bst-table-cell>{{ subscription.support_level }}</td>
           <td bst-table-cell>{{ subscription.contract_number }}</td>
           <td bst-table-cell>{{ subscription.account_number }}</td>
+          <td bst-table-cell><i class="fa fa-check" ng-if="subscription.virt_who"></i></td>
         </tr>
       </tbody>
     </table>

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -277,6 +277,7 @@ module Katello
       load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/3.0/delete_docker_v1_content.rake"
       load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/3.0/update_puppet_repository_distributors.rake"
       load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/3.0/update_subscription_facet_backend_data.rake"
+      load "#{Katello::Engine.root}/lib/katello/tasks/upgrades/3.3/import_subscriptions.rake"
     end
   end
 

--- a/lib/katello/tasks/upgrades/3.3/import_subscriptions.rake
+++ b/lib/katello/tasks/upgrades/3.3/import_subscriptions.rake
@@ -1,0 +1,12 @@
+namespace :katello do
+  namespace :upgrades do
+    namespace '3.3' do
+      task :import_subscriptions => ["environment"] do
+        User.current = User.anonymous_api_admin
+        puts _("Importing Subscriptions")
+        Katello::Subscription.import_all
+        Katello::Pool.import_all
+      end
+    end
+  end
+end

--- a/test/fixtures/models/katello_pools.yml
+++ b/test/fixtures/models/katello_pools.yml
@@ -12,6 +12,7 @@ pool_one:
   ram: 2
   multi_entitlement: true
   consumed: 1
+  virt_who: true
 
 pool_two:
   cp_id: "xyz123"

--- a/test/models/pool_test.rb
+++ b/test/models/pool_test.rb
@@ -144,6 +144,11 @@ module Katello
       assert_includes subscriptions, @pool_one
     end
 
+    def test_search_virt_who
+      subscriptions = Pool.search_for("virt_who = true")
+      assert_includes subscriptions, @pool_one
+    end
+
     def test_for_activation_key
       Pool::ActiveRecord_Relation.any_instance.expects(:where).with(cp_id: [1])
       Pool.for_activation_key(OpenStruct.new(get_key_pools: [{'id' => 1}]))

--- a/test/models/subscription_test.rb
+++ b/test/models/subscription_test.rb
@@ -26,5 +26,19 @@ module Katello
       @other.products.delete(fedora)
       refute_includes Subscription.with_subscribable_content, @other
     end
+
+    def test_virt_who_scope
+      assert_equal 1, Subscription.using_virt_who.length
+    end
+
+    def test_virt_who
+      assert_equal 1, @basic.virt_who_pools.length
+      assert_equal 0, @other.virt_who_pools.length
+    end
+
+    def test_virt_who?
+      assert @basic.virt_who?
+      refute @other.virt_who?
+    end
   end
 end


### PR DESCRIPTION
Uses the virt_limit property of a pool and if its a Red Hat
subscription to determine if a user needs virt-who. This is displayed
on the subscription list, and subscription details. As well, if
a manifest includes subscriptions that require virt-who an info
alert is displayed to point them to the Red Hat virtual instance
guide.