### PR TITLE
Fixes #19089: ensure table.refreshing is false after tasks load.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/tasks-nutupane.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/tasks-nutupane.factory.js
@@ -40,6 +40,7 @@ angular.module('Bastion.tasks').factory('TasksNutupane',
                 self.refreshTasks(tasks);
                 self.deleteOldRows(tasks);
                 self.table.working = false;
+                self.table.refreshing = false;
             };
 
             self.table.search = function () {


### PR DESCRIPTION
The tasks table always had the table mask applied because
table.refreshing was not set to false correctly. This commit fixes the
issue.

http://projects.theforeman.org/issues/19089