### PR TITLE
Fixes #19002 - introduced ApplicationRecord

### DIFF
--- a/app/models/katello/model.rb
+++ b/app/models/katello/model.rb
@@ -1,5 +1,5 @@
 module Katello
-  class Model < ActiveRecord::Base
+  class Model < ApplicationRecord
     include ActiveModel::ForbiddenAttributesProtection
     self.abstract_class = true
 

--- a/db/migrate/20140422000001_update_products_add_organization.rb
+++ b/db/migrate/20140422000001_update_products_add_organization.rb
@@ -1,5 +1,5 @@
 class UpdateProductsAddOrganization < ActiveRecord::Migration
-  class Katello::Product < ActiveRecord::Base
+  class Katello::Product < ApplicationRecord
     belongs_to :provider
     self.inheritance_column = nil
   end

--- a/db/migrate/20140610154745_content_view_puppet_environment_id.rb
+++ b/db/migrate/20140610154745_content_view_puppet_environment_id.rb
@@ -1,5 +1,5 @@
 class ContentViewPuppetEnvironmentId < ActiveRecord::Migration
-  class ::Environment < ActiveRecord::Base
+  class ::Environment < ApplicationRecord
     def self.find_by_katello_id(org, env, content_view)
       katello_id = Environment.construct_katello_id(org, env, content_view)
       Environment.where(:katello_id => katello_id).first

--- a/db/migrate/20140626204657_add_unlimited_to_activation_keys.rb
+++ b/db/migrate/20140626204657_add_unlimited_to_activation_keys.rb
@@ -1,5 +1,5 @@
 class AddUnlimitedToActivationKeys < ActiveRecord::Migration
-  class ::Katello::ActivationKeys < ActiveRecord::Base
+  class ::Katello::ActivationKeys < ApplicationRecord
   end
 
   def up

--- a/db/migrate/20140626204902_add_unlimited_to_host_collection.rb
+++ b/db/migrate/20140626204902_add_unlimited_to_host_collection.rb
@@ -1,5 +1,5 @@
 class AddUnlimitedToHostCollection < ActiveRecord::Migration
-  class ::Katello::HostCollections < ActiveRecord::Base
+  class ::Katello::HostCollections < ApplicationRecord
   end
 
   def up

--- a/db/migrate/20141209103005_disown_foreman_templates.rb
+++ b/db/migrate/20141209103005_disown_foreman_templates.rb
@@ -1,5 +1,5 @@
 class DisownForemanTemplates < ActiveRecord::Migration
-  class FakeConfigTemplate < ActiveRecord::Base
+  class FakeConfigTemplate < ApplicationRecord
     if ActiveRecord::Base.connection.table_exists?('config_templates')
       self.table_name = 'config_templates'
     else

--- a/db/migrate/20150901213759_remove_distributors.rb
+++ b/db/migrate/20150901213759_remove_distributors.rb
@@ -1,5 +1,5 @@
 class RemoveDistributors < ActiveRecord::Migration
-  class Katello::Distributor < ActiveRecord::Base
+  class Katello::Distributor < ApplicationRecord
     self.table_name = 'katello_distributors'
   end
 

--- a/db/migrate/20150908222711_drop_marketing_engineering_products.rb
+++ b/db/migrate/20150908222711_drop_marketing_engineering_products.rb
@@ -1,5 +1,5 @@
 class DropMarketingEngineeringProducts < ActiveRecord::Migration
-  class Katello::MarketingProduct < ActiveRecord::Base
+  class Katello::MarketingProduct < ApplicationRecord
     self.table_name = "katello_products"
   end
 

--- a/db/migrate/20150930183738_migrate_content_hosts.rb
+++ b/db/migrate/20150930183738_migrate_content_hosts.rb
@@ -1,7 +1,7 @@
 class MigrateContentHosts < ActiveRecord::Migration
   HYPERVISOR_CLASS = 'Katello::Hypervisor'.freeze
 
-  class Location < ActiveRecord::Base
+  class Location < ApplicationRecord
     self.table_name = "taxonomies"
 
     def self.default_location
@@ -10,20 +10,20 @@ class MigrateContentHosts < ActiveRecord::Migration
     end
   end
 
