### PR TITLE
Fixes #18486 - log a warning instead of error when host is missing

### DIFF
--- a/app/models/katello/events/import_host_applicability.rb
+++ b/app/models/katello/events/import_host_applicability.rb
@@ -5,7 +5,7 @@ module Katello
 
       def initialize(object_id)
         @host = ::Host.find_by_id(object_id)
-        fail "Host not found for ID #{object_id}" if @host.nil?
+        Rails.logger.warn "Host not found for ID #{object_id}" if @host.nil?
       end
 
       def run


### PR DESCRIPTION
Previously, an error with stack trace was logged when a host was not found by
the katello_events job listener.

Instead, just log a warning and move on. The `run` phase also checks if `@host`
is set, so there's no need to raise an exeception.