### PR TITLE
Refs #19333 - Fix minitest 5.1 incompatibilities

### DIFF
--- a/app/controllers/katello/concerns/api/v2/content_overrides_controller.rb
+++ b/app/controllers/katello/concerns/api/v2/content_overrides_controller.rb
@@ -7,7 +7,7 @@ module Katello
       def validate_content_overrides_enabled(content_params, overriden_object = nil)
         name = content_params[:name] || "enabled"
         compare_value = content_params[:value].to_s.downcase
-        remove = content_params.key?(:remove) ? Foreman::Cast.to_bool(content_params[:remove]) : nil
+        remove = content_params.key?(:remove) ? ::Foreman::Cast.to_bool(content_params[:remove]) : nil
         content_label = content_params[:content_label]
 
         if !remove && name == "enabled" &&


### PR DESCRIPTION
Fixes the last test to make the job again green, the 500 error is only apparent if you run the entire `test:katello` suite, not running the API::v2 ActivationKeys test only 

http://ci.theforeman.org/job/test_develop_pr_katello/2579/database=postgresql,ruby=2.2,slave=fast/consoleFull