### PR TITLE
Fixes #18459: fix incremental update select content host display

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/apply-errata-select-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/apply-errata-select-content-hosts.html
@@ -1,7 +1,5 @@
 <div data-extend-template="errata/details/views/erratum-content-hosts.html">
-  <div data-block="list-actions"></div>
-
-  <div data-block="footer-actions" class="footer-actions">
+  <div data-block="list-actions">
     <button type="button" class="btn btn-default" ng-click="transitionTo('errata')" translate>Cancel</button>
     <button type="submit" class="btn btn-primary" ng-disabled="table.numSelected === 0 || incrementalUpdates.length > 0"
             ng-click="goToNextStep()" translate>Next</button>


### PR DESCRIPTION
The next and cancel buttons for incremental update were being displayed
below the table and if there were a lot of content hosts the user would
have to scroll through the entire list of content hosts (due to infinite
scrolling) in order to get to the buttons.  This commit temporarily
moves the next/cancel buttons to the top of the table until this entire
workflow can be replaced by the angular-patternfly wizard.

http://projects.theforeman.org/issues/18459