### PR TITLE
Fixes #17559: use URL instead of state for fenced pages.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/fenced-pages.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/fenced-pages.service.js
@@ -6,35 +6,44 @@
  * Service that keeps track of pages that require an organization to be selected
  */
 
-angular.module('Bastion.organizations').service('FencedPages',
-    [function () {
+angular.module('Bastion.organizations').service('FencedPages', ['$state',
+    function ($state) {
         var fencedPages = [
-            'products',
             'activation-keys',
-            'environments',
-            'subscriptions',
-            'gpg-keys',
-            'sync-plans',
-            'docker-tags',
-            'sync-plan',
-            'content-views',
-            'errata',
             'content-hosts',
+            'content-views',
+            'docker-tags',
+            'errata',
+            'gpg-keys',
             'host-collections',
+            'lifecycle-environments',
+            'packages',
+            'products',
             'puppet-modules',
-            'packages'
+            'subscriptions',
+            'sync-plans'
         ];
+
+        function getRootPath(path) {
+            var rootPath = null;
+
+            if (path && angular.isString(path)) {
+                rootPath = path.replace('_', '-').split('/')[1];
+            }
+            return rootPath;
+        }
 
         this.addPages = function (pages) {
             fencedPages = _.uniq(fencedPages.concat(pages));
         };
 
         this.list = function () {
-            return fencedPages.slice();
+            return fencedPages;
         };
 
         this.isFenced = function (toState) {
-            return this.list().indexOf(toState.name.split('.')[0]) !== -1;
+            var stateUrl = $state.href(toState);
+            return fencedPages.indexOf(getRootPath(stateUrl)) !== -1;
         };
-    }]
-);
+    }
+]);

--- a/engines/bastion_katello/test/organizations/fenced-pages.service.test.js
+++ b/engines/bastion_katello/test/organizations/fenced-pages.service.test.js
@@ -1,7 +1,10 @@
 describe('Factory: FencedPages', function() {
+    var $state, FencedPages;
+
     beforeEach(module('Bastion.organizations'));
 
-    beforeEach(inject(function (_FencedPages_) {
+    beforeEach(inject(function (_$state_, _FencedPages_) {
+        $state = _$state_;
         FencedPages = _FencedPages_;
     }));
 
@@ -12,7 +15,12 @@ describe('Factory: FencedPages', function() {
     });
 
     it("should find if page is in the list", function () {
-        expect(FencedPages.isFenced({name: "sync-plan.info"})).toBe(true);
-        expect(FencedPages.isFenced({name: "non-fenced-page.details.show"})).toBe(false);
+        spyOn($state, 'href').and.returnValue('/products/repositories/blah/blah');
+        expect(FencedPages.isFenced({name: 'doesnt matter'})).toBe(true);
+    });
+
+    it("should not find if page is in the list", function () {
+        spyOn($state, 'href').and.returnValue('/not/in/the/list');
+        expect(FencedPages.isFenced({name: 'doesnt matter'})).toBe(false);
     });
 });


### PR DESCRIPTION
In order to ensure that fenced pages are properly fenced we should use
the URL instead of the state name so that all sub-pages are also
properly fenced off and require an organization.  In other words, before
this change it was possible to visit /products/1/repositories without an
organization.

http://projects.theforeman.org/issues/17559