### PR TITLE
Fixes #18448: ensure all buttons have a type.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-add-subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-add-subscriptions.html
@@ -3,7 +3,7 @@
 <div data-extend-template="layouts/partials/table.html">
   <div data-block="list-actions">
     <div ng-hide="denied('edit_activation_keys', activationKey)">
-       <button class="btn btn-primary"
+       <button class="btn btn-primary" type="button"
                translate
                ng-disabled="disableAddButton()"
                ng-click="addSelected()">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-details.html
@@ -7,7 +7,7 @@
 
   <div data-block="item-actions">
     <div class="btn-group" uib-dropdown keyboard-nav bst-feature-flag="custom_products">
-      <button class="btn btn-default" ng-disabled="denied('create_activation_key')" ui-sref="activation-key.copy">
+      <button type="button" class="btn btn-default" ng-disabled="denied('create_activation_key')" ui-sref="activation-key.copy">
         <span translate>Copy Activation Key</span>
       </button>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-host-collections-table.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-host-collections-table.html
@@ -13,6 +13,7 @@
 
     <div data-block="list-actions">
       <button ng-if="isState('activation-key.host-collections.list')"
+              type="button"
               class="btn btn-default"
               ng-hide="denied('edit_activation_keys', activationKey)"
               ng-disabled="table.numSelected == 0 || table.working"
@@ -20,6 +21,7 @@
         {{ 'Remove Selected' | translate }}
       </button>
       <button ng-if="isState('activation-key.host-collections.add')"
+              type="button"
               class="btn btn-default"
               ng-hide="denied('edit_activation_keys', activationKey)"
               ng-disabled="table.numSelected == 0 || table.working"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-subscriptions-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-subscriptions-list.html
@@ -2,8 +2,8 @@
 
 <div data-extend-template="layouts/partials/table.html">
   <div data-block="list-actions">
-    <button class="btn btn-primary"
-           translate
+    <button class="btn btn-primary" type="button"
+            translate
            ng-hide="denied('edit_activation_keys', activationKey)"
            ng-disabled="disableRemoveButton()"
            ng-click="removeSelected()">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/views/activation-keys.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/views/activation-keys.html
@@ -7,7 +7,7 @@
   </div>
 
   <div data-block="list-actions">
-    <button class="btn btn-primary" ui-sref="activation-keys.new" ng-hide="denied('create_activation_keys')">
+    <button type="button" class="btn btn-primary" ui-sref="activation-keys.new" ng-hide="denied('create_activation_keys')">
       <i class="pficon pficon-add-circle-o"></i>
       {{ "Create Activation Key" | translate }}
     </button>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-environment-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-environment-modal.html
@@ -15,8 +15,8 @@
         Are you sure you want to assign the {{ table.numSelected }} content host(s) selected to {{ selected.contentView.name }} in {{ selected.environment.name }}?
       </span>
       <div>
-        <button class="btn btn-default" ng-click="showConfirm = false; performAction()" translate>Yes</button>
-        <button class="btn btn-default" ng-click="showConfirm = false;" translate>No</button>
+        <button type="button" class="btn btn-default" ng-click="showConfirm = false; performAction()" translate>Yes</button>
+        <button type="button" class="btn btn-default" ng-click="showConfirm = false;" translate>No</button>
       </div>
     </div>
 
@@ -47,19 +47,19 @@
         </p>
       </div>
 
-      <button class="btn btn-default fr"
-              translate
+      <button class="btn btn-default"
+              type="button"
               ng-hide="denied('edit_hosts')"
               ng-click="showConfirm = true;"
               ng-disabled="disableAssignButton(confirm)">
-        Assign
+        <span translate>Assign</span>
       </button>
 
     </form>
   </div>
 
   <div data-block="modal-footer">
-    <button class="btn btn-primary" ng-click="ok()" translate>
+    <button type="button" class="btn btn-primary" ng-click="ok()" translate>
       Done
     </button>
   </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-errata-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-errata-modal.html
@@ -7,8 +7,8 @@
         Are you sure you want to apply the {{ table.numSelected }} selected errata to the content hosts chosen?
       </span>
       <div>
-        <button class="btn btn-default" ng-click="showConfirm = false; installErrata()" translate>Yes</button>
-        <button class="btn btn-default" ng-click="showConfirm = false;; table.working = false" translate>No</button>
+        <button type="button" class="btn btn-default" ng-click="showConfirm = false; installErrata()" translate>Yes</button>
+        <button type="button" class="btn btn-default" ng-click="showConfirm = false;; table.working = false" translate>No</button>
       </div>
     </div>
 
@@ -20,19 +20,19 @@
 
     <div data-extend-template="layouts/partials/table.html">
       <div data-block="list-actions">
-        <button class="btn btn-default"
+        <button class="btn btn-default" type="button"
                 ng-disabled="table.numSelected === 0 || table.working"
                 ng-click="fetchErrata()">
           <span translate>Refresh Table</span>
         </button>
 
         <span uib-dropdown class="btn-group">
-          <button class="btn btn-primary"
+          <button class="btn btn-primary" type="button"
                   ng-disabled="table.numSelected === 0 || table.working || table.numSelected === 0"
                   ng-click="showConfirm = true;">
             <span translate>Install Selected</span>
           </button>
-          <button uib-dropdown-toggle class="btn btn-primary"
+          <button uib-dropdown-toggle class="btn btn-primary" type="button"
                   ng-hide="!remoteExecutionPresent"
                   ng-disabled="table.numSelected === 0 || table.working || table.numSelected === 0"
                   type="button" id="use-remote-execution">
@@ -94,7 +94,7 @@
   </div>
 
   <div data-block="modal-footer">
-    <button class="btn btn-primary" ng-click="ok()" translate>
+    <button type="button" class="btn btn-primary" ng-click="ok()" translate>
       Done
     </button>
   </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-host-collections-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-host-collections-modal.html
@@ -13,8 +13,8 @@
         Are you sure you want to add the {{ table.numSelected }} content host(s) selected to the host collection(s) chosen?
       </span>
       <div>
