### PR TITLE
Fixes #17941 - allow force repo metadata  publish

### DIFF
--- a/app/lib/actions/katello/content_view_version/incremental_update.rb
+++ b/app/lib/actions/katello/content_view_version/incremental_update.rb
@@ -69,7 +69,7 @@ module Actions
             new_repo = plan_action(Repository::CloneToVersion, source_repos, new_version, true).new_repository
             copy_output = copy_yum_content(new_repo, dep_solve, content[:package_ids], content[:errata_ids])
 
-            plan_action(Katello::Repository::MetadataGenerate, new_repo, nil)
+            plan_action(Katello::Repository::MetadataGenerate, new_repo)
             plan_action(Katello::Repository::IndexContent, id: new_repo.id)
           end
           copy_output

--- a/app/lib/actions/katello/repository/clone_yum_content.rb
+++ b/app/lib/actions/katello/repository/clone_yum_content.rb
@@ -47,7 +47,8 @@ module Actions
               plan_action(Katello::Repository::IndexPackageGroups, target_repo)
             end
 
-            plan_action(Katello::Repository::MetadataGenerate, target_repo, filters.empty? ? source_repo : nil) if generate_metadata
+            source_repository = filters.empty? ? source_repo : nil
+            plan_action(Katello::Repository::MetadataGenerate, target_repo, :source_repository => source_repository) if generate_metadata
           end
         end
 

--- a/app/lib/actions/katello/repository/finish_upload.rb
+++ b/app/lib/actions/katello/repository/finish_upload.rb
@@ -3,7 +3,7 @@ module Actions
     module Repository
       class FinishUpload < Actions::Base
         def plan(repository, dependency = nil)
-          plan_action(Katello::Repository::MetadataGenerate, repository, nil, dependency)
+          plan_action(Katello::Repository::MetadataGenerate, repository, :dependency => dependency)
 
           recent_range = 5.minutes.ago.utc.iso8601
           plan_action(Katello::Repository::FilteredIndexContent,

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -5,6 +5,7 @@ class ActionDispatch::Routing::Mapper
   include Katello::Routing::MapperExtensions
 end
 
+# rubocop:disable Metrics/BlockLength
 Katello::Engine.routes.draw do
   scope :katello, :path => '/katello' do
     namespace :api do
@@ -226,6 +227,9 @@ Katello::Engine.routes.draw do
             post :sync_complete
             get :auto_complete_search
             get :repository_types
+          end
+          member do
+            put :republish
           end
         end
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details.controller.js
@@ -53,6 +53,12 @@
             }, errorHandler);
         };
 
+        $scope.republishRepository = function (repository) {
+            Repository.republish({id: repository.id}, function (task) {
+                $state.go('product.repository.tasks.details', {taskId: task.id});
+            }, errorHandler);
+        };
+
         $scope.syncInProgress = function (task) {
             var inProgress = false;
             if (task && (task.state === 'pending' || task.state === 'running')) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-details.html
@@ -32,6 +32,22 @@
           </span>
         </li>
 
+        <li role="menuitem">
+          <a ng-click="republishRepository(repository)"
+             ng-hide="syncInProgress(repository.last_sync) || denied('edit_products', product)"
+             translate>
+            Republish Repository Metadata
+          </a>
+
+          <span class="disabled" ng-show="syncInProgress(repository.last_sync)" translate>
+            Cannot republish Repository, a sync is already in progress.
+          </span>
+
+          <span class="disabled" ng-show="denied('sync_products', product)" translate>
+            Cannot republish Repository without the proper permissions.
+          </span>
+        </li>
+
         <li class="divider" bst-feature-flag="custom_products" ng-hide="denied('delete_repositories')"></li>
         <li role="menuitem" ng-hide="denied('delete_repositories')">
           <a ng-click="openModal()" ng-show="canRemove(repository, product)" translate>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/repository.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/repository.factory.js
@@ -20,7 +20,8 @@ angular.module('Bastion.repositories').factory('Repository',
                 removePackages: { method: 'PUT', params: { action: 'remove_packages'}},
                 removeContent: { method: 'PUT', params: { action: 'remove_content'}},
                 autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}},
-                repositoryTypes: {method: 'GET', isArray: true, params: {id: 'repository_types'}}
+                repositoryTypes: {method: 'GET', isArray: true, params: {id: 'repository_types'}},
+                republish: {method: 'PUT', params: { action: 'republish' }}
             }
         );
 

