### PR TITLE
Fixes #18779 - API organization_id can only be numeric

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -4,7 +4,7 @@ module Katello
 
     before_action :verify_presence_of_organization_or_environment, :only => [:index]
     before_action :find_environment, :only => [:index, :create, :update]
-    before_action :find_optional_organization, :only => [:index, :create, :show]
+    before_action :find_optional_nested_object, :only => [:index, :create, :show]
     before_action :find_content_view, :only => [:index]
     before_action :find_activation_key, :only => [:show, :update, :destroy, :available_releases, :copy, :product_content,
                                                   :available_host_collections, :add_host_collections, :remove_host_collections,

--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -108,15 +108,6 @@ module Katello
       return Util::Model.labelize(param_hash[:name]) unless param_hash.try(:[], :name).nil?
     end
 
-    def find_organization
-      @organization = Organization.current || find_optional_organization
-      if @organization.nil?
-        fail HttpErrors::NotFound, _("One of parameters [ %s ] required but not specified.") %
-            organization_id_keys.join(", ")
-      end
-      @organization
-    end
-
     def sort_params
       options = {}
       options[:sort_by] = params[:sort_by] if params[:sort_by]
@@ -124,26 +115,11 @@ module Katello
       options
     end
 
-    def find_optional_organization
-      org_id = organization_id
-      return if org_id.nil?
-
-      @organization = get_organization(org_id)
-      fail HttpErrors::NotFound, _("Couldn't find organization '%s'") % org_id if @organization.nil?
-      @organization
-    end
-
-    def organization_id
-      key = organization_id_keys.find { |k| !params[k].nil? }
-      return params[key]
-    end
-
-    def organization_id_keys
-      return [:organization_id]
-    end
-
-    def get_organization(org_id)
-      return Organization.find_by(:id => org_id)
+    def find_required_nested_object
+      result = super
+      # Foreman tends to use @nested_obj - but Katello controllers tend
+      # to use @organization as it's the most common case for nested objects
+      instance_variable_set("@#{result.class.to_s.downcase}", result)
     end
 
     def find_default_organization_and_or_environment

--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -4,8 +4,8 @@ module Katello
     include Katello::Concerns::FilteredAutoCompleteSearch
 
     before_action :find_content_view, :except => [:index, :create, :auto_complete_search]
-    before_action :find_organization, :only => [:create]
-    before_action :find_optional_organization, :only => [:index, :auto_complete_search]
+    before_action :find_required_nested_object, :only => [:create]
+    before_action :find_optional_nested_object, :only => [:index, :auto_complete_search]
     before_action :find_environment, :only => [:index, :remove_from_environment]
 
     wrap_parameters :include => (ContentView.attribute_names + %w(repository_ids component_ids))

--- a/app/controllers/katello/api/v2/environments_controller.rb
+++ b/app/controllers/katello/api/v2/environments_controller.rb
@@ -34,8 +34,8 @@ module Katello
     end
 
     respond_to :json
-    before_action :find_organization, :only => [:create, :paths, :auto_complete_search]
-    before_action :find_optional_organization, :only => [:index, :show, :update, :destroy]
+    before_action :find_required_nested_object, :only => [:create, :paths, :auto_complete_search]
+    before_action :find_optional_nested_object, :only => [:index, :show, :update, :destroy]
     before_action :find_prior, :only => [:create]
     before_action :find_environment, :only => [:show, :update, :destroy, :repositories]
     before_action :find_content_view, :only => [:repositories]

--- a/app/controllers/katello/api/v2/gpg_keys_controller.rb
+++ b/app/controllers/katello/api/v2/gpg_keys_controller.rb
@@ -2,7 +2,7 @@ module Katello
   class Api::V2::GpgKeysController < Api::V2::ApiController
     include Katello::Concerns::FilteredAutoCompleteSearch
     before_action :authorize
-    before_action :find_organization, :only => [:create, :index, :auto_complete_search]
+    before_action :find_required_nested_object, :only => [:create, :index, :auto_complete_search]
     before_action :find_gpg_key, :only => [:show, :update, :destroy, :content]
     skip_before_action :check_content_type, :only => [:create, :content]
 

--- a/app/controllers/katello/api/v2/host_collections_controller.rb
+++ b/app/controllers/katello/api/v2/host_collections_controller.rb
@@ -5,8 +5,8 @@ module Katello
                                                    :add_hosts, :remove_hosts, :hosts]
     before_action :find_activation_key
     before_action :find_host
