### PR TITLE
Fixes #17867 - Show existing products on discovery create

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery-form.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery-form.controller.js
@@ -21,8 +21,12 @@ angular.module('Bastion.products').controller('DiscoveryFormController',
             $scope.working = false;
             $scope.createRepoChoices.creating = false;
             angular.forEach(response.data.errors, function (errors, field) {
-                $scope.productForm[field].$setValidity('server', false);
-                $scope.productForm[field].$error.messages = errors;
+                if (angular.isUndefined($scope.productForm[field])) {
+                    $scope.productErrorMessages = 'An error occurred while saving the Product: ' + field + ' ' + errors;
+                } else {
+                    $scope.productForm[field].$setValidity('server', false);
+                    $scope.productForm[field].$error.messages = errors;
+                }
             });
         }
 
@@ -30,8 +34,8 @@ angular.module('Bastion.products').controller('DiscoveryFormController',
             var currentlyCreating = $scope.currentlyCreating;
             $scope.currentlyCreating = undefined;
             $scope.createRepoChoices.creating = false;
+            $scope.productErrorMessages = response.data.errors;
             currentlyCreating.form.$invalid = true;
-            currentlyCreating.form.messages = response.data.errors;
         }
 
         function convertToResource(repo) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery-create.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery-create.html
@@ -3,89 +3,76 @@
 <form name="productForm" class="col-sm-5" ng-disabled="creating()" novalidate role="form">
 
   <section>
+    <div bst-alerts error-messages="productErrorMessages"></div>
+
     <h4 translate>Create Repositories Within:</h4>
 
-    <div class="form-group">
+    <div bst-form-group>
       <label class="checkbox-inline">
         <input type="radio"
-               name="newProduct"
-               value="false"
-               ng-model="createRepoChoices.newProduct"
-               ng-disabled="creating()"/>
+        name="newProduct"
+        value="false"
+        ng-model="createRepoChoices.newProduct"
+        ng-disabled="creating()"/>
         <span translate>Existing Product</span>
       </label>
 
       <label class="checkbox-inline">
         <input type="radio"
-               name="newProduct"
-               value="true"
-               ng-model="createRepoChoices.newProduct"
-               ng-disabled="creating()"/>
+        name="newProduct"
+        value="true"
+        ng-model="createRepoChoices.newProduct"
+        ng-disabled="creating()"/>
         <span translate>New Product</span>
       </label>
     </div>
 
-    <div class="form-group">
-      <div class="col-md-5" ng-hide="createRepoChoices.newProduct">
+
+    <div ng-hide="createRepoChoices.newProduct === 'true'">
+      <div bst-form-group label="{{ 'Product' | translate }}">
         <select class="form-control" ng-disabled="creating()"
-                ng-model="createRepoChoices.existingProductId"
-                ng-options="product.id as product.name for product in products">
+          ng-model="createRepoChoices.existingProductId"
+          ng-options="product.id as product.name for product in products">
         </select>
       </div>
     </div>
 
-    <div ng-show="createRepoChoices.newProduct">
-
-      <div bst-alerts error-messages="productErrorMessages"></div>
-
-      <div class="form-group required">
-        <label class="control-label col-sm-1 text-left" translate>Name</label>
-        <div class="col-sm-5 input">
-          <input ng-model="createRepoChoices.product.name"
-                 id="name"
-                 name="name"
-                 type="text"
-                 class="form-control"
-                 tabindex=1
-                 ng-required="createRepoChoices.newProduct === 'true'"/>
-        </div>
+    <div ng-show="createRepoChoices.newProduct === 'true'">
+      <div bst-form-group label="{{ 'Name' | translate }}">
+        <input ng-model="createRepoChoices.product.name"
+        id="name"
+        name="name"
+        type="text"
+        class="form-control"
+        tabindex=1
+        ng-required="createRepoChoices.newProduct === 'true'"/>
       </div>
 
-      <div class="form-group required">
-        <label class="control-label col-sm-1" translate>Label</label>
-        <div class="col-sm-5 input">
-          <input ng-model="createRepoChoices.product.label"
-                 id="label"
-                 name="label"
-                 type="text"
-                 class="form-control"
-                 tabindex=2
-                 ng-required="createRepoChoices.newProduct === 'true'"/>
-        </div>
+      <div bst-form-group label="{{ 'Label' | translate }}">
+        <input ng-model="createRepoChoices.product.label"
+        id="label"
+        name="label"
+        type="text"
+        class="form-control"
+        tabindex=2
+        ng-required="createRepoChoices.newProduct === 'true'"/>
       </div>
 
