### PR TITLE
Fixes #18437 - fix formatting of time sent to Candlepin

### DIFF
--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -145,7 +145,7 @@ module Katello
           end
 
           def checkin(uuid, checkin_date)
-            checkin_date ||= DateTime.now
+            checkin_date ||= Time.now
             self.put(path(uuid), {:lastCheckin => checkin_date}.to_json, self.default_headers).body
           end
 
@@ -683,9 +683,9 @@ module Katello
           end
 
           def create_unlimited_subscription(owner_key, product_id)
-            start_date ||= DateTime.now
+            start_date ||= Time.now
             # End it 100 years from now
-            end_date ||= start_date + 10_950
+            end_date ||= start_date + 10_950.days
 
             subscription = {
               'startDate' => start_date,


### PR DESCRIPTION
With DateTime#to_json, we could get invalid date (such as
"2047-02-01T23:42:09.1000+01:00"). When using Time,
no such issue was observed.