### PR TITLE
Fixes #18706 - Handle 409 RestClient::Conflict

### DIFF
--- a/app/lib/actions/pulp/repository/create.rb
+++ b/app/lib/actions/pulp/repository/create.rb
@@ -31,6 +31,9 @@ module Actions
                                                     importer,
                                                     distributors,
                                                     display_name: input[:name])
+        rescue RestClient::Conflict
+          Rails.logger.warn("Tried to add repository #{input[:pulp_id]} that already exists.")
+          []
         end
 
         def importer


### PR DESCRIPTION
Handle conflict errors when trying to add repositories to a capsule that
already exist.