### PR TITLE
Fixes #18226 - Allow default Location to be removed 

### DIFF
--- a/app/lib/actions/katello/host/hypervisors_update.rb
+++ b/app/lib/actions/katello/host/hypervisors_update.rb
@@ -44,7 +44,8 @@ module Actions
         end
 
         def create_host_for_hypervisor(name, organization, location = nil)
-          location ||= Location.default_location
+          location ||= Location.unscoped.find_by_title(
+            Setting[:default_location_subscribed_hosts])
           host = ::Host::Managed.new(:name => name, :organization => organization,
                                      :location => location, :managed => false)
           host.save!

--- a/app/models/katello/concerns/environment_extensions.rb
+++ b/app/models/katello/concerns/environment_extensions.rb
@@ -38,7 +38,10 @@ module Katello
         def build_by_katello_id(org, env, content_view)
           env_name = Environment.construct_name(org, env, content_view)
           katello_id = Environment.construct_katello_id(org, env, content_view)
-          environment = Environment.new(:name => env_name, :organization_ids => [org.id], :location_ids => ::Location.default_location_ids)
+          default_location_id = ::Location.find_by_title(::Setting[:default_location_puppet_content]).id
+          environment = Environment.new(:name => env_name,
+                                        :organization_ids => [org.id],
+                                        :location_ids => [default_location_id])
           environment.katello_id = katello_id
           environment
         end

--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -86,8 +86,11 @@ module Katello
       def self.find_or_create_host(organization, rhsm_params)
         host = find_host(rhsm_params[:facts], organization)
         unless host
-          host = Katello::Host::SubscriptionFacet.new_host_from_facts(rhsm_params[:facts], organization,
-                                            Location.default_location)
+          host = Katello::Host::SubscriptionFacet.new_host_from_facts(
+            rhsm_params[:facts],
+            organization,
+            Location.unscoped.find_by_title(::Setting[:default_location_subscribed_hosts])
+          )
         end
         host.organization = organization unless host.organization
         host

--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -4,7 +4,8 @@ class Setting::Content < Setting
   def self.load_defaults
     return unless super
 
-    BLANK_ATTRS << 'register_hostname_fact'
+    BLANK_ATTRS.concat %w(register_hostname_fact default_location_subscribed_hosts
+                          default_location_puppet_content)
 
     download_policies = proc { Hash[::Runcible::Models::YumImporter::DOWNLOAD_POLICIES.map { |p| [p, p] }] }
     proxy_download_policies = proc { Hash[::SmartProxy::DOWNLOAD_POLICIES.map { |p| [p, p] }] }
@@ -62,7 +63,15 @@ class Setting::Content < Setting
         self.set('register_hostname_fact', N_("When registering a host via subscription-manager, force use the specified fact (in the form of 'fact.fact')"),
                  '', N_('Subscription manager name registration fact'), nil),
         self.set('erratum_install_batch_size', N_("Errata installed via katello-agent will be triggered in batches of this size. Set to 0 to install all errata in one batch."),
-                 0, N_('Erratum Install Batch Size'))
+                 0, N_('Erratum Install Batch Size')),
+        self.set('default_location_subscribed_hosts',
+                 N_('Default Location where new subscribed hosts will put upon registration'),
+                 nil, N_('Default Location subscribed hosts'), nil,
+                 :collection => proc { Hash[Location.unscoped.all.map { |loc| [loc[:title], loc[:title]] }] }),
+        self.set('default_location_puppet_content',
+                 N_('Default Location where new Puppet content will be put upon Content View publish'),
+                 nil, N_('Default Location Puppet content'), nil,
+                 :collection => proc { Hash[Location.unscoped.all.map { |loc| [loc[:title], loc[:title]] }] })
       ].each { |s| self.create! s.update(:category => "Setting::Content") }
     end
     true

--- a/db/migrate/20170125152421_move_default_location_to_settings.rb
+++ b/db/migrate/20170125152421_move_default_location_to_settings.rb
@@ -1,0 +1,25 @@
+class MoveDefaultLocationToSettings < ActiveRecord::Migration
+  DEFAULT_LOCATION_SETTINGS = ['default_location_subscribed_hosts',
+                               'default_location_puppet_content'].freeze
+  def up
+    default_location = Location.find_by(:katello_default => true)
+    if default_location.present?
+      DEFAULT_LOCATION_SETTINGS.each do |location_setting|
+        Setting.find_by_name(location_setting).update_attribute(
+          :value, default_location.title)
+      end
+    end
+    remove_column :taxonomies, :katello_default
+  end
+
+  def down
+    add_column :taxonomies, :katello_default, :boolean, :null => false,
+      :default => false
+    DEFAULT_LOCATION_SETTINGS.each do |location_setting|
+      default_location = Location.find_by_title(Setting[location_setting])
+      if default_location.present?
+        default_location.update_attribute(:katello_default, true)
+      end
+    end
+  end
+end

