### PR TITLE
Fixes #17644 - mv content_source to content_facet

### DIFF
--- a/app/controllers/katello/api/v2/host_contents_controller.rb
+++ b/app/controllers/katello/api/v2/host_contents_controller.rb
@@ -3,6 +3,7 @@ module Katello
     def_param_group :content_facet_attributes do
       param :content_view_id, Integer
       param :lifecycle_environment_id, Integer
+      param :content_source_id, Integer
       param :kickstart_repository_id, Integer, :desc => N_("Repository Id associated with the kickstart repo used for provisioning")
     end
   end

--- a/app/helpers/katello/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/katello/hosts_and_hostgroups_helper.rb
@@ -175,13 +175,13 @@ module Katello
 
         if (host.is_a? Hostgroup)
           new_host.content_facet = Host::ContentFacet.new(:lifecycle_environment_id => host.lifecycle_environment_id,
-                                                          :content_view_id => host.content_view_id)
+                                                          :content_view_id => host.content_view_id,
+                                                          :content_source_id => host.content_source_id)
         elsif host.content_facet.present?
           new_host.content_facet = Host::ContentFacet.new(:lifecycle_environment_id => host.content_facet.lifecycle_environment_id,
-                                                          :content_view_id => host.content_facet.content_view_id)
+                                                          :content_view_id => host.content_facet.content_view_id,
+                                                          :content_source_id => host.content_source_id)
         end
-
-        new_host.content_source = host.content_source
         new_host.operatingsystem.kickstart_repos(new_host).map { |repo| OpenStruct.new(repo) }
       else
         # case 2
@@ -208,8 +208,8 @@ module Katello
         lifecycle_env = Katello::KTEnvironment.find(host_params[:lifecycle_environment_id])
         content_view = Katello::ContentView.find(host_params[:content_view_id])
         host.content_facet = Host::ContentFacet.new(:lifecycle_environment_id => lifecycle_env.id,
-                                                    :content_view_id => content_view.id)
-        host.content_source = SmartProxy.find(host_params[:content_source_id])
+                                                    :content_view_id => content_view.id,
+                                                    :content_source => SmartProxy.find(host_params[:content_source_id]))
         if host.operatingsystem.is_a?(Redhat)
           view_options = host.operatingsystem.kickstart_repos(host).map { |repo| OpenStruct.new(repo) }
         end

--- a/app/models/katello/concerns/content_facet_host_extensions.rb
+++ b/app/models/katello/concerns/content_facet_host_extensions.rb
@@ -18,6 +18,7 @@ module Katello
         #associations for simpler scoped searches
         has_one :content_view, :through => :content_facet
         has_one :lifecycle_environment, :through => :content_facet
+        has_one :content_source, :through => :content_facet
         has_many :applicable_errata, :through => :content_facet
         has_many :applicable_rpms, :through => :content_facet
 
@@ -29,6 +30,7 @@ module Katello
         scoped_search :relation => :applicable_errata, :on => :errata_id, :rename => :installable_errata, :complete_value => true, :ext_method => :find_by_installable_errata, :only_explicit => true
         scoped_search :relation => :applicable_rpms, :on => :nvra, :rename => :applicable_rpms, :complete_value => true, :ext_method => :find_by_applicable_rpms, :only_explicit => true
         scoped_search :relation => :applicable_rpms, :on => :nvra, :rename => :upgradable_rpms, :complete_value => true, :ext_method => :find_by_installable_rpms, :only_explicit => true