-    before_action :find_optional_organization, :only => [:index]
-    before_action :find_organization, :only => [:create, :auto_complete_search]
+    before_action :find_optional_nested_object, :only => [:index]
+    before_action :find_required_nested_object, :only => [:create, :auto_complete_search]
 
     wrap_parameters :include => (HostCollection.attribute_names + %w(host_ids))
 

--- a/app/controllers/katello/api/v2/products_controller.rb
+++ b/app/controllers/katello/api/v2/products_controller.rb
@@ -3,7 +3,7 @@ module Katello
     include Katello::Concerns::FilteredAutoCompleteSearch
 
     before_action :find_activation_key, :only => [:index]
-    before_action :find_organization, :only => [:create, :index, :auto_complete_search]
+    before_action :find_required_nested_object, :only => [:create, :index, :auto_complete_search]
     before_action :find_product, :only => [:update, :destroy, :sync]
     before_action :find_organization_from_product, :only => [:update]
     before_action :authorize_gpg_key, :only => [:update, :create]

--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -2,7 +2,7 @@ module Katello
   class Api::V2::RepositoriesController < Api::V2::ApiController
     include Katello::Concerns::FilteredAutoCompleteSearch
 
-    before_action :find_optional_organization, :only => [:index, :auto_complete_search]
+    before_action :find_optional_nested_object, :only => [:index, :auto_complete_search]
     before_action :find_product, :only => [:index, :auto_complete_search]
     before_action :find_product_for_create, :only => [:create]
     before_action :find_organization_from_product, :only => [:create]

--- a/app/controllers/katello/api/v2/sync_controller.rb
+++ b/app/controllers/katello/api/v2/sync_controller.rb
@@ -1,6 +1,6 @@
 module Katello
   class Api::V2::SyncController < Api::V2::ApiController
-    before_action :find_optional_organization, :only => [:index]
+    before_action :find_optional_nested_resource, :only => [:index]
     before_action :find_object, :only => [:index]
     before_action :ensure_library, :only => [:index]
 

--- a/app/controllers/katello/api/v2/sync_plans_controller.rb
+++ b/app/controllers/katello/api/v2/sync_plans_controller.rb
@@ -3,7 +3,7 @@ module Katello
     respond_to :json
 
     include Katello::Concerns::FilteredAutoCompleteSearch
-    before_action :find_organization, :only => [:create, :index, :auto_complete_search]
+    before_action :find_required_nested_object, :only => [:create, :index, :auto_complete_search]
     before_action :find_plan, :only => [:update, :show, :destroy, :sync,
                                         :add_products, :remove_products]
 

--- a/app/controllers/katello/concerns/api/api_controller.rb
+++ b/app/controllers/katello/concerns/api/api_controller.rb
@@ -64,10 +64,6 @@ module Katello
         controller_name
       end
 
-      def resource_name
-        controller_name.singularize
-      end
-
       def respond(options = {})
         method_name = 'respond_for_' + params[:action].to_s
         fail "automatic response method '%s' not defined" % method_name unless respond_to?(method_name, true)

--- a/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
+++ b/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
@@ -7,7 +7,7 @@ module Katello
         include Katello::Concerns::FilteredAutoCompleteSearch
 
         before_action :find_repository
-        before_action :find_optional_organization, :only => [:index, :auto_complete_search]
+        before_action :find_optional_nested_object, :only => [:index, :auto_complete_search]
         before_action :find_environment, :only => [:index, :auto_complete_search]
         before_action :find_content_view_version, :only => [:index, :auto_complete_search]
         before_action :find_filter, :only => [:index, :auto_complete_search]

--- a/test/controllers/api/v2/products_controller_test.rb
+++ b/test/controllers/api/v2/products_controller_test.rb
@@ -37,6 +37,13 @@ module Katello
       assert_template 'api/v2/products/index'
     end
 
