### PR TITLE
fixes #18696 - add confirmation modal to 'delete manifest'

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/views/manifest-delete-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/views/manifest-delete-modal.html
@@ -1,0 +1,19 @@
+<div data-extend-template="components/views/bst-modal.html">
+  <h4 data-block="modal-header" translate>Delete Manifest?</h4>
+  <div data-block="modal-body">
+    <p translate>Are you sure you want to delete the manifest?</p>
+    <p translate>Note: Deleting a subscription manifest is STRONGLY discouraged. Deleting a manifest will:</p>
+    <ul class="list-aligned">
+      <li translate>Delete all subscriptions that are attached to running hosts.</li>
+      <li translate>Delete all subscriptions attached to activation keys.</li>
+      <li translate>Disable Red Hat Insights</li>
+      <li translate>Require you to upload the subscription-manifest and re-attach subscriptions to hosts and activation keys.</li>
+    </ul>
+    <p translate>This action should only be taken in extreme circumstances or for debugging purposes.</p>
+  </div>
+  <span data-block="modal-confirm-button">
+    <button class="btn btn-danger" ng-click="ok()">
+        <span translate>Delete Manifest</span>
+    </button>
+  </span>
+</div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/views/manifest-import.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/views/manifest-import.html
@@ -28,7 +28,8 @@
     <div class="detail pull-left" ng-show="upstream != null">
       <button type="button" class="btn btn-default" ng-disabled="isTaskPending()"
               ng-hide="denied('delete_manifest')"
-              ng-click="deleteManifest()">
+              ng-click="openModal()">
+         <span bst-modal="deleteManifest()" template-url="subscriptions/manifest/views/manifest-delete-modal.html"></span>
          <i class="fa fa-spinner fa-spin" ng-show="deleteTask.pending"></i>
           <span ng-show="deleteTask.pending" translate>Deleting Manifest...</span>
           <span ng-hide="deleteTask.pending" translate>Delete Manifest</span>


### PR DESCRIPTION
This commit adds a confirmation modal to the 'Delete Manifest'
operation in the UI.

The content of the text is derived from input received on
a downstream bugzilla, but essentially applies upstream as well.