### PR TITLE
Fixes #19302 - Notification for Pulp low disk space

### DIFF
--- a/app/jobs/create_pulp_disk_space_notifications.rb
+++ b/app/jobs/create_pulp_disk_space_notifications.rb
@@ -1,0 +1,9 @@
+class CreatePulpDiskSpaceNotifications < ApplicationJob
+  after_perform do
+    self.class.set(:wait => 12.hours).perform_later
+  end
+
+  def perform
+    Katello::UINotifications::Pulp::ProxyDiskSpace.deliver!
+  end
+end

--- a/app/services/katello/ui_notifications/pulp/proxy_disk_space.rb
+++ b/app/services/katello/ui_notifications/pulp/proxy_disk_space.rb
@@ -1,0 +1,49 @@
+module Katello
+  module UINotifications
+    module Pulp
+      class ProxyDiskSpace
+        class << self
+          def deliver!
+            SmartProxy.unscoped.with_content.each do |proxy|
+              percentage = proxy.statuses[:pulp].storage['pulp_dir']['percent']
+              if percentage[0..2].to_i < 90 && notification_already_exists?(proxy)
+                blueprint.notifications.where(subject: proxy).destroy_all
+                next
+              end
+              next unless update_notifications(proxy).empty?
+              ::Notification.create!(
+                :subject => proxy,
+                :initiator => User.anonymous_admin,
+                :audience => Notification::AUDIENCE_ADMIN,
+                :message => ::UINotifications::StringParser.new(
+                  blueprint.message,
+                  :subject => proxy,
+                  :percentage => percentage
+                ),
+                :notification_blueprint => blueprint
+              )
+            end
+          end
+
+          def notification_already_exists?(subject)
+            low_disk_notification = Notification.unscoped.find_by(:subject => subject)
+            return false if low_disk_notification.blank?
+            low_disk_notification.notification_blueprint == blueprint
+          end
+
+          def update_notifications(subject)
+            return if blueprint.notifications.empty?
+            blueprint.notifications.
+              where(subject: subject).
+              update_attributes(expired_at: blueprint.expired_at)
+          end
+
+          def blueprint
+            @blueprint ||= NotificationBlueprint.unscoped.find_by(
+              :name => 'pulp_low_disk_space')
+          end
+        end
+      end
+    end
+  end
+end

--- a/db/seeds.d/109-katello-notification-blueprints.rb
+++ b/db/seeds.d/109-katello-notification-blueprints.rb
@@ -1,0 +1,18 @@
+blueprints = [
+  {
+    group: N_('Proxies'),
+    name: 'pulp_low_disk_space',
+    message: _("%{subject}'s disk is %{percentage} full. Since this proxy is running Pulp, it needs disk space to publish content views. Please ensure the disk does not get full."),
+    level: 'warning',
+    actions:
+    {
+      links:
+      [
+        path_method: :smart_proxy_path,
+        title: N_('Details')
+      ]
+    }
+  }
+]
+
+blueprints.each { |blueprint| UINotifications::Seed.new(blueprint).configure }

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -265,6 +265,7 @@ module Katello
       end
 
       load 'katello/repository_types.rb'
+      load 'katello/scheduled_jobs.rb'
     end
 
     rake_tasks do

--- a/lib/katello/scheduled_jobs.rb
+++ b/lib/katello/scheduled_jobs.rb
@@ -1,0 +1,12 @@
+# First, we check if there's a job already enqueued for Pulp notifications
+::Foreman::Application.dynflow.config.on_init do |world|
+  pending_jobs = world.persistence.find_execution_plans(filters: { :state => 'scheduled' })
+  scheduled_job = pending_jobs.select do |job|
+    delayed_plan = world.persistence.load_delayed_plan job.id
+    next if delayed_plan.blank?
+    delayed_plan.to_hash[:serialized_args].first["job_class"] == 'CreatePulpDiskSpaceNotifications'
+  end
+
+  # Only create notifications if there isn't a scheduled job
+  CreatePulpDiskSpaceNotifications.perform_later if scheduled_job.blank?
+end


### PR DESCRIPTION
If some proxy is running out of disk space, this notification will warn
the user about it. This will check all proxies with the Pulp feature for
storage on a cron and create notifications according to that. IF the
notification already exists, then it will not create a new one.

This should be triggered via cron until ActiveJob via Dynflow is available

![screenshot from 2017-04-19 13-34-30](https://cloud.githubusercontent.com/assets/598891/25178252/5ced1d76-2505-11e7-8932-3a30905438d6.png)