-        <button class="btn btn-default" ng-click="performHostCollectionAction()" translate>Yes</button>
-        <button class="btn btn-default" ng-click="hostCollections.action = null; hostCollections.working = false" translate>No</button>
+        <button type="button" class="btn btn-default" ng-click="performHostCollectionAction()" translate>Yes</button>
+        <button type="button" class="btn btn-default" ng-click="hostCollections.action = null; hostCollections.working = false" translate>No</button>
       </div>
     </div>
 
@@ -23,21 +23,21 @@
         Are you sure you want to remove the {{ table.numSelected }} content host(s) selected from the host collection(s) chosen?
       </span>
       <div>
-        <button class="btn btn-default" ng-click="performHostCollectionAction()" translate>Yes</button>
-        <button class="btn btn-default" ng-click="hostCollections.action = null; hostCollections.working = false" translate>No</button>
+        <button type="button" class="btn btn-default" ng-click="performHostCollectionAction()" translate>Yes</button>
+        <button type="button" class="btn btn-default" ng-click="hostCollections.action = null; hostCollections.working = false" translate>No</button>
       </div>
     </div>
 
     <div data-extend-template="layouts/partials/table.html">
       <div data-block="list-actions">
-        <button class="btn btn-default"
+        <button class="btn btn-default" type="button"
                 ng-hide="denied('edit_hosts')"
                 ng-disabled="table.numSelected == 0"
                 ng-click="hostCollections.action = 'add'; hostCollections.working = true">
           <span translate>Add To</span>
         </button>
 
-        <button class="btn btn-default"
+        <button class="btn btn-default" type="button"
                 ng-hide="denied('edit_hosts')"
                 ng-disabled="table.numSelected == 0"
                 ng-click="hostCollections.action = 'remove'; hostCollections.working = true">
@@ -84,7 +84,7 @@
   </div>
 
   <div data-block="modal-footer">
-    <button class="btn btn-primary" ng-click="ok()" translate>
+    <button type="button" class="btn btn-primary" ng-click="ok()" translate>
       Done
     </button>
   </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-packages-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-packages-modal.html
@@ -68,7 +68,7 @@
 
       <div>
       <span uib-dropdown class="input-group-btn">
-        <button class="btn btn-default"
+        <button class="btn btn-default" type="button"
                 translate
                 ng-hide="denied('edit_hosts')"
                 ng-click="confirmContentAction('install', content)"
@@ -89,7 +89,7 @@
       </span>
 
       <span uib-dropdown class="input-group-btn">
-        <button class="btn btn-default"
+        <button class="btn btn-default" type="button"
                 translate
                 ng-hide="denied('edit_hosts')"
                 ng-click="confirmContentAction('update', content)"
@@ -111,7 +111,7 @@
       </span>
 
       <span uib-dropdown class="input-group-btn">
-        <button class="btn btn-default"
+        <button class="btn btn-default" type="button"
                 translate
                 ng-hide="content.contentType == 'errata' || denied('edit_hosts')"
                 ng-click="confirmContentAction('remove', content)"
@@ -146,7 +146,7 @@
           Are you sure you want to update all packages on the {{ getSelectedSystemIds().length }} system(s) selected?
         </div>
 
-        <button class="btn btn-default" ng-click="performContentAction()" translate>Yes</button>
+        <button type="submit" class="btn btn-default" ng-click="performContentAction()" translate>Yes</button>
         <button type="button" class="btn btn-default" ng-click="content.confirm = false" translate>No</button>
       </div>
 
@@ -154,7 +154,7 @@
   </div>
 
   <div data-block="modal-footer">
-    <button class="btn btn-primary" ng-click="ok()" translate>
+    <button type="button" class="btn btn-primary" ng-click="ok()" translate>
       Done
     </button>
   </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-subscriptions-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-subscriptions-modal.html
@@ -35,7 +35,7 @@
 
     <div data-extend-template="layouts/partials/table.html">
       <div data-block="list-actions">
-        <button class="btn btn-primary"
+        <button class="btn btn-primary" type="button"
                 translate
                 ng-hide="denied('edit_hosts', host)"
                 ng-disabled="table.numSelected === 0 || isWorking"
@@ -43,7 +43,7 @@
           Add Selected
         </button>
 
-        <button class="btn btn-primary"
+        <button class="btn btn-primary" type="button"
                 translate
                 ng-hide="denied('edit_hosts', host)"
                 ng-disabled="table.numSelected === 0 || isWorking"
@@ -114,7 +114,7 @@
   </div>
 
   <div data-block="modal-footer">
-    <button class="btn btn-primary" ng-click="ok()" translate>
+    <button type="button" class="btn btn-primary" ng-click="ok()" translate>
       Done
     </button>
   </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
@@ -60,7 +60,7 @@
 
         <span bst-feature-flag="remote_actions">
           <span uib-dropdown class="btn-group">
-            <button class="btn btn-default"
+            <button class="btn btn-default" type="button"
                     translate
                     ng-hide="denied('edit_hosts', host)"
                     ng-disabled="table.getSelected().length == 0"
@@ -80,7 +80,7 @@
             </ul>
           </span>
         </span>
-        <button class="btn btn-default"
+        <button class="btn btn-default" type="button"
                 translate
                 ng-hide="denied('edit_hosts', host)"
                 ng-disabled="calculatingApplicability"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-actions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-actions.html
@@ -32,7 +32,7 @@
                    ng-model="packageAction.term"/>
 
             <span uib-dropdown class="input-group-btn">
-              <button class="btn btn-default"
+              <button class="btn btn-default" type="button"
                       ng-hide="denied('edit_hosts', host)"
                       ng-disabled="working || packageAction.term === undefined || packageAction.term.length === 0"
                       translate>
@@ -54,7 +54,7 @@
         </div>
 
         <div class="form-group">
-          <button class="btn btn-primary"
+          <button class="btn btn-primary" type="button"
                   translate
                   ng-disabled="working"
                   ng-click="updateAll()">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-applicable.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-applicable.html
@@ -19,7 +19,7 @@
       <form ng-submit="performDefaultUpdateAction()" role="form">
 
         <span uib-dropdown class="btn-group">
-          <button class="btn btn-default"
+          <button class="btn btn-default" type="button"
                   ng-hide="denied('edit_hosts', host)"
                   ng-disabled="working || table.numSelected === 0"
                   translate>