+        scoped_search :relation => :content_source, :on => :name, :complete_value => true, :rename => :content_source
 
         # preserve options set by facets framework, but add new :reject_if statement
         accepts_nested_attributes_for(

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -7,10 +7,8 @@ module Katello
 
       included do
         alias_method_chain :validate_media?, :capsule
-        alias_method_chain :inherited_attributes, :katello
         alias_method_chain :info, :katello
         alias_method_chain :smart_proxy_ids, :katello
-        belongs_to :content_source, :class_name => "::SmartProxy", :foreign_key => :content_source_id, :inverse_of => :hosts
 
         has_many :host_installed_packages, :class_name => "::Katello::HostInstalledPackage", :foreign_key => :host_id, :dependent => :destroy
         has_many :installed_packages, :class_name => "::Katello::InstalledPackage", :through => :host_installed_packages
@@ -21,7 +19,6 @@ module Katello
 
         before_save :correct_puppet_environment
 
-        scoped_search :relation => :content_source, :on => :name, :complete_value => true, :rename => :content_source
         scoped_search :relation => :host_collections, :on => :id, :complete_value => false, :rename => :host_collection_id, :only_explicit => true
         scoped_search :relation => :host_collections, :on => :name, :complete_value => true, :rename => :host_collection
         scoped_search :relation => :installed_packages, :on => :nvra, :complete_value => true, :rename => :installed_package, :only_explicit => true
@@ -76,10 +73,6 @@ module Katello
       def content_and_puppet_match?
         content_facet && content_facet.content_view_id == environment.try(:content_view).try(:id) &&
             content_facet.lifecycle_environment_id == self.environment.try(:lifecycle_environment).try(:id)
-      end
-
-      def inherited_attributes_with_katello
-        inherited_attributes_without_katello.concat(%w(content_source_id))
       end
 
       def import_package_profile(simple_packages)

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -7,6 +7,7 @@ module Katello
       belongs_to :kickstart_repository, :class_name => "::Katello::Repository", :foreign_key => :kickstart_repository_id, :inverse_of => :kickstart_content_facets
       belongs_to :content_view, :inverse_of => :content_facets, :class_name => "Katello::ContentView"
       belongs_to :lifecycle_environment, :inverse_of => :content_facets, :class_name => "Katello::KTEnvironment"
+      belongs_to :content_source, :class_name => "::SmartProxy", :foreign_key => :content_source_id, :inverse_of => :hosts
 
       has_many :applicable_errata, :through => :content_facet_errata, :class_name => "Katello::Erratum", :source => :erratum
       has_many :content_facet_errata, :class_name => "Katello::ContentFacetErratum", :dependent => :destroy, :inverse_of => :content_facet
@@ -179,6 +180,7 @@ module Katello
         facet_attributes[:kickstart_repository_id] ||= hostgroup.inherited_kickstart_repository_id
         facet_attributes[:content_view_id] ||= hostgroup.inherited_content_view_id
         facet_attributes[:lifecycle_environment_id] ||= hostgroup.inherited_lifecycle_environment_id
+        facet_attributes[:content_source_id] ||= hostgroup.inherited_content_source_id
         facet_attributes
       end
 

--- a/app/views/katello/api/v2/content_facet/base.json.rabl
+++ b/app/views/katello/api/v2/content_facet/base.json.rabl
@@ -1,6 +1,7 @@
 attributes :id, :uuid
 attributes :content_view_id, :content_view_name
 attributes :lifecycle_environment_id, :lifecycle_environment_name
+attributes :content_source_id, :content_source_name
 
 child :content_view => :content_view do
   attributes :id, :name
@@ -8,6 +9,10 @@ end
 
 child :lifecycle_environment => :lifecycle_environment do
   attributes :id, :name
+end
+
+child :content_source => :content_source do
+  attributes :id, :name, :url
 end
 
 node :errata_counts do |content_facet|

--- a/app/views/katello/api/v2/content_facet/show.json.rabl
+++ b/app/views/katello/api/v2/content_facet/show.json.rabl
@@ -26,4 +26,4 @@ child :host_collections => :host_collections do
   attributes :id, :name
 end
 
-attributes :description, :facts, :content_source_id
+attributes :description, :facts

--- a/app/views/overrides/activation_keys/_host_environment_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_environment_select.html.erb
@@ -30,14 +30,15 @@ end %>
   end
 end %>
 
-<% if @host %>
-  <input type="hidden" name="host[content_facet_attributes][id]" value="<%= @host.content_facet.try(:id) %>">
-<% end %>
-
 <% proxies = SmartProxy.with_content.unscoped.with_taxonomy_scope(@location,@organization,:path_ids) %>
-<% if proxies.count > 0 %>
-    <%= select_f f, :content_source_id, proxies, :id, :name,
-             { :include_blank => blank_or_inherit_f(f, :content_source) },
-             { :label       => _("Content Source"),
-               :help_inline => _("Use this as a source for installation and updates.") } %>
-<% end %>
+<% cs_select_id =  using_hostgroups_page? ? :hostgroup_content_source_id : :host_content_source_id %>
+<% cs_select_name =  using_hostgroups_page? ? 'hostgroup[content_source_id]' : 'host[content_facet_attributes][content_source_id]' %>
+<% cs_select_attr = using_hostgroups_page? ? 'content_source' : 'content_facet.content_source' %>
+<%= field(f, cs_select_attr, {:label => _("Content Source")}) do
+  if using_hostgroups_page?
+    select_tag cs_select_id, options_from_collection_for_select(proxies, :id, :name, @hostgroup.content_source_id), :data => {"spinner_path" => spinner_path},
+               :class => 'form-control',  :name => cs_select_name, include_blank: true
+  else
+    select_tag cs_select_id, options_from_collection_for_select(proxies, :id, :name, (@hostgroup || @host).content_source_id), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cs_select_name, include_blank: true
+  end
+end %>

--- a/db/migrate/20161214151548_move_content_source_id_to_content_facets.rb
+++ b/db/migrate/20161214151548_move_content_source_id_to_content_facets.rb
@@ -1,0 +1,38 @@
+class MoveContentSourceIdToContentFacets < ActiveRecord::Migration
+  def up
+    add_column :katello_content_facets, :content_source_id, :integer
+    add_index :katello_content_facets, :content_source_id
+    add_foreign_key :katello_content_facets, :smart_proxies, :name => "katello_content_facets_content_source_id_fk", :column => "content_source_id"
+
+    Host.find_each do |host|
+      content_facet = host.content_facet
+      if content_facet && host.content_source_id
+        content_facet.content_source_id = host.content_source_id
+        content_facet.save!
+      end
+    end
+
+    remove_foreign_key :hosts, :name => "hosts_content_source_id_fk"
+    remove_index :hosts, :content_source_id
+    remove_column :hosts, :content_source_id
+  end
+
+  def down
+    add_column :hosts, :content_source_id, :integer
+    add_index :hosts, :content_source_id
+    add_foreign_key :hosts, :smart_proxies, :name => "hosts_content_source_id_fk", :column => "content_source_id"
+
+    Host.find_each do |host|
+      if host.content_facet
+        host.content_source_id = host.content_facet.content_source_id
+        if host.content_facet.content_source
+          host.save!
+        end
+      end
+    end
+
+    remove_foreign_key :katello_content_facets, :name => "katello_content_facets_content_source_id_fk"
+    remove_index :katello_content_facets, :content_source_id
+    remove_column :katello_content_facets, :content_source_id
+  end
+end

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -158,8 +158,8 @@ Foreman::Plugin.register :katello do
   apipie_documented_controllers ["#{Katello::Engine.root}/app/controllers/katello/api/v2/*.rb"]
   apipie_ignored_controllers %w(::Api::V2::OrganizationsController)
 
-  parameter_filter ::Host::Managed, :content_source_id, :host_collection_ids => [],
-    :content_facet_attributes => [:content_view_id, :lifecycle_environment_id,
+  parameter_filter ::Host::Managed, :host_collection_ids => [],
+    :content_facet_attributes => [:content_view_id, :lifecycle_environment_id, :content_source_id,
                                   :host, :kickstart_repository_id],
     :subscription_facet_attributes => [:release_version, :autoheal, :service_level, :host,
                                        {:installed_products => [:product_id, :product_name, :arch, :version]}, :facts, :hypervisor_guest_uuids => []]
@@ -206,6 +206,7 @@ Foreman::Plugin.register :katello do
   register_facet Katello::Host::ContentFacet, :content_facet do
     api_view :list => 'katello/api/v2/content_facet/base_with_root', :single => 'katello/api/v2/content_facet/show'
     api_docs :content_facet_attributes, ::Katello::Api::V2::HostContentsController
+    template_compatibility_properties :content_source_id, :content_source
   end
 
   register_facet Katello::Host::SubscriptionFacet, :subscription_facet do

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -30,7 +30,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
 
     get :show, :id => host.id
     response = ActiveSupport::JSON.decode(@response.body)
-    assert_equal smart_proxy.id, response["content_source_id"]
+    assert_equal smart_proxy.id, response["content_facet_attributes"]["content_source_id"]
     assert_response :success
   end
 
@@ -70,10 +70,9 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
   end
 
   def test_with_smartproxy
-    host = FactoryGirl.create(:host, :with_content, :with_subscription, :content_view => @content_view,
-                              :lifecycle_environment => @environment)
     smart_proxy = FactoryGirl.create(:smart_proxy, :features => [FactoryGirl.create(:feature, name: 'Pulp')])
-    host.update_column(:content_source_id, smart_proxy.id)
+    host = FactoryGirl.create(:host, :with_content, :with_subscription, :content_view => @content_view,
+                              :lifecycle_environment => @environment, :content_source => smart_proxy)
     host_show(host, smart_proxy)
   end
 

--- a/test/factories/host_factory.rb
+++ b/test/factories/host_factory.rb
@@ -3,6 +3,7 @@ FactoryGirl.modify do
     transient do
       content_view nil
       lifecycle_environment nil
+      content_source nil
     end
 
     trait :with_content do
@@ -12,6 +13,7 @@ FactoryGirl.modify do
         if host.content_facet
           host.content_facet.content_view = evaluator.content_view if evaluator.content_view
           host.content_facet.lifecycle_environment = evaluator.lifecycle_environment if evaluator.lifecycle_environment
+          host.content_facet.content_source = evaluator.content_source if evaluator.content_source
         end
       end
     end

--- a/test/helpers/hosts_and_hostgroups_helper_test.rb
+++ b/test/helpers/hosts_and_hostgroups_helper_test.rb
@@ -51,8 +51,8 @@ class HostsAndHostGroupsHelperKickstartRepositoryOptionsTest < HostsAndHostGroup
   test "kickstart_repository_options should provide options for a populated host" do
     host = ::Host.new(:architecture => @arch, :operatingsystem => @os,
                       :content_facet_attributes => {:lifecycle_environment_id => @env.id,
-                                                    :content_view_id => @cv.id})
-    host.content_source = @content_source
+                                                    :content_view_id => @cv.id,
+                                                    :content_source_id => @content_source.id})
     ret = [{:name => "boo" }]
 
     @os.expects(:kickstart_repos).returns(ret).with do |param_host|
