### PR TITLE
Fixes #17857 - Update syntax to scoped_search 4

### DIFF
--- a/app/helpers/katello/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/katello/hosts_and_hostgroups_helper.rb
@@ -170,11 +170,6 @@ module Katello
         return [] unless host.operatingsystem.is_a?(Redhat)
 
         new_host = ::Host.new
-        # there is foreman bug right now that prevents
-        # os and arch to get updated properly,
-        # http://projects.theforeman.org/issues/14737
-        # so we are going to hard code it to use what
-        # is in the param host for now.
         new_host.operatingsystem = param_host.operatingsystem.present? ? param_host.operatingsystem : host.operatingsystem
         new_host.architecture = param_host.architecture.present? ? param_host.architecture : host.architecture
 

--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -50,8 +50,8 @@ module Katello
 
     scoped_search :on => :name, :complete_value => true
     scoped_search :on => :organization_id, :complete_value => true, :only_explicit => true
-    scoped_search :rename => :environment, :on => :name, :in => :environment, :complete_value => true
-    scoped_search :rename => :content_view, :on => :name, :in => :content_view, :complete_value => true
+    scoped_search :rename => :environment, :on => :name, :relation => :environment, :complete_value => true
+    scoped_search :rename => :content_view, :on => :name, :relation => :content_view, :complete_value => true
     scoped_search :on => :content_view_id, :complete_value => true, :only_explicit => true
     scoped_search :on => :description, :complete_value => true
 

--- a/app/models/katello/concerns/content_facet_host_extensions.rb
+++ b/app/models/katello/concerns/content_facet_host_extensions.rb
@@ -12,7 +12,7 @@ module Katello
         }.freeze
 
         has_one :errata_status_object, :class_name => 'Katello::ErrataStatus', :foreign_key => 'host_id'
-        scoped_search :on => :status, :in => :errata_status_object, :rename => :errata_status,
+        scoped_search :on => :status, :relation => :errata_status_object, :rename => :errata_status,
                      :complete_value => ERRATA_STATUS_MAP
 
         #associations for simpler scoped searches
@@ -21,14 +21,14 @@ module Katello
         has_many :applicable_errata, :through => :content_facet
         has_many :applicable_rpms, :through => :content_facet
 
