### PR TITLE
Fixes #18896 - stop usage of candlepin /pools

### DIFF
--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -185,7 +185,7 @@ module Katello
       end
 
       def candlepin_consumer
-        @candlepin_consumer ||= Katello::Candlepin::Consumer.new(self.uuid)
+        @candlepin_consumer ||= Katello::Candlepin::Consumer.new(self.uuid, self.host.organization.label)
       end
 
       def backend_update_needed?

--- a/app/models/katello/subscription_status.rb
+++ b/app/models/katello/subscription_status.rb
@@ -37,7 +37,7 @@ module Katello
 
     def to_status(_options = {})
       return UNKNOWN unless host.subscription_facet.try(:uuid)
-      case Katello::Candlepin::Consumer.new(host.subscription_facet.uuid).entitlement_status
+      case Katello::Candlepin::Consumer.new(host.subscription_facet.uuid, host.organization.label).entitlement_status
       when Katello::Candlepin::Consumer::ENTITLEMENTS_VALID
         VALID
       when Katello::Candlepin::Consumer::ENTITLEMENTS_PARTIAL

--- a/app/services/katello/candlepin/consumer.rb
+++ b/app/services/katello/candlepin/consumer.rb
@@ -16,14 +16,15 @@ module Katello
       lazy_accessor :events, :initializer => lambda { |_s| Resources::Candlepin::Consumer.events(uuid) }
       lazy_accessor :consumer_attributes, :initializer => lambda { |_s| Resources::Candlepin::Consumer.get(uuid) }
       lazy_accessor :installed_products, :initializer => lambda { |_s| consumer_attributes['installedProducts'] }
-      lazy_accessor :available_pools, :initializer => lambda { |_s| Resources::Candlepin::Consumer.available_pools(uuid, false) }
-      lazy_accessor :all_available_pools, :initializer => lambda { |_s| Resources::Candlepin::Consumer.available_pools(uuid, true) }
+      lazy_accessor :available_pools, :initializer => lambda { |_s| Resources::Candlepin::Consumer.available_pools(owner_label, uuid, false) }
+      lazy_accessor :all_available_pools, :initializer => lambda { |_s| Resources::Candlepin::Consumer.available_pools(owner_label, uuid, true) }
       lazy_accessor :content_overrides, :initializer => lambda { |_s| Resources::Candlepin::Consumer.content_overrides(uuid) }
 
-      attr_accessor :uuid
+      attr_accessor :uuid, :owner_label
 
-      def initialize(uuid)
+      def initialize(uuid, owner_label)
         self.uuid = uuid
+        self.owner_label = owner_label
       end
 
       def regenerate_identity_certificates

--- a/app/views/katello/api/v2/subscription_facet/show.json.rabl
+++ b/app/views/katello/api/v2/subscription_facet/show.json.rabl
@@ -1,6 +1,6 @@
 child :subscription_facet => :subscription_facet_attributes do |facet|
   extends 'katello/api/v2/subscription_facet/base'
-  consumer = Katello::Candlepin::Consumer.new(facet.uuid)
+  consumer = Katello::Candlepin::Consumer.new(facet.uuid, facet.host.organization.label)
 
   node :compliance_reasons do
     consumer.compliance_reasons

--- a/test/actions/katello/host/register_test.rb
+++ b/test/actions/katello/host/register_test.rb
@@ -24,7 +24,7 @@ module Katello::Host
     describe 'Host Register' do
       it 'plans' do
         action = create_action action_class
-        new_host = Host::Managed.new(:name => 'foobar', :managed => false)
+        new_host = Host::Managed.new(:name => 'foobar', :managed => false, :organization => @library.organization)
         action.stubs(:action_subject).with(new_host)
         plan_action action, new_host, rhsm_params, @content_view_environment
 
@@ -47,7 +47,7 @@ module Katello::Host
         Katello::ActivationKey.any_instance.stubs(:cp_name).returns('cp_name_baz')
         cvpe = Katello::ContentViewEnvironment.where(:content_view_id => @activation_key.content_view, :environment_id => @activation_key.environment).first
         action = create_action action_class
-        new_host = Host::Managed.new(:name => 'foobar', :managed => false)
+        new_host = Host::Managed.new(:name => 'foobar', :managed => false, :organization => @host_collection.organization)
         action.stubs(:action_subject).with(new_host)
 
         activation_keys = []
@@ -69,7 +69,7 @@ module Katello::Host
 
       it 'plans with existing host' do
         @host = FactoryGirl.create(:host, :with_content, :with_subscription, :content_view => @content_view,
-                                   :lifecycle_environment => @library)
+                                   :lifecycle_environment => @library, :organization => @content_view.organization)
         action = create_action action_class
         action.stubs(:action_subject).with(@host)
         plan_action action, @host, rhsm_params, @content_view_environment

--- a/test/lib/tasks/upgrades/3.0/update_subscription_facet_backend_data_test.rb
+++ b/test/lib/tasks/upgrades/3.0/update_subscription_facet_backend_data_test.rb
@@ -9,6 +9,7 @@ module Katello
       Rake::Task['katello:upgrades:3.0:update_subscription_facet_backend_data'].reenable
       Rake::Task.define_task(:environment)
       @host = hosts(:one)
+      @host.organization = get_organization
     end
 
     def test_run

--- a/test/models/subscription_status_test.rb
+++ b/test/models/subscription_status_test.rb
@@ -3,7 +3,7 @@ require 'katello_test_helper'
 module Katello
   class SubscriptionStatusTest < ActiveSupport::TestCase
     let(:host) do
-      FactoryGirl.build(:host, :with_subscription)
+      FactoryGirl.build(:host, :with_subscription, :organization => get_organization)
     end
 
     let(:status) { host.get_status(Katello::SubscriptionStatus) }

--- a/test/services/katello/candlepin/consumer_test.rb
+++ b/test/services/katello/candlepin/consumer_test.rb
@@ -25,7 +25,7 @@ module Katello
       def setup
         super
         Katello::Candlepin::Consumer.any_instance.stubs(:entitlements).returns(ENTITLEMENTS)
-        @consumer = Katello::Candlepin::Consumer.new('foo')
+        @consumer = Katello::Candlepin::Consumer.new('foo', 'org_label')
       end
 
       def test_filter_entitlements_simple


### PR DESCRIPTION
as it has been deprecated in favor of
/owners/ID/pools