### PR TITLE
Fixes #17427 - Enable OSTree Upstream Sync Depth

### DIFF
--- a/app/lib/actions/katello/repository/create.rb
+++ b/app/lib/actions/katello/repository/create.rb
@@ -26,6 +26,8 @@ module Actions
                                         checksum_type: repository.checksum_type,
                                         path: path,
                                         download_policy: repository.download_policy,
+                                        ostree_upstream_sync_depth: repository.compute_ostree_upstream_sync_depth,
+                                        ostree_publish_depth: repository.compute_ostree_upstream_sync_depth,
                                         with_importer: true,
                                         mirror_on_sync: repository.mirror_on_sync?,
                                         ssl_validation: certs[:ssl_validation],

--- a/app/lib/actions/pulp/repository/create.rb
+++ b/app/lib/actions/pulp/repository/create.rb
@@ -23,6 +23,8 @@ module Actions
           param :ssl_validation
           param :upstream_username
           param :upstream_password
+          param :ostree_upstream_sync_depth
+          param :ostree_publish_depth
         end
 
         def run
@@ -77,6 +79,7 @@ module Actions
           importer.ssl_client_cert = input[:ssl_client_cert]
           importer.ssl_client_key  = input[:ssl_client_key]
           importer.ssl_validation  = input[:ssl_validation]
+          importer.depth           = input[:ostree_upstream_sync_depth]
           importer.basic_auth_username = input[:upstream_username] if input[:upstream_username].present?
           importer.basic_auth_password = input[:upstream_password] if input[:upstream_password].present?
           importer
@@ -180,6 +183,7 @@ module Actions
           options = { id: input[:pulp_id],
                       relative_path: input[:path],
                       auto_publish: true }
+          options[:depth] = input[:ostree_publish_depth] if input[:ostree_publish_depth]
           Runcible::Models::OstreeDistributor.new(options)
         end
       end

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -167,7 +167,7 @@ module Katello
           Runcible::Models::DockerImporter.new(importer_ssl_options(capsule).merge(options))
         when Repository::OSTREE_TYPE
           options = importer_ssl_options(capsule)
-
+          options[:depth] = capsule.default_capsule? ? compute_ostree_upstream_sync_depth : ostree_capsule_sync_depth
           options[:feed] = self.importer_feed_url(capsule)
           Runcible::Models::OstreeImporter.new(options)
         else
@@ -277,7 +277,9 @@ module Katello
         when Repository::OSTREE_TYPE
           options = { :id => self.pulp_id,
                       :auto_publish => true,
-                      :relative_path => relative_path }
+                      :relative_path => relative_path,
+                      :depth => self.ostree_publish_depth }
+
           dist = Runcible::Models::OstreeDistributor.new(options)
           distributors = [dist]
         else

--- a/app/views/katello/api/v2/repositories/show.json.rabl
+++ b/app/views/katello/api/v2/repositories/show.json.rabl
@@ -19,6 +19,7 @@ attributes :product_type
 attributes :promoted? => :promoted
 attributes :ostree_branch_names => :ostree_branches
 attributes :upstream_username
+attributes :ostree_upstream_sync_policy, :ostree_upstream_sync_depth, :compute_ostree_upstream_sync_depth => :computed_ostree_upstream_sync_depth
 
 if @resource.is_a?(Katello::Repository)
   if @resource.distribution_version || @resource.distribution_arch || @resource.distribution_family || @resource.distribution_variant

--- a/db/migrate/20170114051758_add_depth_to_repositories.rb
+++ b/db/migrate/20170114051758_add_depth_to_repositories.rb
@@ -1,0 +1,6 @@
+class AddDepthToRepositories < ActiveRecord::Migration
+  def change
+    add_column :katello_repositories, :ostree_upstream_sync_policy, :string, :limit => 25
+    add_column :katello_repositories, :ostree_upstream_sync_depth, :integer
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
@@ -8,13 +8,14 @@
  * @requires GPGKey
  * @requires CurrentOrganization
  * @requires DownloadPolicy
