### PR TITLE
Fixes #18188 - Allow notifications in RH repositories

### DIFF
--- a/app/controllers/katello/providers_controller.rb
+++ b/app/controllers/katello/providers_controller.rb
@@ -1,5 +1,7 @@
 module Katello
   class ProvidersController < Katello::ApplicationController
+    helper Rails.application.routes.url_helpers
+    helper ReactjsHelper
     before_action :find_rh_provider, :only => [:redhat_provider, :redhat_provider_tab]
     before_action :search_filter, :only => [:auto_complete_search]
 
@@ -37,7 +39,7 @@ module Katello
     end
 
     def controller_display_name
-      return 'provider'
+      'provider'
     end
 
     def search_filter

--- a/app/views/katello/providers/redhat/_repo_sets.html.erb
+++ b/app/views/katello/providers/redhat/_repo_sets.html.erb
@@ -32,7 +32,7 @@
                       <tr class="collapsed repo_set" id="repo_set_<%= product_content.content.id %>">
                         <td>
                           <span class="expander_area clickable"
-                                data-url="<%= available_repositories_product_path(product.id)%>"
+                                data-url="<%= katello.available_repositories_product_path(product.id)%>"
                                 data-content-id="<%= product_content.content.id %>"
                                 data-orphaned="<%= orphaned.to_s %>">
                             <%= image_tag( "katello/icons/spinner.gif", :class=>"hidden fl repo_set_spinner",

--- a/app/views/katello/providers/redhat/_repos.html.erb
+++ b/app/views/katello/providers/redhat/_repos.html.erb
@@ -30,7 +30,7 @@
                      id="input_repo_<%= result[:pulp_id] %>"
                      type="checkbox"
                      value="<%= result[:pulp_id] %>"
-                     data-url="<%= toggle_repository_product_path(scan_cdn.input[:product_id]) %>"
+                     data-url="<%= katello.toggle_repository_product_path(scan_cdn.input[:product_id]) %>"
                      data-content-id="<%= scan_cdn.input[:content_id] %>"
                      data-pulp-id="<%= result[:pulp_id] %>"
                      <% if result[:registry_name] %>

--- a/app/views/katello/providers/redhat/show.html.erb
+++ b/app/views/katello/providers/redhat/show.html.erb
@@ -23,7 +23,7 @@
       <ul>
         <% for tab in tabs %>
           <li>
-            <a href="<%= redhat_provider_tab_providers_path({:tab => tab[:id]}) %>">
+            <a href="<%= katello.redhat_provider_tab_providers_path({:tab => tab[:id]}) %>">
               <%= tab[:name] %>
             </a>
           </li>


### PR DESCRIPTION
The Red Hat Repositories page is missing the proper helpers to display
notifications. Tt's trying to render the user dropdown (which
makes use of those helpers), but since the needed helpers are not
available, it fails to do so.