### PR TITLE
Fixes #19283: fix misaligned CV filter repo. page.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filter-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filter-repositories.html
@@ -55,7 +55,6 @@
              ng-class="{'table-mask': table.working}">
         <thead>
           <tr bst-table-head row-select>
-            <th bst-table-column="affectedRepos">Affected?</th>
             <th bst-table-column="name" translate>Name</th>
             <th bst-table-column="product" translate>Product</th>
             <th bst-table-column="type" translate>Type</th>


### PR DESCRIPTION
Fix the misaligned CV filter affected repository page by removing the
superfluous column.

http://projects.theforeman.org/issues/19283