### PR TITLE
Fixes #18032 - Skip pulp metadata regeneration on CVV promote

### DIFF
--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -53,10 +53,13 @@ module Katello
     param :environment_id, :identifier, :deprecated => true, :desc => N_("LifeCycle Environment identifier")
     param :environment_ids, Array, :desc => N_("Identifiers for Lifecycle Environment")
     param :description, String, :desc => N_("The description for the content view version promotion")
+    param :force_yum_metadata_regeneration, :bool, :desc => N_("Force metadata regeneration on the repositories " \
+                                                           "in the content view version")
     def promote
       is_force = ::Foreman::Cast.to_bool(params[:force])
       task = async_task(::Actions::Katello::ContentView::Promote,
-                        @version, @environments, is_force, params[:description])
+                        @version, @environments, is_force, params[:description],
+                        :force_yum_metadata_regeneration => params[:force_yum_metadata_regeneration])
       respond_for_async :resource => task
     end
 

--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -76,8 +76,11 @@ module Katello
     api :POST, "/content_views/:id/publish", N_("Publish a content view")
     param :id, :identifier, :desc => N_("Content view identifier"), :required => true
     param :description, String, :desc => N_("Description for the new published content view version")
+    param :force_yum_metadata_regeneration, :bool, :desc => N_("Force yum metadata regeneration on the repositories " \
+                                                           "in the content view version")
     def publish
-      task = async_task(::Actions::Katello::ContentView::Publish, @view, params[:description])
+      task = async_task(::Actions::Katello::ContentView::Publish, @view, params[:description],
+                        :force_yum_metadata_regeneration => params[:force_yum_metadata_regeneration])
       respond_for_async :resource => task
     end
 

--- a/app/lib/actions/katello/content_view/promote.rb
+++ b/app/lib/actions/katello/content_view/promote.rb
@@ -4,14 +4,15 @@ module Actions
       class Promote < Actions::EntryAction
         middleware.use Actions::Middleware::KeepCurrentUser
 
-        def plan(version, environments, is_force = false, description = nil)
+        def plan(version, environments, is_force = false, description = nil, options = {})
           action_subject(version.content_view)
           version.check_ready_to_promote!(environments)
 
           fail ::Katello::HttpErrors::BadRequest, _("Cannot promote environment out of sequence. Use force to bypass restriction.") if !is_force && !version.promotable?(environments)
 
           environments.each do |environment|
-            plan_action(ContentView::PromoteToEnvironment, version, environment, description)
+            plan_action(ContentView::PromoteToEnvironment, version, environment, description,
+                        :force_yum_metadata_regeneration => options[:force_yum_metadata_regeneration])
           end
         end
       end

--- a/app/lib/actions/katello/content_view/promote_to_environment.rb
+++ b/app/lib/actions/katello/content_view/promote_to_environment.rb
@@ -5,7 +5,7 @@ module Actions
       class PromoteToEnvironment < Actions::EntryAction
         middleware.use Actions::Middleware::KeepCurrentUser
 
