### PR TITLE
Fixes #18497 - Allow creating package groups via API

### DIFF
--- a/app/controllers/katello/api/v2/package_groups_controller.rb
+++ b/app/controllers/katello/api/v2/package_groups_controller.rb
@@ -3,6 +3,57 @@ module Katello
     apipie_concern_subst(:a_resource => N_("a package group"), :resource => "package_groups")
     include Katello::Concerns::Api::V2::RepositoryContentController
 
+    before_action :find_repository
+
+    api :POST, "/package_group", N_("Create a package group")
+    param :repository_id, String, :required => true, :desc => N_("repository_id")
+    param :name, String, :required => true, :desc => N_("package group name.")
+    param :description, String, :desc => N_("package group description. Defaults to params[:name]")
+    param :user_visible, :bool, :desc => N_("set \"user_visible\" flag on package group. Defaults to true")
+    param :mandatory_package_names, Array, :desc => N_("mandatory package names to include in the package group")
+    param :optional_package_names, Array, :desc => N_("optional package names to include in the package group")
+    param :conditional_package_names, Array, :desc => N_("conditional package names to include in the package group")
+    param :default_package_names, Array, :desc => N_("default package names to include in the package group")
+
+    def create
+      fail HttpErrors::BadRequest, _("name not defined.") if params[:name].blank?
+      fail HttpErrors::BadRequest, _("repository_id not defined.") if params[:repository_id].blank?
+      fail Katello::Errors::InvalidRepositoryContent, _("Can only upload to Yum Repositories.") unless @repo.yum?
+
+      if params[:mandatory_package_names].empty? && params[:optional_package_names].empty? &&
+         params[:conditional_package_names].empty? && params[:default_package_names].empty?
+        fail HttpErrors::BadRequest, _("Must supply at least one of mandatory_package_names, " \
+          "optional_package_names, conditional_package_names, default_package_names parameters")
+      end
+
+      params.each do |key, value|
+        if key.to_s.include?('_package_names')
+          if value.present?
+            fail HttpErrors::BadRequest, _("%s must be an array.") % key unless value.is_a?(Array)
+          end
+        end
+      end
+
+      params[:description] = params[:name] if params[:description].empty?
+      params[:user_visible] = ::Foreman::Cast.to_bool(params[:user_visible])
+      params[:user_visible] ||= true
+
+      sync_task(::Actions::Katello::Repository::UploadPackageGroup, @repo, params)
+      render :json => {:status => "success"}
+    end
+
+    api :DELETE, "/package_group", N_("Delete a package group")
+    param :name, String, :required => true, :desc => N_("package group name")
+    param :repository_id, String, :required => true, :desc => N_("repository_id")
+
+    def destroy
+      fail Katello::Errors::InvalidRepositoryContent, _("Can only destroy on Yum Repositories.") unless @repo.yum?
+      fail _("name not defined.") if params[:name].blank?
+
+      sync_task(::Actions::Katello::Repository::DestroyPackageGroup, @repo, params[:name])
+      render :json => {:status => "success"}
+    end
+
     def available_for_content_view_filter(filter, collection)
       collection_ids = []
       current_ids = filter.package_group_rules.map(&:uuid)

--- a/app/lib/actions/katello/repository/destroy_package_group.rb
+++ b/app/lib/actions/katello/repository/destroy_package_group.rb
@@ -1,0 +1,26 @@
+module Actions
+  module Katello
+    module Repository
+      class DestroyPackageGroup < Actions::EntryAction
+        def plan(repository, pkg_group_id)
+          action_subject(repository)
+          criteria = { type_ids: ["package_group"], filters: {"unit": {"name": pkg_group_id} } }
+
+          sequence do
+            ::Katello.pulp_server.extensions.repository.unassociate_units(repository.pulp_id, criteria)
+            plan_action(IndexPackageGroups, repository)
+            plan_action(Katello::Repository::MetadataGenerate, repository)
+          end
+        end
+
+        def rescue_strategy
+          Dynflow::Action::Rescue::Skip
+        end
+
+        def humanized_name
+          _("Delete Package Group")
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/repository/upload_package_group.rb
+++ b/app/lib/actions/katello/repository/upload_package_group.rb
@@ -1,0 +1,34 @@
+module Actions
+  module Katello
+    module Repository
+      class UploadPackageGroup < Actions::EntryAction
+        def plan(repository, params)
+          action_subject(repository)
+          unit_key = {"repo_id": repository.pulp_id, "id": params[:name].parameterize.underscore}
+          params = params.slice(:name, :description, :user_visible, :mandatory_package_names, :optional_package_names, :conditional_package_names, :default_package_names)
+
+          sequence do
+            upload_request = plan_action(Pulp::Repository::CreateUploadRequest)
+            pkg_group_upload = plan_action(Pulp::Repository::ImportUpload,
+                                           pulp_id: repository.pulp_id,
+                                           unit_type_id: 'package_group',
+                                           unit_key: unit_key,
+                                           upload_id: upload_request.output[:upload_id],
+                                           unit_metadata: params)
+
+            plan_action(IndexPackageGroups, repository)
+            plan_action(FinishUpload, repository, :dependency => pkg_group_upload.output, :generate_metadata => true)
+          end
+        end
+
+        def rescue_strategy
+          Dynflow::Action::Rescue::Skip
+        end
+
+        def humanized_name
+          _("Create Package Group")
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp/repository/import_upload.rb
+++ b/app/lib/actions/pulp/repository/import_upload.rb
@@ -7,6 +7,7 @@ module Actions
           param :unit_type_id
           param :upload_id
           param :unit_key
+          param :unit_metadata
         end
 
         def invoke_external_task
@@ -14,7 +15,7 @@ module Actions
                                                    input[:unit_type_id],
                                                    input[:upload_id],
                                                    input[:unit_key],
-                                                    unit_metadata: {})
+                                                   unit_metadata: input[:unit_metadata] || {})
         end
       end
     end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -193,6 +193,8 @@ Katello::Engine.routes.draw do
         api_resources :package_groups, :only => [:index, :show] do
           collection do
             get :auto_complete_search
+            post :create
+            delete :destroy
           end
         end
 

--- a/lib/katello/permissions/product_permissions.rb
+++ b/lib/katello/permissions/product_permissions.rb
@@ -38,7 +38,8 @@ Foreman::Plugin.find(:katello).security_block :products do
   permission :create_products,
              {
                'katello/api/v2/products' => [:create],
-               'katello/api/v2/repositories' => [:create]
+               'katello/api/v2/repositories' => [:create],
+               'katello/api/v2/package_groups' => [:create]
              },
              :resource_type => 'Katello::Product'
   permission :edit_products,
@@ -55,7 +56,8 @@ Foreman::Plugin.find(:katello).security_block :products do
                'katello/api/v2/products' => [:destroy],
                'katello/api/v2/repositories' => [:destroy],
                'katello/api/v2/products_bulk_actions' => [:destroy_products],
-               'katello/api/v2/repositories_bulk_actions' => [:destroy_repositories]
+               'katello/api/v2/repositories_bulk_actions' => [:destroy_repositories],
+               'katello/api/v2/package_groups' => [:destroy]
              },
              :resource_type => 'Katello::Product'
   permission :sync_products,


### PR DESCRIPTION
This creates a POST API at `/katello/api/package_groups` for creation and a DELETE API at `/katello/api/package_groups`for deletion.

I've split the API and UI into separate issues because I don't feel like there is a good place to put the UI for this currently. 