### PR TITLE
Fixes #18781 - CSV export for products table

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.controller.js
@@ -49,6 +49,7 @@ angular.module('Bastion.products').controller('ProductsController',
 
         nutupane = new Nutupane(Product, params);
         $scope.controllerName = 'katello_products';
+        $scope.current_organization = CurrentOrganization;
         nutupane.masterOnly = true;
 
         $scope.table = nutupane.table;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/products.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/products.html
@@ -21,6 +21,10 @@
       <span translate>Repo Discovery</span>
     </button>
 
+    <a href="/katello/api/v2/organizations/{{current_organization}}/products.csv" class="btn btn-default">
+      <span translate>Export</span>
+    </a>
+
     <div class="btn-group" uib-dropdown keyboard-nav>
       <button type="button" class="btn btn-default"
               ng-show="permitted('sync_products')"


### PR DESCRIPTION
Since we are providing the ability to export to CSV on
projects.theforeman.org/issues/18670 , I think products is a table that
could easily use this feature.
This ticket is meant just as a way to introduce the feature in Katello
(reusing the infrastructure in Foreman), and the aim is to extend it
over to more tables. 

A few things I think would be nice to have before releasing this into the wild:

- [ ] Be able to specify any columns you want, hammer-cli-csv has this option. This is done on the Foreman side already.
- [ ] Extend the table directive to include this in any possible table with just a small flag

This is *NOT* meant to be merged as-is, it's only 
meant to demonstrate how easy it's to use the solution proposed in 
 https://github.com/theforeman/foreman/pull/4270 for all controllers. 

An alternative would be to make Foreman rely on the RABL templates and render those as CSV, as `Rabl.render(:format => :csv)` works.

Sample data (rename to `.csv`):
[products.csv.txt](https://github.com/Katello/katello/files/814490/products-2017-03-02.2.txt)

And the regular JSON output, for reference (rename to `.json`):
[products.json.txt](https://github.com/Katello/katello/files/814525/products.txt)


---------------------------

PS for @Rohoover 

I noticed this contradiction on the way the buttons are ordered in some tables. Notice the "blue" button in the two tables below. To me, it makes more sense that the "Create" button is positioned on the leftmost place, but I'm not sure nor I have data to proof anything. Any hints?

![screenshot from 2017-03-02 17-26-00](https://cloud.githubusercontent.com/assets/598891/23516682/3ac0c6e2-ff6e-11e6-931d-5b316a564779.png)
![screenshot from 2017-03-02 17-26-14](https://cloud.githubusercontent.com/assets/598891/23516681/3abe6596-ff6e-11e6-96de-4568608c82be.png)
 
cc @tbrisker @ares @thomasmckay @ohadlevy as I see you're interested on it (based on mails)