--- a/lib/katello/permissions/product_permissions.rb
+++ b/lib/katello/permissions/product_permissions.rb
@@ -44,7 +44,7 @@ Foreman::Plugin.find(:katello).security_block :products do
   permission :edit_products,
              {
                'katello/api/v2/products' => [:update],
-               'katello/api/v2/repositories' => [:update, :remove_content, :import_uploads, :upload_content],
+               'katello/api/v2/repositories' => [:update, :remove_content, :import_uploads, :upload_content, :republish],
                'katello/api/v2/products_bulk_actions' => [:update_sync_plans],
                'katello/api/v2/content_uploads' => [:create, :update, :destroy],
                'katello/api/v2/organizations' => [:repo_discover, :cancel_repo_discover]

--- a/test/actions/katello/repository/metadata_generate_test.rb
+++ b/test/actions/katello/repository/metadata_generate_test.rb
@@ -1,0 +1,59 @@
+require 'katello_test_helper'
+
+module Actions
+  describe Katello::Repository::MetadataGenerate do
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+    include FactoryGirl::Syntax::Methods
+
+    let(:action_class) { ::Actions::Katello::Repository::MetadataGenerate }
+    let(:pulp_publish_class) { ::Actions::Pulp::Repository::DistributorPublish }
+    let(:yum_repo) { katello_repositories(:fedora_17_x86_64) }
+    let(:yum_repo2) { katello_repositories(:fedora_17_x86_64_dev) }
+    let(:puppet_repo) { katello_repositories(:p_forge) }
+
+    it 'plans a yum refresh' do
+      action = create_action(action_class)
+      plan_action(action, yum_repo)
+
+      assert_action_planed_with(action, pulp_publish_class, :pulp_id => yum_repo.pulp_id,
+          :distributor_type_id => Runcible::Models::YumDistributor.type_id,
+          :source_pulp_id => nil,
+          :override_config => {:force_full => false},
+          :dependency => nil)
+    end
+
+    it 'plans a yum refresh with force true' do
+      action = create_action(action_class)
+      plan_action(action, yum_repo, :force => true)
+
+      assert_action_planed_with(action, pulp_publish_class, :pulp_id => yum_repo.pulp_id,
+          :distributor_type_id => Runcible::Models::YumDistributor.type_id,
+          :source_pulp_id => nil,
+          :override_config => {:force_full => true},
+          :dependency => nil)
+    end
+
+    it 'plans a yum refresh with source repo' do
+      action = create_action(action_class)
+      plan_action(action, yum_repo, :source_repository => yum_repo2)
+
+      assert_action_planed_with(action, pulp_publish_class, :pulp_id => yum_repo.pulp_id,
+          :distributor_type_id => Runcible::Models::YumCloneDistributor.type_id,
+          :source_pulp_id => yum_repo2.pulp_id,
+          :override_config => {},
+          :dependency => nil)
+    end
+
+    it 'plans a puppet refresh' do
+      action = create_action(action_class)
+      plan_action(action, puppet_repo)
+
+      assert_action_planed_with(action, pulp_publish_class, :pulp_id => puppet_repo.pulp_id,
+          :distributor_type_id => Runcible::Models::PuppetDistributor.type_id,
+          :source_pulp_id => nil,
+          :override_config => {},
+          :dependency => nil)
+    end
+  end
+end

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -661,6 +661,24 @@ module Katello
       end
     end
 
+    def test_republish
+      assert_async_task ::Actions::Katello::Repository::MetadataGenerate do |repo, options|
+        repo.id == @repository.id && options == {:force => true}
+      end
+
+      put :republish, :id => @repository.id
+      assert_response :success
+    end
+
+    def test_republish_protected
+      allowed_perms = [@update_permission]
+      denied_perms = [@read_permission, @create_permission, @destroy_permission]
+
+      assert_protected_action(:republish, allowed_perms, denied_perms) do
+        put :republish, :id => @repository.id
+      end
+    end
+
     def test_sync
       assert_async_task ::Actions::Katello::Repository::Sync do |repo|
         repo.id == @repository.id


### PR DESCRIPTION
This provides the ability for the user to force regenerate the
metadata for a repository in order to try to resolve issues when
something has gone wrong