### PR TITLE
fixes #18018 - GPG key to product link should work

### DIFF
--- a/app/views/katello/api/v2/gpg_keys/show.json.rabl
+++ b/app/views/katello/api/v2/gpg_keys/show.json.rabl
@@ -8,8 +8,7 @@ attributes :name
 attributes :content
 
 child :products => :products do
-  attributes :cp_id => :id
-  attributes :name
+  attributes :id, :cp_id, :name
   node :repository_count do |product|
     product.repositories.count
   end
@@ -25,8 +24,7 @@ child :repositories => :repositories do
   attribute :content_type
 
   child :product do |_product|
-    attributes :cp_id => :id
-    attribute :name
+    attributes :id, :cp_id, :name
   end
 end
 


### PR DESCRIPTION
This commit contains a minor change to the gpg_key rabl to:

1. make it consistent w/ existing rabl for products and repositories
2. fix the link that is broken when attempting to click the product
   from the gpg keys ui
   (GPG Keys -> [somekey] -> Products -> [someproduct])