### PR TITLE
Fixes #18036 - Correctly sets  sync plan schedules

### DIFF
--- a/app/models/katello/sync_plan.rb
+++ b/app/models/katello/sync_plan.rb
@@ -53,7 +53,7 @@ module Katello
     def schedule_format
       return nil if DURATION[self.interval].nil?
       date = self.sync_date
-      date = next_sync_date if self.sync_date < DateTime.now
+      date = next_sync_date if enabled? && self.sync_date < DateTime.now
       "#{date.iso8601}/P#{DURATION[self.interval]}"
     end
 

--- a/test/models/sync_plan_test.rb
+++ b/test/models/sync_plan_test.rb
@@ -118,5 +118,16 @@ module Katello
       assert_match(/\/PT24H$/, schedule)
       assert_includes schedule, @plan.next_sync_date.iso8601
     end
+
+    def test_schedule_format_disabled
+      @plan.interval = 'daily'
+      @plan.sync_date = DateTime.now - 3.days
+      @plan.enabled = false
+
+      schedule = @plan.schedule_format
+      refute_nil schedule
+      assert_match(/\/PT24H$/, schedule)
+      assert_includes schedule, @plan.sync_date.iso8601
+    end
   end
 end


### PR DESCRIPTION
This commit fixes a bug where a disabled sync plan caused an ISE when
a new repository was being created in the product associated to the sync plan.
The issue occured when there was an attempt to calculate the  "next_sync_date"
even if the sync plan was disabled. This commit fixes that issue by
making sure that the next sync date would not get calculated if the plan
is disabled.