### PR TITLE
Fixes #13935 - Adjust permissions to promote a version

### DIFF
--- a/app/models/katello/authorization/content_view.rb
+++ b/app/models/katello/authorization/content_view.rb
@@ -21,7 +21,7 @@ module Katello
     end
 
     def promotable_or_removable?
-      authorized?(:promote_or_remove_content_views) && Katello::KTEnvironment.any_promotable?
+      authorized?(:promote_or_remove_content_views)
     end
 
     module ClassMethods

--- a/app/models/katello/authorization/lifecycle_environment.rb
+++ b/app/models/katello/authorization/lifecycle_environment.rb
@@ -20,21 +20,17 @@ module Katello
       authorized?(:destroy_lifecycle_environments)
     end
 
-    def promotable_or_removable?
-      authorized?(:promote_or_remove_content_views_to_environments)
-    end
-
     module ClassMethods
       def readable
         authorized(:view_lifecycle_environments)
       end
 
       def promotable
-        authorized(:promote_or_remove_content_views_to_environments)
+        authorized(:promote_or_remove_content_views)
       end
 
       def promotable?
-        User.current.can?(:promote_or_remove_content_views_to_environments)
+        User.current.can?(:promote_or_remove_content_views)
       end
 
       def any_promotable?

--- a/app/views/katello/api/v2/content_view_versions/base.json.rabl
+++ b/app/views/katello/api/v2/content_view_versions/base.json.rabl
@@ -47,7 +47,6 @@ child :environments => :environments do
   node :permissions do |env|
     {
       :readable => env.readable?,
-      :promotable_or_removable => env.promotable_or_removable?,
       :all_hosts_editable => version.all_hosts_editable?(env),
       :all_keys_editable => Katello::ActivationKey.all_editable?(version.content_view_id, env.id)
     }

--- a/app/views/katello/api/v2/environments/show.json.rabl
+++ b/app/views/katello/api/v2/environments/show.json.rabl
@@ -40,8 +40,7 @@ node :permissions do |env|
     :create_lifecycle_environments => env.creatable?,
     :view_lifecycle_environments => env.readable?,
     :edit_lifecycle_environments => env.editable?,
-    :destroy_lifecycle_environments => env.deletable?,
-    :promote_or_remove_content_views_to_environments => env.promotable_or_removable?
+    :destroy_lifecycle_environments => env.deletable?
   }
 end
 

--- a/db/migrate/20170112092655_remove_cv_permission_for_env.rb
+++ b/db/migrate/20170112092655_remove_cv_permission_for_env.rb
@@ -1,0 +1,5 @@
+class RemoveCvPermissionForEnv < ActiveRecord::Migration
+  def change
+    Permission.find_by(:name => "promote_or_remove_content_views_to_environments").destroy!
+  end
+end

--- a/lib/katello/permissions/lifecycle_environment_permissions.rb
+++ b/lib/katello/permissions/lifecycle_environment_permissions.rb
@@ -22,8 +22,4 @@ Foreman::Plugin.find(:katello).security_block :lifecycle_environments do
                'katello/api/v2/environments' => [:destroy]
              },
              :resource_type => 'Katello::KTEnvironment'
-
-  permission :promote_or_remove_content_views_to_environments,
-             {},
-             :resource_type => 'Katello::KTEnvironment'
 end


### PR DESCRIPTION
:promote_or_remove_content_views permission (on ContentView resource)
is not enough for non-admin users to promote a content view,
they need :promote_or_remove_content_views_to_environments
(on KTEnvironment resource) as well. I think the former can work on
its own and the latter can be removed.