### PR TITLE
Fixes #18820 - fill in CV id on components

### DIFF
--- a/db/migrate/20170321012632_fill_in_content_view_components.rb
+++ b/db/migrate/20170321012632_fill_in_content_view_components.rb
@@ -1,0 +1,32 @@
+class FillInContentViewComponents < ActiveRecord::Migration
+  class FakeContentView < ActiveRecord::Base
+    self.table_name = 'katello_content_views'
+
+    has_many :content_view_components, :class_name => "FakeContentViewVersion", :dependent => :destroy,
+             :inverse_of => :composite_content_view, :foreign_key => :composite_content_view_id
+  end
+
+  class FakeContentViewVersion < ActiveRecord::Base
+    self.table_name = 'katello_content_view_versions'
+
+    has_many :content_view_components, :inverse_of => :content_view_version, :dependent => :destroy, :class_name => 'FakeContentViewComponent'
+  end
+
+  class FakeContentViewComponent < ActiveRecord::Base
+    self.table_name = 'katello_content_view_components'
+
+    belongs_to :content_view_version, :class_name => "FakeContentViewVersion",
+                              :inverse_of => :content_view_components
+    belongs_to :content_view, :class_name => "FakeContentView",
+                              :inverse_of => :component_composites
+  end
+
+  def up
+    FakeContentViewComponent.find_each do |cvc|
+      if cvc.content_view_id.nil? && cvc.content_view_version_id
+        cvc.content_view_id = cvc.content_view_version.content_view_id
+        cvc.save!
+      end
+    end
+  end
+end


### PR DESCRIPTION
during the migration to add latest to component
content views, the content view id field is used
but not populated during the migration.