### PR TITLE
Refs #18498 - More visibility to package groups in the UI

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/views/product-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/views/product-repositories.html
@@ -141,6 +141,12 @@
                   {{ repository.content_counts.erratum || 0 }} Errata
                 </a>
               </div>
+
+              <div>
+                <a ui-sref="product.repository.manage-content.package-groups({productId: product.id, repositoryId: repository.id})">
+                  {{ repository.content_counts.package_group || 0 }} Package Groups
+                </a>
+              </div>
             </span>
 
             <span ng-show="repository.content_type == 'docker'">


### PR DESCRIPTION
Small change so Package Groups are listed in the repos page as well

![screenshot from 2017-02-14 17-06-05](https://cloud.githubusercontent.com/assets/13135483/22939849/ebf2daca-f2d7-11e6-957c-1fe2794832e0.png)
 
