### PR TITLE
Fixes #17692 - Handle nil response from CDN

### DIFF
--- a/app/controllers/katello/api/v2/repository_sets_controller.rb
+++ b/app/controllers/katello/api/v2/repository_sets_controller.rb
@@ -35,7 +35,7 @@ module Katello
     param :product_id, :number, :required => true, :desc => N_("ID of a product to list repository sets from")
     def available_repositories
       scan_cdn = sync_task(::Actions::Katello::RepositorySet::ScanCdn, @product, @product_content.content.id)
-      repos = scan_cdn.output[:results]
+      repos = scan_cdn.output[:results] || []
 
       repos = repos.select do |repo|
         if repo[:path].include?('kickstart')


### PR DESCRIPTION
Handle a nil response from the CDN when listing available repositories
in a repository set.