### PR TITLE
Fixes #17696 - Make Candlepin API calls smaller

### DIFF
--- a/app/controllers/katello/providers_controller.rb
+++ b/app/controllers/katello/providers_controller.rb
@@ -16,8 +16,8 @@ module Katello
     def redhat_provider_tab
       #preload orphaned product information, as it is very slow per product
       subscription_product_ids = []
-
-      subscriptions = Resources::Candlepin::Subscription.get_for_owner(current_organization.label)
+      included_list = %w(product.id providedProducts.id derivedProvidedProducts.id)
+      subscriptions = Resources::Candlepin::Subscription.get_for_owner(current_organization.label, included_list)
       subscriptions.each do |sub|
         subscription_product_ids << sub['product']['id'] if sub['product']['id']
         subscription_product_ids += sub['providedProducts'].map { |p| p['id'] } if sub['providedProducts']

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -577,8 +577,11 @@ module Katello
             subscription
           end
 
-          def get_for_owner(owner_key)
-            content_json = Candlepin::CandlepinResource.get("/candlepin/owners/#{owner_key}/subscriptions", self.default_headers).body
+          def get_for_owner(owner_key, included = [])
+            included_list = included.map { |value| "include=#{value}" }.join('&')
+            content_json = Candlepin::CandlepinResource.get(
+              "/candlepin/owners/#{owner_key}/subscriptions?#{included_list}",
+              self.default_headers).body
             JSON.parse(content_json)
           end
 


### PR DESCRIPTION
This change affects the redhat repositories page. Prior to this, the
calls were huge, and they were slowing down the load a lot (because of
parsing of the returned data and writing it to logs)

This takes advantage of 'include' in Candlepin's API to request only the
info we need. 

We can use this approach in other calls to the Candlepin API as generally the returned data is too much. This PR doesn't address another problem this page has, that it makes tons of calls to /product when it needs nearly no info for each of them. I've taken a stab at it here https://github.com/dLobatog/katello/commit/89ef53ce226b537ee76206ba2e5ef4f009b9c148#diff-d4ada19367f2e37f2adeafa9de778bccR639 , but other things broke. I'll keep on trying things so that we can make those calls faster too.