### PR TITLE
Fixes #18254 - Initialize blank array in incremental update

### DIFF
--- a/app/lib/actions/katello/content_view_version/incremental_update.rb
+++ b/app/lib/actions/katello/content_view_version/incremental_update.rb
@@ -108,7 +108,8 @@ module Actions
                 end
               end
             end
-            new_repos.concat(old_repos)
+            new_repos.concat(old_repos) unless old_repos.blank?
+            new_repos
           else
             [old_version_repo]
           end


### PR DESCRIPTION
When these variables stay nil and try to be concatenated into
an array, the error "no implicit conversion of nil into Array"
is thrown