### PR TITLE
fixes #19250 - repo sync: several parameters not passed to pulp

### DIFF
--- a/app/lib/actions/pulp/repository/sync.rb
+++ b/app/lib/actions/pulp/repository/sync.rb
@@ -30,7 +30,7 @@ module Actions
             sync_options[:feed] = input[:source_url] if input[:source_url]
             sync_options[:validate] = !(SETTINGS[:katello][:pulp][:skip_checksum_validation])
 
-            sync_options.merge(input[:options]) if input[:options]
+            sync_options.merge!(input[:options]) if input[:options]
 
             output[:pulp_tasks] = pulp_tasks =
                 [pulp_resources.repository.sync(input[:pulp_id], override_config: sync_options)]


### PR DESCRIPTION
Observed that several parameters associated with a 'Validate
Content Sync' were not passed to pulp, resulting in unexpected
behavior.

Refer to issue for more details:
http://projects.theforeman.org/issues/19250