### PR TITLE
Disable http positional args cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -118,3 +118,6 @@ Style/SignalException:
 # Don't enforce frozen string literals
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+Rails/HttpPositionalArguments:
+  Enabled: false


### PR DESCRIPTION
If you can convince me that this is a good cop, I'll close this PR. http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Rails/HttpPositionalArguments