### PR TITLE
fixes #18048 - fix ostree and docker cv pages

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-docker-repositories-list.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-docker-repositories-list.controller.js
@@ -1,19 +1,19 @@
-/**
- * @ngdoc object
- * @name  Bastion.content-views.controller:ContentViewDockerRepositoriesListController
- *
- * @requires $scope
- * @requires Repository
- * @requires Nutupane
- * @requires CurrentOrganization
- * @requires ContentViewRepositoriesUtil
- *
- * @description
- *    Provides UI functionality list/remove docker repositories from a content view
- */
-angular.module('Bastion.content-views').controller('ContentViewDockerRepositoriesListController',
-    ['$scope', 'Repository', 'Nutupane', 'CurrentOrganization', 'ContentViewRepositoriesUtil',
-    function ($scope, Repository, Nutupane, CurrentOrganization, ContentViewRepositoriesUtil) {
+(function () {
+
+    /**
+     * @ngdoc object
+     * @name  Bastion.content-views.controller:ContentViewDockerRepositoriesListController
+     *
+     * @requires $scope
+     * @requires Repository
+     * @requires Nutupane
+     * @requires CurrentOrganization
+     * @requires ContentViewRepositoriesUtil
+     *
+     * @description
+     *    Provides UI functionality list/remove docker repositories from a content view
+     */
+    function ContentViewDockerRepositoriesListController($scope, Repository, Nutupane, CurrentOrganization, ContentViewRepositoriesUtil) {
         var nutupane;
 
         ContentViewRepositoriesUtil($scope);
@@ -22,16 +22,25 @@ angular.module('Bastion.content-views').controller('ContentViewDockerRepositorie
             'organization_id': CurrentOrganization,
             'content_view_id': $scope.$stateParams.contentViewId,
             'content_type': 'docker'
-
         },
         'queryUnpaged');
 
         nutupane.masterOnly = true;
+        nutupane.load();
 
         $scope.table = nutupane.table;
 
         $scope.removeRepositories = function () {
             $scope.removeSelectedRepositoriesFromContentView(nutupane, $scope.contentView);
         };
-    }]
-);
+    }
+
+    angular
+        .module('Bastion.content-views')
+        .controller('ContentViewDockerRepositoriesListController', ContentViewDockerRepositoriesListController);
+
+    ContentViewDockerRepositoriesListController.$inject = [
+        '$scope', 'Repository', 'Nutupane', 'CurrentOrganization', 'ContentViewRepositoriesUtil'
+    ];
+
+})();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-ostree-repositories-list.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-ostree-repositories-list.controller.js
@@ -1,19 +1,19 @@
-/**
- * @ngdoc object
- * @name  Bastion.content-views.controller:ContentViewOstreeRepositoriesListController
- *
- * @requires $scope
- * @requires Repository
- * @requires Nutupane
- * @requires CurrentOrganization
- * @requires ContentViewRepositoriesUtil
- *
- * @description
- *    Provides UI functionality list/remove ostree repositories from a content view
- */
-angular.module('Bastion.content-views').controller('ContentViewOstreeRepositoriesListController',
-    ['$scope', 'Repository', 'Nutupane', 'CurrentOrganization', 'ContentViewRepositoriesUtil',
-    function ($scope, Repository, Nutupane, CurrentOrganization, ContentViewRepositoriesUtil) {
+(function () {
+
+    /**
+     * @ngdoc object
+     * @name  Bastion.content-views.controller:ContentViewOstreeRepositoriesListController
+     *
+     * @requires $scope
+     * @requires Repository
+     * @requires Nutupane
+     * @requires CurrentOrganization
+     * @requires ContentViewRepositoriesUtil
+     *
+     * @description
+     *    Provides UI functionality list/remove ostree repositories from a content view
+     */
+    function ContentViewOstreeRepositoriesListController($scope, Repository, Nutupane, CurrentOrganization, ContentViewRepositoriesUtil) {
         var nutupane;
 
         ContentViewRepositoriesUtil($scope);
@@ -22,16 +22,25 @@ angular.module('Bastion.content-views').controller('ContentViewOstreeRepositorie
             'organization_id': CurrentOrganization,
             'content_view_id': $scope.$stateParams.contentViewId,
             'content_type': 'ostree'
-
         },
         'queryUnpaged');
 
         nutupane.masterOnly = true;
+        nutupane.load();
 
         $scope.table = nutupane.table;
 
         $scope.removeRepositories = function () {
             $scope.removeSelectedRepositoriesFromContentView(nutupane, $scope.contentView);
         };
-    }]
-);
+    }
+
+    angular
+        .module('Bastion.content-views')
+        .controller('ContentViewOstreeRepositoriesListController', ContentViewOstreeRepositoriesListController);
+
+    ContentViewOstreeRepositoriesListController.$inject = [
+        '$scope', 'Repository', 'Nutupane', 'CurrentOrganization', 'ContentViewRepositoriesUtil'
+    ];
+
+})();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-file-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-file-repositories.html
@@ -4,7 +4,7 @@
   <h3 translate>File Repositories</h3>
 </header>
 
-<nav>
+<nav data-block="navigation">
   <ul class="nav nav-tabs" ng-show="permitted('edit_content_views', contentView)">
     <li ng-class="{active: isState('content-view.repositories.file.list')}">
       <a ui-sref="content-view.repositories.file.list">
@@ -40,10 +40,10 @@
 
   <span data-block="no-rows-message">
     <span ng-show="isState('content-view.repositories.file.list')" translate>
-      There are currently no Repositories associated with this Content View, you can add some by clicking on the "Add" tab above.
+      There are currently no File Repositories associated with this Content View, you can add some by clicking on the "Add" tab above.
     </span>
     <span ng-show="isState('content-view.repositories.file.available')">
