### PR TITLE
Refs #17691 - Add param to not regen repository on upload

### DIFF
--- a/app/lib/actions/katello/repository/finish_upload.rb
+++ b/app/lib/actions/katello/repository/finish_upload.rb
@@ -2,8 +2,10 @@ module Actions
   module Katello
     module Repository
       class FinishUpload < Actions::Base
-        def plan(repository, dependency = nil)
-          plan_action(Katello::Repository::MetadataGenerate, repository, :dependency => dependency)
+        def plan(repository, options = {})
+          dependency = options.fetch(:dependency, nil)
+          generate_metadata = options.fetch(:generate_metadata, true)
+          plan_action(Katello::Repository::MetadataGenerate, repository, :dependency => dependency) if generate_metadata
 
           recent_range = 5.minutes.ago.utc.iso8601
           plan_action(Katello::Repository::FilteredIndexContent,

--- a/app/lib/actions/katello/repository/import_upload.rb
+++ b/app/lib/actions/katello/repository/import_upload.rb
@@ -2,15 +2,17 @@ module Actions
   module Katello
     module Repository
       class ImportUpload < Actions::EntryAction
-        def plan(repository, upload_id, unit_key = {})
+        def plan(repository, upload_id, options = {})
           action_subject(repository)
+          unit_key = options.fetch(:unit_Key, {})
+          generate_metadata = options.fetch(:generate_metadata, true)
           import_upload = plan_action(Pulp::Repository::ImportUpload,
                                       pulp_id: repository.pulp_id,
                                       unit_type_id: repository.unit_type_id,
                                       unit_key: unit_key,
                                       upload_id: upload_id)
 
-          plan_action(FinishUpload, repository, import_upload.output)
+          plan_action(FinishUpload, repository, :dependency => import_upload.output, :generate_metadata => generate_metadata)
         end
 
         def rescue_strategy

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -227,6 +227,11 @@ module ::Actions::Katello::Repository
       plan_action action, puppet_repository
       assert_action_planed(action, ::Actions::Katello::Repository::MetadataGenerate)
     end
+
+    it "does not plan metadata generate for puppet repository" do
+      plan_action action, puppet_repository, :generate_metadata => false
+      refute_action_planed(action, ::Actions::Katello::Repository::MetadataGenerate)
+    end
   end
 
   class SyncTest < TestBase

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -792,16 +792,25 @@ module Katello
     end
 
     def test_import_upload_ids
-      assert_sync_task ::Actions::Katello::Repository::ImportUpload, @repository, '1'
+      assert_sync_task ::Actions::Katello::Repository::ImportUpload, @repository, '1', :unit_key => {}, :generate_metadata => false
 
-      put :import_uploads, :id => @repository.id, :upload_ids => [1]
+      put :import_uploads, :id => @repository.id, :upload_ids => [1], :publish_repository => 'false'
+
+      assert_response :success
+    end
+
+    def test_two_import_upload_ids
+      assert_sync_task ::Actions::Katello::Repository::ImportUpload, @repository, '1', :unit_key => {}, :generate_metadata => false
+      assert_sync_task ::Actions::Katello::Repository::ImportUpload, @repository, '2', :unit_key => {}, :generate_metadata => true
+
+      put :import_uploads, :id => @repository.id, :upload_ids => [1, 2]
 
       assert_response :success
     end
 
     def test_import_uploads
       unit_key = {'size' => '12333', 'checksum' => 'asf23421324', 'name' => 'test'}
-      assert_sync_task ::Actions::Katello::Repository::ImportUpload, @repository, '1', unit_key
+      assert_sync_task ::Actions::Katello::Repository::ImportUpload, @repository, '1', :unit_key => unit_key, :generate_metadata => true
 
       put :import_uploads, :id => @repository.id, :uploads => [{'id' => 1}.merge(unit_key)]
 


### PR DESCRIPTION
This allows for multiple content uploads before
publishing repository metadata

Note this requires https://github.com/Katello/katello/pull/6527

but i've included that commit here for testing.  Will rebase once that is merged.