### PR TITLE
Fixes #18656 - fix smart proxy sync without user

### DIFF
--- a/app/lib/actions/pulp/abstract.rb
+++ b/app/lib/actions/pulp/abstract.rb
@@ -7,7 +7,7 @@ module Actions
       def pulp_resources(capsule_id = nil)
         capsule_id ||= input["capsule_id"]
         if capsule_id
-          capsule_content = ::Katello::CapsuleContent.new(SmartProxy.find(capsule_id))
+          capsule_content = ::Katello::CapsuleContent.new(SmartProxy.unscoped.find(capsule_id))
           capsule_content.pulp_server.resources
         else
           ::Katello.pulp_server.resources
@@ -17,7 +17,7 @@ module Actions
       def pulp_extensions(capsule_id = nil)
         capsule_id ||= input["capsule_id"]
         if capsule_id
-          capsule_content = ::Katello::CapsuleContent.new(SmartProxy.find(capsule_id))
+          capsule_content = ::Katello::CapsuleContent.new(SmartProxy.unscoped.find(capsule_id))
           capsule_content.pulp_server.extensions
         else
           ::Katello.pulp_server.extensions


### PR DESCRIPTION
after 5f606e11cf39719bf62f8b1f3396861b32387905 was merged into foreman
smart proxy with content could not sync because there is no user being set
as we do not need a user to talk to pulp.  So now just look up the smart
proxy unscoped