### PR TITLE
Fixes #18416 - Weight capsule sync task

### DIFF
--- a/app/lib/actions/pulp/consumer/sync_capsule.rb
+++ b/app/lib/actions/pulp/consumer/sync_capsule.rb
@@ -14,6 +14,16 @@ module Actions
         def invoke_external_task
           pulp_resources.repository.sync(input[:repo_pulp_id])
         end
+
+        def run_progress
+          # override this method so this task's progress isn't 0.5
+          # when it is initiated, skewing the progress bar progress
+          self.done? ? 1 : 0.1
+        end
+
+        def run_progress_weight
+          100
+        end
       end
     end
   end


### PR DESCRIPTION
SyncCapsule task will take the longest by far during a capsule
sync so we should weight it heavily.

Once the SyncCapsule task initiates the pulp tasks, the
progress_weight of that step jumps to 0.5 (half done).
This is resulting in the progress bar jumping to over
half done very shortly after the sync is executed, even
if it will take hours more. This commit will modify each
SyncCapsule step to have a 0.1 progress weight until it
finishes. As the SyncCapsule steps finish, the progress
bar will move incrementally at a more even pace.

