### PR TITLE
Fixes #18621 - Remove permissions for Katello::System

### DIFF
--- a/db/migrate/20170220679403_remove_system_permissions.rb
+++ b/db/migrate/20170220679403_remove_system_permissions.rb
@@ -1,0 +1,7 @@
+class RemoveSystemPermissions < ActiveRecord::Migration
+  def up
+    system_permissions = Permission.where(:resource_type => 'Katello::System')
+    system_permissions.flat_map(&:filters).map(&:destroy!)
+    system_permissions.map(&:destroy!)
+  end
+end


### PR DESCRIPTION
I do not think these are needed any more.