### PR TITLE
Refs #19189 - Check if adapter includes sqlite

### DIFF
--- a/db/migrate/20170222131211_change_pool_columns_to_dates.rb
+++ b/db/migrate/20170222131211_change_pool_columns_to_dates.rb
@@ -1,6 +1,6 @@
 class ChangePoolColumnsToDates < ActiveRecord::Migration
   def up
-    if connection.adapter_name.downcase != 'sqlite3'
+    unless connection.adapter_name.downcase.include?('sqlite')
       change_column(:katello_pools, :start_date, 'timestamp USING CAST(start_date AS timestamp without time zone)')
       change_column(:katello_pools, :end_date, 'timestamp USING CAST(end_date AS timestamp without time zone)')
     end
@@ -9,7 +9,7 @@ class ChangePoolColumnsToDates < ActiveRecord::Migration
   end
 
   def down
-    if connection.adapter_name.downcase != 'sqlite3'
+    unless connection.adapter_name.downcase.include?('sqlite')
       change_column(:katello_pools, :start_date, :string, :limit => 255)
       change_column(:katello_pools, :end_date, :string, :limit => 255)
     end


### PR DESCRIPTION
Turns out the adapter is SQlite which downcases to sqlite and does
not match the name of the adapter that one would specify in
the database.yml. This switches to check for include to match sqlite
in case Rails for some reason changes this name.