### PR TITLE
Fixes #18122 - move rhsm fact update to run phase

### DIFF
--- a/test/actions/katello/host/register_test.rb
+++ b/test/actions/katello/host/register_test.rb
@@ -26,7 +26,6 @@ module Katello::Host
         action = create_action action_class
         new_host = Host::Managed.new(:name => 'foobar', :managed => false)
         action.stubs(:action_subject).with(new_host)
-        ::Katello::Host::SubscriptionFacet.expects(:update_facts).with(new_host, rhsm_params[:facts])
         plan_action action, new_host, rhsm_params, @content_view_environment
 
         assert_action_planed_with(action, candlepin_class, :cp_environment_id => @content_view_environment.cp_id,


### PR DESCRIPTION
During fact importing, RhsmFactName objects are created
in large quantity. Because first_or_create is very susceptible
to race conditions, we rescue on RecordNotUnique within
RhsmFactImporter#add_fact_name.  However if duplicate record
exception is thrown while in a transaction the entire
transaction is aborted.  The run phase does not use a transaction
so the problem should not occur there.