### PR TITLE
Fixes #19174 - prepare tests for external auth source seed

### DIFF
--- a/test/lib/tasks/seeds_test.rb
+++ b/test/lib/tasks/seeds_test.rb
@@ -8,6 +8,7 @@ module Katello
       Setting.stubs(:[]).with(regexp_matches(/katello_default_/)).returns("Crazy Template")
       Setting.stubs(:[]).with(:default_location_subscribed_hosts).returns('')
       Setting.stubs(:[]).with(:default_location_puppet_content).returns('')
+      Setting.stubs(:[]).with(:authorize_login_delegation_auth_source_user_autocreate).returns('EXTERNAL')
       Katello::Repository.stubs(:ensure_sync_notification)
     end
 


### PR DESCRIPTION
This should be safe change that will prevent breaking tests when this core PR is merged https://github.com/theforeman/foreman/pull/4420