### PR TITLE
Fixes #18054 - Fixes Atomic KS Template error

### DIFF
--- a/app/views/foreman/unattended/kickstart-katello-atomic.erb
+++ b/app/views/foreman/unattended/kickstart-katello-atomic.erb
@@ -14,7 +14,7 @@ timezone --utc <%= @host.params['time-zone'] || 'UTC' %>
 <% dhcp = !@static -%>
 <% end -%>
 
-network --bootproto <%= dhcp ? 'dhcp' : "static --ip=#{@host.ip} --netmask=#{subnet.mask} --gateway=#{subnet.gateway} --nameserver=#{[subnet.dns_primary, subnet.dns_secondary].select(&:present?).join(',')}" %> --hostname <%= @host %><%= os_major >= 6 ? " --device=#{@host.mac}" : '' -%>
+network --bootproto <%= dhcp ? 'dhcp' : "static --ip=#{@host.ip} --netmask=#{subnet.mask} --gateway=#{subnet.gateway} --nameserver=#{[subnet.dns_primary, subnet.dns_secondary].select(&:present?).join(',')}" %> --hostname <%= @host %><%= " --device=#{@host.mac}" -%>
 
 # Partition table should create /boot and a volume atomicos
 <% if @dynamic -%>


### PR DESCRIPTION
The atomic ks template after
https://github.com/Katello/katello/pull/6522
had a bug that said something along the lines of
""undefined local variable or method `os_major' ""

This fix corrects that issue by removing the need for os_major since
atomic kickstarts are anyway only being used from RHEL 7 onwards.