### PR TITLE
Fixes #18220: remove unused sub-header block.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
@@ -1,6 +1,6 @@
 <span page-title ng-model="host">{{ 'Errata for: ' | translate }} {{ host.name }}</span>
 
-<div data-block="sub-header" bst-feature-flag="remote_actions">
+<div bst-feature-flag="remote_actions">
   <h3 translate ng-hide="selectedErrataOption === 'current'">Applicable Errata</h3>
   <h3 translate ng-show="selectedErrataOption === 'current'">Installable Errata</h3>
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-applicable.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-applicable.html
@@ -1,8 +1,6 @@
 <span page-title ng-model="host">{{ 'Packages for: ' | translate }} {{ host.name }}</span>
 
-<div data-block="sub-header">
-  <h3 translate>Applicable Packages</h3>
-</div>
+<h3 translate>Applicable Packages</h3>
 
 <div data-extend-template="layouts/partials/table.html">
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-installed.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-installed.html
@@ -11,9 +11,7 @@
   </p>
 </section>
 
-<header data-block="sub-header" translate>
-  Installed Packages
-</header>
+<h3 translate>Installed Packages</h3>
 
 <div data-extend-template="layouts/partials/table.html">
   <span data-block="no-rows-message" translate>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-traces.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-traces.html
@@ -24,11 +24,9 @@
     <input type="hidden" name="authenticity_token" ng-value="traceActionFormValues.authenticityToken"/>
   </form>
 
-  <div data-extend-template="layouts/partials/table.html">
-    <div data-block="sub-header" bst-feature-flag="remote_actions" translate>
-      Traces
-    </div>
+  <h3 translate bst-feature-flag="remote_actions">Traces</h3>
 
+  <div data-extend-template="layouts/partials/table.html">
     <span data-block="list-actions" ng-hide="contentHost.readonly">
       <div bst-modal="performViaRemoteExecution(false)" model="host">
         <div data-block="modal-header" translate>Restart Services on Content Host "{{host.name}}"?</div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/components/views/content-view-composite-available-content-views.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/components/views/content-view-composite-available-content-views.html
@@ -1,10 +1,8 @@
 <span page-title ng-model="contentView">{{ 'Available Content Views for Composite Content View:' | translate }} {{ contentView.name }}</span>
 
-<header data-block="sub-header">
-  <h3 translate>
-    Add Content Views to {{ contentView.name }}
-  </h3>
-</header>
+<h3 translate>
+  Add Content Views to {{ contentView.name }}
+</h3>
 
 <div data-extend-template="layouts/partials/table.html">
   <div data-block="messages">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/components/views/content-view-composite-content-views-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/components/views/content-view-composite-content-views-list.html
@@ -1,10 +1,8 @@
 <span page-title ng-model="contentView">{{ 'Content Views for Composite Content View:' | translate }} {{ contentView.name }}</span>
 
-<header data-block="sub-header">
-  <h3 translate>
-    Content Views for {{ contentView.name }}
-  </h3>
-</header>
+<h3 translate>
+  Content Views for {{ contentView.name }}
+</h3>
 
 <div data-extend-template="layouts/partials/table.html">
   <div data-block="list-actions">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/new-filter.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/new-filter.html
@@ -1,9 +1,7 @@
 <span page-title ng-model="contentView">{{ 'New Filter for Content View:' | translate }} {{ contentView.name }}</span>
 
-<header data-block="sub-header`">
-  <h3 ng-show="stateIncludes('content-view.yum')" translate>Add New Yum Filter</h3>
-  <h3 ng-show="stateIncludes('content-view.docker')" translate>Add New Docker Tag Filter</h3>
-</header>
+<h3 ng-show="stateIncludes('content-view.yum')" translate>Add New Yum Filter</h3>
+<h3 ng-show="stateIncludes('content-view.docker')" translate>Add New Docker Tag Filter</h3>
 
 <form name="filterForm" class="col-sm-5" role="form" novalidate>
   <div bst-form-group label="{{ 'Name' | translate }}">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/histories/views/content-view-history.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/histories/views/content-view-history.html
@@ -1,8 +1,6 @@
 <span page-title ng-model="contentView">{{ 'History for Content View:' | translate }} {{ contentView.name }}</span>
 
