### PR TITLE
Fixes #18141 - Move environment override to pagelet

### DIFF
--- a/app/overrides/add_activation_keys_input.rb
+++ b/app/overrides/add_activation_keys_input.rb
@@ -13,11 +13,6 @@ Deface::Override.new(:virtual_path => "hostgroups/_form",
                      :insert_before => 'erb[loud]:contains("hostgroup_puppet_environment_field")',
                      :partial => 'overrides/activation_keys/host_environment_select')
 
-Deface::Override.new(:virtual_path => "hosts/_form",
-                     :name => "hosts_update_environments_select",
-                     :insert_after => 'erb[loud]:contains("Deploy on")',
-                     :partial => 'overrides/activation_keys/host_environment_select')
-
 Deface::Override.new(:virtual_path => "common/os_selection/_operatingsystem",
                      :name => "hosts_select_media_type",
                      :insert_before => 'erb[loud]:contains("select_f"):contains(":medium_id")',

--- a/app/views/overrides/activation_keys/_host_environment_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_environment_select.html.erb
@@ -1,3 +1,4 @@
+<% f ||= form %>
 <%= javascript "katello/hosts/host_and_hostgroup_edit" %>
 <style>
     option.kt-env { margin-left: 0em; }

--- a/config/initializers/pagelets.rb
+++ b/config/initializers/pagelets.rb
@@ -1,0 +1,6 @@
+# initialize katello related pagelets
+mgr = Pagelets::Manager.new "hosts/_form"
+
+mgr.add_pagelet :main_tab_fields,
+  :partial => "overrides/activation_keys/host_environment_select",
+  :priority => 80


### PR DESCRIPTION
No need to use deface in order to add fields to host's main tab, or adding additional tabs to host edit form.