### PR TITLE
Fixes #18166 - Add required helpers to Sync controller

### DIFF
--- a/app/controllers/katello/sync_management_controller.rb
+++ b/app/controllers/katello/sync_management_controller.rb
@@ -4,6 +4,8 @@ module Katello
     include ActionView::Helpers::DateHelper
     include ActionView::Helpers::NumberHelper
     include SyncManagementHelper::RepoMethods
+    helper Rails.application.routes.url_helpers
+    helper ReactjsHelper
     respond_to :html, :json
 
     def section_id


### PR DESCRIPTION
Notifications will not be able to run without that helper on this page,
as mount_react_component will not be available. Also the
notifications_recipients_path will not be available if the
proper url helpers are not included in the controller. The
reason this is needed now is because the user dropdown in
the top-right corner is calling those helpers on #18010

This allows tests in https://github.com/theforeman/foreman/pull/4170 to pass