### PR TITLE
fixes #19249 - toggle repo sets

### DIFF
--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -167,8 +167,12 @@ module Katello
 
     api :GET, "/hosts/:host_id/subscriptions/product_content", N_("Get content and overrides for the host")
     param :host_id, String, :desc => N_("Id of the host"), :required => true
+    param :content_access_mode_all, :bool, :desc => N_("Get all content available, not just that provided by subscriptions")
+    param :content_access_mode_env, :bool, :desc => N_("Limit content to just that available in the host's content view version")
     def product_content
-      content = @host.subscription_facet.candlepin_consumer.available_product_content
+      content_access_mode_all = ::Foreman::Cast.to_bool(params[:content_access_mode_all])
+      content_access_mode_env = ::Foreman::Cast.to_bool(params[:content_access_mode_env])
+      content = @host.subscription_facet.candlepin_consumer.available_product_content(content_access_mode_all, content_access_mode_env)
       overrides = @host.subscription_facet.candlepin_consumer.content_overrides
       results = content.map { |product_content| Katello::ProductContentPresenter.new(product_content, overrides) }
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-repository-sets.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-repository-sets.controller.js
@@ -16,7 +16,7 @@
 angular.module('Bastion.content-hosts').controller('ContentHostRepositorySetsController',
     ['$scope', 'translate', 'Nutupane', 'HostSubscription', 'ContentOverrideHelper', 'GlobalNotification', 'CurrentOrganization',
     function ($scope, translate, Nutupane, HostSubscription, ContentOverrideHelper, GlobalNotification, CurrentOrganization) {
-        var nutupane, params, saveContentOverride, success, error;
+        var params, saveContentOverride, success, error;
 
         params = {
             id: $scope.$stateParams.hostId,
@@ -27,13 +27,23 @@ angular.module('Bastion.content-hosts').controller('ContentHostRepositorySetsCon
         };
 
         $scope.controllerName = 'katello_products';
-        nutupane = new Nutupane(HostSubscription, params, 'repositorySets');
-        $scope.table = nutupane.table;
+        $scope.nutupane = new Nutupane(HostSubscription, params, 'repositorySets');
+        $scope.table = $scope.nutupane.table;
+
+        $scope.contentAccessModes = {
+            contentAccessModeAll: false,
+            contentAccessModeEnv: false
+        };
+        $scope.toggleFilters = function () {
+            $scope.nutupane.table.params['content_access_mode_all'] = $scope.contentAccessModes.contentAccessModeAll;
+            $scope.nutupane.table.params['content_access_mode_env'] = $scope.contentAccessModes.contentAccessModeEnv;
+            $scope.nutupane.refresh();
+        };
 
         success = function () {
             $scope.table.working = false;
             GlobalNotification.setSuccessMessage(translate('Repository Sets settings saved successfully.'));
-            nutupane.refresh();
+            $scope.nutupane.refresh();
         };
 
         error = function (response) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-repository-sets.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-repository-sets.html
@@ -23,6 +23,17 @@
              ng-model="repositorySetFilter"/>
     </div>
 
+    <div data-block="filters">
+      <label class="checkbox-inline" title="{{ 'Show all Repository Sets in Organization' | translate }}">
+        <input type="checkbox" ng-model="contentAccessModes.contentAccessModeAll" ng-change="toggleFilters()"/>
+        <span translate>Show All</span>
+      </label>
+      <label class="checkbox-inline" title="{{ 'Limit Repository Sets to only those available in this Host\'s Lifecycle Environment' | translate }}">
+        <input type="checkbox" ng-model="contentAccessModes.contentAccessModeEnv" ng-change="toggleFilters()"/>
+        <span translate>Limit to Environment</span>
+      </label>
+    </div>
+
     <div data-block="list-actions">
       <span select-action-dropdown>
         <ul class="dropdown-menu-right" uib-dropdown-menu role="menu" aria-labelledby="split-button">

--- a/engines/bastion_katello/test/content-hosts/details/content-host-repository-sets.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/details/content-host-repository-sets.controller.test.js
@@ -173,4 +173,14 @@ describe('Controller: ContentHostRepositorySetsController', function () {
             expect(GlobalNotification.setErrorMessage).toHaveBeenCalled();
         });
     });
+
+    describe("can toggle repository set filters", function () {
+        it("all and env toggles", function () {
+            $scope.contentAccessModes.contentAccessModeAll = true;
+            $scope.contentAccessModes.contentAccessModeEnv = false;
+            $scope.toggleFilters();
+            expect($scope.nutupane.table.params['content_access_mode_all']).toEqual($scope.contentAccessModes.contentAccessModeAll);
+            expect($scope.nutupane.table.params['content_access_mode_env']).toEqual($scope.contentAccessModes.contentAccessModeEnv);
+        });
+    });
 });

--- a/test/controllers/api/v2/host_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/host_subscriptions_controller_test.rb
@@ -144,7 +144,6 @@ module Katello
 
       ::Katello::Host::SubscriptionFacet.expects(:find_or_create_host).returns(@host)
       assert_sync_task(::Actions::Katello::Host::Register, @host, expected_consumer_params, content_view_environment)
-
       post(:create, :lifecycle_environment_id => content_view_environment.environment_id,
            :content_view_id => content_view_environment.content_view_id, :facts => facts, :installed_products => installed_products)
 
@@ -170,8 +169,22 @@ module Katello
     end
 
     def test_product_content
-      get :product_content, :host_id => @host.id
+      result = get(:product_content, :host_id => @host.id)
+      content = JSON.parse(result.body)['results'][0]['content']
 
+      assert_equal('some-content', content['label'])
+      assert_response :success
+      assert_template 'api/v2/host_subscriptions/product_content'
+    end
+
+    def test_product_content_access_mode_all
+      mode_all = true
+      mode_env = false
+      result = get(:product_content, :host_id => @host.id, :content_access_mode_all => mode_all,
+                   :content_view_version_env => mode_env)
+      content = JSON.parse(result.body)['results'][0]['content']
+
+      assert_equal('some-content', content['label'])
       assert_response :success
       assert_template 'api/v2/host_subscriptions/product_content'
     end

--- a/test/models/host/subscription_facet_test.rb
+++ b/test/models/host/subscription_facet_test.rb
@@ -277,5 +277,15 @@ module Katello
       assert host.valid_content_override_label?('some-label')
       refute host.valid_content_override_label?('some-label1')
     end
+
+    def test_not_all_available_product_content
+      subscription_facet.candlepin_consumer.expects(:products).returns([]).at_least_once
+      subscription_facet.candlepin_consumer.available_product_content(false, false)
+    end
+
+    def test_all_available_product_content
+      subscription_facet.candlepin_consumer.expects(:all_products).returns([]).at_least_once
+      subscription_facet.candlepin_consumer.available_product_content(true, false)
+    end
   end
 end


### PR DESCRIPTION


Allows displaying repo sets three ways:
1. repos available in the subscriptions attached (existing code, unchanged)
2. all repos, regardless of subscriptions (toggle)
3. only repos available in the content view environment (toggle)