+    def test_index_organization_name
+      get :index, :organization_id => @organization.name
+
+      assert_response :success
+      assert_template 'api/v2/products/index'
+    end
+
     def test_index_name
       get :index, :organization_id => @organization.id, :name => @product.name
 

--- a/test/controllers/api/v2/subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/subscriptions_controller_test.rb
@@ -42,10 +42,10 @@ module Katello
     end
 
     def test_index_protected
-      allowed_perms = [@read_permission]
+      allowed_perms = [@read_permission, :view_organizations]
       denied_perms = [@attach_permission, @unattach_permission, @import_permission, @delete_permission]
 
-      assert_protected_action(:index, allowed_perms, denied_perms) do
+      assert_protected_action(:index, [allowed_perms], denied_perms, [@organization]) do
         get :index, :organization_id => @organization.id
       end
     end
@@ -76,10 +76,10 @@ module Katello
     end
 
     def test_upload_protected
-      allowed_perms = [@import_permission]
+      allowed_perms = [@import_permission, :view_organizations]
       denied_perms = [@attach_permission, @unattach_permission, @delete_permission, @read_permission]
 
-      assert_protected_action(:upload, allowed_perms, denied_perms) do
+      assert_protected_action(:upload, [allowed_perms], denied_perms, [@organization]) do
         post :upload, :organization_id => @organization.id
       end
     end
@@ -93,10 +93,10 @@ module Katello
     end
 
     def test_refresh_protected
-      allowed_perms = [@import_permission]
+      allowed_perms = [@import_permission, :view_organizations]
       denied_perms = [@attach_permission, @unattach_permission, @delete_permission, @read_permission]
 
-      assert_protected_action(:refresh_manifest, allowed_perms, denied_perms) do
+      assert_protected_action(:refresh_manifest, [allowed_perms], denied_perms, [@organization]) do
         put :refresh_manifest, :organization_id => @organization.id
       end
     end
@@ -110,10 +110,10 @@ module Katello
     end
 
     def test_delete_protected
-      allowed_perms = [@delete_permission]
+      allowed_perms = [@delete_permission, :view_organizations]
       denied_perms = [@attach_permission, @unattach_permission, @import_permission, @read_permission]
 
-      assert_protected_action(:delete_manifest, allowed_perms, denied_perms) do
+      assert_protected_action(:delete_manifest, [allowed_perms], denied_perms, [@organization]) do
         post :delete_manifest, :organization_id => @organization.id
       end
     end
@@ -125,10 +125,10 @@ module Katello
     end
 
     def test_manifest_history_protected
-      allowed_perms = [@read_permission]
+      allowed_perms = [@read_permission, :view_organizations]
       denied_perms = [@attach_permission, @unattach_permission, @import_permission, @delete_permission]
 
-      assert_protected_action(:manifest_history, allowed_perms, denied_perms) do
+      assert_protected_action(:manifest_history, [allowed_perms], denied_perms, [@organization]) do
         get :manifest_history, :organization_id => @organization.id
       end
     end

--- a/test/support/auth_support.rb
+++ b/test/support/auth_support.rb
@@ -50,7 +50,7 @@ module Katello
                             end
 
       role = create_role_with_permissions(actual_permissions)
-      user.roles = [role]
+      user.roles << role
       user
     end
 

--- a/test/support/controller_support.rb
+++ b/test/support/controller_support.rb
@@ -40,6 +40,10 @@ module ControllerSupport
         :organizations => organizations
     )
 
+    # Flush any roles to ensure the next check on refute_authorized
+    # does not carry an user with roles
+    User.unscoped.find(users(:restricted).id).roles = []
+
     unless denied_perms.empty?
       refute_authorized(
           :permission => denied_perms,


### PR DESCRIPTION
In paths like 'api/v2/organizations/:organization_id/products', or
'api/v2/products?organization_id=:organization_id' when you try to use a
name (e.g "ACMECORP") as the organization id, Foreman returns a 404.

However, the organization_id can be a name in most Foreman API paths and
'katello/api/v2/organizations/:organization_id'.

The problem is that the API controller is only searching by ID, but it
should use the 'friendly' scope provided by 'friendly_id' to search by
both name, title (for nested orgs) or numeric id.