### PR TITLE
Fixes #18370: fix styling of katello dropdown buttons.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-details.html
@@ -7,8 +7,8 @@
 
   <div data-block="item-actions">
     <div class="btn-group" uib-dropdown keyboard-nav bst-feature-flag="custom_products">
-      <button type="button" class="btn btn-default" ng-disabled="denied('create_activation_key')" ui-sref="activation-key.copy">
-        <span translate>Copy Activation Key</span>
+      <button type="button" class="btn btn-default" uib-dropdown-toggle>
+        <span translate>Select Action</span>
       </button>
 
       <button type="button" class="btn btn-default" uib-dropdown-toggle>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-repository-sets.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-repository-sets.html
@@ -19,35 +19,29 @@
   <div data-block="list-actions">
     <div class="btn-group" uib-dropdown keyboard-nav>
 
-      <button class="btn btn-default" type="button"
-              translate
-              ng-disabled="table.numSelected === 0"
-              ng-hide="denied('edit_activation_keys', activationKey)"
-              ng-click="overrideToEnabled()">
-        Override to Enabled
+      <button class="btn btn-default" type="button" uib-dropdown-toggle translate>
+        Select Action
       </button>
 
-      <button type="button" class="btn btn-default" uib-dropdown-toggle
-              ng-disabled="table.numSelected === 0"
-              ng-show="permitted('edit_activation_keys', activationKey)">
+      <button type="button" class="btn btn-default" uib-dropdown-toggle>
         <span class="caret"></span>
       </button>
 
       <ul class="dropdown-menu-right" uib-dropdown-menu role="menu" aria-labelledby="split-button">
-        <li role="menuitem">
-          <a ng-click="overrideToEnabled()" ng-show="permitted('edit_activation_keys', activationKey)" translate>
+        <li role="menuitem" ng-show="permitted('edit_activation_keys', activationKey)" ng-class="{disabled: table.numSelected === 0}">
+          <a ng-click="overrideToEnabled()" disable-link="table.numSelected === 0" translate>
             Override to Enabled
           </a>
         </li>
 
-        <li role="menuitem">
-          <a ng-click="overrideToDisabled()" ng-show="permitted('edit_activation_keys', activationKey)" translate>
+        <li role="menuitem" ng-show="permitted('edit_activation_keys', activationKey)" ng-class="{disabled: table.numSelected === 0}">
+          <a ng-click="overrideToDisabled()" disable-link="table.numSelected === 0" translate>
             Override to Disabled
           </a>
         </li>
 
-        <li role="menuitem">
-          <a ng-click="resetToDefault()" ng-show="permitted('edit_activation_keys', activationKey)" translate>
+        <li role="menuitem" ng-show="permitted('edit_activation_keys', activationKey)" ng-class="{disabled: table.numSelected === 0}">
+          <a ng-click="resetToDefault()" disable-link="table.numSelected === 0" translate>
             Reset to Default
           </a>
         </li>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-repository-sets.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-repository-sets.html
@@ -26,35 +26,29 @@
     <div data-block="list-actions">
       <div class="btn-group" uib-dropdown keyboard-nav>
 
-        <button class="btn btn-default" type="button"
-                translate
-                ng-disabled="table.numSelected === 0"
-                ng-hide="denied('edit_activation_keys', activationKey)"
-                ng-click="overrideToEnabled()">
-          Override to Enabled
+        <button class="btn btn-default" type="button" uib-dropdown-toggle>
+          <span translate>Select Action</span>
         </button>
 
-        <button type="button" class="btn btn-default" uib-dropdown-toggle
-                ng-disabled="table.numSelected === 0"
-                ng-show="permitted('edit_activation_keys', activationKey)">
+        <button type="button" class="btn btn-default" uib-dropdown-toggle>
           <span class="caret"></span>
         </button>
 
         <ul class="dropdown-menu-right" uib-dropdown-menu role="menu" aria-labelledby="split-button">
-          <li role="menuitem">
-            <a ng-click="overrideToEnabled()" ng-show="permitted('edit_activation_keys', activationKey)" translate>
+          <li role="menuitem" ng-show="permitted('edit_activation_keys', activationKey)" ng-class="{disabled: table.numSelected === 0}">
+            <a ng-click="overrideToEnabled()" disable-link="table.numSelected === 0" translate>
               Override to Enabled
             </a>
           </li>
 
