### PR TITLE
fixes #18441 - datetime format should be db independent

### DIFF
--- a/app/models/katello/concerns/pulp_database_unit.rb
+++ b/app/models/katello/concerns/pulp_database_unit.rb
@@ -95,7 +95,7 @@ module Katello
         end
 
         unless new_ids.empty?
-          inserts = new_ids.map { |unit_id| "(#{unit_id.to_i}, #{repository.id.to_i}, '#{Time.now.utc}', '#{Time.now.utc}')" }
+          inserts = new_ids.map { |unit_id| "(#{unit_id.to_i}, #{repository.id.to_i}, '#{Time.now.utc.to_s(:db)}', '#{Time.now.utc.to_s(:db)}')" }
           queries << "INSERT INTO #{table_name} (#{attribute_name}, repository_id, created_at, updated_at) VALUES #{inserts.join(', ')}"
         end
 


### PR DESCRIPTION
simple change datetime format correct for pgsql and for mysql
http://projects.theforeman.org/issues/18441
there is problem if switch db to mysql - datetime format not fit.
but by default rails has option to adapt datetime format based on current database.