### PR TITLE
Fixes #18987 - Check ueber certs on each proxy sync

### DIFF
--- a/app/lib/actions/katello/capsule_content/sync.rb
+++ b/app/lib/actions/katello/capsule_content/sync.rb
@@ -12,6 +12,7 @@ module Actions
 
         def plan(capsule_content, options = {})
           capsule_content.ping_pulp
+          capsule_content.verify_ueber_certs
           action_subject(capsule_content.capsule)
 
           environment = options.fetch(:environment, nil)

--- a/app/lib/katello/capsule_content.rb
+++ b/app/lib/katello/capsule_content.rb
@@ -147,6 +147,12 @@ module Katello
       raise ::Katello::Errors::CapsuleCannotBeReached, _("%s is unreachable. %s" % [@capsule.name, error])
     end
 
+    def verify_ueber_certs
+      self.capsule.organizations.each do |org|
+        Cert::Certs.verify_ueber_cert(org)
+      end
+    end
+
     def self.with_environment(environment, include_default = false)
       features = [SmartProxy::PULP_NODE_FEATURE]
       features << SmartProxy::PULP_FEATURE if include_default

--- a/app/models/katello/concerns/organization_extensions.rb
+++ b/app/models/katello/concerns/organization_extensions.rb
@@ -154,6 +154,10 @@ module Katello
           end
           discovery
         end
+
+        def regenerate_ueber_cert
+          ::Katello::Resources::Candlepin::Owner.generate_ueber_cert(self.label)
+        end
       end
     end
   end

--- a/app/services/cert/certs.rb
+++ b/app/services/cert/certs.rb
@@ -15,5 +15,12 @@ module Cert
     def self.ssl_client_key
       @ssl_client_key ||= OpenSSL::PKey::RSA.new(File.open(Setting['pulp_client_key'], 'r').read)
     end
+
+    def self.verify_ueber_cert(organization)
+      ueber_cert = OpenSSL::X509::Certificate.new(self.ueber_cert(organization)[:cert])
+      cert_store = OpenSSL::X509::Store.new
+      cert_store.add_file Setting[:ssl_ca_file]
+      organization.regenerate_ueber_cert unless cert_store.verify ueber_cert
+    end
   end
 end

--- a/lib/katello/tasks/regenerate_ueber_certs.rake
+++ b/lib/katello/tasks/regenerate_ueber_certs.rake
@@ -8,7 +8,7 @@ namespace :katello do
     organizations = user_org.present? ? [user_org] : Organization.all
 
     organizations.each do |org|
-      ::Katello::Resources::Candlepin::Owner.generate_ueber_cert(org.label)
+      org.regenerate_ueber_cert
     end
     puts "Regenerated the ueber certificate(s) for #{organizations.map(&:name).join(', ')}"
   end

