### PR TITLE
fixes #18163 - fix cancel new docker filter

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/new-filter.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/new-filter.html
@@ -52,7 +52,7 @@
        working="working">
   </div>
   <div bst-form-buttons
-       on-cancel="transitionTo('content-view.yum.filters', {contentViewId: contentView.id})"
+       on-cancel="transitionTo('content-view.docker.filters', {contentViewId: contentView.id})"
        on-save="save(filter, contentView)"
        ng-show="stateIncludes('content-view.docker')"
        working="working">


### PR DESCRIPTION
Cancel of a new docker filter was incorrectly going to the yum filters page.