### PR TITLE
Fixes #19120 - support async hypervisor checkin

### DIFF
--- a/app/lib/actions/candlepin/async_hypervisors.rb
+++ b/app/lib/actions/candlepin/async_hypervisors.rb
@@ -1,0 +1,22 @@
+module Actions
+  module Candlepin
+    class AsyncHypervisors < Candlepin::AbstractAsyncTask
+      # this action is for tracking an async candlepin task when the task id is already known
+      input_format do
+        param :task_id
+      end
+
+      def poll_external_task(task_id = external_task[:id])
+        task = ::Katello::Resources::Candlepin::Job.get(task_id, :result_data => true)
+        unless ::Katello::Resources::Candlepin::Job.not_finished?(task)
+          output[:hypervisors] = ::Actions::Katello::Host::Hypervisors.parse_hypervisors(task.delete('resultData'))
+        end
+        task
+      end
+
+      def invoke_external_task
+        poll_external_task(input[:task_id])
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/host/hypervisors_update.rb
+++ b/app/lib/actions/katello/host/hypervisors_update.rb
@@ -4,8 +4,8 @@ module Actions
       class HypervisorsUpdate < Actions::EntryAction
         middleware.use ::Actions::Middleware::RemoteAction
 
-        def plan(hypervisors)
-          plan_self(:hypervisors => hypervisors)
+        input_format do
+          param :hypervisors
         end
 
         def run

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -117,6 +117,14 @@ module Katello
             JSON.parse(response).with_indifferent_access
           end
 
+          def async_hypervisors(owner, raw_json)
+            url = "/candlepin/hypervisors/#{owner}"
+            headers = self.default_headers
+            headers['content-type'] = 'text/plain'
+            response = self.post(url, raw_json, headers)
+            JSON.parse(response).with_indifferent_access
+          end
+
           def register_hypervisors(params)
             url = "/candlepin/hypervisors"
             url << "?owner=#{params[:owner]}&env=#{params[:env]}"
@@ -619,8 +627,8 @@ module Katello
             NOT_FINISHED_STATES.include?(job[:state])
           end
 
-          def get(id)
-            job_json = super(path(id), self.default_headers).body
+          def get(id, params = {})
+            job_json = super(path(id) + hash_to_query(params), self.default_headers).body
             job = JSON.parse(job_json)
             job.with_indifferent_access
           end

--- a/config/routes/api/rhsm.rb
+++ b/config/routes/api/rhsm.rb
@@ -16,6 +16,7 @@ Katello::Engine.routes.draw do
       end
       match '/consumers' => 'candlepin_proxies#consumer_create', :via => :post
       match '/hypervisors' => 'candlepin_proxies#hypervisors_update', :via => :post
+      match '/hypervisors/:owner/' => 'candlepin_proxies#async_hypervisors_update', :via => :post
       match '/owners/:organization_id/environments' => 'candlepin_proxies#rhsm_index', :via => :get
       match '/owners/:organization_id/pools' => 'candlepin_proxies#get', :via => :get, :as => :proxy_owner_pools_path
       match '/owners/:organization_id/servicelevels' => 'candlepin_proxies#get', :via => :get, :as => :proxy_owner_servicelevels_path
@@ -54,6 +55,7 @@ Katello::Engine.routes.draw do
       match '/consumers/:id/content_overrides/' => 'candlepin_proxies#delete', :via => :delete, :as => :proxy_consumer_content_overrides_delete_path
       match '/consumers/:id/available_releases' => 'candlepin_proxies#available_releases', :via => :get
       match '/systems/:id/enabled_repos' => 'candlepin_proxies#enabled_repos', :via => :put
+      match '/jobs/:jobId' => 'candlepin_proxies#get', :via => :get, :as => :proxy_jobs_get_path
       match '/status' => 'candlepin_proxies#server_status', :via => :get
     end
   end

--- a/lib/katello/permissions/host_permissions.rb
+++ b/lib/katello/permissions/host_permissions.rb
@@ -26,6 +26,7 @@ Foreman::AccessControl.permission(:edit_hosts).actions.concat [
   'katello/api/rhsm/candlepin_proxies/upload_package_profile',
   'katello/api/rhsm/candlepin_proxies/regenerate_identity_certificates',
   'katello/api/rhsm/candlepin_proxies/hypervisors_update',
+  'katello/api/rhsm/candlepin_proxies/async_hypervisors_update',
   'katello/api/rhsm/candlepin_proxies/upload_tracer_profile'
 ]
 
