### PR TITLE
fixes #19057 - Consistent ProductContent json labeling

### DIFF
--- a/app/presenters/katello/product_content_presenter.rb
+++ b/app/presenters/katello/product_content_presenter.rb
@@ -18,7 +18,7 @@ module Katello
     end
 
     def content_overrides
-      overrides.find { |pc| pc.content_label == content.label }
+      overrides.select { |pc| pc.content_label == content.label }
     end
   end
 end

--- a/app/views/katello/api/v2/host_subscriptions/product_content.json.rabl
+++ b/app/views/katello/api/v2/host_subscriptions/product_content.json.rabl
@@ -12,7 +12,7 @@ child @collection[:results] => :results do
     attribute :contentUrl => :content_url
   end
 
-  child :overrides => :content_overrides do
+  child :content_overrides => :overrides do
     attributes :name
     attribute :computed_value => :value
   end


### PR DESCRIPTION
After merging https://github.com/Katello/katello/pull/6667 I noticed there was an inconsistency between the product content jsons for host subs and ak subs. I also noticed that the content overrides value instead of returning an array of overrides was just returning one override. This commit tries to address that