@@ -39,6 +39,7 @@
         </span>
 
         <button class="btn btn-primary"
+                type="button"
                 translate
                 ng-disabled="working"
                 ng-click="updateAll()">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-installed.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-installed.html
@@ -25,7 +25,7 @@
   </span>
 
   <div data-block="list-actions" bst-feature-flag="remote_actions">
-    <button class="btn btn-default"
+    <button class="btn btn-default" type="button"
             ng-hide="denied('edit_hosts', host)"
             ng-disabled="working || table.numSelected === 0"
             ng-click="removeSelectedPackages()">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-traces.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-traces.html
@@ -38,7 +38,7 @@
 
       <span bst-feature-flag="remote_actions">
         <span class="btn-group" uib-dropdown>
-          <button class="btn btn-default"
+          <button class="btn btn-default" type="button"
                   translate
                   ng-hide="denied('edit_hosts', host)"
                   ng-disabled="table.getSelected().length == 0 || !remoteExecutionPresent"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-add-subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-add-subscriptions.html
@@ -2,7 +2,7 @@
 
 <div data-extend-template="layouts/partials/table.html">
   <div data-block="list-actions">
-     <button class="btn btn-default"
+     <button class="btn btn-default" type="button"
              translate
              ng-hide="denied('edit_hosts', host)"
              ng-disabled="disableAddButton()"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-details.html
@@ -6,7 +6,7 @@
   </header>
 
   <nav data-block="item-actions">
-    <button class="btn btn-default"
+    <button class="btn btn-default" type="button"
             ng-disabled="host.deleting"
             ng-hide="denied('destroy_hosts', host)"
             ng-click="openModal()">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-host-collections-table.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-host-collections-table.html
@@ -1,6 +1,7 @@
 <section data-extend-template="layouts/partials/table.html">
   <div data-block="list-actions">
     <button ng-if="isState('content-host.host-collections.list')"
+            type="button"
             class="btn btn-default"
             ng-hide="denied('edit_hosts', host)"
             ng-disabled="table.numSelected == 0 || table.working"
@@ -8,6 +9,7 @@
       <span translate>Remove Selected</span>
     </button>
     <button ng-if="isState('content-host.host-collections.add')"
+            type="button"
             class="btn btn-default"
             ng-hide="denied('edit_hosts', host)"
             ng-disabled="table.numSelected == 0 || table.working"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions-list.html
@@ -3,7 +3,7 @@
 <div data-extend-template="layouts/partials/table.html">
   <div data-block="list-actions">
     <div ng-hide="system.readonly">
-       <button class="btn btn-default"
+       <button class="btn btn-default" type="button"
                translate
                ng-hide="denied('edit_hosts', host)"
                ng-disabled="disableRemoveButton()"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
@@ -6,6 +6,7 @@
 
   <div data-block="list-actions">
     <button class="btn btn-default"
+            type="button"
             ng-show="permitted('create_hosts')"
             ui-sref="content-hosts.register">
       <span translate>Register Content Host</span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/views/content-view-deletion.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/views/content-view-deletion.html
@@ -24,7 +24,7 @@
           <td>{{ environmentNames(version).join(', ') }}</td>
           <td>
             <a ui-sref="content-view.version-deletion.environments({contentViewId: contentView.id, versionId: version.id})" ng-show="version.permissions.deletable">
-              <button class="btn btn-default">
+              <button class="btn btn-default" type="button" >
                 <span translate>Remove Version</span>
               </button>
             </a>
@@ -46,7 +46,7 @@
       </span>
     </div>
 
-    <button ng-disabled="working" class="btn btn-danger" ng-click="delete()" >
+    <button ng-disabled="working" type="button" class="btn btn-danger" ng-click="delete()" >
       <i class="fa fa-spinner fa-spin" ng-show="working"></i>
       <span translate>Remove</span>
     </button>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/views/version-deletion-activation-keys.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/views/version-deletion-activation-keys.html
@@ -46,14 +46,14 @@
 
       <div class="fr">
         <a ui-sref="content-view.versions({contentViewId: contentView.id})" >
-          <button class="btn btn-default" translate>
+          <button type="button" class="btn btn-default" translate>
             Cancel
           </button>
         </a>
-        <button class="btn btn-default" ng-click="transitionBack()" translate>
+        <button type="button" class="btn btn-default" ng-click="transitionBack()" translate>
           Back
         </button>
-        <button class="btn btn-primary" ng-click="processSelection()" ng-disabled="selectedContentViewId === undefined" translate>
+        <button type="button" class="btn btn-primary" ng-click="processSelection()" ng-disabled="selectedContentViewId === undefined" translate>
           Next
         </button>
       </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/views/version-deletion-confirm.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/views/version-deletion-confirm.html
@@ -61,14 +61,14 @@
 
     <div class="fr">
       <a ui-sref="content-view.versions({contentViewId: contentView.id})" >
-        <button class="btn btn-default" ng-disabled="deleting" translate>
+        <button type="button" class="btn btn-default" ng-disabled="deleting" translate>
           Cancel
         </button>
       </a>
-      <button class="btn btn-default" ng-click="transitionBack()" ng-disabled="deleting" translate>
+      <button type="button" class="btn btn-default" ng-click="transitionBack()" ng-disabled="deleting" translate>
         Back
       </button>
-      <button class="btn btn-primary" ng-click="performDeletion()" ng-disabled="deleting">
+      <button type="button" class="btn btn-primary" ng-click="performDeletion()" ng-disabled="deleting">
         <i class="fa fa-spinner fa-spin" ng-show="deleting"></i>
         <span translate>Confirm Remove</span>
       </button>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/views/version-deletion-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/views/version-deletion-content-hosts.html
@@ -37,14 +37,14 @@
 
     <div class="fr">
       <a ui-sref="content-view.versions({contentViewId: contentView.id})" >
-        <button class="btn btn-default" translate>
+        <button type="button" class="btn btn-default" translate>
           Cancel
         </button>
       </a>
-      <button class="btn btn-default" ng-click="transitionBack()" translate>
+      <button type="button" class="btn btn-default" ng-click="transitionBack()" translate>
         Back
       </button>
