### PR TITLE
Fixes #19339: fix typo in repositorySetsEnabledFilter.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repository-sets/repository-sets-enabled.filter.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repository-sets/repository-sets-enabled.filter.js
@@ -30,5 +30,5 @@
     }
 
     angular.module('Bastion.repository-sets').filter('repositorySetsEnabled', repositorySetsEnabled);
-    repositorySetsEnabled().$inject = ['translate'];
+    repositorySetsEnabled.$inject = ['translate'];
 })();


### PR DESCRIPTION
There was a typo in the repositorySetsEnabledFilter that was causing
dependency injection to fail in production mode.  This commit fixes the
typo.

http://projects.theforeman.org/issues/19339