### PR TITLE
Fixes #19162 - update foreman-tasks to 0.9.0

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rest-client"
 
   gem.add_dependency "rabl"
-  gem.add_dependency "foreman-tasks", "~> 0.8.0"
+  gem.add_dependency "foreman-tasks", "~> 0.8"
   gem.add_dependency "foreman_docker", ">= 0.2.0"
 
   gem.add_dependency "qpid_messaging", '< 1.0.0'


### PR DESCRIPTION
Not backward incompatibilities other than requiring Foreman 1.15