-      <button class="btn btn-primary" ng-click="processSelection()" ng-disabled="selectedContentViewId === undefined" translate>
+      <button type="button" class="btn btn-primary" ng-click="processSelection()" ng-disabled="selectedContentViewId === undefined" translate>
         Next
       </button>
     </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/views/version-deletion-environments.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/deletion/views/version-deletion-environments.html
@@ -59,12 +59,12 @@
     <br/>
     <div class="fr">
       <a ui-sref="content-view.versions({contentViewId: contentView.id})" >
-        <button class="btn btn-default" translate>
+        <button type="button" class="btn btn-default" translate>
           Cancel
         </button>
       </a>
 
-      <button class="btn btn-primary" ng-click="processSelection()" ng-disabled="!anySelectable() || selectionEmpty()" translate>
+      <button type="button" class="btn btn-primary" ng-click="processSelection()" ng-disabled="!anySelectable() || selectionEmpty()" translate>
         Next
       </button>
     </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/components/views/content-view-composite-available-content-views.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/components/views/content-view-composite-available-content-views.html
@@ -16,7 +16,7 @@
   </div>
 
   <div data-block="list-actions">
-    <button class="btn btn-primary"
+    <button type="button" class="btn btn-primary"
             ng-disabled="table.numSelected === 0"
             ng-click="addContentViews()">
       <span translate>Add Content Views</span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/components/views/content-view-composite-content-views-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/components/views/content-view-composite-content-views-list.html
@@ -8,7 +8,7 @@
 
 <div data-extend-template="layouts/partials/table.html">
   <div data-block="list-actions">
-    <button class="btn btn-default fr"
+    <button type="button" class="btn btn-default fr"
             ng-hide="denied('edit_content_views', contentView)"
             ng-disabled="table.numSelected === 0"
             ng-click="removeContentViewComponents()">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/docker-tag-filter-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/docker-tag-filter-details.html
@@ -8,7 +8,7 @@
     </div>
   </div>
 
-  <button class="btn btn-default fr"
+  <button type="button" class="btn btn-default"
           ng-disabled="getSelectedRules(filter).length === 0"
           ng-hide="denied('edit_content_views', contentView)"
           ng-click="removeRules(filter)">
@@ -42,7 +42,7 @@
       </td>
 
       <td class="action-cell">
-        <button class="btn btn-default"
+        <button type="button" class="btn btn-default"
                 ng-click="addRule(rule, filter)"
                 ng-hide="denied('edit_content_views', contentView)"
                 ng-disabled="!valid(rule)">
@@ -67,7 +67,7 @@
       </td>
 
       <td class="action-cell">
-        <button class="btn btn-default" ng-click="rule.editMode = true; backupPrevious(rule)" ng-hide="rule.editMode">
+        <button type="button" class="btn btn-default" ng-click="rule.editMode = true; backupPrevious(rule)" ng-hide="rule.editMode">
           <i class="fa fa-edit"></i>
           <span translate>Edit</span>
         </button>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/errata-filter-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/errata-filter-details.html
@@ -14,13 +14,13 @@
   </span>
 
   <div data-block="list-actions">
-    <button class="btn btn-primary"
+    <button type="button" class="btn btn-primary"
             ng-show="isState('content-view.yum.filter.erratum.list') && permitted('edit_content_views', contentView)"
             ng-disabled="table.working || table.numSelected === 0"
             ng-click="removeErrata(contentView)">
       <span translate>Remove Errata</span>
     </button>
-    <button class="btn btn-primary"
+    <button type="button" class="btn btn-primary"
             ng-show="isState('content-view.yum.filter.erratum.available') && permitted('edit_content_views', contentView)"
             ng-disabled="table.working || table.numSelected === 0"
             ng-click="addErrata(filter)">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filter-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filter-repositories.html
@@ -27,7 +27,7 @@
 <div ng-class="{'table-mask': !showRepos}">
   <div data-extend-template="layouts/partials/table.html">
     <div data-block="list-actions">
-      <button class="btn btn-default"
+      <button type="button" class="btn btn-default"
               translate
               ng-hide="denied('edit_content_views', contentView)"
               ng-disabled="!showRepos || table.numSelected === 0"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filters.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filters.html
@@ -2,17 +2,17 @@
 
 <div data-extend-template="layouts/partials/table.html">
   <div data-block="list-actions">
-    <button class="btn btn-default"
+    <button type="button" class="btn btn-default"
             ng-hide="denied('edit_content_views', contentView) || !stateIncludes('content-view.yum')"
             ui-sref="content-view.yum.filters.new">
       <span translate>New Filter</span>
     </button>
-    <button class="btn btn-default"
+    <button type="button" class="btn btn-default"
             ng-hide="denied('edit_content_views', contentView) || stateIncludes('content-view.yum')"
             ui-sref="content-view.docker.filters.new">
       <span translate>New Filter</span>
     </button>
-    <button class="btn btn-default"
+    <button type="button" class="btn btn-default"
             ng-hide="denied('edit_content_views', contentView)"
             ng-disabled="table.numSelected === 0"
             ng-click="removeFilters()">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/package-filter-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/package-filter-details.html
@@ -24,7 +24,7 @@
     </div>
   </div>
 
-  <button class="btn btn-default fr"
+  <button type="button" class="btn btn-default fr"
           ng-disabled="getSelectedRules(filter).length === 0"
           ng-hide="denied('edit_content_views', contentView)"
           ng-click="removeRules(filter)">
@@ -109,7 +109,7 @@
       </td>
 
       <td class="action-cell">
-        <button class="btn btn-default"
+        <button type="button" class="btn btn-default"
                 ng-click="addRule(rule, filter)"
                 ng-hide="denied('edit_content_views', contentView)"
                 ng-disabled="!valid(rule)">
@@ -186,7 +186,7 @@
       </td>
 
       <td class="action-cell">
-        <button class="btn btn-default" ng-click="rule.editMode = true; backupPrevious(rule)" ng-hide="rule.editMode">
+        <button type="button" class="btn btn-default" ng-click="rule.editMode = true; backupPrevious(rule)" ng-hide="rule.editMode">
           <i class="fa fa-edit"></i>
           <span translate>Edit</span>
         </button>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/package-group-filter-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/package-group-filter-details.html
