### PR TITLE
fixes #18983 - correct composite view 'component repositories'

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -315,7 +315,7 @@ module Katello
     end
 
     def component_repositories
-      components.map(&:repositories).flatten
+      components.map(&:archived_repos).flatten
     end
 
     def repos_in_product(env, product)


### PR DESCRIPTION
Simple change to correctly reflect the repositories that are
part of a composite content view.

Example scenario:

1. component version 2.0 is associated with the composite
2. the component version (2.0) has 4 repositories associated with it
3. the component version (2.0) has been promoted to 3 lifecycle
   environments (dev, test & prod)

Prior to the change, the result would be:

4 repos to represent the 2.0 version (archived repos)
4 repos in dev
4 repos in test
4 repos in prod
for total of 16 repos

The correct behavior should be to only returned the archived
repos (4), since that is what is associated to the composite.