--- a/test/fixtures/vcr_cassettes/lib/tasks/verify_ueber_cert.yml
+++ b/test/fixtures/vcr_cassettes/lib/tasks/verify_ueber_cert.yml
@@ -1,0 +1,299 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://sausage.example.com:8443/candlepin/owners/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJrZXkiOiJFbXB0eV9Pcmdhbml6YXRpb24iLCJkaXNwbGF5TmFtZSI6IkVt
+        cHR5IE9yZ2FuaXphdGlvbiIsImNvbnRlbnRQcmVmaXgiOiIvRW1wdHlfT3Jn
+        YW5pemF0aW9uLyRlbnYifQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="NW2eUY9FSHDYjtYZTFNebKV8CYcu4HHU",
+        oauth_nonce="XS0wY6j7OHbztJ2OvnzXpkdzVqyFx3TBpjaevmXuUiU", oauth_signature="1%2F6wpiaB%2F8oANwOjIor4froT29Y%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1492453802", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '106'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - e9e371dd-5744-4ebc-bd4a-407f00b53884
+      X-Version:
+      - 2.0.26-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 17 Apr 2017 18:30:02 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiI0MDI4ZjkxZDViN2JkYzg4MDE1
+        YjdkMmRjM2Q2MDA1NiIsImtleSI6IkVtcHR5X09yZ2FuaXphdGlvbiIsImRp
+        c3BsYXlOYW1lIjoiRW1wdHkgT3JnYW5pemF0aW9uIiwiY29udGVudFByZWZp
+        eCI6Ii9FbXB0eV9Pcmdhbml6YXRpb24vJGVudiIsImRlZmF1bHRTZXJ2aWNl
+        TGV2ZWwiOm51bGwsInVwc3RyZWFtQ29uc3VtZXIiOm51bGwsImxvZ0xldmVs
+        IjpudWxsLCJhdXRvYmluZERpc2FibGVkIjpudWxsLCJjb250ZW50QWNjZXNz
+        TW9kZSI6bnVsbCwiY29udGVudEFjY2Vzc01vZGVMaXN0IjpudWxsLCJocmVm
+        IjoiL293bmVycy9FbXB0eV9Pcmdhbml6YXRpb24iLCJjcmVhdGVkIjoiMjAx
+        Ny0wNC0xN1QxODozMDowMiswMDAwIiwidXBkYXRlZCI6IjIwMTctMDQtMTdU
+        MTg6MzA6MDIrMDAwMCJ9
+    http_version: 
+  recorded_at: Mon, 17 Apr 2017 18:30:02 GMT
+- request:
+    method: get
+    uri: https://sausage.example.com:8443/candlepin/owners/Empty_Organization/uebercert
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - OAuth oauth_consumer_key="NW2eUY9FSHDYjtYZTFNebKV8CYcu4HHU", oauth_nonce="Gq8AjBu3N7KTnZE0qC0Hf8oGG5aOFyixXLeL8VLRY",
+        oauth_signature="WdOuoBxeimkDdfb0Ro0VowKF8%2Bw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1492453802", oauth_version="1.0"
+      Cp-User:
+      - foreman_admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 28a217c4-b5dc-4e76-8328-a30c1f8b67e8
+      X-Version:
+      - 2.0.26-1
+      - 2.0.26-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 17 Apr 2017 18:30:02 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJkaXNwbGF5TWVzc2FnZSI6InViZXIgY2VydGlmaWNhdGUgZm9yIG93bmVy
+        IEVtcHR5X09yZ2FuaXphdGlvbiB3YXMgbm90IGZvdW5kLiBQbGVhc2UgZ2Vu
+        ZXJhdGUgb25lLiIsInJlcXVlc3RVdWlkIjoiMjhhMjE3YzQtYjVkYy00ZTc2
+        LTgzMjgtYTMwYzFmOGI2N2U4In0=
+    http_version: 
+  recorded_at: Mon, 17 Apr 2017 18:30:03 GMT
+- request:
+    method: post
+    uri: https://sausage.example.com:8443/candlepin/owners/Empty_Organization/uebercert
+    body:
+      encoding: UTF-8
+      base64_string: |
+        e30=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="NW2eUY9FSHDYjtYZTFNebKV8CYcu4HHU",
+        oauth_nonce="8G8ONiMF5S2dUdQOKwKmPI25DAyMXxc5QHX8xCElKMI", oauth_signature="%2BBG%2FsnAaaEkWcMIPSCL9NRMrVpk%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1492453803", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '2'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 746676a3-932c-43a6-85b6-9d127b4c592f
+      X-Version:
+      - 2.0.26-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 17 Apr 2017 18:30:02 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJrZXkiOiItLS0tLUJFR0lOIFJTQSBQUklWQVRFIEtFWS0tLS0tXG5NSUlF
+        b3dJQkFBS0NBUUVBcDNUQnhHbmRuc3kvZVc3UzhNQ0JKWU0vc2Z6VS9OSUtJ
+        OWdWTWNTT0JKcCtBUmZyXG5ObFN4ZDZiUkkycFNxY0EyeW5VU3BRTkFUcksx
+        Yit0VHI1akgrY2lQeVNZNmRLZVd3bjdxMWRYTEVmU2V6RFhHXG5CTXdWeHVY
+        SzVKSjBWQk4zOUxpVFJXNVFtUWF6Vy9Pd0xoOUdybFFUVWd2b0FDMkpJemFN
+        MDNKKzVwY3laWXgwXG5zemt3TXJFU0hrcmFDdFB6T0h3dWV2eHNCd1NnbDNk
+        TDJJc2k5R0tPL3FZRkFFMFdhcXd1T3I5UHFyVy9Sdk5GXG5rWmdickJ5b2tE
+        UVkxclVhOTc5UmpwQk4xTWlReC9keEFydWF0MStYamxQbjFDbE1TRmtvYzlz
+        eWRkYm5KOFBKXG5jY3pNUzRCczRxR0hYcDZqaTBTeDQ3Uy9LRWlXL0x5aFNw
+        dUZwUUlEQVFBQkFvSUJBRG9JNi9LZlloQmNFMndKXG5iWS9FbDcyaGZCeTZi
+        REptdE43eFQzOGRDTDh0cjhlL08yUnIrOGxsQmd4SkYvYit4NzVvenBwand4
+        RERQTUJhXG5CWG5ROEZWd0hlenZrOGpFSUNxdUE4TXlRaHVwOUxML1crNWpz
+        SlJySldNTUlzYlVySGtpMHQ5NE9QU2Y3dDlLXG5XRi9UdFJKTHp4cGJSLzl2
+        eUp4c2xtZmR3WDgyalBNWTU3S28xa1FUby9VVTJGMXI5RHkvZnhYOWozT201
+        QS9zXG5vUDFtNm16NGhtTXV5Rk5ER29nQTk2WGMzNWQ1RkdqbmVYUlRUcXpT
+        RUtyVGM1citjY2l3YUYzNHdnMW5GOHV2XG5BeUNkaDJZNVVudngrOStSOTRH
+        eHFHZXdXNkJwUmsvZjBvalh3NFZ6bXhpSElBdTh5QWw3WUhuWGVOQi9uQ2RJ
+        XG5vWksyK1MwQ2dZRUE1N2ZBM0YwSG82MTZGUHRXUE02eGNXNTR2anJycFlW
+        WUs2T2F4V0F4NnZPTSt1U0ZLNEszXG5QTjJ0MHVFY0RBU3I2NnJrRituc2pz
+        cGt1SXNMN1VkQ3ZUWWFsZ05RRm1xZFJOSmRLOGpPSWcwY3Q3MVp0VWVKXG4r
+        U0NBTnU0RisyTm8xWHR3cW5XSmNocmZqN1l1aHBuNWt2RzhTSVVBczF0ZFJG
+        VXEvR0FFVm84Q2dZRUF1UUVSXG5VZnpPMEtxUmRoeTJyTElnekRGZlNkSllk
+        endTSmRJSGRURHlnZUx1dysyMUEzRG1pckp6K1haMm1tWHVwRjlwXG5Na2RD
+        ajJxUVI4b016M1dYSDZ4L0xUNElBZUFUQVZ2UG1KU0JnV29Lc1BXZFJQdUlG
+        VDlZaFFqbFNMeUMrdUdmXG54V0pVbzFZNkxhTG40S3R1N3JHQWRHYmdHODVF
+        V0lSSUZ6d3FHb3NDZ1lBV3F0QVAvbjIvMGptT0VlUW13S1YxXG5EalI3ajNI
+        NzJDWis1bHMra2FGd2RYREdIbEswcGUzYzQyYWNxVzYvOGprTExjVndYVzdK
+        clJ6YlBLYm5DRUNNXG5GOTNUN1BFSnNGWkFKRC8vQjM2NnNBT3VLYlM3Mmdx
+        eU55NnpzT2NlNTJPYTlwOVgzWFdibHV0bHVKR21reXRwXG41NEhlcWp3ZVQ0
+        SzVLNGV2OW9pV0d3S0JnSHBRN0dTcW93cHZXNUVkMXVGRFBGQUU3SjFnUjBF
+        K0pEbUJMWkViXG45WnBPc2RJMG5aTlMxL29ubG1uL0d0ZG1RV3ZIOFVOZXZm
+        RVlZYUExUkZiOXhoY1k4MVMwU0pNRTFVdjJxY0NWXG5uekl6TERKbmtiMkVH
+        Q3NFSU1DRWF5TzJEMXRVUlZBNWZRQXBDSG9YMVB0RUhTb1BqWUJvYkErMlJw
+        WEhqK3BjXG55dkdWQW9HQkFMWndFcGVTSE4valRxelJuMDAwa2xFZmROdU51
+        Mjd2TUlzV01wdXc0dWdFZGIyU3lMUnF0SWREXG55aFNrZ042enMxVmFJUkh3
+        VnRHbm5xRFJPZlVEQjc2TnRwMVdmZUJ2R1hUV1ZNRjZwUW9LMEwxMXFjZDZx
+        dFFnXG5MYkhzcHQ2ZTVCOXZkbXQ3UzhOalhvcFpNcGRncjByZWdUWk8ydm92
+        MFU1VmZMWXBqc01LXG4tLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLVxu
+        IiwiY2VydCI6Ii0tLS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0tLVxuTUlJRzlE
+        Q0NCZHlnQXdJQkFnSUlMaTEzbXh2b1lEb3dEUVlKS29aSWh2Y05BUUVGQlFB
+        d2ZqRUxNQWtHQTFVRVxuQmhNQ1ZWTXhGekFWQmdOVkJBZ1REazV2Y25Sb0lF
+        TmhjbTlzYVc1aE1SQXdEZ1lEVlFRSEV3ZFNZV3hsYVdkb1xuTVJBd0RnWURW
+        UVFLRXdkTFlYUmxiR3h2TVJRd0VnWURWUVFMRXd0VGIyMWxUM0puVlc1cGRE
+        RWNNQm9HQTFVRVxuQXhNVGMyRjFjMkZuWlM1bGVHRnRjR3hsTG1OdmJUQWVG
+        dzB4TnpBME1UY3hPRE13TUROYUZ3MDBPVEV5TURFeFxuTXpBd01EQmFNQjB4
+        R3pBWkJnTlZCQW9NRWtWdGNIUjVYMDl5WjJGdWFYcGhkR2x2YmpDQ0FTSXdE
+        UVlKS29aSVxuaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFLZDB3Y1Jw
+        M1o3TXYzbHUwdkRBZ1NXRFA3SDgxUHpTQ2lQWVxuRlRIRWpnU2FmZ0VYNnpa
+        VXNYZW0wU05xVXFuQU5zcDFFcVVEUUU2eXRXL3JVNitZeC9uSWo4a21PblNu
+        bHNKK1xuNnRYVnl4SDBuc3cxeGdUTUZjYmx5dVNTZEZRVGQvUzRrMFZ1VUpr
+        R3MxdnpzQzRmUnE1VUUxSUw2QUF0aVNNMlxuak5OeWZ1YVhNbVdNZExNNU1E
+        S3hFaDVLMmdyVDh6aDhMbnI4YkFjRW9KZDNTOWlMSXZSaWp2Nm1CUUJORm1x
+        c1xuTGpxL1Q2cTF2MGJ6UlpHWUc2d2NxSkEwR05hMUd2ZS9VWTZRVGRUSWtN
+        ZjNjUUs3bXJkZmw0NVQ1OVFwVEVoWlxuS0hQYk1uWFc1eWZEeVhITXpFdUFi
+        T0toaDE2ZW80dEVzZU8wdnloSWx2eThvVXFiaGFVQ0F3RUFBYU9DQTlVd1xu
+        Z2dQUk1CRUdDV0NHU0FHRytFSUJBUVFFQXdJRm9EQUxCZ05WSFE4RUJBTUNC
+        TEF3Z2JJR0ExVWRJd1NCcWpDQlxucDRBVWdCYmZaVnQrQmNsWUpiZDcwekpj
+        ZWgxMk4rdWhnWU9rZ1lBd2ZqRUxNQWtHQTFVRUJoTUNWVk14RnpBVlxuQmdO
+        VkJBZ1REazV2Y25Sb0lFTmhjbTlzYVc1aE1SQXdEZ1lEVlFRSEV3ZFNZV3hs
+        YVdkb01SQXdEZ1lEVlFRS1xuRXdkTFlYUmxiR3h2TVJRd0VnWURWUVFMRXd0
+        VGIyMWxUM0puVlc1cGRERWNNQm9HQTFVRUF4TVRjMkYxYzJGblxuWlM1bGVH
+        RnRjR3hsTG1OdmJZSUpBTXNSOUJua1cvaEJNQjBHQTFVZERnUVdCQlN2amFO
+        YytOTU9Vc0RHSGt2NlxubkFWKzFYRUhRVEFUQmdOVkhTVUVEREFLQmdnckJn
+        RUZCUWNEQWpBMkJoQXJCZ0VFQVpJSUNRR3J0K20zaVJFQlxuQkNJTUlFVnRj
+        SFI1WDA5eVoyRnVhWHBoZEdsdmJsOTFaV0psY2w5d2NtOWtkV04wTUJZR0VD
+        c0dBUVFCa2dnSlxuQWF1MzZiZUpFUU1FQWd3QU1CWUdFQ3NHQVFRQmtnZ0pB
+        YXUzNmJlSkVRSUVBZ3dBTUJZR0VDc0dBUVFCa2dnSlxuQWF1MzZiZUpFUVVF
+        QWd3QU1Ca0dFQ3NHQVFRQmtnZ0pBcXUzNmJlSkVnRUVCUXdEZVhWdE1DUUdF
+        U3NHQVFRQlxua2dnSkFxdTM2YmVKRWdFQkJBOE1EWFZsWW1WeVgyTnZiblJs
+        Ym5Rd01nWVJLd1lCQkFHU0NBa0NxN2ZwdDRrU1xuQVFJRUhRd2JNVFE1TWpR
+        MU16Z3dNekUxTTE5MVpXSmxjbDlqYjI1MFpXNTBNQjBHRVNzR0FRUUJrZ2dK
+        QXF1M1xuNmJlSkVnRUZCQWdNQmtOMWMzUnZiVEFxQmhFckJnRUVBWklJQ1FL
+        cnQrbTNpUklCQmdRVkRCTXZSVzF3ZEhsZlxuVDNKbllXNXBlbUYwYVc5dU1C
+        Y0dFU3NHQVFRQmtnZ0pBcXUzNmJlSkVnRUhCQUlNQURBWUJoRXJCZ0VFQVpJ
+        SVxuQ1FLcnQrbTNpUklCQ0FRRERBRXhNREFHQ2lzR0FRUUJrZ2dKQkFFRUln
+        d2dSVzF3ZEhsZlQzSm5ZVzVwZW1GMFxuYVc5dVgzVmxZbVZ5WDNCeWIyUjFZ
+        M1F3RUFZS0t3WUJCQUdTQ0FrRUFnUUNEQUF3SFFZS0t3WUJCQUdTQ0FrRVxu
+        QXdRUERBMHhORGt5TkRVek9EQXpNVFV6TUJFR0Npc0dBUVFCa2dnSkJBVUVB
+        d3dCTVRBa0Jnb3JCZ0VFQVpJSVxuQ1FRR0JCWU1GREl3TVRjdE1EUXRNVGRV
+        TVRnNk16QTZNRE5hTUNRR0Npc0dBUVFCa2dnSkJBY0VGZ3dVTWpBMFxuT1Mw
+        eE1pMHdNVlF4TXpvd01Eb3dNRm93RVFZS0t3WUJCQUdTQ0FrRURBUUREQUV3
+        TUJBR0Npc0dBUVFCa2dnSlxuQkFvRUFnd0FNQkFHQ2lzR0FRUUJrZ2dKQkEw
+        RUFnd0FNQkVHQ2lzR0FRUUJrZ2dKQkE0RUF3d0JNREFSQmdvclxuQmdFRUFa
+        SUlDUVFMQkFNTUFURXdOQVlLS3dZQkJBR1NDQWtGQVFRbURDUTJOVFEyTm1V
+        MVlpMDRNMll5TFRRMFxuWkRRdFltUXpNeTB4WmpOa04ySmpORE16T1RBd0RR
+        WUpLb1pJaHZjTkFRRUZCUUFEZ2dFQkFLSStLUTRMdlMzb1xuZVhQQ29MTFpC
+        WXlJZm8yWTZPaXI0b1lXRDF1SzNITm1kNERnLzB6em5hSmxMRTA4WXBHWU04
+        dndiT28xek5ablxuQ052WlhkaVV4UWcrNURYTVBMeDZ5NzFzamVEaVQwdG9m
+        T2s0SGxxMmxnSUZTa3oxTmYyQXFOWmVmMldjRkd2a1xuVE1ablNsYVp4bFN3
+        cG41cTJDSFRjTnFGSE5ZUTMwRXUyNTc0Z0cwWEFpRkZ3OWNXUVJWOVVEeXl3
+        M3VTVXhhelxucEpIQXhLbXdRVVoyMWgzUlM0OG5jbUtiZWFCQXVNK0tTTHhi
+        R1JqQklXOGV0SDdLSjIzemJrNTk1L0VXNVBpclxuTGJnVFd5dUoydElPQUNB
+        K0grRmwxbWdyTTNVL3hFOTQ2SFdKWTFnWG00YWxvbjlxc0xtdEV6bXhqVVFo
+        QWU2MlxuOFBwM1pvaXNlWHc9XG4tLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t
+        XG4iLCJpZCI6IjQwMjhmOTFkNWI3YmRjODgwMTViN2QyZGM1NjgwMDU5Iiwi
+        c2VyaWFsIjp7ImlkIjozMzI3NDQ3MjA3NzY4NTE0NjE4LCJyZXZva2VkIjpm
+        YWxzZSwiY29sbGVjdGVkIjpmYWxzZSwiZXhwaXJhdGlvbiI6IjIwNDktMTIt
+        MDFUMTM6MDA6MDArMDAwMCIsInNlcmlhbCI6MzMyNzQ0NzIwNzc2ODUxNDYx
+        OCwiY3JlYXRlZCI6IjIwMTctMDQtMTdUMTg6MzA6MDMrMDAwMCIsInVwZGF0
+        ZWQiOiIyMDE3LTA0LTE3VDE4OjMwOjAzKzAwMDAifSwib3duZXIiOnsiaWQi
+        OiI0MDI4ZjkxZDViN2JkYzg4MDE1YjdkMmRjM2Q2MDA1NiIsImtleSI6IkVt
+        cHR5X09yZ2FuaXphdGlvbiIsImRpc3BsYXlOYW1lIjoiRW1wdHkgT3JnYW5p
+        emF0aW9uIiwiaHJlZiI6Ii9vd25lcnMvRW1wdHlfT3JnYW5pemF0aW9uIn0s
+        ImNyZWF0ZWQiOiIyMDE3LTA0LTE3VDE4OjMwOjAzKzAwMDAiLCJ1cGRhdGVk
+        IjoiMjAxNy0wNC0xN1QxODozMDowMyswMDAwIn0=
+    http_version: 
+  recorded_at: Mon, 17 Apr 2017 18:30:03 GMT
+- request:
+    method: delete
+    uri: https://sausage.example.com:8443/candlepin/owners/Empty_Organization
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - OAuth oauth_consumer_key="NW2eUY9FSHDYjtYZTFNebKV8CYcu4HHU", oauth_nonce="NbMNq2uh9nxcMiempljaNQOBHisV7y96bB1zggYWWEE",
+        oauth_signature="8UXM%2FAPiL3g8iZOv9%2FmBr0sq11s%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1492453803", oauth_version="1.0"
+      Cp-User:
+      - foreman_admin
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 2f1fb30b-a415-4554-8dea-9e7bba5ea2f7
+      X-Version:
+      - 2.0.26-1
+      Date:
+      - Mon, 17 Apr 2017 18:30:02 GMT
+    body:
+      encoding: UTF-8
+      base64_string: ''
+    http_version: 
+  recorded_at: Mon, 17 Apr 2017 18:30:03 GMT
+recorded_with: VCR 3.0.3

