### PR TITLE
Fixes #18141 - Fix Host form endpoints for Katello props

### DIFF
--- a/app/overrides/add_activation_keys_input.rb
+++ b/app/overrides/add_activation_keys_input.rb
@@ -15,7 +15,7 @@ Deface::Override.new(:virtual_path => "hostgroups/_form",
 
 Deface::Override.new(:virtual_path => "hosts/_form",
                      :name => "hosts_update_environments_select",
-                     :insert_before => 'erb[loud]:contains("host_puppet_environment_field")',
+                     :insert_after => 'erb[loud]:contains("Deploy on")',
                      :partial => 'overrides/activation_keys/host_environment_select')
 
 Deface::Override.new(:virtual_path => "common/os_selection/_operatingsystem",


### PR DESCRIPTION
Properties like Content Source and friends did no longer show up in the
Host UI after #15405 was merged. The endpoints changed, this commit
hooks now the Katello properties to show up below "Deploy on".

To test, simply try to create a host with the latest Foreman branch and Katello - you won't be able to set any Katello-related properties unless this patch is in, deface will not match anything