### PR TITLE
Fixes #18984 - update orphan cleanup for cp 2.0

### DIFF
--- a/test/services/katello/candlepin/consumer_test.rb
+++ b/test/services/katello/candlepin/consumer_test.rb
@@ -61,11 +61,14 @@ module Katello
       end
 
       def test_orphaned_consumer_ids
+        org = get_organization
+        Organization.stubs(:all).returns([org])
+
         orphaned_uuid = 'annie'
         consumer = {'type' => {'label' => nil}, 'uuid' => orphaned_uuid}
         ueber_consumer = {'type' => {'label' => 'uebercert'}, 'uuid' => 'my_ueber_cert'}
 
-        ::Katello::Resources::Candlepin::Consumer.expects(:get).with({}).returns([consumer, ueber_consumer])
+        ::Katello::Resources::Candlepin::Consumer.expects(:get).with('owner' => org.label).returns([consumer, ueber_consumer])
         orphaned = Katello::Candlepin::Consumer.orphaned_consumer_ids
 
         assert_equal [orphaned_uuid], orphaned


### PR DESCRIPTION
as you can no longer request all consumers
across all owners