-  class Organization < ActiveRecord::Base
+  class Organization < ApplicationRecord
     self.table_name = "taxonomies"
 
     has_many :kt_environments, :class_name => "MigrateContentHosts::KTEnvironment",
              :dependent => :restrict_with_exception, :inverse_of => :organization
   end
 
-  class SmartProxy < ActiveRecord::Base
+  class SmartProxy < ApplicationRecord
     self.table_name = "smart_proxies"
 
     belongs_to :content_host, :class_name => "MigrateContentHosts::System", :inverse_of => :capsule
   end
 
-  class KTEnvironment < ActiveRecord::Base
+  class KTEnvironment < ApplicationRecord
     self.table_name = "katello_environments"
 
     belongs_to :organization, :class_name => "MigrateContentHosts::Organization", :inverse_of => :kt_environments
@@ -34,7 +34,7 @@ class MigrateContentHosts < ActiveRecord::Migration
              :dependent => :restrict_with_exception, :foreign_key => :environment_id
   end
 
-  class ContentView < ActiveRecord::Base
+  class ContentView < ApplicationRecord
     self.table_name = "katello_content_views"
 
     has_many :systems, :class_name => "MigrateContentHosts::System", :dependent => :restrict_with_exception
@@ -42,7 +42,7 @@ class MigrateContentHosts < ActiveRecord::Migration
              :inverse_of => :content_view, :dependent => :restrict_with_exception
   end
 
-  class Repository < ActiveRecord::Base
+  class Repository < ApplicationRecord
     self.table_name = "katello_repositories"
 
     has_many :content_facet_repositories, :class_name => "MigrateContentHosts::ContentFacetRepository", :dependent => :destroy
@@ -52,41 +52,41 @@ class MigrateContentHosts < ActiveRecord::Migration
     has_many :systems, :through => :system_repositories
   end
 
-  class SystemRepository < ActiveRecord::Base
+  class SystemRepository < ApplicationRecord
     self.table_name = "katello_system_repositories"
     belongs_to :system, :inverse_of => :system_repositories, :class_name => 'MigrateContentHosts::System'
     belongs_to :repository, :inverse_of => :system_repositories, :class_name => 'MigrateContentHosts::Repository'
   end
 
-  class HostCollection < ActiveRecord::Base
+  class HostCollection < ApplicationRecord
     self.table_name = "katello_host_collection"
 
     has_many :system_host_collections, :class_name => "MigrateContentHosts::SystemHostCollection", :dependent => :destroy
     has_many :systems, :through => :system_host_collections, :class_name => "MigrateContentHosts::System"
   end
 
-  class SystemHostCollections < ActiveRecord::Base
+  class SystemHostCollections < ApplicationRecord
     self.table_name = "katello_system_host_collections"
 
     belongs_to :system, :inverse_of => :system_host_collections, :class_name => 'MigrateContentHosts::System'
     belongs_to :host_collection, :inverse_of => :system_host_collections
   end
 
-  class Erratum < ActiveRecord::Base
+  class Erratum < ApplicationRecord
     self.table_name = "katello_errata"
 
     has_many :systems_applicable, :through => :system_errata, :class_name => "MigrateContentHosts::System", :source => :system
     has_many :content_facet_errata, :class_name => "MigrateContentHosts::ContentFacetErratum", :source => :erratum
   end
 
-  class SystemErratum < ActiveRecord::Base
+  class SystemErratum < ApplicationRecord
     self.table_name = "katello_system_errata"
 
     belongs_to :system, :inverse_of => :system_errata, :class_name => 'MigrateContentHosts::System'
     belongs_to :erratum, :inverse_of => :system_errata, :class_name => 'MigrateContentHosts::Erratum'
   end
 
-  class ActivationKey < ActiveRecord::Base
+  class ActivationKey < ApplicationRecord
     self.table_name = "katello_activation_keys"
 
     has_many :system_activation_keys, :class_name => "MigrateContentHosts::SystemActivationKey", :dependent => :destroy
@@ -94,14 +94,14 @@ class MigrateContentHosts < ActiveRecord::Migration
     has_many :subscription_facets, :through => :subscription_facet_activation_keys
   end
 