--- a/test/services/cert/certs_test.rb
+++ b/test/services/cert/certs_test.rb
@@ -1,0 +1,29 @@
+require 'katello_test_helper'
+require 'support/candlepin/owner_support'
+
+module Katello
+  class CertsTest < ActiveSupport::TestCase
+    def setup
+      VCR.insert_cassette('lib/tasks/verify_ueber_cert')
+      @org = get_organization
+      Resources::Candlepin::Owner.create(@org.label, @org.name)
+    end
+
+    def teardown
+      Resources::Candlepin::Owner.destroy(@org.label)
+      VCR.eject_cassette
+    end
+
+    def test_verify_ueber_cert_no_change
+      Setting.stubs(:[]).with(:ssl_ca_file).returns(File.join("#{Katello::Engine.root}", "/test/services/cert/helpers/ca.crt"))
+      @org.expects(:regenerate_ueber_cert).never
+      Cert::Certs.verify_ueber_cert(@org)
+    end
+
+    def test_verify_ueber_cert_changes
+      Setting.stubs(:[]).with(:ssl_ca_file).returns(File.join("#{Katello::Engine.root}", "/ca/redhat-uep.pem"))
+      @org.expects(:regenerate_ueber_cert).once
+      Cert::Certs.verify_ueber_cert(@org)
+    end
+  end
+end

