### PR TITLE
Fixes #19099 - Use consistent candlepin requests

### DIFF
--- a/app/lib/actions/candlepin/product/create.rb
+++ b/app/lib/actions/candlepin/product/create.rb
@@ -4,6 +4,7 @@ module Actions
       class Create < Candlepin::Abstract
         input_format do
           param :name, String
+          param :id
           param :multiplier
           param :attributes
           param :owner
@@ -11,18 +12,9 @@ module Actions
 
         def run
           output[:response] = ::Katello::Resources::Candlepin::Product.create(input[:owner], :name => input[:name],
-                                                                              :id => unused_product_id,
+                                                                              :id => input[:id],
                                                                               :multiplier => input[:multiplier],
                                                                               :attributes => input[:attributes])
-        end
-
-        def unused_product_id
-          id = SecureRandom.random_number(999_999_999_999)
-          if ::Katello::Product.find_by(:cp_id => id)
-            unused_product_id
-          else
-            id
-          end
         end
       end
     end

--- a/app/lib/actions/candlepin/product/create_unlimited_subscription.rb
+++ b/app/lib/actions/candlepin/product/create_unlimited_subscription.rb
@@ -5,11 +5,18 @@ module Actions
         input_format do
           param :owner_key, String
           param :product_id, String
+          param :start_time, Time
         end
 
         def run
+          if input[:start_time]
+            start_time = Time.iso8601(input[:start_time])
+          else
+            start_time = nil
+          end
           output[:response] = ::Katello::Resources::Candlepin::Product.create_unlimited_subscription(input[:owner_key],
-                                                                                                     input[:product_id])
+                                                                                                     input[:product_id],
+                                                                                                     start_time)
         end
       end
     end

--- a/app/lib/actions/katello/product/create.rb
+++ b/app/lib/actions/katello/product/create.rb
@@ -2,31 +2,44 @@ module Actions
   module Katello
     module Product
       class Create < Actions::EntryAction
-        def plan(product, organization)
+        def plan(product, organization, subscription_start = nil)
           sequence do
             product.provider = organization.anonymous_provider
             product.organization = organization
+            product.setup_label_from_name
+            product.cp_id = unused_product_id(organization.label, product.label)
+            product.save!
 
-            cp_create = plan_action(::Actions::Candlepin::Product::Create,
-                                    :owner => product.organization.label,
-                                    :name => product.name,
-                                    :multiplier => 1,
-                                    :attributes => [{:name => "arch", :value => "ALL"}])
-
-            cp_id = cp_create.output[:response][:id]
+            plan_action(::Actions::Candlepin::Product::Create,
+                        :owner => product.organization.label,
+                        :name => product.name,
+                        :id => product.cp_id,
+                        :multiplier => 1,
+                        :attributes => [{:name => "arch", :value => "ALL"}])
 
             sub_create = plan_action(::Actions::Candlepin::Product::CreateUnlimitedSubscription,
                         :owner_key => organization.label,
-                        :product_id => cp_id)
+                        :product_id => product.cp_id,
+                        :start_time => subscription_start)
 
             subscription_id = sub_create.output[:response][:id]
 
-            product.save!
-            action_subject product, :cp_id => cp_id
+            action_subject product, :cp_id => product.cp_id
 
             plan_self
             plan_action Katello::Product::ReindexSubscriptions, product, subscription_id
           end
+        end
+
+        def unused_product_id(owner, product_label)
+          id = ::Katello::Util::Data.md5hash("#{owner}-#{product_label}")
+
+          count = 0
+          while ::Katello::Product.find_by(:cp_id => id)
+            id = ::Katello::Util::Data.md5hash("#{owner}-#{product_label}#{count}")
+            count += 1
+          end
+          id
         end
 
         def finalize

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -698,7 +698,7 @@ module Katello
             self.delete(join_path(path(owner_label, product_id), "content/#{content_id}"), self.default_headers).code.to_i
           end
 
-          def create_unlimited_subscription(owner_key, product_id)
+          def create_unlimited_subscription(owner_key, product_id, start_date)
             start_date ||= Time.now
             # End it 100 years from now
             end_date ||= start_date + 10_950.days