-<header data-block="sub-header">
-  <h3 translate>Promotion History</h3>
-</header>
+<h3 translate>Promotion History</h3>
 
 <div data-extend-template="layouts/partials/table.html">
   <span data-block="no-rows-message" translate>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/views/content-view-puppet-module-names.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/views/content-view-puppet-module-names.html
@@ -1,10 +1,8 @@
 <span page-title ng-model="contentView">{{ 'Available Puppet Modules for Content View:' | translate }} {{ contentView.name }}</span>
 
-<header data-block="sub-header">
-  <h3 translate>
-    Select A New Puppet Module To Add
-  </h3>
-</header>
+<h3 translate>
+  Select A New Puppet Module To Add
+</h3>
 
 <div data-extend-template="layouts/partials/table.html">
   <span data-block="no-rows-message" translate>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/views/content-view-puppet-module-versions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/views/content-view-puppet-module-versions.html
@@ -1,10 +1,8 @@
 <span page-title ng-model="$stateParams">{{ 'Versions for Puppet Module:' | translate }} {{ $stateParams.moduleName }}</span>
 
-<header data-block="sub-header">
-  <h3 translate>
-    Select an Available Version of {{ $stateParams.moduleName }}
-  </h3>
-</header>
+<h3 translate>
+  Select an Available Version of {{ $stateParams.moduleName }}
+</h3>
 
 <div data-extend-template="layouts/partials/table.html">
   <span data-block="no-rows-message" translate>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-docker-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-docker-repositories.html
@@ -1,10 +1,8 @@
 <span page-title ng-model="contentView">{{ 'Repositories for Content View:' | translate }} {{ contentView.name }}</span>
 
-<header data-block="sub-header">
-  <h3 translate>
-    Docker Repository Selection
-  </h3>
-</header>
+<h3 translate>
+  Docker Repository Selection
+</h3>
 
 <nav data-block="navigation">
   <ul class="nav nav-tabs nav-tabs-pf" ng-show="permitted('edit_content_views', contentView)">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-file-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-file-repositories.html
@@ -1,8 +1,6 @@
 <span page-title ng-model="contentView">{{ 'Repositories for Content View:' | translate }} {{ contentView.name }}</span>
 
-<header data-block="sub-header">
-  <h3 translate>File Repositories</h3>
-</header>
+<h3 translate>File Repositories</h3>
 
 <nav data-block="navigation">
   <ul class="nav nav-tabs nav-tabs-pf" ng-show="permitted('edit_content_views', contentView)">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-info.html
@@ -1,7 +1,6 @@
 <span page-title ng-model="contentView">{{ 'Details for Content View:' | translate }} {{ contentView.name }}</span>
-<header data-block="sub-header">
-  <h3 translate>Details for {{ contentView.name }}</h3>
-</header>
+
+<h3 translate>Details for {{ contentView.name }}</h3>
 
 <div class="row">
   <div class="col-sm-6">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-ostree-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-ostree-repositories.html
@@ -1,8 +1,6 @@
 <span page-title ng-model="contentView">{{ 'Repositories for Content View:' | translate }} {{ contentView.name }}</span>
 
-<header data-block="sub-header">
-  <h3 translate>OSTree Repositories</h3>
-</header>
+<h3 translate>OSTree Repositories</h3>
 
 <nav data-block="navigation">
   <ul class="nav nav-tabs nav-tabs-pf" ng-show="permitted('edit_content_views', contentView)">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-repositories.html
@@ -1,10 +1,8 @@
 <span page-title ng-model="contentView">{{ 'Repositories for Content View:' | translate }} {{ contentView.name }}</span>
 
-<header data-block="sub-header">
-  <h3 translate>
-    Repository Selection
-  </h3>
-</header>
+<h3 translate>
+  Repository Selection
+</h3>
 
 <nav>
   <ul class="nav nav-tabs nav-tabs-pf" ng-show="permitted('edit_content_views', contentView)">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/erratum-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/erratum-content-hosts.html
@@ -1,8 +1,6 @@
 <span page-title>{{ 'Apply Errata to Content Hosts' | translate }}</span>
 
