### PR TITLE
Fixes #19056: Use URI to parse Candlepin URL

### DIFF
--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -44,8 +44,9 @@ module Katello
       class CandlepinResource < HttpResource
         cfg = SETTINGS[:katello][:candlepin]
         url = cfg[:url]
-        self.prefix = URI.parse(url).path
-        self.site = url.gsub(self.prefix, "")
+        uri = URI.parse(url)
+        self.prefix = uri.path
+        self.site = "#{uri.scheme}://#{uri.host}"
         self.consumer_secret = cfg[:oauth_secret]
         self.consumer_key = cfg[:oauth_key]
         self.ca_cert_file = cfg[:ca_cert_file]


### PR DESCRIPTION
The old method of setting the site variable disallowed the use of
hostnames that matched 'candlepin' within them. This is problematic
for an external Candlepin or using conventions for tools like
docker-compose where services reflect the hostname to refer them
as.