### PR TITLE
Fixes #17949 - adjust generation of pulp_id

### DIFF
--- a/app/lib/actions/katello/repository/create.rb
+++ b/app/lib/actions/katello/repository/create.rb
@@ -30,7 +30,8 @@ module Actions
                                         mirror_on_sync: repository.mirror_on_sync?,
                                         ssl_validation: certs[:ssl_validation],
                                         upstream_username: repository.upstream_username,
-                                        upstream_password: repository.upstream_password)
+                                        upstream_password: repository.upstream_password,
+                                        repo_registry_id: repository.container_repository_name)
 
             return if create_action.error
 

--- a/app/lib/actions/katello/repository_set/scan_cdn.rb
+++ b/app/lib/actions/katello/repository_set/scan_cdn.rb
@@ -59,7 +59,6 @@ module Actions
               substitutions: {},
               path:          mapper.feed_url,
               repo_name:     mapper.name,
-              pulp_id:       mapper.pulp_id,
               registry_name: registry["name"],
               enabled:       !repo.nil?,
               promoted:      (!repo.nil? && repo.promoted?)
@@ -74,7 +73,6 @@ module Actions
             path:          mapper.path,
             repo_name:     mapper.name,
             name:          mapper.content.name,
-            pulp_id:       mapper.pulp_id,
             enabled:       !repo.nil?,
             promoted:      (!repo.nil? && repo.promoted?)
           }

--- a/app/lib/actions/pulp/repository/create.rb
+++ b/app/lib/actions/pulp/repository/create.rb
@@ -162,7 +162,8 @@ module Actions
         def docker_distributor
           options = { protected: !input[:unprotected] || false,
                       id: input[:pulp_id],
-                      auto_publish: true }
+                      auto_publish: true,
+                      repo_registry_id: input[:repo_registry_id]}
           Runcible::Models::DockerDistributor.new(options)
         end
 

--- a/app/models/katello/candlepin/content.rb
+++ b/app/models/katello/candlepin/content.rb
@@ -46,8 +46,10 @@ module Katello
 
       def find_repository
         ::Katello::Repository.where(product_id: product.id,
+                                    content_id: content.id,
                                     environment_id: product.organization.library.id,
-                                    pulp_id: pulp_id).first
+                                    minor: minor,
+                                    arch: arch).first
       end
 
       def build_repository
