### PR TITLE
Fixes #18063 - Org create failure with specific msg

### DIFF
--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -78,8 +78,8 @@ module Katello
       sync_task(::Actions::Katello::Organization::Create, @organization)
       @organization.reload
       respond_for_show :resource => @organization
-    rescue
-      process_resource_error
+    rescue => e
+      process_resource_error(message: e.message)
     end
 
     api :DELETE, '/organizations/:id', N_('Delete an organization')

--- a/test/controllers/api/v2/organizations_controller_test.rb
+++ b/test/controllers/api/v2/organizations_controller_test.rb
@@ -79,6 +79,11 @@ module Katello
       assert_response :success
     end
 
+    def test_create_with_exception
+      post(:create, :organization => { name: "test_cli_org", description: "desc", smart_proxy_ids: ["2"], domain_ids: ["1"], subnet_ids: ["1", "2"]})
+      assert_match Regexp.new("Couldn't find"), response.body
+    end
+
     def test_create_duplicate_name
       post(:create, :organization => {"name" => @organization.name})
       assert_response :unprocessable_entity


### PR DESCRIPTION
While creating an Organization and passing non existing attributes as parameter values should give appropriate message.

[this commit has partial dependency on foreman side as katello is making a call to foreman's base controller action, can be merged in any order, katello first or foreman first]