### PR TITLE
Fixes #18774 - Can provide content overrides to AK in bulk

### DIFF
--- a/app/controllers/katello/concerns/api/v2/content_overrides_controller.rb
+++ b/app/controllers/katello/concerns/api/v2/content_overrides_controller.rb
@@ -1,0 +1,28 @@
+module Katello
+  module Concerns
+    module Api::V2::ContentOverridesController
+      extend ActiveSupport::Concern
+
+      # overriden_object => pass it either an activation key or content host
+      def validate_content_overrides_enabled(content_params, overriden_object)
+        value = content_params[:value].to_s.downcase
+
+        if value.blank? || (value != "default" && ::Foreman::Cast.to_bool(value).nil?)
+          fail HttpErrors::BadRequest, _("Value must either be a boolean or 'default'")
+        end
+
+        unless overriden_object.valid_content_override_label?(content_params[:content_label])
+          fail HttpErrors::BadRequest, _("Invalid content label: %s") % content_params[:content_label]
+        end
+
+        override = ::Katello::ContentOverride.new(content_params[:content_label])
+        if value == "default"
+          override.enabled = nil
+        else
+          override.enabled = ::Foreman::Cast.to_bool(value) ? "1" : '0'
+        end
+        override
+      end
+    end
+  end
+end

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -805,16 +805,28 @@ module Katello
             ::Katello::Util::Data.array_with_indifferent_access(JSON.parse(result))
           end
 
-          def update_content_override(id, content_label, name, value = nil)
-            attrs = [{ :contentLabel => content_label, :name => name }]
-            if value
-              attrs[0][:value] = value
+          # expected params
+          # id : ID of the Activation Key
+          # content_overrides => Array of ::Katello::ContentOverride objects
+          def update_content_overrides(id, content_overrides)
+            attrs_to_delete = []
+            attrs_to_update = []
+            content_overrides.each do |content_override|
+              if content_override.value
+                attrs_to_update << content_override.to_entitlement_hash
+              else
+                attrs_to_delete << content_override.to_entitlement_hash
+              end
+            end
+
+            if attrs_to_update.present?
               result = Candlepin::CandlepinResource.put(join_path(path(id), 'content_overrides'),
-                                                        attrs.to_json, self.default_headers)
-            else
+                                                        attrs_to_update.to_json, self.default_headers)
+            end
+            if attrs_to_delete.present?
               client = Candlepin::CandlepinResource.rest_client(Net::HTTP::Delete, :delete,
                                                                 join_path(path(id), 'content_overrides'))
-              client.options[:payload] = attrs.to_json
+              client.options[:payload] = attrs_to_delete.to_json
               result = client.delete({:accept => :json, :content_type => :json}.merge(User.cp_oauth_header))
             end
             ::Katello::Util::Data.array_with_indifferent_access(JSON.parse(result))

--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -108,7 +108,7 @@ module Katello
       self.products ? self.products.map(&:available_content).flatten.uniq { |product| product.content.id } : []
     end
 
-    def valid_content_label?(content_label)
+    def valid_content_override_label?(content_label)
       self.available_content.map(&:content).any? { |content| content.label == content_label }
     end
 

--- a/app/models/katello/content_override.rb
+++ b/app/models/katello/content_override.rb
@@ -1,0 +1,22 @@
+module Katello
+  class ContentOverride
+    attr_accessor :content_label, :name, :value
+
+    def initialize(content_label, params = {})
+      @content_label = content_label
+      self.enabled = params[:enabled] if params.key?(:enabled)
+    end
+
+    def enabled=(value = nil)
+      @name = "enabled"
+      @value = value
+    end
+
+    def to_entitlement_hash
+      ret = {"contentLabel" => @content_label}
+      ret["name"] = @name if @name
+      ret["value"] = @value if @value
+      ret
+    end
+  end
+end

--- a/app/models/katello/glue/candlepin/activation_key.rb
+++ b/app/models/katello/glue/candlepin/activation_key.rb
@@ -63,8 +63,8 @@ module Katello
         self.import_pools
       end
 
-      def set_content_override(content_label, name, value = nil)
-        Resources::Candlepin::ActivationKey.update_content_override(self.cp_id, content_label, name, value)
+      def set_content_overrides(overrides)
+        Resources::Candlepin::ActivationKey.update_content_overrides(self.cp_id, overrides)
       end
 
       def content_overrides

--- a/test/models/activation_key_test.rb
+++ b/test/models/activation_key_test.rb
@@ -107,9 +107,9 @@ module Katello
       assert_includes activation_keys, @dev_staging_view_key
     end
 
-    def test_valid_content_label?
+    def test_valid_content_override_label?
       @dev_key.stubs(:available_content).returns([OpenStruct.new(:content => OpenStruct.new(:label => 'some-label'))])
-      assert @dev_key.valid_content_label?('some-label')
+      assert @dev_key.valid_content_override_label?('some-label')
     end
 
     def test_max_hosts_not_exceeded

--- a/test/models/content_override_test.rb
+++ b/test/models/content_override_test.rb
@@ -1,0 +1,44 @@
+require 'katello_test_helper'
+
+module Katello
+  class ContentOverrideTest < ActiveSupport::TestCase
+    def test_new
+      label = "boo"
+      value = 1
+      override = ContentOverride.new(label)
+
+      assert_nil override.name
+      assert_nil override.value
+
+      override.enabled = value
+
+      assert_equal "enabled", override.name
+      assert_equal value, override.value
+      assert_equal label, override.content_label
+
+      label2 = "bar"
+      override2 = ContentOverride.new(label2, :enabled => 0)
+
+      assert_equal "enabled", override2.name
+      assert_equal 0, override2.value
+      assert_equal label2, override2.content_label
+    end
+
+    def test_entitlement_hash
+      label = "boo"
+      value = 1
+      override = ContentOverride.new(label)
+      override.enabled = value
+      assert_equal({"contentLabel" => label, "value" => value, "name" => "enabled"}, override.to_entitlement_hash)
+
+      override.enabled = 0
+      assert_equal({"contentLabel" => label, "value" => 0, "name" => "enabled"}, override.to_entitlement_hash)
+
+      override.enabled = nil
+      assert_equal({"contentLabel" => label, "name" => "enabled"}, override.to_entitlement_hash)
+
+      override.name = nil
+      assert_equal({"contentLabel" => label}, override.to_entitlement_hash)
+    end
+  end
+end


### PR DESCRIPTION
Api bindings to provide content overrides in bulk
for activation keys