@@ -56,7 +58,6 @@ module Katello
         repository = Repository.new(
           :environment => product.organization.library,
           :product => product,
-          :pulp_id => pulp_id,
           :cp_label => content.label,
           :content_id => content.id,
           :arch => arch,
@@ -105,10 +106,6 @@ module Katello
         repo_name_parts = [content.name,
                            sorted_substitutions].flatten.compact
         repo_name_parts.join(" ").gsub(/[^a-z0-9\-\._ ]/i, "")
-      end
-
-      def pulp_id
-        product.repo_id(name)
       end
 
       def path
@@ -212,7 +209,6 @@ module Katello
         end
         ::Katello::Repository.new(:environment => product.organization.library,
                                  :product => product,
-                                 :pulp_id => pulp_id,
                                  :cp_label => content.label,
                                  :content_id => content.id,
                                  :relative_path => relative_path,
@@ -235,10 +231,6 @@ module Katello
 
       def name
         "#{content.name} - (#{registry['name']})"
-      end
-
-      def pulp_id
-        product.repo_id(content.name, nil, registry['name'])
       end
 
       def feed_url

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -476,15 +476,10 @@ module Katello
       content_view = self
       to_version   = version || content_view.version(to_env)
 
-      # Construct the pulp id using org/view/version or org/env/view
-      pulp_id = ContentViewPuppetEnvironment.generate_pulp_id(organization.label, to_env.try(:label),
-                                                              self.label, version.try(:version))
-
       ContentViewPuppetEnvironment.new(
         :environment => to_env,
         :content_view_version => to_version,
-        :name => self.name,
-        :pulp_id => pulp_id
+        :name => self.name
       )
     end
 

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -270,7 +270,8 @@ module Katello
 
           distributors = [puppet_dist, puppet_install_dist]
         when Repository::DOCKER_TYPE
-          options = { :protected => !self.unprotected, :id => self.pulp_id, :auto_publish => true}
+          options = { :protected => !self.unprotected, :id => self.pulp_id, :auto_publish => true,
+                      :repo_registry_id => container_repository_name}
           docker_dist = Runcible::Models::DockerDistributor.new(options)
           distributors = [docker_dist]
         when Repository::OSTREE_TYPE
@@ -690,7 +691,7 @@ module Katello
       pulp_uri = URI.parse(smart_proxy ? smart_proxy.url : SETTINGS[:katello][:pulp][:url])
       scheme   = (self.unprotected && !force_https) ? 'http' : 'https'
       if docker?
-        "#{pulp_uri.host.downcase}:#{Setting['pulp_docker_registry_port']}/#{pulp_id}"
+        "#{pulp_uri.host.downcase}:#{Setting['pulp_docker_registry_port']}/#{container_repository_name}"
       elsif file?
         "#{scheme}://#{pulp_uri.host.downcase}/pulp/isos/#{pulp_id}/"
       elsif puppet?

--- a/app/models/katello/glue/pulp/repos.rb
+++ b/app/models/katello/glue/pulp/repos.rb
@@ -205,13 +205,6 @@ module Katello
         end
       end
 
-      def repo_id(content_name, env_label = nil, docker_repo_name = nil)
-        return if content_name.nil?
-        return content_name if content_name.include?(self.organization.label) && content_name.include?(self.label.to_s)
-        Repository.repo_id(self.label.to_s, content_name.to_s, env_label,
-                           self.organization.label, nil, nil, docker_repo_name)
-      end
-
       def repo_url(content_url)
         if self.provider.provider_type == Provider::CUSTOM
           content_url.dup
@@ -234,7 +227,6 @@ module Katello
                    end
         Repository.new(:environment => self.organization.library,
                        :product => self,
-                       :pulp_id => repo_id(label),
                        :relative_path => rel_path,
                        :arch => arch,
                        :name => name,

--- a/app/views/katello/api/v2/repositories/base.json.rabl
+++ b/app/views/katello/api/v2/repositories/base.json.rabl
@@ -3,6 +3,7 @@ object @resource
 extends 'katello/api/v2/common/identifier'
 
 attributes :content_type, :url, :relative_path
+attributes :pulp_id => :backend_identifier
 
 child :product do |_product|
   attributes :id, :cp_id, :name

--- a/db/migrate/20170208215148_add_docker_repo_name.rb
+++ b/db/migrate/20170208215148_add_docker_repo_name.rb
@@ -1,0 +1,14 @@
+class AddDockerRepoName < ActiveRecord::Migration
+  def up
+    add_column :katello_repositories, :container_repository_name, :string
+
+    Katello::Repository.docker_type.find_each do |repo|
+      repo.set_container_repository_name
+      repo.save!
+    end
+  end
+
+  def down
+    remove_column :katello_repositories, :container_repository_name
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -14,6 +14,9 @@
       <dt translate>Label</dt>
       <dd>{{ repository.label }}</dd>
 
+      <dt translate>Backend Identifier</dt>
+      <dd>{{ repository.backend_identifier }}</dd>
+
       <dt translate>Type</dt>
       <dd>{{ repository.content_type }}</dd>
 

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -105,28 +105,6 @@ module Katello
       end
     end
 
-    describe "product repos" do
-      before(:each) do
-        disable_product_orchestration
-        Katello.pulp_server.extensions.repository.stubs(:publish_all).returns([])
-      end
-
-      describe "repo id" do
-        before do
-          Resources::Candlepin::Product.stubs(:create).returns(:id => ProductTestData::PRODUCT_ID)
-          @p = Product.create!(ProductTestData::SIMPLE_PRODUCT.merge(:organization_id => @organization.id))
-        end
-
-        specify "format" do
-          @p.repo_id('123', 'root').must_equal("#{@organization.label}-root-#{ProductTestData::SIMPLE_PRODUCT[:label]}-123")
-        end
-
-        it "should be the same as content id for cloned repository" do
-          @p.repo_id("#{@organization.label}-root-#{ProductTestData::SIMPLE_PRODUCT[:label]}-123").must_equal("#{@organization.label}-root-#{ProductTestData::SIMPLE_PRODUCT[:label]}-123")
-        end
-      end
-    end
-
     describe "#environments" do
       it "should contain a unique list of environments" do
         disable_repo_orchestration

--- a/test/actions/katello/docker_repository_set_test.rb
+++ b/test/actions/katello/docker_repository_set_test.rb
@@ -58,13 +58,10 @@ module ::Actions::Katello::DockerRepositorySet
       }
     end
 
-    let(:expected_pulp_id) { "empty_organization-redhat_label-docker_content_123-#{registry_name}".downcase }
     let(:expected_relative_path) { "Empty_Organization/library_label/product/x86_64/6Server" }
 
     def repository_already_enabled!
-      katello_repositories(:rhel_6_x86_64).
-          update_attributes!(relative_path: "#{expected_relative_path}",
-                             pulp_id: expected_pulp_id,
+      katello_repositories(:rhel_6_x86_64).update_attributes!(relative_path: "#{expected_relative_path}",
                              docker_upstream_name: registry_name)
     end
   end
@@ -93,7 +90,6 @@ module ::Actions::Katello::DockerRepositorySet
                                  [{ "substitutions" => {},
                                     "path" => "https://#{registry_feed_url}",
                                     "repo_name" => "#{content.name} - (#{registry_name})",
-                                    "pulp_id" => expected_pulp_id,
                                     "registry_name" => "dream-registry",
                                     "enabled" => false,
                                     "promoted" => false}])
@@ -118,7 +114,6 @@ module ::Actions::Katello::DockerRepositorySet
 
     it 'plans' do
       action.expects(:action_subject).with do |repository|
-        repository.pulp_id.must_equal expected_pulp_id
         repository.docker_upstream_name.must_equal registry_name
         repository.url.must_equal "https://#{registry_feed_url}"
       end
@@ -142,7 +137,6 @@ module ::Actions::Katello::DockerRepositorySet
       repository_already_enabled!
 
       action.expects(:action_subject).with do |repository|
-        repository.pulp_id.must_equal expected_pulp_id
         repository.docker_upstream_name.must_equal registry_name
       end
       plan_action action, product, content, options

--- a/test/actions/katello/repository_set_test.rb
+++ b/test/actions/katello/repository_set_test.rb
@@ -29,13 +29,12 @@ module ::Actions::Katello::RepositorySet
                                         contentUrl: content_url)
     end
     let(:substitutions) { { basearch: 'x86_64', releasever: '6Server' } }
-    let(:expected_pulp_id) { "Empty_Organization-redhat_label-Content_123_x86_64_6Server" }
     let(:expected_relative_path) { "Empty_Organization/library_label/product/x86_64/6Server" }
 
     def repository_already_enabled!
       katello_repositories(:rhel_6_x86_64).
-          update_attributes!(relative_path: "#{expected_relative_path}",
-                             pulp_id: expected_pulp_id)
+          update_attributes!(:relative_path => "#{expected_relative_path}", :content_id => content.id,
+                            :arch => 'x86_64', :minor => '6Server')
     end
   end
 
@@ -44,7 +43,6 @@ module ::Actions::Katello::RepositorySet
 
     it 'plans' do
       action.expects(:action_subject).with do |repository|
-        repository.pulp_id.must_equal expected_pulp_id
         repository.relative_path.must_equal expected_relative_path
       end
       content.expects(:modifiedProductIds).returns([])
@@ -68,7 +66,6 @@ module ::Actions::Katello::RepositorySet
       repository_already_enabled!
 
       action.expects(:action_subject).with do |repository|
-        repository.pulp_id.must_equal expected_pulp_id
         repository.relative_path.must_equal expected_relative_path
       end
       plan_action action, product, content, substitutions
@@ -109,7 +106,6 @@ module ::Actions::Katello::RepositorySet
                          "path" => "/product/x86_64/6Server",
                          "repo_name" => "Content 123 x86_64 6Server",
                          "name" => "Content 123",
-                         "pulp_id" => "Empty_Organization-redhat_label-Content_123_x86_64_6Server",
                          "enabled" => false,
                          "promoted" => false}])
     end

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -430,7 +430,7 @@ module ::Actions::Katello::Repository
       Setting['pulp_export_destination'] = '/tmp'
 
       action.stubs(:action_subject)
