### PR TITLE
Fixes #19061 - kick off async fact update

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -259,7 +259,8 @@ module Katello
 
     #api :PUT, "/consumers/:id", N_("Update consumer information")
     def facts
-      sync_task(::Actions::Katello::Host::Update, @host, rhsm_params)
+      User.current = User.anonymous_admin
+      async_task(::Actions::Katello::Host::Update, @host, rhsm_params)
       update_host_registered_through(@host, request.headers)
       render :json => {:content => _("Facts successfully updated.")}, :status => 200
     end

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -103,7 +103,7 @@ module Katello
 
       it "should update facts" do
         facts = {'rhsm_fact' => 'rhsm_value'}
-        assert_sync_task(::Actions::Katello::Host::Update)
+        assert_async_task(::Actions::Katello::Host::Update)
 
         put :facts, :id => @host.subscription_facet.uuid, :facts => facts
         assert_equal 200, response.status
@@ -123,7 +123,7 @@ module Katello
         uuid = @host.subscription_facet.uuid
         stub_cp_consumer_with_uuid(uuid)
         facts = {'rhsm_fact' => 'rhsm_value'}
-        assert_sync_task(::Actions::Katello::Host::Update)
+        assert_async_task(::Actions::Katello::Host::Update)
         put :facts, :id => @host.subscription_facet.uuid, :facts => facts
         assert_response 200
       end


### PR DESCRIPTION
Previously, the POST call to update facts waited on a synchronous
task. This meant that if there was a backlog of tasks, passenger
workers would start to fill up, causing katello to fall over.

Instead, just kick off an async task to update facts. If the task
fails, users may not know without checking the task status, but it
should be OK to do this given the recurring nature of fact updates.