### PR TITLE
Refs #18558 - Add advanced sync options

### DIFF
--- a/app/lib/actions/pulp/repository/download.rb
+++ b/app/lib/actions/pulp/repository/download.rb
@@ -1,0 +1,16 @@
+module Actions
+  module Pulp
+    module Repository
+      class Download < Pulp::AbstractAsyncTask
+        input_format do
+          param :pulp_id
+          param :options
+        end
+
+        def invoke_external_task
+          output[:pulp_tasks] = pulp_resources.repository.download(input[:pulp_id], input[:options])
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp/repository/sync.rb
+++ b/app/lib/actions/pulp/repository/sync.rb
@@ -8,6 +8,7 @@ module Actions
           param :pulp_id
           param :task_id # In case we need just pair this action with existing sync task
           param :source_url # allow overriding the feed URL
+          param :options # Pulp sync options
         end
 
         def invoke_external_task
@@ -27,10 +28,9 @@ module Actions
             end
 
             sync_options[:feed] = input[:source_url] if input[:source_url]
-
-            sync_options[:remove_missing] = input[:remove_missing] if input.key? :remove_missing
-
             sync_options[:validate] = !(SETTINGS[:katello][:pulp][:skip_checksum_validation])
+
+            sync_options.merge(input[:options]) if input[:options]
 
             output[:pulp_tasks] = pulp_tasks =
                 [pulp_resources.repository.sync(input[:pulp_id], override_config: sync_options)]

--- a/app/lib/katello/errors.rb
+++ b/app/lib/katello/errors.rb
@@ -1,5 +1,7 @@
 module Katello
   module Errors
+    class InvalidActionOptionError < StandardError; end
+
     class InvalidRepositoryContent < StandardError; end
 
     class InvalidPuppetModuleError < InvalidRepositoryContent; end

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "gettext_i18n_rails"
 
   # Pulp
-  gem.add_dependency "runcible", ">= 1.9.0", "< 2.0.0"
+  gem.add_dependency "runcible", ">= 1.9.3", "< 2.0.0"
   gem.add_dependency "anemone"
 
   # UI

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -689,21 +689,21 @@ module Katello
     end
 
     def test_sync_with_url_override
-      assert_async_task ::Actions::Katello::Repository::Sync do |repo, pulp_task_id, source_url|
+      assert_async_task ::Actions::Katello::Repository::Sync do |repo, pulp_task_id, options|
         repo.id.must_equal(@repository.id)
         pulp_task_id.must_equal(nil)
-        source_url.must_equal('file:///tmp/')
+        options[:source_url].must_equal('file:///tmp/')
       end
       post :sync, :id => @repository.id, :source_url => 'file:///tmp/'
       assert_response :success
     end
 
     def test_sync_with_incremental_flag
-      assert_async_task ::Actions::Katello::Repository::Sync do |repo, pulp_task_id, source_url, incremental|
+      assert_async_task ::Actions::Katello::Repository::Sync do |repo, pulp_task_id, options|
         repo.id.must_equal(@repository.id)
         pulp_task_id.must_equal(nil)
-        source_url.must_equal('file:///tmp/')
-        incremental.must_equal true
+        options[:source_url].must_equal('file:///tmp/')
+        options[:incremental].must_equal true
       end
       post :sync, :id => @repository.id, :source_url => 'file:///tmp/', :incremental => true
       assert_response :success


### PR DESCRIPTION
This adds two new sync options to the sync action:
* skip_metadata_check - pulp's version of 'force_full'
* validate_contents - uses on_demand, repository download action
   with verify_all_units to verify checksums and redownload corrupt
   or missing packages