-        def plan(version, environment, description)
+        def plan(version, environment, description, options = {})
           history = ::Katello::ContentViewHistory.create!(:content_view_version => version, :user => ::User.current.login,
                                                           :environment => environment, :task => self.task,
                                                           :status => ::Katello::ContentViewHistory::IN_PROGRESS,
@@ -17,7 +17,8 @@ module Actions
             concurrence do
               version.archived_repos.non_puppet.each do |repository|
                 sequence do
-                  plan_action(Repository::CloneToEnvironment, repository, environment)
+                  plan_action(Repository::CloneToEnvironment, repository, environment,
+                              :force_yum_metadata_regeneration => options[:force_yum_metadata_regeneration])
                 end
               end
 

--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -6,7 +6,7 @@ module Actions
         middleware.use Actions::Middleware::KeepCurrentUser
 
         # rubocop:disable MethodLength
-        def plan(content_view, description = "")
+        def plan(content_view, description = "", options = {})
           action_subject(content_view)
           content_view.check_ready_to_publish!
           version = content_view.create_new_version
@@ -26,7 +26,8 @@ module Actions
               content_view.publish_repositories do |repositories|
                 sequence do
                   clone_to_version = plan_action(Repository::CloneToVersion, repositories, version)
-                  plan_action(Repository::CloneToEnvironment, clone_to_version.new_repository, library)
+                  plan_action(Repository::CloneToEnvironment, clone_to_version.new_repository, library,
+                              :force_yum_metadata_regeneration => options[:force_yum_metadata_regeneration])
                 end
               end
 

--- a/app/lib/actions/katello/repository/check_matching_content.rb
+++ b/app/lib/actions/katello/repository/check_matching_content.rb
@@ -1,0 +1,49 @@
+module Actions
+  module Katello
+    module Repository
+      class CheckMatchingContent < Actions::Base
+        input_format do
+          param :source_repo
+          param :target_repo
+        end
+
+        # Check if content in the repositories has changed. We can use
+        # this info to skip regenerating metadata in pulp, keeping the
+        # revision number on the repo the same
+        def run
+          source_repo = ::Katello::Repository.find(input[:source_repo_id])
+          target_repo = ::Katello::Repository.find(input[:target_repo_id])
+
+          rpms = rpms_match?(source_repo, target_repo)
+          errata = errata_match?(source_repo, target_repo)
+          package_groups = package_groups_match?(source_repo, target_repo)
+          distributions = distributions_match?(source_repo, target_repo)
+
+          output[:matching_content] = rpms && errata && package_groups && distributions
+        end
+
+        def rpms_match?(source_repo, target_repo)
+          source_repo_ids = source_repo.rpm_ids.sort
+          target_repo_ids = target_repo.rpm_ids.sort
+          source_repo_ids == target_repo_ids
+        end
+
+        def errata_match?(source_repo, target_repo)
+          source_repo_ids = source_repo.erratum_ids.sort
+          target_repo_ids = target_repo.erratum_ids.sort
+          source_repo_ids == target_repo_ids
+        end
+
+        def package_groups_match?(source_repo, target_repo)
+          source_repo_ids = source_repo.package_group_ids.sort
+          target_repo_ids = target_repo.package_group_ids.sort
+          source_repo_ids == target_repo_ids
+        end
+
+        def distributions_match?(source_repo, target_repo)
+          source_repo.distribution_information == target_repo.distribution_information
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/repository/clone_to_environment.rb
+++ b/app/lib/actions/katello/repository/clone_to_environment.rb
@@ -4,7 +4,7 @@ module Actions
       # Clones the contnet of the repository into the environment
       # effectively promotion the repository to the environment
       class CloneToEnvironment < Actions::Base
-        def plan(repository, environment)
+        def plan(repository, environment, options = {})
           clone = find_or_build_environment_clone(repository, environment)
 
           sequence do
@@ -21,7 +21,8 @@ module Actions
             end
 
             if repository.yum?
-              plan_action(Repository::CloneYumContent, repository, clone, [], false)
+              plan_action(Repository::CloneYumContent, repository, clone, [], false,
+                          :force_yum_metadata_regeneration => options[:force_yum_metadata_regeneration])
             elsif repository.docker?
               plan_action(Repository::CloneDockerContent, repository, clone, [])
             elsif repository.ostree?

--- a/app/lib/actions/katello/repository/metadata_generate.rb
+++ b/app/lib/actions/katello/repository/metadata_generate.rb
@@ -13,7 +13,8 @@ module Actions
                         :distributor_type_id => distributor.type_id,
                         :source_pulp_id => source_repository.try(:pulp_id),
                         :override_config => override_config(distributor, force),
-                        :dependency => dependency)
+                        :dependency => dependency,
+                        :matching_content => options[:matching_content])
           end
         end
 

--- a/app/lib/actions/middleware/skip_if_matching_content.rb
+++ b/app/lib/actions/middleware/skip_if_matching_content.rb
@@ -1,0 +1,24 @@
+module Actions
+  module Middleware
+    class SkipIfMatchingContent < Dynflow::Middleware
+      def run(*args)
+        pass(*args) if execute?
+      end
+
+      def finalize(*args)
+        pass(*args) if execute?
+      end
+
+      private
+
+      def execute?
+        if action.input.keys.include?('matching_content') && action.input['matching_content']
+          self.action.output[:matching_content_skip] = true
+          false
+        else
+          true
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp/repository/distributor_publish.rb
+++ b/app/lib/actions/pulp/repository/distributor_publish.rb
@@ -2,12 +2,15 @@ module Actions
   module Pulp
     module Repository
       class DistributorPublish < Pulp::AbstractAsyncTask
+        middleware.use Actions::Middleware::SkipIfMatchingContent
+
         input_format do
           param :pulp_id
           param :distributor_type_id
           param :source_pulp_id
           param :dependency
           param :override_config