-      plan_action(action, [repository], false, nil, 0, repository.pulp_id)
+      plan_action(action, [repository], false, nil, 0, "8")
 
       # ensure arguments get transformed and bubble through to pulp actions.
       # Org label defaults to blank for this test, hence the group ID starts
@@ -452,7 +452,7 @@ module ::Actions::Katello::Repository
       action.stubs(:action_subject)
 
       assert_raises(Foreman::Exception) do
-        plan_action(action, [repository], false, nil, 0, repository.pulp_id)
+        plan_action(action, [repository], false, nil, 0, "8")
       end
     end
 

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -131,7 +131,7 @@ rhel_7_x86_64:
 
 rhel_6_x86_64:
   name:                 RHEL 6 x86_64
-  pulp_id:              8
+  pulp_id:              pulp-uuid-rhel_6_x86_64
   content_id:           1
   major:                6
   minor:                6Server

--- a/test/models/content_view_puppet_environment_test.rb
+++ b/test/models/content_view_puppet_environment_test.rb
@@ -48,15 +48,38 @@ module Katello
       assert @puppet_env.archive?
     end
 
-    def test_generate_pulp_id
-      assert_equal ContentViewPuppetEnvironment.generate_pulp_id("org", "env", "view", "version"),
-                   "org-env-view-version"
+    def test_sets_pulp_id_on_save
+      @puppet_env.pulp_id = nil
+      @puppet_env.save!
+      assert @puppet_env.pulp_id
+    end
+  end
 