@@ -1,14 +1,14 @@
 <div data-extend-template="layouts/partials/table.html">
 
   <div data-block="list-actions">
-    <button class="btn btn-primary"
+    <button type="button" class="btn btn-primary"
             ng-disabled="table.numSelected === 0"
             ng-show="isState('content-view.yum.filter.package_group.list') && permitted('edit_content_views', contentView)"
             ng-click="removePackageGroups(filter)">
       <span translate>Remove Package Group</span>
     </button>
 
-    <button class="btn btn-primary"
+    <button type="button" class="btn btn-primary"
             ng-disabled="table.numSelected === 0"
             ng-show="isState('content-view.yum.filter.package_group.available') && permitted('edit_content_views', contentView)"
             ng-click="addPackageGroups(filter)">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/views/content-view-puppet-module-names.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/views/content-view-puppet-module-names.html
@@ -45,6 +45,8 @@
           <td >{{ item.name }}</td>
           <td  class="action-cell">
             <button translate
+                    type="button"
+                    class="btn btn-default"
                     ng-hide="denied('edit_content_views', contentView)"
                     ng-click="selectVersion(item.name)">
               Select a Version

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/views/content-view-puppet-module-versions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/views/content-view-puppet-module-versions.html
@@ -54,7 +54,7 @@
           </ul>
         </td>
         <td bst-table-cell class="action-cell">
-          <button translate
+          <button type="button" class="btn btn-default" translate
                   ng-hide="denied('edit_content_views', contentView)"
                   ng-click="selectVersion(item)">
             Select Version

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/views/content-view-puppet-modules.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/views/content-view-puppet-modules.html
@@ -4,7 +4,7 @@
   <span data-block="header" translate>Currently Selected Puppet Modules</span>
 
   <div data-block="list-actions">
-    <button class="btn btn-default"
+    <button type="button" class="btn btn-default"
             ng-hide="denied('edit_content_views', contentView)"
             ui-sref="content-view.puppet-modules.names">
       <span translate>Add New Module</span>
@@ -36,12 +36,12 @@
           <td bst-table-cell >{{ contentViewPuppetModule.author}}</td>
           <td bst-table-cell >{{ versionText(contentViewPuppetModule) }}</td>
           <td bst-table-cell class="action-cell">
-            <button translate
+            <button type="button" class="btn btn-default" translate
                     ng-hide="denied('edit_content_views', contentView)"
                     ng-click="selectNewVersion(contentViewPuppetModule)">
               Select new version
             </button>
-            <button translate
+            <button type="button" class="btn btn-default" translate
                     ng-hide="denied('edit_content_views', contentView)"
                     ng-click="removeModule(contentViewPuppetModule)">
               Remove Module

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-details.html
@@ -14,7 +14,7 @@
 
   <nav data-block="item-actions">
     <div class="btn-group" uib-dropdown keyboard-nav bst-feature-flag="custom_products">
-      <button class="btn btn-default" ng-disabled="denied('publish_content_views', contentView)" ui-sref="content-view.publish">
+      <button type="button" class="btn btn-default" ng-disabled="denied('publish_content_views', contentView)" ui-sref="content-view.publish">
         <span translate>Publish New Version</span>
       </button>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-docker-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-docker-repositories.html
@@ -27,13 +27,13 @@
 <div data-extend-template="layouts/partials/table.html">
   <div data-block="list-actions">
     <div class="col-sm-4">
-      <button class="btn btn-default"
+      <button type="button" class="btn btn-default"
               ng-disabled="table.numSelected === 0"
               ng-show="isState('content-view.repositories.docker.list') && permitted('edit_content_views', contentView)"
               ng-click="removeRepositories(contentView)">
         <span translate>Remove Repositories</span>
       </button>
-      <button class="btn btn-default"
+      <button type="button" class="btn btn-default"
               ng-disabled="table.numSelected === 0"
               ng-show="isState('content-view.repositories.docker.available') && permitted('edit_content_views', contentView)"
               ng-click="addRepositories(contentView)">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-file-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-file-repositories.html
@@ -24,13 +24,13 @@
 
 <div data-extend-template="layouts/partials/table.html">
   <div data-block="list-actions">
-    <button class="btn btn-primary"
+    <button type="button" class="btn btn-primary"
             ng-disabled="table.numSelected === 0"
             ng-show="isState('content-view.repositories.file.list') && permitted('edit_content_views', contentView)"
             ng-click="removeRepositories(contentView)">
       <span translate>Remove Repositories</span>
     </button>
-    <button class="btn btn-primary"
+    <button type="button" class="btn btn-primary"
             ng-disabled="table.numSelected === 0"
             ng-show="isState('content-view.repositories.file.available') && permitted('edit_content_views', contentView)"
             ng-click="addRepositories(contentView)">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-ostree-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-ostree-repositories.html
@@ -24,13 +24,13 @@
 
 <div data-extend-template="layouts/partials/table.html">
   <div data-block="list-actions">
-    <button class="btn btn-primary"
+    <button type="button" class="btn btn-primary"
             ng-disabled="table.numSelected === 0"
             ng-show="isState('content-view.repositories.ostree.list') && permitted('edit_content_views', contentView)"
             ng-click="removeRepositories(contentView)">
       <span translate>Remove Repositories</span>
     </button>
-    <button class="btn btn-primary"
+    <button type="button" class="btn btn-primary"
             ng-disabled="table.numSelected === 0"
             ng-show="isState('content-view.repositories.ostree.available') && permitted('edit_content_views', contentView)"
             ng-click="addRepositories(contentView)">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-promotion.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-promotion.html
@@ -37,7 +37,7 @@
   </div>
 
   <div>
-    <button class="btn btn-primary btn-lg" ng-disabled="promoting || !selectedEnvironment" ng-click="verifySelection()" translate>
+    <button type="button" class="btn btn-primary btn-lg" ng-disabled="promoting || !selectedEnvironment" ng-click="verifySelection()" translate>
       Promote Version
     </button>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-repositories.html
@@ -26,13 +26,13 @@
 
 <div data-extend-template="layouts/partials/table.html">
   <div data-block="list-actions">