--- a/db/seeds.d/101-locations.rb
+++ b/db/seeds.d/101-locations.rb
@@ -4,9 +4,15 @@
 # !!! PLEASE KEEP THIS SCRIPT IDEMPOTENT !!!
 #
 
-if Location.exists? && !Location.default_location
+if Location.exists? &&
+    !Setting[:default_location_subscribed_hosts].present? ||
+    !Setting[:default_location_puppet_content].present?
   # Create a new location to be used as the Katello Default.
-  Location.create!(:name => "Default Location") do |loc|
-    loc.katello_default = true
+  default_location = Location.where(:name => ENV['SEED_LOCATION']).first_or_create
+  if Setting[:default_location_subscribed_hosts].empty?
+    Setting[:default_location_subscribed_hosts] = default_location.title
+  end
+  if Setting[:default_location_puppet_content].empty?
+    Setting[:default_location_puppet_content] = default_location.title
   end
 end

--- a/db/seeds.d/103-provisioning_templates.rb
+++ b/db/seeds.d/103-provisioning_templates.rb
@@ -36,8 +36,8 @@ end
 # Ensure all default templates are seeded into the first org and loc
 ProvisioningTemplate.where(:default => true).each do |template|
   template.organizations << Organization.first unless template.organizations.include?(Organization.first) || Organization.count.zero?
-  if Location.exists? && Location.default_location && !template.locations.include?(Location.default_location)
-    template.locations << Location.default_location
+  if Location.exists? && !template.location_ids.include?(Location.default_location_ids)
+    template.location_ids << Location.default_location_ids
   end
 end
 

--- a/test/actions/katello/content_view_puppet_environment_test.rb
+++ b/test/actions/katello/content_view_puppet_environment_test.rb
@@ -8,10 +8,7 @@ module ::Actions::Katello::ContentViewPuppetEnvironment
     include Support::CapsuleSupport
 
     let(:puppet_env) { katello_content_view_puppet_environments(:library_view_puppet_environment) }
-
-    setup do
-      set_default_location
-    end
+    setup { set_default_location }
   end
 
   class CreateTest < TestBase

--- a/test/factories/smart_proxy_factory.rb
+++ b/test/factories/smart_proxy_factory.rb
@@ -1,0 +1,7 @@
+FactoryGirl.modify do
+  factory :smart_proxy do
+    transient do
+      download_policy 'on_demand'
+    end
+  end
+end

--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -233,13 +233,8 @@ class ActiveSupport::TestCase
   end
 
   def set_default_location
-    loc = Location.first
-    loc.katello_default = true
-    loc.save!
-  end
-
-  def reset_default_location
-    Location.where(katello_default: true).update_all(katello_default: false)
+    Setting[:default_location_subscribed_hosts] = Location.first.title
+    Setting[:default_location_puppet_content] = Location.first.title
   end
 end
 

--- a/test/models/concerns/environment_extensions_test.rb
+++ b/test/models/concerns/environment_extensions_test.rb
@@ -49,7 +49,6 @@ module Katello
     end
 
     def test_locations_disabled_build_by_katello_id
-      reset_default_location
       assert_nothing_raised do
         Environment.build_by_katello_id(@org, @env, @content_view)
       end

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -16,7 +16,7 @@ module Katello
       @foreman_host.puppetclasses = []
       @foreman_host.save!
 
-      new_puppet_environment = Environment.find(environments(:testing))
+      new_puppet_environment = Environment.find(environments(:testing).id)
 
       @foreman_host.environment = new_puppet_environment
     end

--- a/test/models/concerns/redhat_extensions_test.rb
+++ b/test/models/concerns/redhat_extensions_test.rb
@@ -59,7 +59,7 @@ module Katello
 
   class RedhatExtensionsMediaTest < ActiveSupport::TestCase
     def setup
-      User.current = User.find(users(:admin))
+      User.current = User.find(users(:admin).id)
       @repo_with_distro = katello_repositories(:fedora_17_x86_64)
       version = @repo_with_distro.distribution_version.split('.')
       @os = ::Redhat.create_operating_system("RedHat", version[0], version[1])


### PR DESCRIPTION
The default location provided a location for new Puppet content
publishes and for new hosts coming through subscription manager. This PR
adds a setting for these two things, which would allow an user to change
the location they want for each of these things separately. It still
protects that the setting must always have a value