--- a/app/lib/katello/util/data.rb
+++ b/app/lib/katello/util/data.rb
@@ -5,6 +5,12 @@ module Katello
         variable.map { |x| x.with_indifferent_access }
       end
 
+      def self.md5hash(string)
+        md5 = Digest::MD5.new
+        md5.update(string)
+        md5.hexdigest
+      end
+
       def self.ostructize(obj, options = {})
         options[:prefix_keys] ||= []
         options[:prefix] ||= '_'

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -613,11 +613,12 @@ module Katello
     end
 
     def generate_cp_environment_id(env)
-      # The id for a default view, will simply be the env id; otherwise, it
+      # The id for a default view, will simply be the org label; otherwise, it
       # will be a combination of env id and view id.  The reason being,
       # for a default view, the same candlepin environment will be referenced
       # by the kt_environment and content_view_environment.
-      self.default ? env.id.to_s : [env.id, self.id].join('-')
+      value = self.default ? env.organization.label.to_s : [env.organization.label, env.label, self.label].join('-')
+      Katello::Util::Data.md5hash(value)
     end
 
     def confirm_not_promoted

--- a/app/models/katello/content_view_environment.rb
+++ b/app/models/katello/content_view_environment.rb
@@ -45,10 +45,10 @@ module Katello
 
       if content_view.default?
         self.label ||= environment.label
-        self.cp_id ||= environment.id.to_s
+        self.cp_id ||= Katello::Util::Data.md5hash(environment.organization.label)
       else
         self.label ||= [environment.label, content_view.label].join('/')
-        self.cp_id ||= [environment.id, content_view.id].join('-')
+        self.cp_id ||= Katello::Util::Data.md5hash([environment.id, content_view.id].join('-'))
       end
     end
   end

--- a/test/actions/candlepin/product_test.rb
+++ b/test/actions/candlepin/product_test.rb
@@ -11,21 +11,13 @@ class Actions::Candlepin::Product::ContentUpdateTest < ActiveSupport::TestCase
   describe 'Create' do
     let(:action_class) { ::Actions::Candlepin::Product::Create }
     let(:planned_action) do
-      create_and_plan_action action_class, :name => 'foo', :owner => 'default_org', :multiplier => nil, :attributes => {}
+      create_and_plan_action action_class, :id => 4, :name => 'foo', :owner => 'default_org', :multiplier => nil, :attributes => {}
     end
 
     it 'runs' do
-      SecureRandom.expects(:random_number).returns(4) #chosen by fair dice roll. guarenteed to be random.
       ::Katello::Resources::Candlepin::Product.expects(:create).with('default_org', :name => 'foo', :id => 4,
                                                                      :multiplier => nil, :attributes => {})
       run_action planned_action
-    end
-
-    it 'properly determines an unused id' do
-      katello_products(:fedora).update_attributes!(:cp_id => 4)
-      SecureRandom.stubs(:random_number).returns(4).then.returns(99)
-
-      assert_equal 99, create_action(action_class).unused_product_id
     end
   end
 

--- a/test/actions/katello/product_test.rb
+++ b/test/actions/katello/product_test.rb
@@ -76,17 +76,18 @@ module ::Actions::Katello::Product
     end
 
     it 'plans' do
-      action.stubs(:action_subject).with do |subject, params|
+      action.stubs(:action_subject).with do |subject, _params|
         subject.must_equal(product)
-        params[:cp_id].must_be_kind_of Dynflow::ExecutionPlan::OutputReference
-        params[:cp_id].subkeys.must_equal %w(response id)
       end
       product.expects(:save!).returns([])
+      product.organization.label = 'somelabel'
 
+      Katello::Util::Data.expects(:md5hash).returns('foobar')
       plan_action(action, product, product.organization)
 
       assert_action_planed_with(action,
                                 ::Actions::Candlepin::Product::Create,
+                                :id => 'foobar',
                                 :name => product.name,
                                 :owner => product.organization.label,
                                 :multiplier => 1,


### PR DESCRIPTION
This allows us to record and playback creation of candlepin environments as part of a vcr recording.  While its relying on database ids, it would not be possible.  Initially i tried to use the labels themselves, but candlepin has a 32 character limit on ids.  

So to solve this, we create an md5sum of the different labels merged together.  This creates predictable ids.