-    <button class="btn btn-primary"
+    <button type="button" class="btn btn-primary"
             ng-disabled="table.numSelected === 0"
             ng-show="isState('content-view.repositories.yum.list') && permitted('edit_content_views', contentView)"
             ng-click="removeRepositories(contentView)">
       <span translate>Remove Repositories</span>
     </button>
-    <button class="btn btn-primary"
+    <button type="button" class="btn btn-primary"
             ng-disabled="table.numSelected === 0"
             ng-show="isState('content-view.repositories.yum.available') && permitted('edit_content_views', contentView)"
             ng-click="addRepositories(contentView)">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
@@ -77,7 +77,7 @@
           </td>
           <td bst-table-cell class="preserve-newlines">{{ version.description }}</td>
           <td class="col-sm-2">
-            <button class="btn btn-default"
+            <button type="button" class="btn btn-default"
               ng-click="$state.go('content-view.promotion', {contentViewId: contentView.id, versionId: version.id})"
               ng-hide="denied('promote_or_remove_content_views', contentView)"
               ng-disabled="taskInProgress(version) || taskFailed(version) || pendingVersionTask">
@@ -85,7 +85,7 @@
                 Promote
               </span>
             </button>
-            <button class="btn btn-default"
+            <button type="button" class="btn btn-default"
               ng-click="$state.go('content-view.version-deletion.environments', {contentViewId: contentView.id, versionId: version.id})"
               ng-hide="denied('promote_or_remove_content_views', contentView)"
               ng-disabled="taskInProgress(version) || taskFailed(version) || pendingVersionTask">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment.html
@@ -6,7 +6,8 @@
   <div data-block="item-actions">
     <button ng-show="!environment.library && !environment.successor"
             ng-click="remove(environment)"
-            class="btn btn-default fr">
+            type="button"
+            class="btn btn-default">
       <span translate>Remove Environment</span>
     </button>
   </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/erratum-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/erratum-content-hosts.html
@@ -6,7 +6,7 @@
 
 <div data-extend-template="layouts/partials/table.html">
   <div data-block="list-actions">
-    <button class="btn btn-primary"
+    <button type="button" class="btn btn-primary"
             ng-click="goToNextStep()"
             ng-hide="denied('edit_hosts')"
             ng-disabled="table.numSelected == 0 || incrementalUpdates.length > 0">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata-task-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata-task-details.html
@@ -1,7 +1,7 @@
 <div data-extend-template="tasks/views/task-details.html">
   <div data-block="back-button"></div>
   <div class="details-actions fr">
-    <button class="btn btn-default" ui-sref="errata">
+    <button type="button" class="btn btn-default" ui-sref="errata">
       <i class="fa fa-remove"></i>
       {{ "Close" | translate }}
     </button>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata.html
@@ -6,7 +6,7 @@
   </div>
 
   <div data-block="list-actions">
-    <button class="btn btn-primary"
+    <button type="button" class="btn btn-primary"
             ng-click="goToNextStep()"
             ng-hide="denied('edit_hosts')"
             ng-disabled="table.numSelected == 0 || incrementalUpdates.length > 0">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/details/views/gpg-key-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/details/views/gpg-key-info.html
@@ -28,7 +28,7 @@
           </div>
 
           <div class="form-group">
-            <button class="btn btn-default" upload-submit ng-click="progress.uploading = true">
+            <button type="button" class="btn btn-default" upload-submit ng-click="progress.uploading = true">
               <i class="fa fa-spinner fa-spin" ng-show="progress.uploading"></i>
               <span ng-show="progress.uploading" translate>Uploading...</span>
               <span ng-hide="progress.uploading" translate>Upload</span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/views/gpg-keys.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/views/gpg-keys.html
@@ -6,7 +6,7 @@
   </div>
 
   <div data-block="list-actions">
-    <button class="btn btn-primary" ui-sref="gpg-keys.new" ng-hide="denied('create_gpg_keys')">
+    <button type="button" class="btn btn-primary" ui-sref="gpg-keys.new" ng-hide="denied('create_gpg_keys')">
       <span translate>Create GPG Key</span>
     </button>
   </div>
@@ -21,6 +21,7 @@
 
   <div data-block="table">
     <table bst-table="table"
+           type="button"
            class="table table-striped table-bordered"
            ng-class="{'table-mask': table.working}"
            ng-show="table.rows.length > 0">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-add-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-add-hosts.html
@@ -4,12 +4,11 @@
 
   <div data-block="list-actions">
     <div ng-hide="hostCollection.readonly" class="nutupane-actions fr">
-       <button class="btn btn-default"
-               translate
+       <button type="button" class="btn btn-default"
                ng-hide="denied('edit_hosts')"
                ng-disabled="disableAddButton()"
                ng-click="addSelected()">
-         {{ 'Add Selected' | translate }}
+         <span translate>Add Selected</span>
        </button>
     </div>
   </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-copy.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-copy.html
@@ -9,7 +9,7 @@
                ng-model="copyName" tabindex="1" autofocus required/>
       </div>
 
-      <button class="btn btn-default" type="submit" ng-click="copy(copyName)">
+      <button type="button" class="btn btn-default" type="submit" ng-click="copy(copyName)">
         <span translate>Create</span>
       </button>
     </form>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-details.html
@@ -7,11 +7,11 @@
 
   <div data-block="item-actions">
     <div class="btn-group" uib-dropdown keyboard-nav bst-feature-flag="custom_products">
-      <button class="btn btn-default" ui-sref="host-collection.copy" ng-disabled="denied('create_host_collections')">
+      <button type="button" class="btn btn-default" ui-sref="host-collection.copy" ng-disabled="denied('create_host_collections')">
         <span translate>Copy Host Collection</span>
       </button>
 
-      <button type="button" class="btn btn-default" uib-dropdown-toggle>
+      <button type="button" type="button" class="btn btn-default" uib-dropdown-toggle>
         <span class="caret"></span>
         <span class="sr-only" translate>Toggle Dropdown</span>
       </button>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-hosts-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-hosts-list.html
@@ -4,7 +4,7 @@
 
   <div data-block="list-actions">
     <div ng-hide="denied('edit_hosts')" class="nutupane-actions fr">
