### PR TITLE
Fixes #18655 - Only index new rpms on repository sync

### DIFF
--- a/app/lib/actions/katello/repository/index_content.rb
+++ b/app/lib/actions/katello/repository/index_content.rb
@@ -9,11 +9,12 @@ module Actions
           param :id, Integer
           param :dependency, Hash
           param :contents_changed
+          param :full_index
         end
 
         def run
           repo = ::Katello::Repository.find(input[:id])
-          repo.index_content
+          repo.index_content(input[:full_index])
         end
       end
     end

--- a/app/lib/actions/katello/repository/sync.rb
+++ b/app/lib/actions/katello/repository/sync.rb
@@ -38,7 +38,7 @@ module Actions
             output = plan_action(Pulp::Repository::Sync, sync_args).output
 
             contents_changed = skip_metadata_check || output[:contents_changed]
-            plan_action(Katello::Repository::IndexContent, :id => repo.id, :contents_changed => contents_changed)
+            plan_action(Katello::Repository::IndexContent, :id => repo.id, :contents_changed => contents_changed, :full_index => skip_metadata_check)
             plan_action(Katello::Foreman::ContentUpdate, repo.environment, repo.content_view, repo)
             plan_action(Katello::Repository::CorrectChecksum, repo)
             concurrence do

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -703,9 +703,9 @@ module Katello
       end
     end
 
-    def index_content
+    def index_content(full_index = false)
       if self.yum?
-        Katello::Rpm.import_for_repository(self)
+        Katello::Rpm.import_for_repository(self, full_index)
         Katello::Erratum.import_for_repository(self)
         Katello::PackageGroup.import_for_repository(self)
         self.import_distribution_data

--- a/test/services/katello/pulp/rpm_test.rb
+++ b/test/services/katello/pulp/rpm_test.rb
@@ -13,7 +13,7 @@ module Katello
         VCR.insert_cassette('services/pulp/rpm')
         repo = Repository.find(@loaded_fixtures['katello_repositories']['fedora_17_x86_64']['id'])
         RepositorySupport.create_and_sync_repo(repo.id)
-        Katello::Rpm.import_for_repository(RepositorySupport.repo)
+        Katello::Rpm.import_for_repository(RepositorySupport.repo, true)
         @package_id = RepositorySupport.repo.rpms.first.id
       end
 


### PR DESCRIPTION
We index all rpms after a repository sync, which is unnecessary
for the already present rpms (in katello db). We should only
index the rpms that are not present in katello's db. This
new logic will say "What rpms are in pulp that are not in
our db for this repository?" and index those.

- [x] This needs an option to force a sync of all the rpms in a repository - waiting on https://github.com/Katello/katello/pull/6618 to be merged before adding