### PR TITLE
Fixes #17793: fix styling of lifecycle environment columns.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/views/environments.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/views/environments.html
@@ -17,11 +17,9 @@
     </h2>
   </div>
 
-  <section class="row nutupane-sub-section">
-
+  <section class="row">
     <div class="col-sm-12">
-
-      <div class="col-sm-12" ng-hide="denied('view_lifecycle_environments', library)">
+      <div ng-hide="denied('view_lifecycle_environments', library)">
         <table class="table table-bordered info-blocks">
           <tbody>
             <tr>
@@ -39,7 +37,7 @@
         </table>
       </div>
 
-      <div class="col-sm-12 environment" ng-repeat="path in paths">
+      <div class="environment" ng-repeat="path in paths">
         <div class="row">
           <div class="col-sm-12">
             <a ng-hide="denied('create_lifecycle_environments', path['environments'][0])" ui-sref="environments.new({priorId: lastEnvironment(path).id})" class="btn btn-default fr">
@@ -73,8 +71,6 @@
           </tbody>
         </table>
       </div>
-
     </div>
   </section>
-
 </section>


### PR DESCRIPTION
There was two columns being used directly inside each other
unnecessarily which was causing the columns in the environment tables to
overlap at smaller screen widths. This PR corrects the use of the .row
and .col-* classes.

http://projects.theforeman.org/issues/17793