### PR TITLE
Fixes #18138: Throw useful error message when updating puppet repo

### DIFF
--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -255,7 +255,7 @@ module Katello
           dist.auto_publish = true
           distributors = [dist]
         when Repository::PUPPET_TYPE
-          capsule ||= SmartProxy.default_capsule
+          capsule ||= SmartProxy.default_capsule!
           dist_options = { :id => self.pulp_id, :auto_publish => true }
           repo_path =  File.join(capsule.puppet_path,
                                  Environment.construct_name(self.organization,


### PR DESCRIPTION
Switches to throwing a missing default smart proxy error message
when one cannot be found and trying to update a repository.