### PR TITLE
Fixes #17787 - Keyboard tab doesnt function well

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/new/views/activation-key-new.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/new/views/activation-key-new.html
@@ -13,7 +13,6 @@
                name="name"
                ng-model="activationKey.name"
                type="text"
-               tabindex="1"
                autofocus
                required/>
       </div>
@@ -32,16 +31,14 @@
                  ng-required="!activationKey.unlimited_hosts"
                  type="number"
                  min="1"
-                 max="2147483648"
-                 tabindex="2"/>
+                 max="2147483648"/>
         </div>
       </div>
 
       <div bst-form-group label="{{ 'Description' | translate }}">
         <textarea id="description"
                   name="description"
-                  ng-model="activationKey.description"
-                  tabindex="3">
+                  ng-model="activationKey.description">
         </textarea>
       </div>
 
@@ -63,7 +60,6 @@
                   name="content_view_id"
                   ng-model="activationKey.content_view_id"
                   ng-options="contentView.id as contentView.name for contentView in contentViews"
-                  tabindex="4"
                   autofocus>
           </select>
           <span class="help-block" ng-show="activationKey.environment !== undefined && contentViews.length === 0" translate>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/new/views/product-new-form.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/new/views/product-new-form.html
@@ -5,7 +5,6 @@
            name="name"
            ng-model="product.name"
            type="text"
-           tabindex="1"
            autofocus
            required/>
   </div>
@@ -15,7 +14,6 @@
            name="label"
            ng-model="product.label"
            type="text"
-           tabindex="2"
            required/>
   </div>
 
@@ -23,8 +21,7 @@
     <select id="gpg_key_id"
             name="gpg_key_id"
             ng-model="product.gpg_key_id"
-            ng-options="gpg_key.id as gpg_key.name for gpg_key in gpgKeys"
-            tabindex="4">
+            ng-options="gpg_key.id as gpg_key.name for gpg_key in gpgKeys">
       <option value=""></option>
     </select>
   </div>
@@ -33,8 +30,7 @@
     <select id="sync_plan_id"
             name="sync_plan_id"
             ng-model="product.sync_plan_id"
-            ng-options="syncPlan.id as syncPlan.name for syncPlan in syncPlans"
-            tabindex="5">
+            ng-options="syncPlan.id as syncPlan.name for syncPlan in syncPlans">
       <option value=""></option>
     </select>
     <a ui-sref="products.new.sync-plan" translate>+ New Sync Plan</a>


### PR DESCRIPTION
Previously, keyboard tab doesn't function well with Products
or Activation-key page. For repository page, already resolved.

As no need to explicitly set the tabindex
except on customer's demand because it’s all handled in
the browser, in this commit removed existing tabindex attr
from HTML tags.