### PR TITLE
Fixes #18577: fix autocomplete on content view filters.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/docker-tag-filter-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/docker-tag-filter-details.html
@@ -40,6 +40,7 @@
             <input class="form-control"
                    ng-hide="denied('edit_content_views', contentView)"
                    ng-model="rule.name"
+                   uib-typeahead="name for name in fetchAutocompleteName($viewValue)"
                    ng-readonly="!rule.editMode"/>
           </td>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/package-filter-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/package-filter-details.html
@@ -61,6 +61,7 @@
               <input class="form-control"
                      ng-hide="denied('edit_content_views', contentView)"
                      ng-model="rule.name"
+                     uib-typeahead="name for name in fetchAutocompleteName($viewValue)"
                      ng-readonly="!rule.editMode"/>
             </div>
           </td>
@@ -70,7 +71,7 @@
               <input class="form-control"
                      ng-hide="denied('edit_content_views', contentView)"
                      ng-model="rule.architecture"
-                     typeahead="arch for arch in fetchAutocompleteArch($viewValue)"
+                     uib-typeahead="arch for arch in fetchAutocompleteArch($viewValue)"
                      ng-readonly="!rule.editMode"/>
             </div>
           </td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/views/content-view-puppet-module-versions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/views/content-view-puppet-module-versions.html
@@ -21,7 +21,7 @@
              ng-model="table.searchTerm"
              bst-on-enter="table.search(table.searchTerm)"
              ng-trim="false"
-             typeahead="item.label for item in table.fetchAutocomplete($viewValue)"
+             uib-typeahead="item.label for item in table.fetchAutocomplete($viewValue)"
              typeahead-empty
              typeahead-template-url="components/views/autocomplete-scoped-search.html"/>
       <span class="input-group-btn">


### PR DESCRIPTION
The autocomplete functionality was broken in a few different places due
to using the directive name from an older verison of ui-bootstrap. This
commit corrects the directive name.

http://projects.theforeman.org/issues/18577