### PR TITLE
Fixes #17719 - katello:check_ping should load environment

### DIFF
--- a/lib/katello/tasks/reimport.rake
+++ b/lib/katello/tasks/reimport.rake
@@ -1,7 +1,9 @@
+require File.expand_path("../engine", File.dirname(__FILE__))
+
 namespace :katello do
   desc "Runs a katello ping and prints out the statuses of each service"
-  task :check_ping do
-    User.current = User.anonymous_admin
+  task :check_ping => :environment do
+    ::User.current = ::User.anonymous_admin
     ping_results = Katello::Ping.ping
     if ping_results[:status] != "ok"
       pp ping_results


### PR DESCRIPTION
If the task doesn't load the environment and is ran through
`foreman-rake katello:check_ping` we get `uninitialized constant User`.
Today I wanted to use it on its own and there was no way to do it. It's
listed on the list of tasks that one sees through `rake -T` so I can see
more people wanting to try it out.