-      <div class="form-group">
-        <label class="control-label col-sm-1" translate>GPG Key</label>
-        <div class="col-sm-5 input">
-          <select class="form-control" ng-model="createRepoChoices.product.gpg_key_id"
-                  ng-options="gpg_key.id as gpg_key.name for gpg_key in gpgKeys">
-          </select>
-        </div>
+      <div bst-form-group label="{{ 'GPG Key' | translate }}">
+        <select class="form-control" ng-model="createRepoChoices.product.gpg_key_id"
+          ng-options="gpg_key.id as gpg_key.name for gpg_key in gpgKeys">
+        </select>
       </div>
-
-     </div>
+    </div>
   </section>
 
   <section>
-    <h4 translate>Options:</h4>
-    <div class="checkbox">
-      <label>
-        <input type="checkbox"
-               id="unprotected"
-               ng-model="createRepoChoices.unprotected"
-               ng-disabled="creating()"/>
-        <span translate>Serve via HTTP.</span>
-      </label>
+    <div bst-form-group label="{{ 'Options' | translate }}">
+      <input type="checkbox"
+      id="unprotected"
+      ng-model="createRepoChoices.unprotected"
+      ng-disabled="creating()"/>
+      <span translate>Serve via HTTP.</span>
     </div>
   </section>
 
@@ -95,48 +82,35 @@
     <div ng-repeat="repo in discovery.selected">
 
       <div class="col-sm-offset-0 bottom-padding">
-        <i class="fa fa-circle"></i>
+        <i class="fa fa-angle-right"></i>
         <span>{{  repo.url }}</span>
         <i class="fa fa-check" ng-show="repo.created"></i>
       </div>
 
-      <div class="form-group required">
-        <label class="control-label col-sm-1" translate>Name</label>
-        <div class="col-sm-4 input">
-          <input ng-model="repo.name"
-                 ng-disabled="creating() || repo.created"
-                 name="repo_name"
-                 type="text"
-                 class="form-control"
-                 required/>
-        </div>
+      <div bst-form-group label="{{ 'Name' | translate }}">
+        <input ng-model="repo.name"
+        ng-disabled="creating() || repo.created"
+        name="repo_name"
+        type="text"
+        class="form-control"
+        required/>
       </div>
 
-      <div class="form-group required">
-        <label class="control-label col-sm-1" translate>Label</label>
-        <div class="col-sm-4 input">
-          <input ng-model="repo.label"
-                 ng-disabled="creating() || repo.created"
-                 name="repo_label"
-                 type="text"
-                 class="form-control"
-                 required/>
-        </div>
+      <div bst-form-group label="{{ 'Label' | translate }}">
+        <input ng-model="repo.label"
+        ng-disabled="creating() || repo.created"
+        name="repo_label"
+        type="text"
+        class="form-control"
+        required/>
       </div>
     </div>
-
-    <div class="form">
-      <div class="control-group buttons">
-        <div class="input">
-          <button ng-click="createRepos()"
-                  ng-disabled="creating() || !requiredFieldsEnabled()"
-                  translate
-                  class="btn btn-primary btn-large">
-            <i class="fa fa-spinner fa-spin" ng-show="creating()"></i>
-            Create
-          </button>
-        </div>
-      </div>
-    </div>
+    <button ng-click="createRepos()"
+      ng-disabled="creating() || !requiredFieldsEnabled()"
+      translate
+      class="btn btn-primary">
+      <i class="pficon-add-circle-o inline-icon"></i>	Create
+      <i class="fa fa-spinner fa-spin" ng-show="creating()"></i>
+    </button>
   </section>
 </form>


### PR DESCRIPTION
The create products after discovery page does not use the styles
described on
http://www.patternfly.org/pattern-library/forms-and-controls/forms/#_

Another problem it has is that even when there are no products
available, it shows you an option 'existing product' but clicking on it
does nothing at all

![screenshot from 2016-12-28 11-46-53](https://cloud.githubusercontent.com/assets/598891/21521372/8e8ac56a-ccfc-11e6-8813-df1f7c67ef42.png)
