### PR TITLE
fixes #18838 - modify repository get/update/create permissions

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -389,11 +389,13 @@ module Katello
     end
 
     def find_product_for_create
-      @product = Product.find(params[:product_id])
+      @product = Product.editable.where(:id => params[:product_id]).first
+      fail HttpErrors::NotFound, _("Couldn't find product '%s'") % params[:product_id] if @product.nil?
     end
 
     def find_repository
-      @repository = Repository.find(params[:id])
+      @repository = Repository.readable.where(:id => params[:id]).first
+      fail HttpErrors::NotFound, _("Couldn't find repository '%s'") % params[:id] if @repository.nil?
     end
 
     def find_gpg_key


### PR DESCRIPTION
This change is to ensure that a user with restricted permissions
cannot access or change a repository that they do not have
for.

E.g.

User perms:

  resource: Organization
    permissions: view_organizations
    search: name = "Default Organization"

  resource: Product and Repositories
    permissions: view_products, edit_products, sync_products,
                 create_products
    search: name = rpm

CLI attempts to modify the 'zoo' product, which does not have perms to:

hammer> repository info --organization "Default Organization"
        --product zoo --name zoo
Error: product not found

hammer> repository info --organization "Default Organization" --id 1
Couldn't find repository '1'

hammer> repository upload-content --organization "Default Organization"
        --product zoo --name zoo --path test-0.0.1.noarch.rpm
Failed to upload file '' to repository. Please check the file and try again.
Could not upload the content:
  Error: product not found

hammer> repository upload-content --id 1 --path test-0.0.1.noarch.rpm
Failed to upload file 'test-0.0.1.noarch.rpm' to repository.
Please check the file and try again.

hammer> repository create --organization "Default Organization"
        --product zoo --name test --content-type yum
Could not create the repository:
  Error: product not found

hammer> repository create --organization "Default Organization"
        --product-id 1 --name test --content-type yum
Could not create the repository:
  Couldn't find product '1'