### PR TITLE
Fixes #18499 - Add UUID in ContentView Filter Rule API

### DIFF
--- a/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
@@ -20,6 +20,7 @@ module Katello
         N_("Create a filter rule. The parameters included should be based upon the filter type.")
     param :content_view_filter_id, :identifier, :desc => N_("filter identifier"), :required => true
     param :name, [String, Array], :desc => N_("package, package group, or docker tag names")
+    param :uuid, String, :desc => N_("package group: uuid")
     param :version, String, :desc => N_("package: version")
     param :arch, String, :desc => N_("package: architecture")
     param :min_version, String, :desc => N_("package: minimum version")


### PR DESCRIPTION
UUID field is mandatory in adding Package Group to a Content View Filter. So its missing the API. This commit fixes that part of it.