-  class SystemActivationKey < ActiveRecord::Base
+  class SystemActivationKey < ApplicationRecord
     self.table_name = "katello_system_activation_keys"
 
     belongs_to :system, :inverse_of => :system_activation_keys
     belongs_to :activation_key, :inverse_of => :system_activation_keys
   end
 
-  class Host < ActiveRecord::Base
+  class Host < ApplicationRecord
     self.table_name = "hosts"
     self.inheritance_column = nil
 
@@ -112,7 +112,7 @@ class MigrateContentHosts < ActiveRecord::Migration
     belongs_to :location, :class_name => "MigrateContentHosts::Location"
   end
 
-  class System < ActiveRecord::Base
+  class System < ApplicationRecord
     self.table_name = "katello_systems"
     self.inheritance_column = nil
 
@@ -139,7 +139,7 @@ class MigrateContentHosts < ActiveRecord::Migration
     has_one :capsule, :class_name => "MigrateContentHosts::SmartProxy", :inverse_of => :content_host, :foreign_key => :content_host_id, :dependent => :nullify
   end
 
-  class ContentFacet < ActiveRecord::Base
+  class ContentFacet < ApplicationRecord
     self.table_name = "katello_content_facets"
 
     belongs_to :host, :inverse_of => :content_facet, :class_name => "MigrateContentHosts::Host"
@@ -152,21 +152,21 @@ class MigrateContentHosts < ActiveRecord::Migration
     has_many :content_facet_errata, :class_name => "MigrateContentHosts::ContentFacetErratum", :dependent => :destroy, :inverse_of => :content_facet
   end
 
-  class ContentFacetRepository < ActiveRecord::Base
+  class ContentFacetRepository < ApplicationRecord
     self.table_name = "katello_content_facet_repositories"
 
     belongs_to :content_facet, :inverse_of => :content_facet_repositories, :class_name => 'MigrateContentHosts::ContentFacet'
     belongs_to :repository, :inverse_of => :content_facet_repositories, :class_name => 'MigrateContentHosts::Repository'
   end
 
-  class ContentFacetErratum < ActiveRecord::Base
+  class ContentFacetErratum < ApplicationRecord
     self.table_name = "katello_content_facet_errata"
 
     belongs_to :content_facet, :inverse_of => :content_facet_errata, :class_name => 'MigrateContentHosts::ContentFacet'
     belongs_to :erratum, :inverse_of => :content_facet_errata, :class_name => 'MigrateContentHosts::Erratum'
   end
 
-  class SubscriptionFacet < ActiveRecord::Base
+  class SubscriptionFacet < ApplicationRecord
     self.table_name = "katello_subscription_facets"
 
     belongs_to :host, :inverse_of => :subscription_facet, :class_name => "MigrateContentHosts::Host"
@@ -174,7 +174,7 @@ class MigrateContentHosts < ActiveRecord::Migration
     has_many :subscription_facet_activation_keys, :class_name => "MigrateContentHosts::SubscriptionFacetActivationKey", :dependent => :destroy, :inverse_of => :subscription_facet
   end
 
-  class SubscriptionFacetActivationKey < ActiveRecord::Base
+  class SubscriptionFacetActivationKey < ApplicationRecord
     self.table_name = "katello_subscription_facet_activation_keys"
 
     belongs_to :subscription_facet, :inverse_of => :subscription_facet_activation_keys, :class_name => 'MigrateContentHosts::SubscriptionFacet'

--- a/db/migrate/20151014144004_host_collection_to_hosts.rb
+++ b/db/migrate/20151014144004_host_collection_to_hosts.rb
@@ -1,21 +1,21 @@
 class HostCollectionToHosts < ActiveRecord::Migration
-  class Host < ActiveRecord::Base
+  class Host < ApplicationRecord
     self.table_name = "hosts"
   end
 
-  class System < ActiveRecord::Base
+  class System < ApplicationRecord
     self.table_name = "katello_systems"
   end
 
-  class HostCollection < ActiveRecord::Base
+  class HostCollection < ApplicationRecord
     self.table_name = "katello_host_collections"
   end
 
-  class SystemHostCollections < ActiveRecord::Base
+  class SystemHostCollections < ApplicationRecord
     self.table_name = "katello_system_host_collections"
   end
 
-  class HostCollectionHosts < ActiveRecord::Base
+  class HostCollectionHosts < ApplicationRecord
     self.table_name = "katello_host_collection_hosts"
   end
 

