### PR TITLE
Fixes #18140: replace search on CH errata modal with filter.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-errata-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-errata-modal.html
@@ -19,6 +19,12 @@
     </div>
 
     <div data-extend-template="layouts/partials/table.html">
+      <div data-block="search">
+        <input type="text" class="form-control" stop-event="click"
+               placeholder="{{ 'Filter...' | translate }}"
+               ng-model="errataFilter"/>
+      </div>
+
       <div data-block="list-actions">
         <button class="btn btn-default"
                 ng-disabled="table.numSelected === 0 || table.working"
@@ -69,7 +75,7 @@
          </thead>
 
          <tbody>
-           <tr bst-table-row ng-repeat="erratum in table.rows" row-select="erratum">
+           <tr bst-table-row ng-repeat="erratum in table.rows | filter:errataFilter" row-select="erratum">
              <td class="small" bst-table-cell>
                  {{ erratum.type }}
              </td>


### PR DESCRIPTION
The search on the content host errata modal does not work because of the
requirement of using HostBulkAction.installableErrata() to display the
errata for the selected content hosts.  Instead of using search we
should use a filter. Also fix issue with the input not retaining focus
by using the stop event propagation directive workaround.

http://projects.theforeman.org/issues/18140