### PR TITLE
Fixes #18738 - fixes the sub query

### DIFF
--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -51,6 +51,7 @@ module Katello
 
       total = scoped_search_total(query, group)
 
+      query = query.pluck(:id) if query.respond_to?(:pluck)
       query = resource.search_for(*search_options).where("#{resource.table_name}.id" => query)
 
       query = query.select(group).group(group) if group


### PR DESCRIPTION
I think this has been introduced by this change https://github.com/Katello/katello/commit/142ccd5dd837553626e79a603985b19216f773ed#diff-56ae1a984a0feed9e676a8e2f8240113R90

I'm not sure but I think it's similarly broken for all katello resources since this is generic method in api_controller. The problem I believe is in the fact the query needs to select only id attribute but it can contain other conditions, like `name = Library`. Doing the pluck introduces one more SQL query but make it safer since it does the (SELECT *) and returns id only, therefore it supports all conditions specified in filters.

I'm not familiar enough with katello testing infrastructure, so pointing me to some place where I could add a test for this and tips how to stub data would be appreciated.