### PR TITLE
fixes #18859 - Can set content overrides for a host

### DIFF
--- a/app/controllers/katello/concerns/api/v2/content_overrides_controller.rb
+++ b/app/controllers/katello/concerns/api/v2/content_overrides_controller.rb
@@ -4,22 +4,31 @@ module Katello
       extend ActiveSupport::Concern
 
       # overriden_object => pass it either an activation key or content host
-      def validate_content_overrides_enabled(content_params, overriden_object)
-        value = content_params[:value].to_s.downcase
+      def validate_content_overrides_enabled(content_params, overriden_object = nil)
+        name = content_params[:name] || "enabled"
+        compare_value = content_params[:value].to_s.downcase
+        remove = content_params.key?(:remove) ? Foreman::Cast.to_bool(content_params[:remove]) : nil
 
-        if value.blank? || (value != "default" && ::Foreman::Cast.to_bool(value).nil?)
-          fail HttpErrors::BadRequest, _("Value must either be a boolean or 'default'")
+        if remove.nil? && name == "enabled" &&
+                       (compare_value.blank? || (compare_value != "default" &&
+                        ::Foreman::Cast.to_bool(compare_value).nil?))
+          fail HttpErrors::BadRequest, _("Value must either be a boolean or 'default' for 'enabled'")
         end
 
-        unless overriden_object.valid_content_override_label?(content_params[:content_label])
+        if overriden_object && !overriden_object.valid_content_override_label?(content_params[:content_label])
           fail HttpErrors::BadRequest, _("Invalid content label: %s") % content_params[:content_label]
         end
 
         override = ::Katello::ContentOverride.new(content_params[:content_label])
-        if value == "default"
-          override.enabled = nil
+        override.name = name
+        if remove || (name == "enabled" && compare_value == "default")
+          override.value = nil
         else
-          override.enabled = ::Foreman::Cast.to_bool(value) ? "1" : '0'
+          if name == "enabled"
+            override.value = ::Foreman::Cast.to_bool(compare_value) ? "1" : "0"
+          else
+            override.value = content_params[:value]
+          end
         end
         override
       end

--- a/app/lib/actions/candlepin/consumer/update_content_overrides.rb
+++ b/app/lib/actions/candlepin/consumer/update_content_overrides.rb
@@ -1,0 +1,17 @@
+module Actions
+  module Candlepin
+    module Consumer
+      class UpdateContentOverrides < Candlepin::Abstract
+        middleware.use Actions::Middleware::KeepCurrentUser
+        input_format do
+          param :uuid, String
+          param :content_overrides, Array
+        end
+
+        def run
+          ::Katello::Resources::Candlepin::Consumer.update_content_overrides(input[:uuid], input[:content_overrides])
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/host/update_content_overrides.rb
+++ b/app/lib/actions/katello/host/update_content_overrides.rb
@@ -1,0 +1,29 @@
+module Actions
+  module Katello
+    module Host
+      class UpdateContentOverrides < Actions::EntryAction
+        middleware.use Actions::Middleware::KeepCurrentUser
+
+        def plan(host, content_overrides)
+          action_subject(host)
+          plan_action(::Actions::Candlepin::Consumer::UpdateContentOverrides,
+                      :uuid => host.subscription_facet.uuid,
+                      :content_overrides => content_overrides.map(&:to_entitlement_hash))
+          plan_self(:host_id => host.id, :host_name => host.name)
+        end
+
+        def humanized_name
+          if input.try(:[], :host_name)
+            _('Update Content Overrides to %s') % (input[:host_name] || _('Unknown'))
+          else
+            _('Update Content Overrides')
+          end
+        end
+
+        def resource_locks
+          :link
+        end
+      end
+    end
+  end
+end

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -246,16 +246,28 @@ module Katello
             ::Katello::Util::Data.array_with_indifferent_access(JSON.parse(result))
           end
 
