### PR TITLE
Fixes #17132 - content-host total memory now reports in GB

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details-info.controller.js
@@ -129,5 +129,9 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsInfoContro
 
             return ids.join(" or ");
         };
+
+        $scope.convertMemToGB = function (memoryValue) {
+            return (memoryValue / 1024000).toFixed(2);
+        };
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -141,8 +141,8 @@
       </div>
 
       <div class="detail">
-        <span class="info-label" translate>RAM </span>
-        <span class="info-value">{{ host.facts["dmi::memory::size"] }}</span>
+        <span class="info-label" translate>RAM (GB)</span>
+        <span class="info-value">{{ convertMemtoGB(host.facts["memory::memtotal"]) }}</span>
       </div>
 
       <div class="divider"></div>

--- a/engines/bastion_katello/test/content-hosts/details/content-host-details-info.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/details/content-host-details-info.controller.test.js
@@ -136,4 +136,8 @@ describe('Controller: ContentHostDetailsInfoController', function() {
         expect($scope.host.content_facet_attributes.lifecycle_environment.id).toBe(2);
         expect($scope.editContentView).toBe(false);
     });
+
+    it('should convert Mem to GB', function() {
+        expect($scope.convertMemToGB(74051368)).toBe('72.32')
+    });
 });


### PR DESCRIPTION
I wasn't able to test this patch as I don't have a development environment (only have a production environment).