### PR TITLE
Fixes #17617: Ensure cv puppet env distributors are up to date

### DIFF
--- a/app/lib/actions/katello/content_view_puppet_environment/clone.rb
+++ b/app/lib/actions/katello/content_view_puppet_environment/clone.rb
@@ -48,6 +48,10 @@ module Actions
             clone.puppet_environment.try(:save!) #manually save puppet environment in case of error
             clone.save!
             plan_action(ContentViewPuppetEnvironment::Clear, clone)
+
+            unless ::Katello::Repository.needs_distributor_updates([clone], ::Katello::CapsuleContent.new(::SmartProxy.default_capsule)).empty?
+              plan_action(Pulp::Repository::Refresh, clone)
+            end
           end
           clone
         end

--- a/test/actions/katello/content_view_puppet_environment_test.rb
+++ b/test/actions/katello/content_view_puppet_environment_test.rb
@@ -60,6 +60,7 @@ module ::Actions::Katello::ContentViewPuppetEnvironment
     let(:source_puppet_env) { katello_content_view_puppet_environments(:archive_view_puppet_environment) }
 
     it 'plans with existing puppet environment' do
+      ::Katello::Repository.expects(:needs_distributor_updates).returns([{}])
       plan_action action, puppet_env.content_view_version, :environment => dev
 
       assert_action_planed_with action, ::Actions::Katello::ContentViewPuppetEnvironment::Clear, dev_puppet_env
@@ -102,6 +103,13 @@ module ::Actions::Katello::ContentViewPuppetEnvironment
       refute_action_planed action, ::Actions::Katello::ContentViewPuppetEnvironment::Create
       refute_action_planed action, ::Actions::Pulp::Repository::CopyPuppetModule
       refute_action_planed action, ::Actions::Katello::Repository::MetadataGenerate
+    end
+
+    it 'plans repository refresh when distributor config changes' do
+      ::Katello::Repository.expects(:needs_distributor_updates).returns([{}])
+      plan_action action, puppet_env.content_view_version, :environment => dev
+
+      assert_action_planed action, ::Actions::Pulp::Repository::Refresh
     end
   end
 


### PR DESCRIPTION
For Puppet 3 to Puppet 4 upgrades, the distributor path for puppet
content changes. When publishing or promoting we need to ensure that
this update is detected and content lands in the new location.