### PR TITLE
fixes #19182 - Updates ostree repo correctly

### DIFF
--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -280,7 +280,7 @@ module Katello
           options = { :id => self.pulp_id,
                       :auto_publish => true,
                       :relative_path => relative_path,
-                      :depth => self.ostree_publish_depth }
+                      :depth => self.compute_ostree_upstream_sync_depth }
 
           dist = Runcible::Models::OstreeDistributor.new(options)
           distributors = [dist]
@@ -379,7 +379,7 @@ module Katello
 
       def pulp_update_needed?
         changeable_attributes = %w(url unprotected checksum_type docker_upstream_name download_policy mirror_on_sync verify_ssl_on_sync
-                                   upstream_username upstream_password)
+                                   upstream_username upstream_password ostree_upstream_sync_policy ostree_upstream_sync_depth)
         changeable_attributes << "name" if docker?
         changeable_attributes.any? { |key| previous_changes.key?(key) }
       end

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -419,16 +419,17 @@ rhel_6_x86_64_composite_view_version_1:
 
 ostree:
   name:                 ostree
-  pulp_id:              "Default_Organization-Test-ostree"
+  pulp_id:              100
   content_id:           1
   content_type:         ostree
   label:                ostree
+  url:                  "http://www.ostree-zoo.com/ostree"
   relative_path:        '/ACME_Corporation/library/ostree'
   environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>
   product_id:           <%= ActiveRecord::FixtureSet.identify(:puppet_product) %>
   gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>
-  unprotected:           <%= true %>
+  unprotected:           <%= false %>
   ostree_upstream_sync_policy: latest
 
 ostree_view1:


### PR DESCRIPTION
When updating an OSTree repo one would encounter a stack trace saying
"undefined method `ostree_publish_depth'
This commit fixes that issue