### PR TITLE
Fixes #18667 - Adapt HostsCollectionsController to Rails 4.2.8

### DIFF
--- a/app/controllers/katello/api/v2/host_collections_controller.rb
+++ b/app/controllers/katello/api/v2/host_collections_controller.rb
@@ -92,7 +92,8 @@ module Katello
       already_added_host_ids = @host_collection.host_ids & host_ids
       unfound_host_ids = host_ids - @hosts.pluck(:id)
 
-      @host_collection.host_ids += @editable_hosts.pluck(:id)
+      @host_collection.host_ids = (@host_collection.host_ids +
+                                   @editable_hosts.pluck(:id)).uniq
       @host_collection.save!
 
       messages = format_bulk_action_messages(


### PR DESCRIPTION
The controller knowingly tried to assign `@host_collection.host_ids =
[array with 2 equal ids]`. In Rails 4.2.8 this throws an exception, as
if you try to assign multiple IDs but there's only 1 object that matches
all of them, ActiveRecord will say "found 1 results but looking for 2"
and throw an exception.

Meant to be merged before https://github.com/theforeman/foreman/pull/4317/ so that we can upgrade the project to Rails 4.2.8. There is another failing test on a Pulp action related to VCR.