-        scoped_search :in => :content_view, :on => :name, :complete_value => true, :rename => :content_view
-        scoped_search :in => :content_facet, :on => :content_view_id, :rename => :content_view_id, :only_explicit => true
-        scoped_search :in => :lifecycle_environment, :on => :name, :complete_value => true, :rename => :lifecycle_environment
-        scoped_search :in => :content_facet, :on => :lifecycle_environment_id, :rename => :lifecycle_environment_id, :only_explicit => true
-        scoped_search :in => :applicable_errata, :on => :errata_id, :rename => :applicable_errata, :complete_value => true, :ext_method => :find_by_applicable_errata, :only_explicit => true
-        scoped_search :in => :applicable_errata, :on => :errata_id, :rename => :installable_errata, :complete_value => true, :ext_method => :find_by_installable_errata, :only_explicit => true
-        scoped_search :in => :applicable_rpms, :on => :nvra, :rename => :applicable_rpms, :complete_value => true, :ext_method => :find_by_applicable_rpms, :only_explicit => true
-        scoped_search :in => :applicable_rpms, :on => :nvra, :rename => :upgradable_rpms, :complete_value => true, :ext_method => :find_by_installable_rpms, :only_explicit => true
+        scoped_search :relation => :content_view, :on => :name, :complete_value => true, :rename => :content_view
+        scoped_search :relation => :content_facet, :on => :content_view_id, :rename => :content_view_id, :only_explicit => true
+        scoped_search :relation => :lifecycle_environment, :on => :name, :complete_value => true, :rename => :lifecycle_environment
+        scoped_search :relation => :content_facet, :on => :lifecycle_environment_id, :rename => :lifecycle_environment_id, :only_explicit => true
+        scoped_search :relation => :applicable_errata, :on => :errata_id, :rename => :applicable_errata, :complete_value => true, :ext_method => :find_by_applicable_errata, :only_explicit => true
+        scoped_search :relation => :applicable_errata, :on => :errata_id, :rename => :installable_errata, :complete_value => true, :ext_method => :find_by_installable_errata, :only_explicit => true
+        scoped_search :relation => :applicable_rpms, :on => :nvra, :rename => :applicable_rpms, :complete_value => true, :ext_method => :find_by_applicable_rpms, :only_explicit => true
+        scoped_search :relation => :applicable_rpms, :on => :nvra, :rename => :upgradable_rpms, :complete_value => true, :ext_method => :find_by_installable_rpms, :only_explicit => true
 
         # preserve options set by facets framework, but add new :reject_if statement
         accepts_nested_attributes_for(

--- a/app/models/katello/concerns/environment_extensions.rb
+++ b/app/models/katello/concerns/environment_extensions.rb
@@ -11,8 +11,8 @@ module Katello
         has_one :content_view, :class_name => "Katello::ContentView", :through => :content_view_puppet_environment
         has_one :lifecycle_environment, :class_name => "Katello::KTEnvironment", :through => :content_view_puppet_environment, :source => :environment
 
-        scoped_search :in => :content_view, :on => :name, :rename => :content_view, :complete_value => true
-        scoped_search :in => :lifecycle_environment, :on => :name, :rename => :lifecycle_environment, :complete_value => true
+        scoped_search :relation => :content_view, :on => :name, :rename => :content_view, :complete_value => true
+        scoped_search :relation => :lifecycle_environment, :on => :name, :rename => :lifecycle_environment, :complete_value => true
       end
 
       def content_view

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -21,14 +21,14 @@ module Katello
 
         before_save :correct_puppet_environment
 
-        scoped_search :in => :content_source, :on => :name, :complete_value => true, :rename => :content_source
-        scoped_search :in => :host_collections, :on => :id, :complete_value => false, :rename => :host_collection_id, :only_explicit => true
-        scoped_search :in => :host_collections, :on => :name, :complete_value => true, :rename => :host_collection
-        scoped_search :in => :installed_packages, :on => :nvra, :complete_value => true, :rename => :installed_package, :only_explicit => true
-        scoped_search :in => :installed_packages, :on => :name, :complete_value => true, :rename => :installed_package_name, :only_explicit => true
-        scoped_search :in => :host_traces, :on => :application, :complete_value => true, :rename => :trace_app, :only_explicit => true
-        scoped_search :in => :host_traces, :on => :app_type, :complete_value => true, :rename => :trace_app_type, :only_explicit => true
-        scoped_search :in => :host_traces, :on => :helper, :complete_value => true, :rename => :trace_helper, :only_explicit => true
+        scoped_search :relation => :content_source, :on => :name, :complete_value => true, :rename => :content_source
+        scoped_search :relation => :host_collections, :on => :id, :complete_value => false, :rename => :host_collection_id, :only_explicit => true
+        scoped_search :relation => :host_collections, :on => :name, :complete_value => true, :rename => :host_collection
+        scoped_search :relation => :installed_packages, :on => :nvra, :complete_value => true, :rename => :installed_package, :only_explicit => true
+        scoped_search :relation => :installed_packages, :on => :name, :complete_value => true, :rename => :installed_package_name, :only_explicit => true
+        scoped_search :relation => :host_traces, :on => :application, :complete_value => true, :rename => :trace_app, :only_explicit => true
+        scoped_search :relation => :host_traces, :on => :app_type, :complete_value => true, :rename => :trace_app_type, :only_explicit => true
+        scoped_search :relation => :host_traces, :on => :helper, :complete_value => true, :rename => :trace_helper, :only_explicit => true
       end
 
       def validate_media_with_capsule?

--- a/app/models/katello/concerns/hostgroup_extensions.rb
+++ b/app/models/katello/concerns/hostgroup_extensions.rb
@@ -13,9 +13,9 @@ module Katello
 
         validates_with Katello::Validators::ContentViewEnvironmentValidator
 
-        scoped_search :in => :content_source, :on => :name, :complete_value => true, :rename => :content_source
-        scoped_search :in => :content_view, :on => :name, :complete_value => true, :rename => :content_view
-        scoped_search :in => :lifecycle_environment, :on => :name, :complete_value => true, :rename => :lifecycle_environment
+        scoped_search :relation => :content_source, :on => :name, :complete_value => true, :rename => :content_source
+        scoped_search :relation => :content_view, :on => :name, :complete_value => true, :rename => :content_view
+        scoped_search :relation => :lifecycle_environment, :on => :name, :complete_value => true, :rename => :lifecycle_environment
       end
 
       def content_view

--- a/app/models/katello/concerns/subscription_facet_host_extensions.rb
+++ b/app/models/katello/concerns/subscription_facet_host_extensions.rb
@@ -16,18 +16,18 @@ module Katello
 
         has_many :activation_keys, :through => :subscription_facet
         has_one :subscription_status_object, :class_name => 'Katello::SubscriptionStatus', :foreign_key => 'host_id'
-        scoped_search :on => :status, :in => :subscription_status_object, :rename => :subscription_status,
+        scoped_search :on => :status, :relation => :subscription_status_object, :rename => :subscription_status,
                       :complete_value => SUBSCRIPTION_STATUS_MAP
 
-        scoped_search :on => :release_version, :in => :subscription_facet, :complete_value => true
-        scoped_search :on => :autoheal, :in => :subscription_facet, :complete_value => true
-        scoped_search :on => :service_level, :in => :subscription_facet, :complete_value => true
-        scoped_search :on => :last_checkin, :in => :subscription_facet, :complete_value => true, :only_explicit => true
-        scoped_search :on => :registered_through, :in => :subscription_facet, :complete_value => true
-        scoped_search :on => :registered_at, :in => :subscription_facet, :rename => :registered_at, :only_explicit => true
-        scoped_search :on => :uuid, :in => :subscription_facet, :rename => :subscription_uuid
-        scoped_search :in => :activation_keys, :on => :name, :rename => :activation_key, :complete_value => true, :ext_method => :find_by_activation_key
-        scoped_search :in => :activation_keys, :on => :id, :rename => :activation_key_id, :complete_value => true, :ext_method => :find_by_activation_key_id, :only_explicit => true
+        scoped_search :on => :release_version, :relation => :subscription_facet, :complete_value => true
+        scoped_search :on => :autoheal, :relation => :subscription_facet, :complete_value => true
+        scoped_search :on => :service_level, :relation => :subscription_facet, :complete_value => true
+        scoped_search :on => :last_checkin, :relation => :subscription_facet, :complete_value => true, :only_explicit => true
+        scoped_search :on => :registered_through, :relation => :subscription_facet, :complete_value => true
+        scoped_search :on => :registered_at, :relation => :subscription_facet, :rename => :registered_at, :only_explicit => true
+        scoped_search :on => :uuid, :relation => :subscription_facet, :rename => :subscription_uuid
+        scoped_search :relation => :activation_keys, :on => :name, :rename => :activation_key, :complete_value => true, :ext_method => :find_by_activation_key
+        scoped_search :relation => :activation_keys, :on => :id, :rename => :activation_key_id, :complete_value => true, :ext_method => :find_by_activation_key_id, :only_explicit => true
       end
 
       def update_action

--- a/app/models/katello/content_view_history.rb
+++ b/app/models/katello/content_view_history.rb
@@ -22,7 +22,7 @@ module Katello
     alias_method :version, :content_view_version
     alias_attribute :description, :notes
 
-    scoped_search :on => :name, :in => :environment, :rename => :environment, :complete_value => true
+    scoped_search :on => :name, :relation => :environment, :rename => :environment, :complete_value => true
 
     enum action: {
       publish: 1,

--- a/app/models/katello/content_view_puppet_module.rb
+++ b/app/models/katello/content_view_puppet_module.rb
@@ -14,7 +14,7 @@ module Katello
     scoped_search :on => :name, :complete_value => true
     scoped_search :on => :author, :complete_value => true
     scoped_search :on => :uuid, :complete_value => true
-    scoped_search :on => :name, :in => :content_view, :rename => :content_view_name
+    scoped_search :on => :name, :relation => :content_view, :rename => :content_view_name
 
     def puppet_module
       PuppetModule.find_by_uuid(self.uuid)

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -47,7 +47,7 @@ module Katello
 
     scoped_search :on => :content_view_id, :only_explicit => true
     scoped_search :on => :major, :rename => :version, :complete_value => true, :ext_method => :find_by_version
-    scoped_search :in => :repositories, :on => :name, :rename => :repository, :complete_value => true
+    scoped_search :relation => :repositories, :on => :name, :rename => :repository, :complete_value => true
 
     def self.find_by_version(_key, operator, value)
       conditions = ""

--- a/app/models/katello/docker_manifest.rb
+++ b/app/models/katello/docker_manifest.rb
@@ -8,7 +8,7 @@ module Katello
 
     CONTENT_TYPE = Pulp::DockerManifest::CONTENT_TYPE
     scoped_search :on => :name, :complete_value => true
-    scoped_search :in => :docker_tag, :on => :name, :rename => :tag, :complete_value => true, :only_explicit => true
+    scoped_search :relation => :docker_tag, :on => :name, :rename => :tag, :complete_value => true, :only_explicit => true
 
     def self.repository_association_class
       RepositoryDockerManifest

--- a/app/models/katello/docker_tag.rb
+++ b/app/models/katello/docker_tag.rb
@@ -6,11 +6,11 @@ module Katello
     belongs_to :repository, :inverse_of => :docker_tags, :class_name => "Katello::Repository"
 
     scoped_search :on => :name, :complete_value => true, :rename => :tag
-    scoped_search :in => :docker_manifest, :on => :name, :rename => :manifest,
+    scoped_search :relation => :docker_manifest, :on => :name, :rename => :manifest,
       :complete_value => true, :only_explicit => false
-    scoped_search :in => :docker_manifest, :on => :digest, :rename => :digest,
+    scoped_search :relation => :docker_manifest, :on => :digest, :rename => :digest,
       :complete_value => false, :only_explicit => true
-    scoped_search :in => :repository, :on => :name, :rename => :repository,
+    scoped_search :relation => :repository, :on => :name, :rename => :repository,
       :complete_value => true, :only_explicit => true
 
     scope :in_repositories, ->(repos) { where(:repository_id => repos) }

--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -27,10 +27,10 @@ module Katello
     scoped_search :on => :issued, :complete_value => true
     scoped_search :on => :updated, :complete_value => true
     scoped_search :on => :reboot_suggested, :complete_value => true
-    scoped_search :in => :cves, :on => :cve_id, :rename => :cve
-    scoped_search :in => :bugzillas, :on => :bug_id, :rename => :bug
-    scoped_search :in => :packages, :on => :nvrea, :rename => :package, :complete_value => true
-    scoped_search :in => :packages, :on => :name, :rename => :package_name, :complete_value => true
+    scoped_search :relation => :cves, :on => :cve_id, :rename => :cve
+    scoped_search :relation => :bugzillas, :on => :bug_id, :rename => :bug
+    scoped_search :relation => :packages, :on => :nvrea, :rename => :package, :complete_value => true
+    scoped_search :relation => :packages, :on => :name, :rename => :package_name, :complete_value => true
 
     before_save lambda { |erratum| erratum.title = erratum.title.truncate(255) unless erratum.title.blank? }
 

--- a/app/models/katello/file_unit.rb
+++ b/app/models/katello/file_unit.rb
@@ -12,7 +12,7 @@ module Katello
     scoped_search :on => :name, :complete_value => true
     scoped_search :on => :path, :complete_value => true
     scoped_search :on => :checksum
-    scoped_search :in => :repositories, :on => :name, :rename => :repository, :complete_value => true
+    scoped_search :relation => :repositories, :on => :name, :rename => :repository, :complete_value => true
 
     def self.default_sort
       order(:name)

--- a/app/models/katello/host_collection.rb
+++ b/app/models/katello/host_collection.rb
@@ -27,7 +27,7 @@ module Katello
 
     scoped_search :on => :name, :complete_value => true
     scoped_search :on => :organization_id, :complete_value => true, :only_explicit => true
-    scoped_search :in => :hosts, :on => :name, :rename => :host, :complete_value => true
+    scoped_search :relation => :hosts, :on => :name, :rename => :host, :complete_value => true
 
     def max_hosts_check
       if !unlimited_hosts && (hosts.length > 0 && (hosts.length.to_i > max_hosts.to_i)) && max_hosts_changed?

--- a/app/models/katello/ostree_branch.rb
+++ b/app/models/katello/ostree_branch.rb
@@ -10,7 +10,7 @@ module Katello
     scoped_search :on => :commit, :complete_value => true
     scoped_search :on => :uuid, :complete_value => true
     scoped_search :on => :version_date, :complete_value => true, :rename => :created
-    scoped_search :in => :repositories, :on => :name, :rename => :repository, :complete_value => true
+    scoped_search :relation => :repositories, :on => :name, :rename => :repository, :complete_value => true
 
     CONTENT_TYPE = Pulp::OstreeBranch::CONTENT_TYPE
 

--- a/app/models/katello/package_group.rb
+++ b/app/models/katello/package_group.rb
@@ -9,7 +9,7 @@ module Katello
 
     scoped_search :on => :name, :complete_value => true
     scoped_search :on => :uuid, :rename => :id, :complete_value => true
-    scoped_search :in => :repositories, :on => :name, :rename => :repository, :complete_value => true
+    scoped_search :relation => :repositories, :on => :name, :rename => :repository, :complete_value => true
 
     def self.repository_association_class
       RepositoryPackageGroup

--- a/app/models/katello/pool.rb
+++ b/app/models/katello/pool.rb
@@ -26,13 +26,13 @@ module Katello
     scoped_search :on => :consumed, :complete_value => true
     scoped_search :on => :account_number, :complete_value => true, :rename => :account
     scoped_search :on => :contract_number, :complete_value => true, :rename => :contract
-    scoped_search :on => :name, :in => :subscription, :complete_value => true, :rename => :name
-    scoped_search :on => :support_level, :in => :subscription, :complete_value => true
-    scoped_search :on => :sockets, :in => :subscription, :complete_value => true
-    scoped_search :on => :cores, :in => :subscription, :complete_value => true
-    scoped_search :on => :product_id, :in => :subscription, :complete_value => true
-    scoped_search :on => :stacking_id, :in => :subscription, :complete_value => true
-    scoped_search :on => :instance_multiplier, :in => :subscription, :complete_value => true
+    scoped_search :on => :name, :relation => :subscription, :complete_value => true, :rename => :name
+    scoped_search :on => :support_level, :relation => :subscription, :complete_value => true
+    scoped_search :on => :sockets, :relation => :subscription, :complete_value => true
+    scoped_search :on => :cores, :relation => :subscription, :complete_value => true
+    scoped_search :on => :product_id, :relation => :subscription, :complete_value => true
+    scoped_search :on => :stacking_id, :relation => :subscription, :complete_value => true
+    scoped_search :on => :instance_multiplier, :relation => :subscription, :complete_value => true
 
     validates_lengths_from_database
 

--- a/app/models/katello/product.rb
+++ b/app/models/katello/product.rb
@@ -32,7 +32,7 @@ module Katello
     scoped_search :on => :organization_id, :complete_value => true, :only_explicit => true
     scoped_search :on => :label, :complete_value => true
     scoped_search :on => :description
-    scoped_search :in => :provider, :on => :provider_type, :rename => :redhat,
+    scoped_search :relation => :provider, :on => :provider_type, :rename => :redhat,
                   :complete_value => {:true => Katello::Provider::REDHAT, :false => Katello::Provider::ANONYMOUS }
 
     def library_repositories

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -122,11 +122,11 @@ module Katello
     scope :subscribable, -> { where(content_type: SUBSCRIBABLE_TYPES) }
 
     scoped_search :on => :name, :complete_value => true
-    scoped_search :rename => :product, :on => :name, :in => :product, :complete_value => true
+    scoped_search :rename => :product, :on => :name, :relation => :product, :complete_value => true
     scoped_search :on => :content_type, :complete_value => -> do
       Katello::RepositoryTypeManager.repository_types.keys.each_with_object({}) { |value, hash| hash[value.to_sym] = value }
     end
-    scoped_search :on => :content_view_id, :in => :content_view_repositories
+    scoped_search :on => :content_view_id, :relation => :content_view_repositories
     scoped_search :on => :distribution_version, :complete_value => true
     scoped_search :on => :distribution_arch, :complete_value => true
     scoped_search :on => :distribution_family, :complete_value => true


### PR DESCRIPTION
Some of the scoped_search calls in Katello use syntax from scoped_search
3 that is now deprecated.