-<header data-block="sub-header" translate>
-  Apply to Content Hosts
-</header>
+<h3 translate>Apply to Content Hosts</h3>
 
 <div data-extend-template="layouts/partials/table.html">
   <div data-block="list-actions">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/erratum-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/erratum-repositories.html
@@ -1,8 +1,6 @@
 <span page-title ng-model="errata">{{ 'Repositories for Errata: ' | translate }} {{ errata.title }}</span>
 
-<div data-block="sub-header">
-  <h3 translate>Repositories containing Errata {{ errata.errata_id }}</h3>
-</div>
+<h3 translate>Repositories containing Errata {{ errata.errata_id }}</h3>
 
 <div data-extend-template="layouts/partials/table.html">
   <div data-block="filters">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/apply-errata-select-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/apply-errata-select-content-hosts.html
@@ -1,5 +1,4 @@
 <div data-extend-template="errata/details/views/erratum-content-hosts.html">
-  <div data-block="sub-header"></div>
   <div data-block="list-actions"></div>
 
   <div data-block="footer-actions" class="footer-actions">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/views/package-files.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/views/package-files.html
@@ -1,8 +1,6 @@
 <span page-title ng-model="package">{{ 'Package: ' | translate }} {{ package.nvrea }}</span>
 
-<header data-block="sub-header">
-  <h3 translate>Files in package {{ package.nvrea }}</h3>
-</header>
+<h3 translate>Files in package {{ package.nvrea }}</h3>
 
 <ul class="list-unstyled">
   <li ng-repeat="item in package.files | orderBy:'toString()'">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/views/package-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/views/package-repositories.html
@@ -1,8 +1,6 @@
 <span page-title ng-model="package">{{ 'Repositories for Package: ' | translate }} {{ package.nvrea }}</span>
 
-<div data-block="sub-header">
-  <h3 translate>Repositories containing package {{ package.nvrea }}</h3>
-</div>
+<h3 translate>Repositories containing package {{ package.nvrea }}</h3>
 
 <div data-extend-template="layouts/partials/table.html">
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-manage-puppet-modules.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-manage-puppet-modules.html
@@ -1,8 +1,6 @@
 <span page-title ng-model="repository">{{ 'Manage Puppet Modules for Repository:' | translate }} {{ repository.name }}</span>
 
-<div data-block="sub-header" translate>
-  Manage Puppet Modules for {{ repository.name }}
-</div>
+<h3 translate>Manage Puppet Modules for {{ repository.name }}</h3>
 
 <div data-block="messages">
   <div bst-alerts success-messages="successMessages" error-messages="errorMessages"></div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -1,8 +1,6 @@
 <span page-title>{{ 'New Repository' | translate }}</span>
 
-<header data-block="sub-header">
-  <h2 translate>New Repository</h2>
-</header>
+<h3 translate>New Repository</h3>
 
 <div bst-alerts error-messages="errorMessages" success-messages="successMessages"></div>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/puppet-modules/details/views/puppet-module-content-views.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/puppet-modules/details/views/puppet-module-content-views.html
@@ -1,8 +1,6 @@
 <span page-title ng-model="puppetModule">{{ 'Content Views for Puppet Module: ' | translate }} {{ puppetModule.name }}</span>
 
-<div data-block="sub-header" translate>
-  Content Views that contain this Puppet Module
-</div>
+<h3 translate>Content Views that contain this Puppet Module</h3>
 
 <div data-extend-template="layouts/partials/table.html">
   <span data-block="no-rows-message" translate>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/puppet-modules/details/views/puppet-module-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/puppet-modules/details/views/puppet-module-repositories.html
@@ -1,8 +1,6 @@
 <span page-title ng-model="puppetModule">{{ 'Repositories for Puppet Module: ' | translate }} {{ puppetModule.name }}</span>
 
-<div data-block="sub-header" translate>
-  Library Repositories that contain this Puppet Module.
-</div>
+<h3 translate>Library Repositories that contain this Puppet Module.</h3>
 
 <div data-extend-template="layouts/partials/table.html">
   <span data-block="no-rows-message" translate>


### PR DESCRIPTION
The sub-header block has been removed so we should go ahead and clean up
katello by removing the references to it.

http://projects.theforeman.org/issues/18220