### PR TITLE
Fixes #17835 - Subscriptions should ask for less information (performance)

### DIFF
--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -84,8 +84,8 @@ module Katello
     end
 
     def available_subscriptions
-      all_pools = self.get_pools.map { |pool| pool["id"] }
-      added_pools = self.get_key_pools.map { |pool| pool["id"] }
+      all_pools = self.get_pools(:include => id).map { |pool| pool["id"] }
+      added_pools = self.get_key_pools(['pools.pool.id']).map { |pool| pool["id"] }
       available_pools = all_pools - added_pools
       Pool.where(:cp_id => available_pools,
                  :subscription_id => Subscription.with_subscribable_content)

--- a/app/models/katello/glue/candlepin/activation_key.rb
+++ b/app/models/katello/glue/candlepin/activation_key.rb
@@ -18,16 +18,18 @@ module Katello
     end
 
     module InstanceMethods
-      def get_pools
-        Resources::Candlepin::ActivationKey.pools(self.organization.label)
+      def get_pools(filter = {})
+        Resources::Candlepin::ActivationKey.pools(self.organization.label, filter)
       end
 
       def get_keys
         Resources::Candlepin::ActivationKey.get
       end
 
-      def get_key_pools
-        key_pools = Resources::Candlepin::ActivationKey.get(self.cp_id)[0][:pools]
+      def get_key_pools(included_list = %w(pools.pool.amount pools.quantity pools.pool.id))
+        key_pools = Resources::Candlepin::ActivationKey.get(
+          self.cp_id, included_list
+        )[0][:pools]
         pools = []
         key_pools.each do |key_pool|
           key_pool[:pool][:amount] = (key_pool[:quantity] ? key_pool[:quantity] : 0)

--- a/app/models/katello/glue/candlepin/candlepin_object.rb
+++ b/app/models/katello/glue/candlepin/candlepin_object.rb
@@ -5,12 +5,14 @@ module Katello
     module ClassMethods
       def get_for_organization(organization)
         # returns objects from AR database rather than candlepin data
-        pool_ids = self.get_for_owner(organization.label).collect { |x| x['id'] }
+        pool_ids = self.get_for_owner(organization.label, ['id']).
+          collect { |pool| pool['id'] }
         self.where(:cp_id => pool_ids)
       end
 
       def get_candlepin_ids(organization)
-        self.get_for_owner(organization).map { |subscription| subscription["id"] }
+        self.get_for_owner(organization, ['id']).
+          map { |subscription| subscription["id"] }
       end
 
       def import_candlepin_ids(organization)

--- a/app/models/katello/glue/candlepin/subscription.rb
+++ b/app/models/katello/glue/candlepin/subscription.rb
@@ -6,18 +6,18 @@ module Katello
     end
 
     module ClassMethods
-      def candlepin_data(cp_id)
-        Katello::Resources::Candlepin::Subscription.get(cp_id)
+      def candlepin_data(cp_id, included = [])
+        Katello::Resources::Candlepin::Subscription.get(cp_id, included)
       end
 
-      def get_for_owner(organization = self.organization.label)
-        Katello::Resources::Candlepin::Subscription.get_for_owner(organization)
+      def get_for_owner(organization = self.organization.label, included = [])
+        Katello::Resources::Candlepin::Subscription.get_for_owner(organization, included)
       end
     end
 
     module InstanceMethods
-      def backend_data
-        self.class.candlepin_data(self.cp_id)
+      def backend_data(included = [])
+        self.class.candlepin_data(self.cp_id, included)
       end
 
       def query_products


### PR DESCRIPTION
Currently the subscription index page is asking Candlepin for all
available information about Pools, Owner and ActivationKeys.
These calls are also made on other pages like the 'list subscriptions'
and 'add/remove subscriptions' of Activation Keys, and
on certain API endpoints like /api/v2/organizations/:id.

The code should make calls that retrieve only the data that the RABL
will use, or that the model will use. Right now there is
no filter at all and the calls retrieve all information for Pools (which
can be very large), etc...

This commit makes the following pages (at least) faster:
  api/v2/organizations/:id
  /subscriptions
  api/v2/subscriptions
  api/v2/subscriptions/:id
  api/v2/subscriptions/:id
  api/v2/activation_keys/:id
  api/v2/activation_keys/:id

and all pages that make calls to those APIs. For me the effect is most
noticeable on add/remove subs for an activation key, and /subscriptions

======================================================

DO NOT MERGE YET - I cannot create custom products (through new product or discovering repos) with this commit, I get a 401 from Candlepin.