### PR TITLE
Fixes #17815 - Prevent HG breaking when os/arch is removed

### DIFF
--- a/app/models/katello/concerns/redhat_extensions.rb
+++ b/app/models/katello/concerns/redhat_extensions.rb
@@ -70,7 +70,7 @@ module Katello
         content_view = host.try(:content_facet).try(:content_view) || host.try(:content_view)
         lifecycle_environment = host.try(:content_facet).try(:lifecycle_environment) || host.try(:lifecycle_environment)
 
-        if content_view && lifecycle_environment
+        if content_view && lifecycle_environment && host.os && host.architecture
           Katello::Repository.in_environment(lifecycle_environment).in_content_views([content_view]).
               where(:distribution_version => host.os.release,
                     :distribution_arch => host.architecture.name,


### PR DESCRIPTION
A hostgroup that has a content view assigned and then has it's os or
architecture removed will break in the UI, including any children
inheriting these attrubutes. This will safely check the related
parameters.