### PR TITLE
Fixes #17916 - properly handle pkg filter equals clause

### DIFF
--- a/test/models/rpm_test.rb
+++ b/test/models/rpm_test.rb
@@ -175,6 +175,10 @@ module Katello
       expected = ["abc123-2"]
       assert_equal expected, results.map(&:uuid).sort
 
+      results = Rpm.in_repositories(@repo).search_version_equal("1.0.0-1.0")
+      expected = ["abc123-1", "abc123-2"]
+      assert_equal expected, results.map(&:uuid).sort
+
       results = Rpm.in_repositories(@repo).search_version_equal("1:1.0.0-1.0")
       expected = ["abc123-2"]
       assert_equal expected, results.map(&:uuid).sort


### PR DESCRIPTION
This resolves an issue where package filter version matching
was improperly matching against all rpms with the same version even
if a release was specified