### PR TITLE
Fixes #17903 - Use the 'built' foreman_url to call home

### DIFF
--- a/app/views/foreman/unattended/kickstart-katello-atomic.erb
+++ b/app/views/foreman/unattended/kickstart-katello-atomic.erb
@@ -34,7 +34,7 @@ reboot
 <%= snippet('remote_execution_ssh_keys') %>
 (
 # Report success back to Foreman
-curl -s -o /dev/null --insecure <%= foreman_url %>
+curl -s -o /dev/null --insecure <%= foreman_url('built') %>
 ) 2>&1 | tee /mnt/sysimage/root/install.post.log
 
 exit 0

--- a/app/views/foreman/unattended/kickstart-katello.erb
+++ b/app/views/foreman/unattended/kickstart-katello.erb
@@ -131,7 +131,7 @@ sync
 <% if @provisioning_type == nil || @provisioning_type == 'host' -%>
 # Inform the build system that we are done.
 echo "Informing Foreman that we are built"
-wget -q -O /dev/null --no-check-certificate <%= foreman_url %>
+wget -q -O /dev/null --no-check-certificate <%= foreman_url('built') %>
 <% end -%>
 ) 2>&1 | tee /root/install.post.log
 exit 0


### PR DESCRIPTION
The two kickstart templates provided by katello (kickstart and kickstart
atomic) call home by calling 'foreman_url', instead of
'foreman_url('built')'. Calling simply foreman_url just fetches the
kickstart, so booting hosts using those templates never set the host
as 'finished build'. This causes a bootloop where the host will end
up installing then rebooting then installing again ...