-       <button class="btn btn-default"
+       <button type="button" class="btn btn-default"
                translate
                ng-disabled="table.getSelected().length == 0 || isRemoving"
                ng-click="removeSelected()">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/views/host-collections.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/views/host-collections.html
@@ -7,7 +7,7 @@
   </div>
 
   <div data-block="list-actions">
-    <button class="btn btn-primary"
+    <button type="button" class="btn btn-primary"
             ui-sref="host-collections.new"
             ng-hide="denied('create_host_collections')">
       {{ "Create Host Collection" | translate }}

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/views/organization-selector.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/views/organization-selector.html
@@ -25,7 +25,9 @@
       </div>
 
       <div class="col-sm-4">
-        <button class="btn btn-primary" ng-disabled="!selectedOrganization.organization" ng-click="selectOrganization(selectedOrganization.organization)">Select</button>
+        <button type="button" class="btn btn-primary" ng-disabled="!selectedOrganization.organization" ng-click="selectOrganization(selectedOrganization.organization)">
+          <span translate>Select</span>
+        </button>
       </div>
     </div>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/views/products-bulk-sync-plan-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/views/products-bulk-sync-plan-modal.html
@@ -13,8 +13,8 @@
         Are you sure you want to add the sync plan to the selected products(s)?
       </span>
       <div>
-        <button class="btn btn-default" ng-click="updateSyncPlan()" translate>Yes</button>
-        <button class="btn btn-default" ng-click="syncPlan.action = null; syncPlan.working = false" translate>No</button>
+        <button type="button" class="btn btn-default" ng-click="updateSyncPlan()" translate>Yes</button>
+        <button type="button" class="btn btn-default" ng-click="syncPlan.action = null; syncPlan.working = false" translate>No</button>
       </div>
     </div>
 
@@ -23,21 +23,21 @@
         Are you sure you want to remove the sync plan from the selected product(s)?
       </span>
       <div>
-        <button class="btn btn-default" ng-click="removeSyncPlan()" translate>Yes</button>
-        <button class="btn btn-default" ng-click="syncPlan.action = null; syncPlan.working = false" translate>No</button>
+        <button type="button" class="btn btn-default" ng-click="removeSyncPlan()" translate>Yes</button>
+        <button type="button" class="btn btn-default" ng-click="syncPlan.action = null; syncPlan.working = false" translate>No</button>
       </div>
     </div>
 
     <div data-extend-template="layouts/partials/table.html">
       <div data-block="list-actions">
-        <button class="btn btn-default"
+        <button type="button" class="btn btn-default"
                 ng-hide="denied('edit_hosts')"
                 ng-disabled="!selectedSyncPlan"
                 ng-click="syncPlan.action = 'add'; syncPlan.working = true">
           <span translate>Update Sync Plan</span>
         </button>
 
-        <button class="btn btn-default"
+        <button type="button" class="btn btn-default"
                 ng-hide="denied('edit_hosts')"
                 ng-click="syncPlan.action = 'remove'; syncPlan.working = true">
           <span translate>Remove Sync Plan</span>
@@ -80,7 +80,7 @@
   </div>
 
   <div data-block="modal-footer">
-    <button class="btn btn-primary" ng-click="ok()" translate>
+    <button type="button" class="btn btn-primary" ng-click="ok()" translate>
       Done
     </button>
   </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -241,7 +241,7 @@
         </div>
 
         <div class="form-group">
-          <button class="btn btn-primary"
+          <button type="button" class="btn btn-primary"
                   ng-hide="denied('edit_products', product)"
                   upload-submit ng-click="progress.uploading = true">
             <i class="fa fa-spinner fa-spin" ng-show="progress.uploading"></i>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-manage-docker-manifests.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-manage-docker-manifests.html
@@ -29,7 +29,7 @@
       </div>
     </div>
 
-    <button class="btn btn-default"
+    <button type="button" class="btn btn-default"
             ng-click="openModal()"
             ng-hide="denied('edit_products')"
             ng-disabled="table.working || table.numSelected === 0">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-manage-packages.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-manage-packages.html
@@ -28,7 +28,7 @@
       </div>
     </div>
 
-    <button class="btn btn-default"
+    <button type="button" class="btn btn-default"
             ng-hide="denied('edit_products')"
             ng-click="openModal()"
             ng-disabled="table.working || table.numSelected === 0">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-manage-puppet-modules.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-manage-puppet-modules.html
@@ -33,7 +33,7 @@
       </div>
     </div>
 
-    <button class="btn btn-default"
+    <button type="button" class="btn btn-default"
             ng-hide="denied('edit_products')"
             ng-click="openModal()"
             ng-disabled="table.numSelected === 0">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/views/product-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/views/product-repositories.html
@@ -22,20 +22,20 @@
 
 <div data-extend-template="layouts/partials/table.html">
   <div data-block="list-actions">
-    <button class="btn btn-default"
+    <button type="button" class="btn btn-default"
             ui-sref="product.repositories.new({productId: product.id})"
             ng-hide="denied('edit_products', product) || product.redhat">
       <span translate>New Repository</span>
     </button>
 
-    <button class="btn btn-default"
+    <button type="button" class="btn btn-default"
             ng-click="syncSelectedRepositories()"
             ng-hide="denied('sync_products', product)"
             ng-disabled="syncInProgress || table.numSelected == 0">
       <span translate>Sync Now</span>
     </button>
 
-    <button class="btn btn-default"
+    <button type="button" class="btn btn-default"
             ng-click="openModal()"
             ng-show="canRemoveRepositories(product)"
             ng-disabled="removingRepositories || table.numSelected == 0">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery-create.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery-create.html
@@ -105,11 +105,11 @@
         required/>
       </div>
     </div>
-    <button ng-click="createRepos()"
+    <button type="button" ng-click="createRepos()"
       ng-disabled="creating() || !requiredFieldsEnabled()"
-      translate
       class="btn btn-primary">
-      <i class="pficon-add-circle-o inline-icon"></i>	Create
+      <i class="pficon-add-circle-o inline-icon"></i>
+      <span translate>Create</span>
       <i class="fa fa-spinner fa-spin" ng-show="creating()"></i>
     </button>
   </section>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery.html