-      <span translate>There are currently no Repositories to add to this Content View,</span>
+      <span translate>There are currently no File Repositories to add to this Content View,</span>
       <a ui-sref="products" translate>add some repositories.</a>
     </span>
   </span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-ostree-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-ostree-repositories.html
@@ -1,9 +1,7 @@
 <span page-title ng-model="contentView">{{ 'Repositories for Content View:' | translate }} {{ contentView.name }}</span>
 
 <header data-block="sub-header">
-  <h3 translate>
-    OSTree Repository Selection
-  </h3>
+  <h3 translate>OSTree Repositories</h3>
 </header>
 
 <nav data-block="navigation">
@@ -25,40 +23,19 @@
 </nav>
 
 <div data-extend-template="layouts/partials/table.html">
-  <div data-block="search">
-    <div class="col-sm-6">
-      <form class="form-inline">
-        <div class="form-group">
-            <select class="form-control" ng-model="product" ng-options="product.name for (id, product) in products"></select>
-            <input type="text"
-                   class="form-control"
-                   placeholder="{{ 'Filter' | translate }}"
-                   ng-model="repositorySearch"/>
-
-        </div>
-      </form>
-    </div>
-  </div>
-
   <div data-block="list-actions">
-    <button class="btn btn-default"
+    <button class="btn btn-primary"
             ng-disabled="table.numSelected === 0"
             ng-show="isState('content-view.repositories.ostree.list') && permitted('edit_content_views', contentView)"
             ng-click="removeRepositories(contentView)">
       <span translate>Remove Repositories</span>
     </button>
-
-    <div ng-show="repositoriesTable.rows.length === 0 && !repositoriesTable.working">
-      <p bst-alert="info" ng-show="isState('content-view.repositories.ostree.list')">
-        <span translate>
-          There are currently no repositories associated with this Content View, you can add some by clicking on the "Add" tab above.
-        </span>
-      </p>
-      <p bst-alert="info" ng-show="isState('content-view.repositories.ostree.available')">
-        <span translate>There are currently no repositories to add to this Content View,</span>
-        <a ui-sref="products.index" translate>add some repositories.</a>
-      </p>
-    </div>
+    <button class="btn btn-primary"
+            ng-disabled="table.numSelected === 0"
+            ng-show="isState('content-view.repositories.ostree.available') && permitted('edit_content_views', contentView)"
+            ng-click="addRepositories(contentView)">
+      <span translate>Add Repositories</span>
+    </button>
   </div>
 
   <span data-block="no-rows-message">
@@ -71,44 +48,42 @@
     </span>
   </span>
 
-  <div data-block="table">
-    <table bst-table="table" class="table table-bordered table-striped">
-      <thead>
-        <tr bst-table-head row-select>
-          <th bst-table-column translate>Name</th>
-          <th bst-table-column translate>Product</th>
-          <th bst-table-column translate>Last Sync</th>
-          <th bst-table-column translate>Sync State</th>
-        </tr>
-      </thead>
+  <table data-block="table" class="table table-bordered table-striped">
+    <thead>
+      <tr bst-table-head row-select>
+        <th bst-table-column translate>Name</th>
+        <th bst-table-column translate>Product</th>
+        <th bst-table-column translate>Last Sync</th>
+        <th bst-table-column translate>Sync State</th>
+      </tr>
+    </thead>
 
-      <tbody>
-        <tr bst-table-row
-            row-select="repository"
-            ng-repeat="repository in table.rows | filter:repositorySearch | filter:repositoryFilter as filteredItems">
-          <td bst-table-cell>
-            <a ui-sref="product.repository.info({productId: repository.product.id, repositoryId: repository.id})">
-              {{ repository.name }}
-            </a>
-          </td>
-          <td bst-table-cell>{{ repository.product.name }}</td>
-          <td bst-table-cell>
-            <span ng-show="repository.url && repository.last_sync == null" translate>
-              Not Synced
-            </span>
-            <span ng-show="repository.url">
-              {{ repository.last_sync.ended_at | date:"short" }}
-            </span>
-            <span ng-hide="repository.url" translate>N/A</span>
-          </td>
-          <td bst-table-cell>
-            <span ng-show="repository.url">
-              <a href="/foreman_tasks/tasks/{{repository.last_sync.id}}">{{ repository.last_sync.result | capitalize }}</a>
-            </span>
-            <span ng-hide="repository.url" translate>N/A</span>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
+    <tbody>
+      <tr bst-table-row
+          row-select="repository"
+          ng-repeat="repository in table.rows | filter:repositorySearch | filter:repositoryFilter as filteredItems">
+        <td bst-table-cell>
+          <a ui-sref="products.details.repositories.info({productId: repository.product.id, repositoryId: repository.id})">
+            {{ repository.name }}
+          </a>
+        </td>
+        <td bst-table-cell>{{ repository.product.name }}</td>
+        <td bst-table-cell>
+          <span ng-show="repository.url && repository.last_sync == null" translate>
+            Not Synced
+          </span>
+          <span ng-show="repository.url">
+            {{ repository.last_sync.ended_at | date:"short" }}
+          </span>
+          <span ng-hide="repository.url" translate>N/A</span>
+        </td>
+        <td bst-table-cell>
+          <span ng-show="repository.url">
+            <a href="/foreman_tasks/tasks/{{repository.last_sync.id}}">{{ repository.last_sync.result | capitalize }}</a>
+          </span>
+          <span ng-hide="repository.url" translate>N/A</span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>


### PR DESCRIPTION
The ostree content view page was not rendering an "add" repo button. The controller for both ostree and docker were also outdated and not triggering calls to the server to fetch already-added repos.