### PR TITLE
Fixes #19026 - reduce qpid-based candlepin callbacks

### DIFF
--- a/app/models/katello/events/import_pool.rb
+++ b/app/models/katello/events/import_pool.rb
@@ -1,0 +1,17 @@
+module Katello
+  module Events
+    class ImportPool
+      EVENT_TYPE = 'import_pool'.freeze
+
+      def initialize(pool_id)
+        @pool = ::Katello::Pool.find_by(:id => pool_id)
+      end
+
+      def run
+        @pool.try(:import_data)
+      rescue RestClient::ResourceNotFound
+        Rails.logger.warn "skipped re-index of non-existent pool #{@pool.cp_id}"
+      end
+    end
+  end
+end

--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -106,8 +106,15 @@ module Katello
         end
       end
 
-      def update_subscription_status
-        host.get_status(::Katello::SubscriptionStatus).refresh!
+      def update_subscription_status(status_override = nil)
+        status = host.get_status(::Katello::SubscriptionStatus)
+        if status_override
+          status.status = status.to_status(:status_override => status_override)
+          status.save!
+        else
+          host.get_status(::Katello::SubscriptionStatus).refresh!
+        end
+
         host.refresh_global_status!
       end
 

--- a/app/models/katello/subscription_status.rb
+++ b/app/models/katello/subscription_status.rb
@@ -35,9 +35,12 @@ module Katello
       end
     end
 
-    def to_status(_options = {})
+    def to_status(options = {})
       return UNKNOWN unless host.subscription_facet.try(:uuid)
-      case Katello::Candlepin::Consumer.new(host.subscription_facet.uuid, host.organization.label).entitlement_status
+      status_override = options.fetch(:status_override, nil)
+      status = status_override || Katello::Candlepin::Consumer.new(host.subscription_facet.uuid, host.organization.label).entitlement_status
+
+      case status
       when Katello::Candlepin::Consumer::ENTITLEMENTS_VALID
         VALID
       when Katello::Candlepin::Consumer::ENTITLEMENTS_PARTIAL

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -242,6 +242,7 @@ module Katello
       end
 
       Katello::EventQueue.register_event(Katello::Events::ImportHostApplicability::EVENT_TYPE, Katello::Events::ImportHostApplicability)
+      Katello::EventQueue.register_event(Katello::Events::ImportPool::EVENT_TYPE, Katello::Events::ImportPool)
 
       ::HostsController.class_eval do
         helper Katello::Concerns::HostsAndHostgroupsHelperExtensions


### PR DESCRIPTION
Previously we would callback to candlepin to fetch pool and consumer
information whenever certain qpid messages were recieved.

This change:

* Makes complicance.created messages no longer call back to candlepin
  at all, instead it uses the data on the message
* Starts using the katello event queue for processing pool updates.
  This feature de-duplication, so if 1000, events come in on the same
  pool, only a few requests should be made.