-          <li role="menuitem">
-            <a ng-click="overrideToDisabled()" ng-show="permitted('edit_activation_keys', activationKey)" translate>
+          <li role="menuitem" ng-show="permitted('edit_activation_keys', activationKey)" ng-class="{disabled: table.numSelected === 0}">
+            <a ng-click="overrideToDisabled()" disable-link="table.numSelected === 0" translate>
               Override to Disabled
             </a>
           </li>
 
-          <li role="menuitem">
-            <a ng-click="resetToDefault()" ng-show="permitted('edit_activation_keys', activationKey)" translate>
+          <li role="menuitem" ng-show="permitted('edit_activation_keys', activationKey)" ng-class="{disabled: table.numSelected === 0}">
+            <a ng-click="resetToDefault()" disable-link="table.numSelected === 0" translate>
               Reset to Default
             </a>
           </li>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
@@ -13,44 +13,39 @@
     </button>
 
     <div class="btn-group" uib-dropdown keyboard-nav>
-      <button type="button" class="btn btn-default"
-              ng-disabled="table.numSelected === 0"
-              ng-show="permitted('edit_hosts')"
-              ng-click="openHostCollectionsModal()">
-        <span translate>Change Host Collection</span>
+      <button type="button" class="btn btn-default" uib-dropdown-toggle>
+        <span translate>Select Action</span>
       </button>
 
-      <button type="button" class="btn btn-default" uib-dropdown-toggle
-              ng-disabled="table.numSelected === 0"
-              ng-show="permitted('edit_hosts') || permitted('destroy_hosts')">
+      <button type="button" class="btn btn-default" uib-dropdown-toggle>
         <span class="caret"></span>
       </button>
 
-      <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="split-button">
-        <li role="menuitem">
-          <a ng-click="openHostCollectionsModal()" ng-show="permitted('edit_hosts')" translate>Change Host Collections</a>
+      <ul class="dropdown-menu dropdown-menu-right" uib-dropdown-menu role="menu" aria-labelledby="split-button">
+        <li role="menuitem" ng-show="permitted('edit_hosts')" ng-class="{disabled: table.numSelected === 0}">
+          <a ng-click="openHostCollectionsModal()" disable-link="table.numSelected === 0" translate>Change Host Collections</a>
         </li>
 
-        <li bst-feature-flag="remote_actions" role="menuitem">
-          <a ng-click="openPackagesModal()" ng-show="permitted('edit_hosts')" translate>Manage Packages</a>
+        <li bst-feature-flag="remote_actions" role="menuitem" ng-show="permitted('edit_hosts')" ng-class="{disabled: table.numSelected === 0}">
+          <a ng-click="openPackagesModal()" disable-link="table.numSelected === 0" translate>Manage Packages</a>
         </li>
 
-        <li bst-feature-flag="remote_actions" role="menuitem">
-          <a ng-click="openErrataModal()" ng-show="permitted('edit_hosts')" translate>Manage Errata</a>
+        <li bst-feature-flag="remote_actions" role="menuitem" ng-show="permitted('edit_hosts')" ng-class="{disabled: table.numSelected === 0}">
+          <a ng-click="openErrataModal()" disable-link="table.numSelected === 0" translate>Manage Errata</a>
         </li>
 
-        <li role="menuitem">
-          <a ng-click="openEnvironmentModal()" ng-show="permitted('edit_hosts')" translate>Change Lifecycle Environment</a>
+        <li role="menuitem" ng-show="permitted('edit_hosts')" ng-class="{disabled: table.numSelected === 0}">
+          <a ng-click="openEnvironmentModal()" disable-link="table.numSelected === 0" translate>Change Lifecycle Environment</a>
         </li>
 
-        <li role="menuitem">
-          <a ng-click="openSubscriptionsModal()" ng-show="permitted('edit_hosts')" translate>Manage Subscriptions</a>
+        <li role="menuitem" ng-show="permitted('edit_hosts')" ng-class="{disabled: table.numSelected === 0}">
+          <a ng-click="openSubscriptionsModal()" disable-link="table.numSelected === 0" translate>Manage Subscriptions</a>
         </li>
 
         <li class="divider"></li>
 