-          def update_content_override(id, content_label, name, value = nil)
-            attrs = [{ :contentLabel => content_label, :name => name }]
-            if value
-              attrs[0][:value] = value
+          # expected params
+          # id : UUID of the consumer
+          # content_overrides => Array of entitlement hashes objects
+          def update_content_overrides(id, content_overrides)
+            attrs_to_delete = []
+            attrs_to_update = []
+            content_overrides.each do |content_override|
+              if content_override[:value]
+                attrs_to_update << content_override
+              else
+                attrs_to_delete << content_override
+              end
+            end
+
+            if attrs_to_update.present?
               result = Candlepin::CandlepinResource.put(join_path(path(id), 'content_overrides'),
-                                                        attrs.to_json, self.default_headers)
-            else
+                                                        attrs_to_update.to_json, self.default_headers)
+            end
+            if attrs_to_delete.present?
               client = Candlepin::CandlepinResource.rest_client(Net::HTTP::Delete, :delete,
                                                                 join_path(path(id), 'content_overrides'))
-              client.options[:payload] = attrs.to_json
+              client.options[:payload] = attrs_to_delete.to_json
               result = client.delete({:accept => :json, :content_type => :json}.merge(User.cp_oauth_header))
             end
             ::Katello::Util::Data.array_with_indifferent_access(JSON.parse(result))
@@ -811,15 +823,15 @@ module Katello
 
           # expected params
           # id : ID of the Activation Key
-          # content_overrides => Array of ::Katello::ContentOverride objects
+          # content_overrides => Array of content override hashes
           def update_content_overrides(id, content_overrides)
             attrs_to_delete = []
             attrs_to_update = []
             content_overrides.each do |content_override|
-              if content_override.value
-                attrs_to_update << content_override.to_entitlement_hash
+              if content_override[:value]
+                attrs_to_update << content_override
               else
-                attrs_to_delete << content_override.to_entitlement_hash
+                attrs_to_delete << content_override
               end
             end
 

--- a/app/models/katello/candlepin/product_content.rb
+++ b/app/models/katello/candlepin/product_content.rb
@@ -30,9 +30,17 @@ module Katello
       @repos ||= self.product.repos(self.product.organization.library).where(:content_id => self.content.id)
     end
 
-    def content_override(activation_key)
-      override = activation_key.content_overrides.find { |pc| pc[:contentLabel] == content.label }
-      override.nil? ? 'default' : override[:value]
+    def legacy_content_override(activation_key)
+      override = activation_key.content_overrides.find { |pc| pc.content_label == content.label && pc.name == "enabled" }
+      override.nil? ? 'default' : override.value
+    end
+
+    def content_overrides(activation_key)
+      activation_key.content_overrides.select { |pc| pc.content_label == content.label }
+    end
+
+    def enabled_content_override(activation_key)
+      activation_key.content_overrides.find { |pc| pc.content_label == content.label && pc.name == "enabled" }
     end
 
     def content_type

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -112,6 +112,11 @@ module Katello
         @errata_status_label ||= get_status(::Katello::ErrataStatus).to_label(options)
       end
 
+      def valid_content_override_label?(content_label)
+        available_content = subscription_facet.candlepin_consumer.available_product_content
+        available_content.map(&:content).any? { |content| content.label == content_label }
+      end
+
       protected
 
       def update_trace_status

--- a/app/models/katello/content_override.rb
+++ b/app/models/katello/content_override.rb
@@ -12,11 +12,35 @@ module Katello
       @value = value
     end
 
+    def computed_value
+      return if self.value.nil?
+
+      if self.name == "enabled"
+        ::Foreman::Cast.to_bool(self.value)
+      else
+        self.value
+      end
+    end
+
     def to_entitlement_hash
       ret = {"contentLabel" => @content_label}
       ret["name"] = @name if @name
       ret["value"] = @value if @value
-      ret
+      ret.with_indifferent_access
+    end
+
+    def self.from_entitlement_hash(entitlement_hash)
+      ent_hash =  entitlement_hash.with_indifferent_access
+      override = ContentOverride.new(ent_hash["contentLabel"])
+      override.name = ent_hash["name"]
+      override.value = ent_hash["value"]
+      override
+    end
+
+    def ==(other)
+      self.content_label == other.content_label &&
+        self.name == other.name &&
+        self.value == other.value
     end
   end
 end