+          param :matching_content
         end
 
         def invoke_external_task

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -543,6 +543,17 @@ module Katello
       end
     end
 
+    def distribution_information
+      {
+        distribution_version: self.distribution_version,
+        distribution_arch: self.distribution_arch,
+        distribution_family: self.distribution_family,
+        distribution_variant: self.distribution_variant,
+        distribution_uuid: self.distribution_uuid,
+        distribution_bootable: self.distribution_bootable
+      }
+    end
+
     def check_duplicate_branch_names(branch_names)
       dupe_branch_checker = {}
       dupe_branch_checker.default = 0

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-promotion.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-promotion.controller.js
@@ -99,6 +99,7 @@ angular.module('Bastion.content-views').controller('ContentViewPromotionControll
             ContentViewVersion.promote({id: $scope.version.id,
                                         'environment_id': $scope.selectedEnvironment.id,
                                         'description': $scope.description,
+                                        'force_yum_metadata_regeneration': $scope.forceMetadataRegeneration,
                                         force: true},
                 success, failure);
         };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-publish.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-publish.controller.js
@@ -34,7 +34,8 @@ angular.module('Bastion.content-views').controller('ContentViewPublishController
 
         $scope.publish = function (contentView) {
             var description = $scope.version.description,
-                data = {'id': contentView.id, 'description': description};
+                forceMetadataRegeneration = $scope.version.forceMetadataRegeneration,
+                data = {'id': contentView.id, 'description': description, 'force_yum_metadata_regeneration': forceMetadataRegeneration};
             $scope.working = true;
             ContentView.publish(data, success, failure);
         };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-promotion.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-promotion.html
@@ -36,6 +36,20 @@
     </textarea>
   </div>
 
+  <div class="checkbox">
+    <label translate>
+      <input id="forceMetadataRegeneration"
+             name="forceMetadataRegeneration"
+             ng-model="forceMetadataRegeneration"
+             type="checkbox"/>
+      Force Yum Metadata Regeneration</label>
+    <i class="fa fa-question-circle"
+       uib-tooltip="{{ 'Forces metadata regeneration on yum repos even if the contents of the repo have not changed' | translate }}"
+       tooltip-animation="false"
+       tooltip-append-to-body="true">
+    </i>
+  </div>
+
   <div>
     <button type="button" class="btn btn-primary btn-lg" ng-disabled="promoting || !selectedEnvironment" ng-click="verifySelection()" translate>
       Promote Version

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-publish.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-publish.html
@@ -26,6 +26,19 @@
     </textarea>
   </div>
 
+  <div class="checkbox">
+    <label translate>
+    <input id="forceMetadataRegeneration"
+           name="forceMetadataRegeneration"
+           ng-model="version.forceMetadataRegeneration"
+           type="checkbox"/>
+    Force Yum Metadata Regeneration</label>
+    <i class="fa fa-question-circle"
+       uib-tooltip="{{ 'Forces metadata regeneration on yum repos even if the contents of the repo have not changed' | translate }}"
+       tooltip-animation="false"
+       tooltip-append-to-body="true"></i>
+  </div>
+
   <div bst-form-buttons
        on-cancel="transitionTo('content-view.versions', {contentViewId: contentView.id})"
        on-save="publish(contentView)"

--- a/test/actions/katello/repository/check_matching_content_test.rb
+++ b/test/actions/katello/repository/check_matching_content_test.rb
@@ -1,0 +1,29 @@
+require 'katello_test_helper'
+
+module Actions
+  describe Katello::Repository::CheckMatchingContent do
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+    include FactoryGirl::Syntax::Methods
+
+    let(:action_class) { ::Actions::Katello::Repository::CheckMatchingContent }
+    let(:yum_repo) { katello_repositories(:fedora_17_x86_64) }
+    let(:yum_repo2) { katello_repositories(:fedora_17_x86_64_dev) }
+
+    def test_check_matching_content_false
+      action = create_action(action_class)
+      plan = plan_action(action, :source_repo_id => yum_repo.id, :target_repo_id => yum_repo2.id)
+      run = run_action plan
+
+      assert_equal false, run.output[:matching_content]
+    end
+
+    def test_check_matching_content_true
+      action = create_action(action_class)
+      plan = plan_action(action, :source_repo_id => yum_repo.id, :target_repo_id => yum_repo.id)
+      run = run_action plan
+
+      assert_equal true, run.output[:matching_content]
+    end
+  end
+end

--- a/test/actions/katello/repository/metadata_generate_test.rb
+++ b/test/actions/katello/repository/metadata_generate_test.rb
@@ -20,7 +20,8 @@ module Actions
           :distributor_type_id => Runcible::Models::YumDistributor.type_id,
           :source_pulp_id => nil,
           :override_config => {:force_full => false},
-          :dependency => nil)
+          :dependency => nil,
+          :matching_content => nil)
     end
 
     it 'plans a yum refresh with force true' do
