### PR TITLE
Fixes #18793: Ensure yum_clone_distributor is on default capsule repo

### DIFF
--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -249,7 +249,7 @@ module Katello
                                                                  :destination_distributor_id => yum_dist_id)
           export_dist = Runcible::Models::ExportDistributor.new(false, false, self.relative_path)
           distributors = [yum_dist, export_dist]
-          distributors << clone_dist unless capsule
+          distributors << clone_dist if capsule.nil? || capsule.default_capsule?
         when Repository::FILE_TYPE
           dist = Runcible::Models::IsoDistributor.new(true, true)
           dist.auto_publish = true

--- a/test/glue/pulp/repository_test.rb
+++ b/test/glue/pulp/repository_test.rb
@@ -180,8 +180,22 @@ module Katello
       assert Repository.delete_orphaned_content.is_a?(Hash)
     end
 
-    def test_generate_distributors
+    def test_generate_distributors_with_nil
       dists = @fedora_17_x86_64.generate_distributors
+      refute_empty dists.select { |d| d.is_a? Runcible::Models::YumDistributor }
+      refute_empty dists.select { |d| d.is_a? Runcible::Models::YumCloneDistributor }
+      refute_empty dists.select { |d| d.is_a? Runcible::Models::ExportDistributor }
+    end
+
+    def test_generate_distributors_with_external_capsule
+      dists = @fedora_17_x86_64.generate_distributors(OpenStruct.new(:default_capsule? => false))
+      refute_empty dists.select { |d| d.is_a? Runcible::Models::YumDistributor }
+      assert_empty dists.select { |d| d.is_a? Runcible::Models::YumCloneDistributor }
+      refute_empty dists.select { |d| d.is_a? Runcible::Models::ExportDistributor }
+    end
+
+    def test_generate_distributors_with_default_capsule
+      dists = @fedora_17_x86_64.generate_distributors(OpenStruct.new(:default_capsule? => true))
       refute_empty dists.select { |d| d.is_a? Runcible::Models::YumDistributor }
       refute_empty dists.select { |d| d.is_a? Runcible::Models::YumCloneDistributor }
       refute_empty dists.select { |d| d.is_a? Runcible::Models::ExportDistributor }


### PR DESCRIPTION
This was an issue hit during upgrade from Katello 3.0+ to Katello 3.3 when the upgrade step `foreman-rake katello:upgrades:3.0:add_export_distributor` was ran. Every repository would get updated and the yum_clone_distributor removed. This in turn led to broken content views. 

To replicate you can either install Katello 3.1 or 3.2 and seed with data then run an upgrade or without applying this patch, run `rake katello:upgrades:3.0:add_export_distributor` (or foreman-rake in production) and try to publish a content view. Then apply this patch, re-run the rake task and resume and re-publish or promote.