-      assert_equal ContentViewPuppetEnvironment.generate_pulp_id("org", "env", "view", nil),
-                   "org-env-view"
+  class ContentViewPuppetEnvironmentPulpIdTest < ActiveSupport::TestCase
+    def test_set_pulp_id_cv_env
+      SecureRandom.expects(:uuid).returns('SECURE_UUID')
+      env = katello_content_view_puppet_environments(:dev_view_puppet_environment)
+      env.pulp_id = nil
+      env.set_pulp_id
 
-      assert_equal ContentViewPuppetEnvironment.generate_pulp_id("org", nil, "view", "version"),
-                   "org-view-version"
+      assert_equal "#{env.organization.id}-published_library_view-dev_label-puppet-SECURE_UUID", env.pulp_id
+    end
+
+    def test_set_pulp_id_cv_archive
+      SecureRandom.expects(:uuid).returns('SECURE_UUID')
+      env = katello_content_view_puppet_environments(:archive_view_puppet_environment)
+      env.pulp_id = nil
+      env.set_pulp_id
+
+      assert_equal "#{env.organization.id}-published_library_view-v2_0-puppet-SECURE_UUID", env.pulp_id
+    end
+
+    def test_set_pulp_id_no_overwrite
+      env = katello_content_view_puppet_environments(:dev_view_puppet_environment)
+      id = env.pulp_id
+      env.set_pulp_id
+
+      assert_equal id, env.pulp_id
     end
   end
 end


### PR DESCRIPTION
This changes how we generate a pulp_id.  Now
for all library instances, we generate a random uuid
and then for each clone we construct a combination of
org id, env label, cv label, and the library instance's uuid.

This also seperates the pulp_id and the docker repository name in pulp
allowing for these to be different