@@ -28,7 +28,7 @@
                 ng-click="cancelDiscovery()"
                 class="btn btn-primary btn-lg">
           <i class="fa fa-spinner fa-spin" ng-show="discovery.pending"></i>
-          {{ 'Cancel' | translate }}
+          <span translate>Cancel</span>
         </button>
       </span>
 
@@ -53,7 +53,7 @@
       </div>   
 
       <div ng-hide="system.readonly" class="nutupane-actions fr">
-        <button class="btn btn-primary"
+        <button type="button" class="btn btn-primary"
                 translate
                 ng-hide="denied('create_products')"
                 ng-disabled="discoveryTable.getSelected().length == 0"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/products.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/products.html
@@ -7,14 +7,14 @@
   </div>
 
   <div data-block="list-actions">
-    <button class="btn btn-primary"
+    <button type="button" class="btn btn-primary"
             ui-sref="products.new.form"
             bst-feature-flag="custom_products"
             ng-show="permitted('create_products')">
       <span translate>Create Product</span>
     </button>
 
-    <button class="btn btn-default"
+    <button type="button" class="btn btn-default"
             ui-sref="product-discovery.scan"
             bst-feature-flag="custom_products"
             ng-show="permitted('edit_products')">
@@ -22,7 +22,7 @@
     </button>
 
     <div class="btn-group" uib-dropdown keyboard-nav>
-      <button class="btn btn-default"
+      <button type="button" class="btn btn-default"
               ng-show="permitted('sync_products')"
               ng-disabled="table.numSelected == 0"
               ng-click="syncProducts()">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/views/manifest-import.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/views/manifest-import.html
@@ -26,14 +26,14 @@
     </div>
 
     <div class="detail pull-left" ng-show="upstream != null">
-      <button class="btn btn-default" ng-disabled="isTaskPending()"
+      <button type="button" class="btn btn-default" ng-disabled="isTaskPending()"
               ng-hide="denied('delete_manifest')"
               ng-click="deleteManifest()">
          <i class="fa fa-spinner fa-spin" ng-show="deleteTask.pending"></i>
           <span ng-show="deleteTask.pending" translate>Deleting Manifest...</span>
           <span ng-hide="deleteTask.pending" translate>Delete Manifest</span>
       </button>
-      <button class="btn btn-default" ng-disabled="upstream.idCert == undefined || upstream.idCert.cert == undefined"
+      <button type="button" class="btn btn-default" ng-disabled="upstream.idCert == undefined || upstream.idCert.cert == undefined"
         ng-click="refreshManifest()">
          <i class="fa fa-spinner fa-spin" ng-show="refreshTask.pending"></i>
           <span ng-show="refreshTask.pending" translate>Refreshing Manifest...</span>
@@ -64,7 +64,7 @@
     </div>
 
     <div class="form-group">
-      <button class="btn btn-primary" ng-disabled="isTaskPending()" upload-submit>
+      <button type="button" class="btn btn-primary" ng-disabled="isTaskPending()" upload-submit>
         <i class="fa fa-spinner fa-spin" ng-show="task.pending"></i>
         <span ng-show="task.pending" translate>Uploading...</span>
         <span ng-hide="task.pending" translate>Upload</span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/subscriptions.html
@@ -7,11 +7,11 @@
   </header>
 
   <div data-block="list-actions">
-    <button class="btn btn-primary" ng-if="!hasManifest" ui-sref="subscriptions-manifest.import"
+    <button type="button" class="btn btn-primary" ng-if="!hasManifest" ui-sref="subscriptions-manifest.import"
             ng-hide="denied('import_manifest') && denied('delete_manifest')">
       <span translate>Import Manifest</span>
     </button>
-    <button class="btn btn-primary" ng-if="hasManifest" ui-sref="subscriptions-manifest.details"
+    <button type="button" class="btn btn-primary" ng-if="hasManifest" ui-sref="subscriptions-manifest.details"
             ng-hide="denied('import_manifest') && denied('delete_manifest')">
       <span translate>Manage Manifest</span>
     </button>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/views/sync-plan-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/views/sync-plan-details.html
@@ -15,7 +15,7 @@
 
   <nav data-block="item-actions">
     <div class="btn-group" uib-dropdown keyboard-nav bst-feature-flag="custom_products">
-      <button class="btn btn-default" ng-disabled="denied('sync_products')" ng-click="runSyncPlan()">
+      <button type="button" class="btn btn-default" ng-disabled="denied('sync_products')" ng-click="runSyncPlan()">
         <span translate>Run Sync Plan</span>
       </button>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/views/sync-plan-products.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/views/sync-plan-products.html
@@ -22,18 +22,20 @@
 <div data-extend-template="layouts/partials/table.html">
   <div data-block="list-actions">
     <button ng-if="isState('sync-plan.products.list')"
+            type="button"
             class="btn btn-default"
             ng-hide="denied('edit_products')"
             ng-disabled="table.numSelected == 0 || table.working"
             ng-click="removeProducts()">
-      {{ 'Remove Selected' | translate}}
+      <span translate>Remove Selected</span>
     </button>
     <button ng-if="isState('sync-plan.products.add')"
+            type="button"
             class="btn btn-default"
             ng-hide="denied('edit_products')"
             ng-disabled="table.numSelected == 0 || table.working"
             ng-click="addProducts()">
-      {{ 'Add Selected' | translate }}
+      <span translate>Add Selected</span>
     </button>
   </div>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/views/sync-plans.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/views/sync-plans.html
@@ -7,8 +7,8 @@
   </header>
 
   <div data-block="list-actions">
-    <button class="btn btn-primary" ui-sref="sync-plans.new" ng-hide="denied('create_sync_plans')">
-      {{ "Create Sync Plan" | translate }}
+    <button type="button" class="btn btn-primary" ui-sref="sync-plans.new" ng-hide="denied('create_sync_plans')">
+      <span translate>Create Sync Plan</span>
     </button>
   </div>
 


### PR DESCRIPTION
Since patternfly tables CSS requires the table actions header to be in a
form it is important for all buttons to have type="button" as the
default type for html buttons is submit which thereby "submits" causing
the ng-click event of the first button in the form to be executed.

http://projects.theforeman.org/issues/18448