--- a/app/models/katello/glue/candlepin/activation_key.rb
+++ b/app/models/katello/glue/candlepin/activation_key.rb
@@ -64,11 +64,13 @@ module Katello
       end
 
       def set_content_overrides(overrides)
-        Resources::Candlepin::ActivationKey.update_content_overrides(self.cp_id, overrides)
+        Resources::Candlepin::ActivationKey.update_content_overrides(self.cp_id, overrides.map(&:to_entitlement_hash))
       end
 
       def content_overrides
-        Resources::Candlepin::ActivationKey.content_overrides(self.cp_id)
+        Resources::Candlepin::ActivationKey.content_overrides(self.cp_id).map do |overrides|
+          ::Katello::ContentOverride.from_entitlement_hash(overrides)
+        end
       end
 
       private

--- a/app/presenters/katello/product_content_presenter.rb
+++ b/app/presenters/katello/product_content_presenter.rb
@@ -8,9 +8,17 @@ module Katello
       @overrides = overrides
     end
 
-    def enabled_override
-      override = overrides.find { |pc| pc[:contentLabel] == content.label }
-      override.nil? ? 'default' : override[:value]
+    def override
+      override = overrides.find { |pc| pc.content_label == content.label && pc.name == "enabled" }
+      override.nil? ? 'default' : override.value
+    end
+
+    def enabled_content_override
+      overrides.find { |pc| pc.content_label == content.label && pc.name == "enabled" }
+    end
+
+    def content_overrides
+      overrides.find { |pc| pc.content_label == content.label }
     end
   end
 end

--- a/app/views/katello/api/v2/activation_keys/product_content.json.rabl
+++ b/app/views/katello/api/v2/activation_keys/product_content.json.rabl
@@ -9,10 +9,23 @@ child @collection[:results] => :results do
 
   child :content => :content do
     attributes :id, :name, :label
+    attribute :contentUrl => :content_url
   end
 
   node :override do |pc|
-    pc.content_override(@activation_key)
+    pc.legacy_content_override(@activation_key)
   end
+
+  node :overrides do |pc|
+    pc.content_overrides(@activation_key).map do |override|
+      {:name => override.name, :value => override.computed_value}
+    end
+  end
+
+  node :enabled_content_override do |pc|
+    override = pc.enabled_content_override(@activation_key)
+    override.computed_value if override
+  end
+
   attributes :enabled
 end

--- a/app/views/katello/api/v2/host_subscriptions/product_content.json.rabl
+++ b/app/views/katello/api/v2/host_subscriptions/product_content.json.rabl
@@ -9,7 +9,21 @@ child @collection[:results] => :results do
 
   child :content => :content do
     attributes :id, :name, :label
+    attribute :contentUrl => :content_url
   end
 
-  attributes :enabled_override, :enabled
+  child :overrides => :content_overrides do
+    attributes :name
+    attribute :computed_value => :value
+  end
+
+  node :enabled_content_override do |pc|
+    override = pc.enabled_content_override
+    override.computed_value if override
+  end
+
+  attributes :override, :enabled
+
+  #TODO: deprecate with 6.4
+  attributes :override => :enabled_override
 end

--- a/test/actions/katello/host/update_content_overrides_test.rb
+++ b/test/actions/katello/host/update_content_overrides_test.rb
@@ -1,0 +1,30 @@
+require 'katello_test_helper'
+
+module Katello::Host
+  class UpdateContentOverridesTest < ActiveSupport::TestCase
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+    include FactoryGirl::Syntax::Methods
+
+    before :all do
+      User.current = users(:admin)
+      @host = FactoryGirl.create(:host, :with_subscription)
+    end
+
+    describe 'auto attach subscriptions' do
+      let(:action_class) { ::Actions::Katello::Host::UpdateContentOverrides }
+
+      it 'plans' do
+        action = create_action action_class
+        action.expects(:action_subject).with(@host)
+
+        content_overrides = [::Katello::ContentOverride.new("foo", :enabled => 1), ::Katello::ContentOverride.new("bar", :enabled => nil)]
+        plan_action action, @host, content_overrides
+
+        assert_action_planed_with action, Actions::Candlepin::Consumer::UpdateContentOverrides,
+                                          :uuid => @host.subscription_facet.uuid,
+                                          :content_overrides => content_overrides.map(&:to_entitlement_hash)
+      end
+    end
+  end
+end

