### PR TITLE
fixes #19323 - Upgradeable/Installable errata should filter on org

### DIFF
--- a/app/controllers/katello/api/v2/errata_controller.rb
+++ b/app/controllers/katello/api/v2/errata_controller.rb
@@ -37,6 +37,7 @@ module Katello
     def custom_index_relation(collection)
       collection = filter_by_cve(params[:cve], collection) if params[:cve]
       hosts = ::Host::Managed.authorized("view_hosts")
+      hosts = hosts.where(:organization_id => params[:organization_id]) if params[:organization_id]
       if ::Foreman::Cast.to_bool(params[:errata_restrict_applicable])
         collection = collection.applicable_to_hosts(hosts)
       end

--- a/app/controllers/katello/api/v2/packages_controller.rb
+++ b/app/controllers/katello/api/v2/packages_controller.rb
@@ -45,13 +45,17 @@ module Katello
         if @host
           collection = collection.installable_for_hosts([@host])
         else
-          collection = collection.installable_for_hosts(::Host::Managed.authorized("view_hosts"))
+          hosts = ::Host::Managed.authorized("view_hosts")
+          hosts = hosts.where(:organization_id => params[:organization_id]) if params[:organization_id]
+          collection = collection.installable_for_hosts(hosts)
         end
       elsif ::Foreman::Cast.to_bool(params[:packages_restrict_applicable]) || @host
         if @host
           collection = collection.applicable_to_hosts([@host])
         else
-          collection = collection.applicable_to_hosts(::Host::Managed.authorized("view_hosts"))
+          hosts = ::Host::Managed.authorized("view_hosts")
+          hosts = hosts.where(:organization_id => params[:organization_id]) if params[:organization_id]
+          collection = collection.applicable_to_hosts(hosts)
         end
       end
 


### PR DESCRIPTION
The Content -> Errata and Content -> Packages are not taking
in to consideration the organization when determining if the
content (Errata or Packages) are applicable/upgradeable/installable
for hosts.  In other words, it is looking at all hosts
across all organizations in the current logic.