### PR TITLE
Fixes #18848 - Check for docker repo when calling container_repo

### DIFF
--- a/app/lib/actions/katello/capsule_content/create_repos.rb
+++ b/app/lib/actions/katello/capsule_content/create_repos.rb
@@ -43,7 +43,7 @@ module Actions
                       checksum_type: checksum_type,
                       path: relative_path,
                       with_importer: true,
-                      docker_upstream_name: repository.container_repository_name,
+                      docker_upstream_name: repository.docker? ? repository.container_repository_name : nil,
                       download_policy: repository.capsule_download_policy(capsule_content.capsule),
                       capsule_id: capsule_content.capsule.id)
         end


### PR DESCRIPTION
...sitory_name

This method doesn't exist for content view puppet environments,
which are created on the capsule the same way repositories are.
Since docker repos only need container_repository_name, we can
only set this for docker repos and have the others be nil.