--- a/db/migrate/20160114200145_add_mirror_on_sync_to_repositories.rb
+++ b/db/migrate/20160114200145_add_mirror_on_sync_to_repositories.rb
@@ -1,5 +1,5 @@
 class AddMirrorOnSyncToRepositories < ActiveRecord::Migration
-  class RepositoryMirrorOnSync < ActiveRecord::Base
+  class RepositoryMirrorOnSync < ApplicationRecord
     self.table_name = "katello_repositories"
   end
   def change

--- a/db/migrate/20160131182301_add_download_policy_to_katello_repositories.rb
+++ b/db/migrate/20160131182301_add_download_policy_to_katello_repositories.rb
@@ -1,5 +1,5 @@
 class AddDownloadPolicyToKatelloRepositories < ActiveRecord::Migration
-  class DownloadPolicyRepository < ActiveRecord::Base
+  class DownloadPolicyRepository < ApplicationRecord
     self.table_name = "katello_repositories"
   end
   def change

--- a/db/migrate/20160222143432_move_system_description_to_host.rb
+++ b/db/migrate/20160222143432_move_system_description_to_host.rb
@@ -1,9 +1,9 @@
 class MoveSystemDescriptionToHost < ActiveRecord::Migration
-  class Host < ActiveRecord::Base
+  class Host < ApplicationRecord
     self.table_name = "hosts"
   end
 
-  class System < ActiveRecord::Base
+  class System < ApplicationRecord
     self.table_name = "katello_systems"
   end
 

--- a/db/migrate/20160404132250_remove_katello_from_notification_name.rb
+++ b/db/migrate/20160404132250_remove_katello_from_notification_name.rb
@@ -1,5 +1,5 @@
 class RemoveKatelloFromNotificationName < ActiveRecord::Migration
-  class FakeMailNotification < ActiveRecord::Base
+  class FakeMailNotification < ApplicationRecord
     self.table_name = 'mail_notifications'
   end
 

--- a/db/migrate/20160426145517_move_host_description_to_host_comment.rb
+++ b/db/migrate/20160426145517_move_host_description_to_host_comment.rb
@@ -1,5 +1,5 @@
 class MoveHostDescriptionToHostComment < ActiveRecord::Migration
-  class Host < ActiveRecord::Base
+  class Host < ApplicationRecord
     self.table_name = "hosts"
   end
 

--- a/db/migrate/20160617124149_remove_duplicate_view_filters.rb
+++ b/db/migrate/20160617124149_remove_duplicate_view_filters.rb
@@ -1,8 +1,8 @@
 class RemoveDuplicateViewFilters < ActiveRecord::Migration
-  class Role < ActiveRecord::Base
+  class Role < ApplicationRecord
   end
 
-  class Filter < ActiveRecord::Base
+  class Filter < ApplicationRecord
     belongs_to :role
     has_many :filterings, :dependent => :destroy
     has_many :permissions, :through => :filterings
@@ -10,12 +10,12 @@ class RemoveDuplicateViewFilters < ActiveRecord::Migration
     scope :unlimited, -> { where(:search => nil, :taxonomy_search => nil) }
   end
 
-  class Filtering < ActiveRecord::Base
+  class Filtering < ApplicationRecord
     belongs_to :filter
     belongs_to :permission
   end
 
-  class Permission < ActiveRecord::Base
+  class Permission < ApplicationRecord
     has_many :filterings, :dependent => :destroy
     has_many :filters, :through => :filterings
   end

--- a/db/migrate/20160619223332_fix_viewer_role.rb
+++ b/db/migrate/20160619223332_fix_viewer_role.rb
@@ -1,9 +1,9 @@
 class FixViewerRole < ActiveRecord::Migration
-  class Role < ActiveRecord::Base
+  class Role < ApplicationRecord
     has_many :filters
   end
 
-  class Filter < ActiveRecord::Base
+  class Filter < ApplicationRecord
     belongs_to :role
     has_many :filterings, :dependent => :destroy
     has_many :permissions, :through => :filterings
@@ -16,12 +16,12 @@ class FixViewerRole < ActiveRecord::Migration
     end
   end
 
