### PR TITLE
fixes #18034 - lifecycle environment paths - only return readable environments

### DIFF
--- a/app/controllers/katello/api/v2/environments_controller.rb
+++ b/app/controllers/katello/api/v2/environments_controller.rb
@@ -125,7 +125,7 @@ module Katello
                   end
 
       paths = env_paths.inject([]) do |result, path|
-        result << { :environments => [@organization.library] + path }
+        result << { :environments => [@organization.library] + path.select(&:readable?) }
       end
       paths = [{ :environments => [@organization.library] }] if paths.empty?
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/views/environments.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/views/environments.html
@@ -21,7 +21,7 @@
 
     <div class="col-sm-12">
 
-      <div class="col-sm-12">
+      <div class="col-sm-12" ng-hide="denied('view_lifecycle_environments', library)">
         <table class="table table-bordered info-blocks">
           <tbody>
             <tr>


### PR DESCRIPTION
When returning a list of lifecycle environment paths to the user, only
return the readable ones.  Without this change, a user that had
view_lifecycle_environments permission for 'dev', could see
all environments (e.g. 'dev', 'test', 'prod').