### PR TITLE
Fixes #18376 - Improved Installable Errata search

### DIFF
--- a/test/models/erratum_test.rb
+++ b/test/models/erratum_test.rb
@@ -8,7 +8,6 @@ module Katello
       @bugfix = katello_errata(:bugfix)
       @enhancement = katello_errata(:enhancement)
       @host = hosts(:one)
-      @host_dev = hosts(:two)
       @host_without_errata = @host.clone
       @host_without_errata.content_facet.applicable_errata = []
     end
@@ -168,16 +167,17 @@ module Katello
       refute_includes errata, @enhancement
     end
 
-    def test_installable_for_hosts_dev_environment
-      errata = Erratum.installable_for_hosts([@host_dev, @host_without_errata])
-      assert_includes errata, @security
-      assert_includes errata, @bugfix
-      refute_includes errata, @enhancement
+    def test_installable_for_hosts_with_no_bound_repos
+      # make sure the @host has no bound repositories
+      @host.content_facet.bound_repositories = []
+      @host.content_facet.save!
+      errata = Erratum.installable_for_hosts([@host, @host_without_errata])
+      assert_empty errata
     end
 
-    def test_installable_for_hosts_dev_environment_with_repos
+    def test_installable_for_hosts_with_repos
       #Tests issue #10681
-      errata = Erratum.installable_for_hosts([@host_dev, @host_without_errata]).in_repositories(@repo)
+      errata = Erratum.installable_for_hosts([@host, @host_without_errata]).in_repositories(@repo)
       assert_includes errata, @security
       assert_includes errata, @bugfix
       refute_includes errata, @enhancement


### PR DESCRIPTION
Check http://projects.theforeman.org/issues/18376#note-3 for more info.

Go to Content -> Errata and select the Installable check box
Prior to this commit the "installable_for_hosts" method would create a
introduce an extra 'inner join' causing the query to perform painfully
slow. This commit fixes that by selectively adding that duplicate join
table only if required.

The installable repo query also had a duplicate join for the katello
errata table. Which got removed in this commit

Also fixed the unit tests to highlight the point that "Installable
Errata" is determined by the repositories bound to that host.
Basically the query says "Find all applicable errata on this host.
Filter this list further by only including those repos that are enabled
on this host"

Fixed the unit tests to something that make more sense.
Installable errata is determined purely by the repos that are bound to
the host. It does not really matter what environment/content view
this host belongs. CVE gives the master list of repos available to the
host of which only a subset are enabled or bound.