--- a/test/services/cert/helpers/ca.crt
+++ b/test/services/cert/helpers/ca.crt
@@ -1,0 +1,96 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 14632745056346044481 (0xcb11f419e45bf841)
+    Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=US, ST=North Carolina, L=Raleigh, O=Katello, OU=SomeOrgUnit, CN=sausage.example.com
+        Validity
+            Not Before: Mar 21 01:42:10 2017 GMT
+            Not After : Jan 18 01:42:10 2038 GMT
+        Subject: C=US, ST=North Carolina, L=Raleigh, O=Katello, OU=SomeOrgUnit, CN=sausage.example.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:b8:e1:84:32:02:73:89:b4:e5:6b:63:7b:b3:9a:
+                    0a:d8:90:53:cc:50:ba:0b:c8:8b:f7:00:10:83:2b:
+                    2f:e1:fb:21:a9:25:82:a2:46:fa:88:d9:53:9c:3b:
+                    86:9a:69:c7:54:19:d8:95:07:8c:36:40:29:f1:ae:
+                    ee:b5:21:f0:d9:ef:89:ce:1e:26:df:98:ee:9a:5c:
+                    14:5e:0e:c9:8e:97:70:65:09:da:40:a4:c7:20:d6:
+                    f2:ff:38:c3:f1:a7:f7:f6:26:33:72:75:8a:e7:ef:
+                    4e:4e:ac:70:56:0e:f5:97:5c:be:f7:0e:98:b3:da:
+                    df:ec:0e:f3:17:c1:32:ae:8a:f7:b5:9f:5a:0a:28:
+                    bc:89:a8:0e:a2:22:a0:d1:fa:5e:d2:e0:fa:c8:f5:
+                    d6:e2:86:a9:df:e4:68:37:c4:9b:b7:a5:d6:94:ef:
+                    90:dd:0b:fa:38:84:db:1a:73:de:97:3f:c9:1b:10:
+                    79:4f:d3:d4:e1:76:20:b3:20:1b:49:92:38:a3:fb:
+                    f2:58:11:39:b0:a9:9c:db:5d:42:8f:30:82:b9:92:
+                    5d:e5:f7:d7:34:f8:f1:01:eb:fa:60:3e:21:65:d8:
+                    ec:f9:00:ff:2d:24:0c:01:90:7f:6c:46:22:41:69:
+                    b8:af:65:8f:55:b8:00:7f:c6:09:42:70:49:84:ba:
+                    d3:d5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints: 
+                CA:TRUE
+            X509v3 Key Usage: 
+                Digital Signature, Key Encipherment, Certificate Sign, CRL Sign
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            Netscape Cert Type: 
+                SSL Server, SSL CA
+            Netscape Comment: 
+                Katello SSL Tool Generated Certificate
+            X509v3 Subject Key Identifier: 
+                80:16:DF:65:5B:7E:05:C9:58:25:B7:7B:D3:32:5C:7A:1D:76:37:EB
+            X509v3 Authority Key Identifier: 
+                keyid:80:16:DF:65:5B:7E:05:C9:58:25:B7:7B:D3:32:5C:7A:1D:76:37:EB
+                DirName:/C=US/ST=North Carolina/L=Raleigh/O=Katello/OU=SomeOrgUnit/CN=sausage.example.com
+                serial:CB:11:F4:19:E4:5B:F8:41
+
+    Signature Algorithm: sha256WithRSAEncryption
+         2d:d0:a2:c6:dd:96:c1:33:d8:82:67:8d:0d:57:47:fa:50:a2:
+         f4:60:65:99:2f:89:72:b2:55:c6:28:38:3b:c7:68:ee:40:4f:
+         45:a0:4b:f7:93:38:c3:56:43:de:10:55:03:0d:12:df:b9:aa:
+         e2:35:f1:87:4d:21:e9:d5:8c:4d:cb:51:71:5d:51:b2:c4:ea:
+         a4:26:30:d6:e2:9e:b8:45:89:6e:a4:f0:b0:4b:0f:6f:08:ce:
+         f5:eb:cb:97:80:17:4f:7b:44:81:49:cd:66:f3:e5:54:5d:05:
+         cf:53:12:48:b0:05:24:83:0f:20:c9:37:06:9c:ae:bb:20:97:
+         d6:1a:dc:5f:a8:59:da:16:77:ce:c1:d5:ff:b5:c7:7c:5a:29:
+         cb:e2:84:bf:e1:9b:0a:79:d0:68:b6:4a:b7:c7:5a:90:89:41:
+         f4:8c:81:59:43:e8:24:a3:21:24:6d:8c:57:71:ae:7e:fe:c2:
+         8b:55:85:22:9d:70:7c:46:2b:70:33:b3:f1:5a:f0:f4:b9:5f:
+         b2:49:4d:82:3f:94:aa:64:db:a0:0b:9b:83:dc:13:da:80:2c:
+         91:db:55:69:60:86:28:68:ac:dc:a2:e2:2f:70:48:ba:0d:0d:
+         8f:66:6a:15:6d:90:e7:de:3f:7b:e0:71:f0:cf:7f:d2:97:4f:
+         66:5d:3c:66
+-----BEGIN CERTIFICATE-----
+MIIE3TCCA8WgAwIBAgIJAMsR9BnkW/hBMA0GCSqGSIb3DQEBCwUAMH4xCzAJBgNV
+BAYTAlVTMRcwFQYDVQQIEw5Ob3J0aCBDYXJvbGluYTEQMA4GA1UEBxMHUmFsZWln
+aDEQMA4GA1UEChMHS2F0ZWxsbzEUMBIGA1UECxMLU29tZU9yZ1VuaXQxHDAaBgNV
+BAMTE3NhdXNhZ2UuZXhhbXBsZS5jb20wHhcNMTcwMzIxMDE0MjEwWhcNMzgwMTE4
+MDE0MjEwWjB+MQswCQYDVQQGEwJVUzEXMBUGA1UECBMOTm9ydGggQ2Fyb2xpbmEx
+EDAOBgNVBAcTB1JhbGVpZ2gxEDAOBgNVBAoTB0thdGVsbG8xFDASBgNVBAsTC1Nv
+bWVPcmdVbml0MRwwGgYDVQQDExNzYXVzYWdlLmV4YW1wbGUuY29tMIIBIjANBgkq
+hkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuOGEMgJzibTla2N7s5oK2JBTzFC6C8iL
+9wAQgysv4fshqSWCokb6iNlTnDuGmmnHVBnYlQeMNkAp8a7utSHw2e+Jzh4m35ju
+mlwUXg7JjpdwZQnaQKTHINby/zjD8af39iYzcnWK5+9OTqxwVg71l1y+9w6Ys9rf
+7A7zF8Eyror3tZ9aCii8iagOoiKg0fpe0uD6yPXW4oap3+RoN8Sbt6XWlO+Q3Qv6
+OITbGnPelz/JGxB5T9PU4XYgsyAbSZI4o/vyWBE5sKmc211CjzCCuZJd5ffXNPjx
+Aev6YD4hZdjs+QD/LSQMAZB/bEYiQWm4r2WPVbgAf8YJQnBJhLrT1QIDAQABo4IB
+XDCCAVgwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMCAaYwHQYDVR0lBBYwFAYIKwYB
+BQUHAwEGCCsGAQUFBwMCMBEGCWCGSAGG+EIBAQQEAwICRDA1BglghkgBhvhCAQ0E
+KBYmS2F0ZWxsbyBTU0wgVG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0O
+BBYEFIAW32VbfgXJWCW3e9MyXHoddjfrMIGyBgNVHSMEgaowgaeAFIAW32VbfgXJ
+WCW3e9MyXHoddjfroYGDpIGAMH4xCzAJBgNVBAYTAlVTMRcwFQYDVQQIEw5Ob3J0
+aCBDYXJvbGluYTEQMA4GA1UEBxMHUmFsZWlnaDEQMA4GA1UEChMHS2F0ZWxsbzEU
+MBIGA1UECxMLU29tZU9yZ1VuaXQxHDAaBgNVBAMTE3NhdXNhZ2UuZXhhbXBsZS5j
+b22CCQDLEfQZ5Fv4QTANBgkqhkiG9w0BAQsFAAOCAQEALdCixt2WwTPYgmeNDVdH
++lCi9GBlmS+JcrJVxig4O8do7kBPRaBL95M4w1ZD3hBVAw0S37mq4jXxh00h6dWM
+TctRcV1RssTqpCYw1uKeuEWJbqTwsEsPbwjO9evLl4AXT3tEgUnNZvPlVF0Fz1MS
+SLAFJIMPIMk3BpyuuyCX1hrcX6hZ2hZ3zsHV/7XHfFopy+KEv+GbCnnQaLZKt8da
+kIlB9IyBWUPoJKMhJG2MV3Gufv7Ci1WFIp1wfEYrcDOz8Vrw9LlfsklNgj+UqmTb
+oAubg9wT2oAskdtVaWCGKGis3KLiL3BIug0Nj2ZqFW2Q594/e+Bx8M9/0pdPZl08
+Zg==
+-----END CERTIFICATE-----


### PR DESCRIPTION
When the CA changes for any reason (like a hostname change), we need to regenerate the ueber certs for organizations. This will automatically verify the ueber cert against the ca cert on each proxy sync.

To-do
- [x] Fix test ssl errors