--- a/test/controllers/api/v2/host_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/host_subscriptions_controller_test.rb
@@ -187,16 +187,45 @@ module Katello
     end
 
     def test_content_override
-      Resources::Candlepin::Consumer.expects(:update_content_override).with(@host.subscription_facet.uuid, 'some-content', 'enabled', 1)
+      content_label = "some-content"
+      value = "1"
+      assert_sync_task(::Actions::Katello::Host::UpdateContentOverrides) do |host, overrides|
+        assert_equal @host, host
+        assert_equal 1, overrides.count
+        assert_equal content_label, overrides.first.content_label
+        assert_equal value, overrides.first.value
+      end
 
-      put :content_override, :host_id => @host.id, :content_label => 'some-content', :value => 1
+      put :content_override, :host_id => @host.id, :content_label => content_label, :value => value
+
+      assert_response :success
+      assert_template 'api/v2/host_subscriptions/content_override'
+    end
+
+    def test_content_override_bulk
+      content_overrides = [{:content_label => 'some-content', :value => 1}]
+      expected_content_labels = content_overrides.map { |override| override[:content_label] }
+      assert_sync_task(::Actions::Katello::Host::UpdateContentOverrides) do |host, overrides|
+        assert_equal @host, host
+        assert_equal content_overrides.count, overrides.count
+        assert_equal expected_content_labels, overrides.map(&:content_label)
+      end
+
+      put :content_override, :host_id => @host.id, :content_overrides => content_overrides
 
       assert_response :success
       assert_template 'api/v2/host_subscriptions/content_override'
     end
 
     def test_content_override_accepts_string_values
-      Resources::Candlepin::Consumer.expects(:update_content_override).with(@host.subscription_facet.uuid, 'some-content', 'enabled', 1)
+      content_label = "some-content"
+      value = "1"
+      assert_sync_task(::Actions::Katello::Host::UpdateContentOverrides) do |host, overrides|
+        assert_equal @host, host
+        assert_equal 1, overrides.count
+        assert_equal content_label, overrides.first.content_label
+        assert_equal value, overrides.first.value
+      end
 
       put :content_override, :host_id => @host.id, :content_label => 'some-content', :value => 'yes'
 

--- a/test/models/content_override_test.rb
+++ b/test/models/content_override_test.rb
@@ -24,7 +24,7 @@ module Katello
       assert_equal label2, override2.content_label
     end
 
-    def test_entitlement_hash
+    def test_to_entitlement_hash
       label = "boo"
       value = 1
       override = ContentOverride.new(label)
@@ -39,6 +39,20 @@ module Katello
 
       override.name = nil
       assert_equal({"contentLabel" => label}, override.to_entitlement_hash)
+    end
+
+    def test_from_entitlement_hash
+      label = "boo"
+      value = 1
+      override = ContentOverride.new(label)
+      override.enabled = value
+      assert_equal(override, ContentOverride.from_entitlement_hash(override.to_entitlement_hash))
+
+      override.enabled = 0
+      assert_equal(override, ContentOverride.from_entitlement_hash(override.to_entitlement_hash))
+
+      override.name = "mirrorlist"
+      assert_equal(override, ContentOverride.from_entitlement_hash(override.to_entitlement_hash))
     end
   end
 end

--- a/test/models/host/subscription_facet_test.rb
+++ b/test/models/host/subscription_facet_test.rb
@@ -271,5 +271,11 @@ module Katello
 
       assert_equal virt_host, subscription_facet.hypervisor_host
     end
+
+    def test_valid_content_override_label?
+      subscription_facet.candlepin_consumer.expects(:available_product_content).returns([OpenStruct.new(:content => OpenStruct.new(:label => 'some-label'))]).at_least_once
+      assert host.valid_content_override_label?('some-label')
+      refute host.valid_content_override_label?('some-label1')
+    end
   end
 end


### PR DESCRIPTION
Added api bindings to set a bunch of content overrides in bulk for a single host.
