### PR TITLE
Fixes #18421 - Pass environments as input in CVV promote

### DIFF
--- a/app/lib/actions/katello/content_view/promote.rb
+++ b/app/lib/actions/katello/content_view/promote.rb
@@ -10,6 +10,8 @@ module Actions
 
           fail ::Katello::HttpErrors::BadRequest, _("Cannot promote environment out of sequence. Use force to bypass restriction.") if !is_force && !version.promotable?(environments)
 
+          # Pass the environments as input in order to make them accessible to UI alerts
+          plan_self(environments: environments.map(&:name))
           environments.each do |environment|
             plan_action(ContentView::PromoteToEnvironment, version, environment, description,
                         :force_yum_metadata_regeneration => options[:force_yum_metadata_regeneration])

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-versions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-versions.controller.js
@@ -63,7 +63,7 @@ angular.module('Bastion.content-views').controller('ContentViewVersionsControlle
             return translate("Successfully promoted %cv version %ver to %env")
                 .replace('%cv', version['content_view'].name)
                 .replace('%ver', version.version)
-                .replace('%env', task.input['environment_name']);
+                .replace('%env', task.input.environments.join(", "));
         }
 
         function deletionCompleteMessage(version, task) {


### PR DESCRIPTION
This will make sure the LEs are properly displayed in the UI

To test:
- Create 2+ lifecycle envs
- Publish a content view
- promote the content view
- check that the message says
"Succesfully promoted <content_view_version> to Dev"
(or whatever your LE is called)