+ * @requires OstreeUpstreamSyncPolicy
  *
  * @description
  *   Provides the functionality for the repository details info page.
  */
 angular.module('Bastion.repositories').controller('RepositoryDetailsInfoController',
-    ['$scope', '$q', 'translate', 'GPGKey', 'CurrentOrganization', 'DownloadPolicy',
-    function ($scope, $q, translate, GPGKey, CurrentOrganization, DownloadPolicy) {
+    ['$scope', '$q', 'translate', 'GPGKey', 'CurrentOrganization', 'DownloadPolicy', 'OstreeUpstreamSyncPolicy',
+    function ($scope, $q, translate, GPGKey, CurrentOrganization, DownloadPolicy, OstreeUpstreamSyncPolicy) {
         $scope.successMessages = [];
         $scope.errorMessages = [];
         $scope.uploadSuccessMessages = [];
@@ -100,10 +101,18 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
             return checksum;
         };
         $scope.downloadPolicies = DownloadPolicy.downloadPolicies;
+        $scope.ostreeUpstreamSyncPolicies = OstreeUpstreamSyncPolicy.syncPolicies;
 
         $scope.downloadPolicyDisplay = function (downloadPolicy) {
             return DownloadPolicy.downloadPolicyName(downloadPolicy);
         };
 
+        $scope.ostreeUpstreamSyncPolicyDisplay = function (repository) {
+            var policy = repository["ostree_upstream_sync_policy"];
+            if ( policy === "custom") {
+                return OstreeUpstreamSyncPolicy.syncPolicyName(policy, repository["ostree_upstream_sync_depth"]);
+            }
+            return OstreeUpstreamSyncPolicy.syncPolicyName(policy);
+        };
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.filter.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.filter.js
@@ -1,0 +1,20 @@
+/**
+ * @ngdoc object
+ * @name  Bastion.repositories.controller:OstreeUpstreamSyncPolicyFilter
+ *
+ * @requires translate
+ * @requires OstreeUpstreamSyncPolicy
+ *
+ * @description
+ *   Provides the Ostree Upstream Sync policy filter functionality for the repository details info page.
+ */
+
+angular.module('Bastion.components.formatters').filter('ostreeUpstreamSyncPolicyFilter', ['translate', 'OstreeUpstreamSyncPolicy', function (translate, OstreeUpstreamSyncPolicy) {
+    return function (displayValue, repository) {
+        var policy = repository["ostree_upstream_sync_policy"];
+        if ( policy === "custom") {
+            return OstreeUpstreamSyncPolicy.syncPolicyName(policy, repository["ostree_upstream_sync_depth"]);
+        }
+        return OstreeUpstreamSyncPolicy.syncPolicyName(policy);
+    };
+}]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -70,7 +70,6 @@
             readonly="denied('edit_products', product)">
         </dd>
       </span>
-      
       <dt translate>Publish via HTTPS</dt>
       <dd translate>Yes</dd>
 
@@ -94,6 +93,23 @@
           </span>
         </p>
       </dd>
+      <span ng-if="repository.content_type == 'ostree'">
+        <dt translate>Upstream Sync Policy</dt>
+        <dd bst-edit-custom="repository.ostree_upstream_sync_policy"
+            readonly="denied('edit_products', product)"
+            on-save="save(repository)"
+            formatter="ostreeUpstreamSyncPolicyFilter"
+            formatter-options="repository"
+            >
+            <select ng-options="id as name for (id, name) in ostreeUpstreamSyncPolicies" ng-model="repository.ostree_upstream_sync_policy">
+            </select>
+            <input id="ostree_upstream_sync_depth"
+              name="ostree_upstream_sync_depth"
+              ng-model="repository.ostree_upstream_sync_depth"
+              type="number"
+              ng-disabled="repository.ostree_upstream_sync_policy !== 'custom'"/>
+        </dd>
+      </span>
 
       <span ng-if="repository.content_type === 'yum' && !product.redhat">
         <dt translate>GPG Key</dt>
@@ -104,7 +120,6 @@
             on-save="save(repository)">
         </dd>
       </span>
-
       <span ng-if="repository.content_type == 'yum'">
         <dt translate>Download Policy</dt>
         <dd bst-edit-select="downloadPolicyDisplay(repository.download_policy)"
@@ -161,7 +176,7 @@
           <th colspan="2" translate>Content Type</th>
         </tr>
         </thead>
-        
+
         <tbody>
         <tr ng-show="repository.content_type === 'yum'">
           <td translate>Packages</td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/new-repository.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/new-repository.controller.js
@@ -12,13 +12,14 @@
  * @requires ApiErrorHandler
  * @requires BastionConfig
  * @requires DownloadPolicy
+ * @requires OstreeUpstreamSyncPolicy
  *
  * @description
  *   Controls the creation of an empty Repository object for use by sub-controllers.
  */
 angular.module('Bastion.repositories').controller('NewRepositoryController',
-    ['$scope', 'Repository', 'Product', 'GPGKey', 'FormUtils', 'translate', 'GlobalNotification', 'ApiErrorHandler', 'BastionConfig', 'DownloadPolicy',
-    function ($scope, Repository, Product, GPGKey, FormUtils, translate, GlobalNotification, ApiErrorHandler, BastionConfig, DownloadPolicy) {
+    ['$scope', 'Repository', 'Product', 'GPGKey', 'FormUtils', 'translate', 'GlobalNotification', 'ApiErrorHandler', 'BastionConfig', 'DownloadPolicy', 'OstreeUpstreamSyncPolicy',
+    function ($scope, Repository, Product, GPGKey, FormUtils, translate, GlobalNotification, ApiErrorHandler, BastionConfig, DownloadPolicy, OstreeUpstreamSyncPolicy) {
 
         function success() {
             GlobalNotification.setSuccessMessage(translate('Repository %s successfully created.').replace('%s', $scope.repository.name));
@@ -59,7 +60,8 @@ angular.module('Bastion.repositories').controller('NewRepositoryController',
 
         $scope.repository = new Repository({'product_id': $scope.$stateParams.productId, unprotected: true,
             'checksum_type': null, 'mirror_on_sync': true, 'verify_ssl_on_sync': true,
-            'download_policy': BastionConfig.defaultDownloadPolicy});
+            'download_policy': BastionConfig.defaultDownloadPolicy,
+            'ostree_upstream_sync_policy': 'latest'});
 
         $scope.product = Product.get({id: $scope.$stateParams.productId}, function () {
             $scope.page.loading = false;
@@ -73,6 +75,7 @@ angular.module('Bastion.repositories').controller('NewRepositoryController',
         });
 
         $scope.downloadPolicies = DownloadPolicy.downloadPolicies;
+        $scope.ostreeUpstreamSyncPolicies = OstreeUpstreamSyncPolicy.syncPolicies;
 
         $scope.$watch('repository.name', function () {
             if ($scope.repositoryForm && $scope.repositoryForm.name) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -47,6 +47,26 @@
 
       </div>
 
+      <div bst-form-group label="{{ 'Upstream Sync Policy' | translate }}"  ng-show="repository.content_type === 'ostree'">
+        <select required
+                id="ostree_upstream_sync_policy"
+                name="ostree_upstream_sync_policy"
+                ng-model="repository.ostree_upstream_sync_policy"
+                ng-options="id as name for (id, name) in ostreeUpstreamSyncPolicies">
+        </select>
+
+        <input id="ostree_upstream_sync_depth"
+               name="ostree_upstream_sync_depth"
+               ng-model="repository.ostree_upstream_sync_depth"
+               type="number"
+               ng-disabled="repository.ostree_upstream_sync_policy !== 'custom'"/>
+        <h6 translate>
+          Choose one of the policy selections for downloading ostree content from upstream url during synchronization. Choose "Latest" for downloading the latest version of the upstream branch. Choose "All History" to download all available versions of the upstream repository (this may take a large amount of space). Choose "Custom Depth" and provide an number to indicate the number of prior versions of the upstream branch to download.
+        </h6>
+
+      </div>
+
+
       <div bst-form-group label="{{ 'Upstream Repository Name' | translate }}"  ng-show="repository.content_type === 'docker'">
         <input id="docker_upstream_name"
                name="docker_upstream_name"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/ostree-upstream-sync-policy.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/ostree-upstream-sync-policy.service.js
@@ -1,0 +1,26 @@
+/**
+ * @ngdoc service
+ * @name  Bastion.repository.service:ostreeUpstreamSyncPolicy
+ *
+ * @requires translate
+ *
+ * @description
+ *   Provides a ostree upstream syncPolicies for repositories
+ */
+angular.module('Bastion.repositories').service('OstreeUpstreamSyncPolicy',
+    ['translate', function (translate) {
+
+        this.syncPolicies = {
+            'latest': translate('Latest Only'),
+            'all': translate('All History'),
+            'custom': translate('Custom Depth')
+        };
+
+        this.syncPolicyName = function (policy, depth) {
+            if (policy === "custom") {
+                return translate('Custom Depth (Currently %s)').replace('%s', depth.toString());
+            }
+            return this.syncPolicies[policy];
+        };
+    }]
+);

--- a/engines/bastion_katello/test/products/details/repositories/details/repository-details-info.controller.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/details/repository-details-info.controller.test.js
@@ -1,5 +1,5 @@
 describe('Controller: RepositoryDetailsInfoController', function() {
-    var $scope, $state, translate, repository, DownloadPolicy;
+    var $scope, $state, translate, repository, DownloadPolicy, OstreeUpstreamSyncPolicy;
 
     beforeEach(module(
         'Bastion.repositories',
@@ -14,6 +14,7 @@ describe('Controller: RepositoryDetailsInfoController', function() {
 
         repository = new Repository();
         DownloadPolicy = $injector.get("DownloadPolicy");
+        OstreeUpstreamSyncPolicy = $injector.get("OstreeUpstreamSyncPolicy");
         $scope = $injector.get('$rootScope').$new();
         $state = $injector.get('$state');
 
@@ -102,6 +103,10 @@ describe('Controller: RepositoryDetailsInfoController', function() {
 
     it ('should set download policies', function() {
        expect($scope.downloadPolicies).toBe(DownloadPolicy.downloadPolicies);
+    });
+
+    it ('should set ostree upstream sync policies', function() {
+       expect($scope.ostreeUpstreamSyncPolicies).toBe(OstreeUpstreamSyncPolicy.syncPolicies);
     });
 
     it('should set the upload status to success and refresh the repository if a file upload status is success', function() {

--- a/engines/bastion_katello/test/products/details/repositories/new/new-repository.controller.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/new/new-repository.controller.test.js
@@ -3,6 +3,7 @@ describe('Controller: NewRepositoryController', function() {
         FormUtils,
         GlobalNotification,
         DownloadPolicy,
+        OstreeUpstreamSyncPolicy,
         $httpBackend;
 
     beforeEach(module('Bastion.repositories', 'Bastion.test-mocks'));
@@ -16,6 +17,7 @@ describe('Controller: NewRepositoryController', function() {
             GPGKey = $injector.get('MockResource').$new();
 
         DownloadPolicy = $injector.get('DownloadPolicy');
+        OstreeUpstreamSyncPolicy = $injector.get('OstreeUpstreamSyncPolicy');
         $scope = $injector.get('$rootScope').$new();
         $httpBackend = $injector.get('$httpBackend');
         FormUtils = $injector.get('FormUtils');
@@ -94,5 +96,9 @@ describe('Controller: NewRepositoryController', function() {
 
     it ('should set download policies', function() {
        expect($scope.downloadPolicies).toBe(DownloadPolicy.downloadPolicies);
+    });
+
+    it ('should set ostree upstream sync policies', function() {
+       expect($scope.ostreeUpstreamSyncPolicies).toBe(OstreeUpstreamSyncPolicy.syncPolicies);
     });
 });

--- a/engines/bastion_katello/test/products/details/repositories/ostree-upstream-sync-policy.service.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/ostree-upstream-sync-policy.service.test.js
@@ -1,0 +1,19 @@
+describe('Service: OstreeUpstreamSyncPolicy', function() {
+    var OstreeUpstreamSyncPolicy;
+
+    beforeEach(module('Bastion.repositories'));
+
+    beforeEach(module(function ($provide) {
+        $provide.value('translate', function (string) { return string; });
+    }));
+
+    beforeEach(inject(function($injector) {
+        OstreeUpstreamSyncPolicy = $injector.get('OstreeUpstreamSyncPolicy');
+    }));
+
+    it("provides a method to convert a OstreeUpstreamSyncPolicy policy to a human readable version", function() {
+        expect(OstreeUpstreamSyncPolicy.syncPolicyName('latest')).toBe('Latest Only');
+        expect(OstreeUpstreamSyncPolicy.syncPolicyName('all')).toBe('All History');
+        expect(OstreeUpstreamSyncPolicy.syncPolicyName('custom', 100)).toBe('Custom Depth (Currently 100)');
+    });
+});

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "gettext_i18n_rails"
 
   # Pulp
-  gem.add_dependency "runcible", ">= 1.9.3", "< 2.0.0"
+  gem.add_dependency "runcible", ">= 1.10.0", "< 2.0.0"
   gem.add_dependency "anemone"
 
   # UI

--- a/test/factories/repository_factory.rb
+++ b/test/factories/repository_factory.rb
@@ -42,6 +42,12 @@ FactoryGirl.define do
       download_policy ""
     end
 
+    trait :ostree do
+      content_type "ostree"
+      download_policy ""
+      ostree_upstream_sync_policy "latest"
+    end
+
     factory :docker_repository, traits: [:docker]
   end
 end

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -429,6 +429,7 @@ ostree:
   gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>
   unprotected:           <%= true %>
+  ostree_upstream_sync_policy: latest
 
 ostree_view1:
   name:                 ostree


### PR DESCRIPTION
This commit enables one to set the Upstream Sync Policy and Sync depth.
Basically with this change one is now able to say "Download complete version history
when syncing an ostree repo"