-  class Filtering < ActiveRecord::Base
+  class Filtering < ApplicationRecord
     belongs_to :filter
     belongs_to :permission
   end
 
-  class Permission < ActiveRecord::Base
+  class Permission < ApplicationRecord
   end
 
   def change

--- a/db/migrate/20160701180402_add_sortable_version_to_puppet_modules.rb
+++ b/db/migrate/20160701180402_add_sortable_version_to_puppet_modules.rb
@@ -1,5 +1,5 @@
 class AddSortableVersionToPuppetModules < ActiveRecord::Migration
-  class PuppetModule < ActiveRecord::Base
+  class PuppetModule < ApplicationRecord
     self.table_name = "katello_puppet_modules"
   end
 

--- a/db/migrate/20160924213020_change_katello_widget_names.rb
+++ b/db/migrate/20160924213020_change_katello_widget_names.rb
@@ -1,5 +1,5 @@
 class ChangeKatelloWidgetNames < ActiveRecord::Migration
-  class Widget < ActiveRecord::Base
+  class Widget < ApplicationRecord
     self.table_name = "widgets"
   end
 

--- a/db/migrate/20161014133811_move_content_view_version_description_to_histories.rb
+++ b/db/migrate/20161014133811_move_content_view_version_description_to_histories.rb
@@ -1,10 +1,10 @@
 class MoveContentViewVersionDescriptionToHistories < ActiveRecord::Migration
-  class Katello::ContentViewVersion < ActiveRecord::Base
+  class Katello::ContentViewVersion < ApplicationRecord
     has_many :history, :class_name => "Katello::CVHistory", :inverse_of => :content_view_version,
                        :dependent => :destroy, :foreign_key => :katello_content_view_version_id
   end
 
-  class Katello::CVHistory < ActiveRecord::Base
+  class Katello::CVHistory < ApplicationRecord
     self.table_name = 'katello_content_view_histories'
     belongs_to :content_view_version, :class_name => "Katello::ContentViewVersion", :foreign_key => :katello_content_view_version_id, :inverse_of => :history
     SUCCESSFUL = 'successful'.freeze

--- a/db/migrate/20161026191118_fix_invalid_interfaces.rb
+++ b/db/migrate/20161026191118_fix_invalid_interfaces.rb
@@ -1,5 +1,5 @@
 class FixInvalidInterfaces < ActiveRecord::Migration
-  class FakeNic < ActiveRecord::Base
+  class FakeNic < ApplicationRecord
     self.table_name = 'nics'
 
     def type

--- a/db/migrate/20170321012632_fill_in_content_view_components.rb
+++ b/db/migrate/20170321012632_fill_in_content_view_components.rb
@@ -1,18 +1,18 @@
 class FillInContentViewComponents < ActiveRecord::Migration
-  class FakeContentView < ActiveRecord::Base
+  class FakeContentView < ApplicationRecord
     self.table_name = 'katello_content_views'
 
     has_many :content_view_components, :class_name => "FakeContentViewVersion", :dependent => :destroy,
              :inverse_of => :composite_content_view, :foreign_key => :composite_content_view_id
   end
 
-  class FakeContentViewVersion < ActiveRecord::Base
+  class FakeContentViewVersion < ApplicationRecord
     self.table_name = 'katello_content_view_versions'
 
     has_many :content_view_components, :inverse_of => :content_view_version, :dependent => :destroy, :class_name => 'FakeContentViewComponent'
   end
 
-  class FakeContentViewComponent < ActiveRecord::Base
+  class FakeContentViewComponent < ApplicationRecord
     self.table_name = 'katello_content_view_components'
 
     belongs_to :content_view_version, :class_name => "FakeContentViewVersion",


### PR DESCRIPTION
Because Rails 5 will require apps to use ApplicationRecord and because this makes things easier for us to redirect orchestration log messages from sql to orch logger, we are making a change in core and introducing this class (#13772).

Most `ActiveRecord::Base` use must be replaced, specifically:

* `app/model/` - model classes
* `db/migrate/` - "fake" reopened classes otherwise TypeError: superclass mismatch for class XYZ
* `test/` - reopened classes otherwise TypeError: superclass mismatch for class XYZ

This requires https://github.com/theforeman/foreman/pull/3729 to be merged in core first. Tests will fail.