### PR TITLE
Fixes #17938: add uib-dropdown-toggle to CV kebab.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-details.html
@@ -14,7 +14,7 @@
 
   <nav data-block="item-actions">
     <div class="dropdown dropdown-kebab-pf pull-right" uib-dropdown keyboard-nav bst-feature-flag="custom_products">
-      <button class="btn btn-link dropdown-toggle">
+      <button class="btn btn-link dropdown-toggle" uib-dropdown-toggle>
         <span class="fa fa-ellipsis-v"></span>
       </button>
 


### PR DESCRIPTION
A bad merge resulted in the uib-dropdown-toggle not being present on the
kebab for content views.  This commit adds the dropdown toggle
directive.

http://projects.theforeman.org/issues/17938