@@ -31,7 +32,8 @@ module Actions
           :distributor_type_id => Runcible::Models::YumDistributor.type_id,
           :source_pulp_id => nil,
           :override_config => {:force_full => true},
-          :dependency => nil)
+          :dependency => nil,
+          :matching_content => nil)
     end
 
     it 'plans a yum refresh with source repo' do
@@ -42,7 +44,8 @@ module Actions
           :distributor_type_id => Runcible::Models::YumCloneDistributor.type_id,
           :source_pulp_id => yum_repo2.pulp_id,
           :override_config => {},
-          :dependency => nil)
+          :dependency => nil,
+          :matching_content => nil)
     end
 
     it 'plans a puppet refresh' do
@@ -53,7 +56,8 @@ module Actions
           :distributor_type_id => Runcible::Models::PuppetDistributor.type_id,
           :source_pulp_id => nil,
           :override_config => {},
-          :dependency => nil)
+          :dependency => nil,
+          :matching_content => nil)
     end
   end
 end

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -160,7 +160,7 @@ module Katello
 
     def test_promote
       version = @library_dev_staging_view.versions.first
-      @controller.expects(:async_task).with(::Actions::Katello::ContentView::Promote, version, [@dev], false, 'trystero').returns({})
+      @controller.expects(:async_task).with(::Actions::Katello::ContentView::Promote, version, [@dev], false, 'trystero', :force_yum_metadata_regeneration => nil).returns({})
       post :promote, :id => version.id, :environment_ids => [@dev.id], :description => 'trystero'
 
       assert_response :success
@@ -181,7 +181,8 @@ module Katello
 
     def test_bad_promote_out_of_sequence
       version = @library_dev_staging_view.versions.first
-      @controller.expects(:async_task).with(::Actions::Katello::ContentView::Promote, version, [@beta], false, nil).raises(::Katello::HttpErrors::BadRequest)
+      @controller.expects(:async_task).with(::Actions::Katello::ContentView::Promote, version, [@beta], false, nil,
+                                            :force_yum_metadata_regeneration => nil).raises(::Katello::HttpErrors::BadRequest)
       post :promote, :id => version.id, :environment_ids => [@beta.id]
 
       assert_response 500
@@ -189,7 +190,8 @@ module Katello
 
     def test_promote_out_of_sequence_force
       version = @library_dev_staging_view.versions.first
-      @controller.expects(:async_task).with(::Actions::Katello::ContentView::Promote, version, [@beta], true, nil).returns({})
+      @controller.expects(:async_task).with(::Actions::Katello::ContentView::Promote, version, [@beta], true, nil,
+                                            :force_yum_metadata_regeneration => nil).returns({})
       post :promote, :id => version.id, :environment_ids => [@beta.id], :force => 1
 
       assert_response :success
@@ -197,7 +199,8 @@ module Katello
 
     def test_promote_out_of_sequence_force_false
       version = @library_dev_staging_view.versions.first
-      @controller.expects(:async_task).with(::Actions::Katello::ContentView::Promote, version, [@beta], false, nil).returns({})
+      @controller.expects(:async_task).with(::Actions::Katello::ContentView::Promote, version, [@beta], false, nil,
+                                            :force_yum_metadata_regeneration => nil).returns({})
       post :promote, :id => version.id, :environment_ids => [@beta.id], :force => 0
 
       assert_response :success


### PR DESCRIPTION
If nothing has changed, we have no reason to regenerate metadata
in the pulp repo. The way things currently are we regenerate the
metadata (even if nothing has changed in the repo) and it is
slowing down Smart Proxy Content syncs. Not regenerating the metadata
will take full advantage of certain optimizations in pulp making
these Smart Proxy syncs much faster.

This commit adds an option to force the metadata regeneration,
it is a checkbox called "Force Metadata Regeneration" on
Content View publish.