### PR TITLE
Fixes #18059 - Rendering RABL for host/main fails

### DIFF
--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -138,6 +138,12 @@ module Katello
       app.routes_reloader.paths.unshift("#{Katello::Engine.root}/config/routes/overrides.rb")
     end
 
+    initializer "katello.add_rabl_view_path" do
+      Rabl.configure do |config|
+        config.view_paths << Katello::Engine.root.join('app', 'views')
+      end
+    end
+
     initializer "katello.helpers" do |_app|
       ActionView::Base.send :include, Katello::TaxonomyHelper
       ActionView::Base.send :include, Katello::HostsAndHostgroupsHelper


### PR DESCRIPTION
Currently, Katello does not add its views to the Rabl paths. For this
reason, when I try to run a playbook with foreman_ansible, I get an
error that  katello/api/v2/content_facet/base_with_root isn't in its
view paths

foreman_ansible InventoryCreator is trying to render the
api/v2/hosts/main using Rabl, however it fails to do so as the
content_facet isn't available to it.

Solution: add an initializer to configure view paths for Rabl in the
Katello engine

Personal note - we should run Foreman tests with Katello in this project Jenkins to catch these kind of things.