@@ -133,8 +133,8 @@ class HostsAndHostGroupsHelperKickstartRepositoryIDTest < HostsAndHostGroupsHelp
 
     @host = ::Host.new(:architecture => @arch, :operatingsystem => @os,
                       :content_facet_attributes => {:lifecycle_environment_id => @env.id,
-                                                    :content_view_id => @cv.id})
-    @host.content_source = @content_source
+                                                    :content_view_id => @cv.id,
+                                                    :content_source_id => @content_source.id})
   end
 
   test "must return host or host group kickstart id" do

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -38,7 +38,8 @@ module Katello
     def test_smart_proxy_ids_with_katello
       content_source = FactoryGirl.create(:smart_proxy,
                                           :features => [Feature.where(:name => "Pulp Node").first_or_create])
-      @foreman_host.content_source = content_source
+      Support::HostSupport.attach_content_facet(@foreman_host, @view, @library)
+      @foreman_host.content_facet.content_source = content_source
       assert @foreman_host.smart_proxy_ids.include?(@foreman_host.content_source_id)
     end
 

--- a/test/models/concerns/redhat_extensions_test.rb
+++ b/test/models/concerns/redhat_extensions_test.rb
@@ -67,9 +67,8 @@ module Katello
 
       @host = ::Host.new(:architecture => architectures(:x86_64), :operatingsystem => @os,
                         :content_facet_attributes => {:lifecycle_environment_id => @repo_with_distro.environment.id,
-                                                      :content_view_id => @repo_with_distro.content_view.id})
-
-      @host.content_source = @content_source
+                                                      :content_view_id => @repo_with_distro.content_view.id,
+                                                      :content_source => @content_source})
 
       @hostgroup = Hostgroup.new(:name => "testhg", :lifecycle_environment_id => @repo_with_distro.environment.id,
                                  :content_view_id => @repo_with_distro.content_view.id)
@@ -82,11 +81,11 @@ module Katello
       # create os
       @os.media.create!(:name => "my-media", :path => "http://www.foo.com/abcd")
       @host.medium = @os.media.first
-      @host.content_source = nil
+      @host.content_facet.content_source = nil
       @host.content_facet.kickstart_repository = @repo_with_distro
       assert_equal @os.media.first.path, @os.medium_uri(@host).to_s
 
-      @host.content_source = @content_source
+      @host.content_facet.content_source = @content_source
       @host.content_facet.kickstart_repository = nil
       assert_equal @os.media.first.path, @os.medium_uri(@host).to_s
     end
@@ -115,7 +114,7 @@ module Katello
 
     def test_kickstart_repos_with_no_content_source
       @os.expects(:distribution_repositories).with(@host).returns([@repo_with_distro])
-      @host.content_source = nil
+      @host.content_facet.content_source = nil
       assert_empty @os.kickstart_repos(@host)
     end
 


### PR DESCRIPTION
Migrate the content_source_id column from the hosts table to the
content_facets table. Update Hosts#Edit and Hostgroups#Edit pages.