@@ -53,5 +54,6 @@ Foreman::AccessControl.permission(:create_hosts).actions.concat [
   'katello/api/v2/host_subscriptions/create',
   'katello/api/rhsm/candlepin_proxies/consumer_create',
   'katello/api/rhsm/candlepin_proxies/consumer_show',
-  'katello/api/rhsm/candlepin_proxies/hypervisors_update'
+  'katello/api/rhsm/candlepin_proxies/hypervisors_update',
+  'katello/api/rhsm/candlepin_proxies/async_hypervisors_update'
 ]

--- a/test/actions/katello/host/hypervisors_test.rb
+++ b/test/actions/katello/host/hypervisors_test.rb
@@ -24,7 +24,7 @@ module Katello::Host
 
         plan_action(action, @hypervisor_params)
         assert_action_planed_with(action, ::Actions::Katello::Host::HypervisorsUpdate) do |results, *_|
-          results.must_equal [{:uuid => 1, :name => 'foo', :organization_label => 'org-label'}]
+          results.must_equal(:hypervisors => [{:uuid => 1, :name => 'foo', :organization_label => 'org-label'}])
         end
       end
 
@@ -39,8 +39,8 @@ module Katello::Host
         expected = [{:uuid => 1, :name => 'foo1', :organization_label => 'org-label'},
                     {:uuid => 2, :name => 'foo2', :organization_label => 'org-label'},
                     {:uuid => 3, :name => 'foo3', :organization_label => 'org-label'}]
-        assert_equal expected, action.parse_hypervisors(json)
-        assert_equal [], action.parse_hypervisors({})
+        assert_equal expected, action.class.parse_hypervisors(json)
+        assert_equal [], action.class.parse_hypervisors({})
       end
     end
   end

--- a/test/actions/katello/host/hypervisors_update_test.rb
+++ b/test/actions/katello/host/hypervisors_update_test.rb
@@ -33,7 +33,7 @@ module Katello::Host
 
         action = create_action(::Actions::Katello::Host::HypervisorsUpdate)
 
-        plan_action(action, @hypervisor_results)
+        plan_action(action, :hypervisors => @hypervisor_results)
         finalize_action(action)
       end
 
@@ -43,7 +43,7 @@ module Katello::Host
         ::Host.expects(:find_by).with(:name => @hypervisor_name).returns(@host)
         action = create_action(::Actions::Katello::Host::HypervisorsUpdate)
 
-        plan_action(action, @hypervisor_results)
+        plan_action(action, :hypervisors => @hypervisor_results)
         finalize_action(action)
       end
 
@@ -53,7 +53,7 @@ module Katello::Host
         ::Katello::Host::SubscriptionFacet.expects(:new).never
         action = create_action(::Actions::Katello::Host::HypervisorsUpdate)
 
-        plan_action(action, @hypervisor_results)
+        plan_action(action, :hypervisors => @hypervisor_results)
         finalize_action(action)
       end
 
@@ -64,7 +64,7 @@ module Katello::Host
 
         action = create_action(::Actions::Katello::Host::HypervisorsUpdate)
 
-        plan_action(action, @hypervisor_results)
+        plan_action(action, :hypervisors => @hypervisor_results)
         action = finalize_action(action)
 
         action.state.must_equal :error

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -223,6 +223,20 @@ module Katello
       end
     end
 
+    describe "async_hypervisors_update" do
+      it "hypervisors_update" do
+        Katello::Resources::Candlepin::Consumer.expects(:async_hypervisors).returns('id' => 'foo')
+
+        assert_async_task(::Actions::Katello::Host::Hypervisors) do |params, options|
+          assert_nil params
+          assert_equal options, :task_id => 'foo'
+        end
+
+        post(:async_hypervisors_update, :owner => @organization.label, :env => 'dev/dev')
+        assert_response 200
+      end
+    end
+
     describe "hypervisors_update_with_consumer_auth" do
       before do
         @controller.stubs(:client_authorized?).returns(true)


### PR DESCRIPTION
This supports two new end points for /rhsm:
POST /hypervisors/OWNER_LABEL - for the async hypervisor checkin
GET /jobs/JOB_ID - for client polling of created job