### PR TITLE
Fixes #18223 - Remove display: initial from selects with spinner

### DIFF
--- a/app/assets/stylesheets/katello/containers/container.scss
+++ b/app/assets/stylesheets/katello/containers/container.scss
@@ -1,4 +1,3 @@
 .spinner-form-control {
-  display: initial;
   width: 90%
 }


### PR DESCRIPTION
Resetting the display property makes the elements a box again,
this caused issues showing the select properly.

The select boxes are now rendered correctly:

![screen shot 2017-04-05 at 19 52 40](https://cloud.githubusercontent.com/assets/7757/24719310/8df35588-1a39-11e7-8888-cd6d1796aaa5.png)