-        <li role="menuitem">
-          <a ng-click="openModal()" ng-show="permitted('destroy_hosts')" translate>Remove Hosts</a>
+        <li role="menuitem" ng-show="permitted('destroy_hosts')" ng-class="{disabled: table.numSelected === 0}">
+          <a ng-click="openModal()" disable-link="table.numSelected === 0" translate>Remove Hosts</a>
           <span bst-modal="performDestroyHosts()" template-url="content-hosts/bulk/views/content-hosts-bulk-destroy-modal.html"></span>
         </li>
       </ul>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-details.html
@@ -7,8 +7,8 @@
 
   <div data-block="item-actions">
     <div class="btn-group" uib-dropdown keyboard-nav bst-feature-flag="custom_products">
-      <button type="button" class="btn btn-default" ui-sref="host-collection.copy" ng-disabled="denied('create_host_collections')">
-        <span translate>Copy Host Collection</span>
+      <button type="button" class="btn btn-default" uib-dropdown-toggle>
+        <span translate>Select Action</span>
       </button>
 
       <button type="button" type="button" class="btn btn-default" uib-dropdown-toggle>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details.controller.js
@@ -55,6 +55,10 @@
             return result;
         };
 
+        $scope.disableSyncLink = function (adavancedSync) {
+            return $scope.hideSyncButton($scope.repository, adavancedSync) || $scope.table.rows === 0;
+        };
+
         $scope.syncRepository = function (repository) {
             Repository.sync({id: repository.id}, function (task) {
                 $state.go('product.repository.tasks.details', {taskId: task.id});

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-details.html
@@ -7,9 +7,8 @@
 
   <div data-block="item-actions">
     <div class="btn-group" uib-dropdown keyboard-nav bst-feature-flag="custom_products">
-      <button type="button" class="btn btn-default" ng-click="syncRepository(repository)"
-              ng-disabled="syncInProgress(repository.last_sync) || !repository.url || denied('sync_products', product)">
-        <span translate>Sync Now</span>
+      <button type="button" class="btn btn-default" uib-dropdown-toggle>
+        <span translate>Select Action</span>
       </button>
 
       <button type="button" class="btn btn-default" uib-dropdown-toggle>
@@ -18,10 +17,8 @@
       </button>
 
       <ul class="dropdown-menu-right" uib-dropdown-menu role="menu">
-        <li role="menuitem">
-          <a ng-click="syncRepository(repository)"
-             ng-hide="hideSyncButton(repository, false)"
-          translate>
+        <li role="menuitem" ng-hide="hideSyncButton(repository, false)" ng-class="{disabled: disableSyncLink()}">
+          <a ng-click="syncRepository(repository)" disable-link="disableSyncLink()" translate>
             Sync Now
           </a>
 
@@ -38,18 +35,14 @@
           </span>
         </li>
 
-        <li role="menuitem">
-          <a ui-sref="product.repository.advanced_sync({repositoryId: repository.id})"
-             ng-hide="hideSyncButton(repository, true)"
-             translate>
+        <li role="menuitem" ng-hide="hideSyncButton(repository, true)" ng-class="{disabled: disableSyncLink()}">
+          <a ui-sref="product.repository.advanced_sync({repositoryId: repository.id})" disable-link="disableSyncLink()" translate>
             Advanced Sync
           </a>
         </li>
 
-        <li role="menuitem">
-          <a ng-click="republishRepository(repository)"
-             ng-hide="syncInProgress(repository.last_sync) || denied('edit_products', product)"
-             translate>
+        <li role="menuitem" ng-hide="syncInProgress(repository.last_sync) || denied('edit_products', product)">
+          <a ng-click="republishRepository(repository)" translate>
             Republish Repository Metadata
           </a>
 
@@ -63,8 +56,8 @@
         </li>
 
         <li class="divider" bst-feature-flag="custom_products" ng-hide="denied('delete_repositories')"></li>
-        <li role="menuitem" ng-hide="denied('delete_repositories')">
-          <a ng-click="openModal()" ng-show="canRemove(repository, product)" translate>
+        <li role="menuitem" ng-show="canRemove(repository, product)">
+          <a ng-click="openModal()" translate>
             Remove Repository
           </a>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-details.html
@@ -7,8 +7,8 @@
 
   <nav data-block="item-actions">
     <div class="btn-group" uib-dropdown keyboard-nav bst-feature-flag="custom_products">
-      <button type="button" class="btn btn-default" ng-disabled="denied('sync_products')" ng-click="syncProduct()">
-        <span translate>Sync Now</span>
+      <button type="button" class="btn btn-default" uib-dropdown-toggle>
+        <span translate>Select Action</span>
       </button>
       <button type="button" class="btn btn-default" uib-dropdown-toggle>
         <span class="caret"></span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/products.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/products.html
@@ -22,36 +22,38 @@
     </button>
 
     <div class="btn-group" uib-dropdown keyboard-nav>
-      <button type="button" class="btn btn-default"
-              ng-show="permitted('sync_products')"
-              ng-disabled="table.numSelected == 0"
-              ng-click="syncProducts()">
-        <span translate>Sync Selected</span>
+      <button type="button" class="btn btn-default" uib-dropdown-toggle>
+        <span translate>Select Action</span>
       </button>
 
-      <button type="button" class="btn btn-default" uib-dropdown-toggle
-              ng-disabled="table.numSelected === 0"
-              ng-show="permitted('sync_products') || permitted('destroy_products')">
+      <button type="button" class="btn btn-default" uib-dropdown-toggle>
         <span class="caret"></span>
+        <span class="sr-only" translate>Toggle Dropdown</span>
       </button>
 
       <ul class="dropdown-menu-right" uib-dropdown-menu role="menu" aria-labelledby="split-button">
-        <li role="menuitem">
-          <a ng-click="syncProducts()" ng-show="permitted('sync_products')" translate>Sync Selected</a>
+        <li role="menuitem" ng-class="{disabled: table.numSelected === 0}">
+          <a ng-click="syncProducts()" ng-show="permitted('sync_products')" disable-link="table.numSelected === 0" translate>
+            Sync Selected
+          </a>
         </li>
 
-        <li role="menuitem">
-          <a ng-click="openAdvancedSyncModal()" ng-show="permitted('edit_products')" translate>Advanced Sync</a>
+        <li role="menuitem" ng-show="permitted('edit_products')" ng-class="{disabled: table.numSelected === 0}">
+          <a ng-click="openAdvancedSyncModal()" disable-link="table.numSelected === 0" translate>
+            Advanced Sync
+          </a>
         </li>
 
-        <li role="menuitem">
-          <a ng-click="openSyncPlanModal()" ng-show="permitted('edit_products')" translate>Manage Sync Plan</a>
+        <li role="menuitem" ng-show="permitted('edit_products')" ng-class="{disabled: table.numSelected === 0}">
+          <a ng-click="openSyncPlanModal()" disable-link="table.numSelected === 0" translate>
+            Manage Sync Plan
+          </a>
         </li>
 
         <li class="divider"></li>
 
-        <li role="menuitem">
-          <a ng-show="permitted('destroy_products')" ng-click="openModal()" translate>Remove</a>
+        <li role="menuitem" ng-show="permitted('destroy_products')" ng-class="{disabled: table.numSelected === 0}">
+          <a ng-click="openModal()" disable-link="table.numSelected === 0" translate>Remove</a>
 
           <div bst-modal="removeProducts()" model="table">
             <div data-block="modal-header"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/views/sync-plan-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/views/sync-plan-details.html
@@ -15,8 +15,8 @@
 
   <nav data-block="item-actions">
     <div class="btn-group" uib-dropdown keyboard-nav bst-feature-flag="custom_products">
-      <button type="button" class="btn btn-default" ng-disabled="denied('sync_products')" ng-click="runSyncPlan()">
-        <span translate>Run Sync Plan</span>
+      <button type="button" class="btn btn-default" uib-dropdown-toggle>
+        <span translate>Select Action</span>
       </button>
 
       <button type="button" class="btn btn-default" uib-dropdown-toggle>


### PR DESCRIPTION
Instead of using the first item in the list of the actions as the button
use the phrase "Select Action" and don't disable the button when rows
are not selected.

http://projects.theforeman.org/issues/18370