### PR TITLE
Fixes #19350 - remove unnecessary "include_root_in_json"

### DIFF
--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -1,7 +1,5 @@
 module Katello
   class ActivationKey < Katello::Model
-    self.include_root_in_json = false
-
     include Glue::Candlepin::ActivationKey if SETTINGS[:katello][:use_cp]
     include Glue if SETTINGS[:katello][:use_cp]
     include Katello::Authorization::ActivationKey

--- a/app/models/katello/content_facet_applicable_rpm.rb
+++ b/app/models/katello/content_facet_applicable_rpm.rb
@@ -1,7 +1,5 @@
 module Katello
   class ContentFacetApplicableRpm < Katello::Model
-    self.include_root_in_json = false
-
     belongs_to :content_facet, :inverse_of => :content_facet_applicable_rpms, :class_name => 'Katello::Host::ContentFacet'
     belongs_to :rpm, :inverse_of => :content_facet_applicable_rpms, :class_name => 'Katello::Rpm'
   end

--- a/app/models/katello/content_facet_erratum.rb
+++ b/app/models/katello/content_facet_erratum.rb
@@ -1,7 +1,5 @@
 module Katello
   class ContentFacetErratum < Katello::Model
-    self.include_root_in_json = false
-
     # Do not use active record callbacks in this join model.  Direct INSERTs and DELETEs are done
     belongs_to :content_facet, :inverse_of => :content_facet_errata, :class_name => 'Katello::Host::ContentFacet'
     belongs_to :erratum, :inverse_of => :content_facet_errata, :class_name => 'Katello::Erratum'

--- a/app/models/katello/content_facet_repository.rb
+++ b/app/models/katello/content_facet_repository.rb
@@ -1,7 +1,5 @@
 module Katello
   class ContentFacetRepository < Katello::Model
-    self.include_root_in_json = false
-
     belongs_to :content_facet, :inverse_of => :content_facet_repositories, :class_name => 'Katello::Host::ContentFacet'
     belongs_to :repository, :inverse_of => :content_facet_repositories, :class_name => 'Katello::Repository'
   end

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -1,8 +1,6 @@
 module Katello
   # rubocop:disable Metrics/ClassLength
   class ContentView < Katello::Model
-    self.include_root_in_json = false
-
     include Ext::LabelFromName
     include Katello::Authorization::ContentView
     include ForemanTasks::Concerns::ActionSubject

--- a/app/models/katello/content_view_component.rb
+++ b/app/models/katello/content_view_component.rb
@@ -1,7 +1,5 @@
 module Katello
   class ContentViewComponent < Katello::Model
-    self.include_root_in_json = false
-
     belongs_to :composite_content_view, :class_name => "Katello::ContentView",
                               :inverse_of => :content_view_components
     belongs_to :content_view_version, :class_name => "Katello::ContentViewVersion",

--- a/app/models/katello/content_view_docker_filter_rule.rb
+++ b/app/models/katello/content_view_docker_filter_rule.rb
@@ -1,7 +1,5 @@
 module Katello
   class ContentViewDockerFilterRule < Katello::Model
-    self.include_root_in_json = false
-
     belongs_to :filter,
                :class_name => "Katello::ContentViewDockerFilter",
                :inverse_of => :docker_rules,

--- a/app/models/katello/content_view_environment.rb
+++ b/app/models/katello/content_view_environment.rb
@@ -1,7 +1,5 @@
 module Katello
   class ContentViewEnvironment < Katello::Model
-    self.include_root_in_json = false
-
     include ForemanTasks::Concerns::ActionSubject
     include Glue::Candlepin::Environment if SETTINGS[:katello][:use_cp]
     include Glue if SETTINGS[:katello][:use_cp]

--- a/app/models/katello/content_view_erratum_filter_rule.rb
+++ b/app/models/katello/content_view_erratum_filter_rule.rb
@@ -1,7 +1,5 @@
 module Katello
   class ContentViewErratumFilterRule < Katello::Model
-    self.include_root_in_json = false
-
     before_create :default_types
 
     ISSUED = "issued".freeze

--- a/app/models/katello/content_view_filter.rb
+++ b/app/models/katello/content_view_filter.rb
@@ -1,7 +1,5 @@
 module Katello
   class ContentViewFilter < Katello::Model
-    self.include_root_in_json = false
-
     DOCKER = 'docker'.freeze
     RPM = Rpm::CONTENT_TYPE
     PACKAGE_GROUP   = PackageGroup::CONTENT_TYPE

--- a/app/models/katello/content_view_package_filter_rule.rb
+++ b/app/models/katello/content_view_package_filter_rule.rb
@@ -1,7 +1,5 @@
 module Katello
   class ContentViewPackageFilterRule < Katello::Model
-    self.include_root_in_json = false
-
     belongs_to :filter,
                :class_name => "Katello::ContentViewPackageFilter",
                :inverse_of => :package_rules,

--- a/app/models/katello/content_view_package_group_filter_rule.rb
+++ b/app/models/katello/content_view_package_group_filter_rule.rb
@@ -1,7 +1,5 @@
 module Katello
   class ContentViewPackageGroupFilterRule < Katello::Model
-    self.include_root_in_json = false
-
     belongs_to :filter,
                :class_name => "Katello::ContentViewPackageGroupFilter",
                :inverse_of => :package_group_rules,

--- a/app/models/katello/content_view_puppet_environment.rb
+++ b/app/models/katello/content_view_puppet_environment.rb
@@ -1,7 +1,5 @@
 module Katello
   class ContentViewPuppetEnvironment < Katello::Model
-    self.include_root_in_json = false
-
     include ForemanTasks::Concerns::ActionSubject
     include Glue::Pulp::Repo if SETTINGS[:katello][:use_pulp]
     include Glue if SETTINGS[:katello][:use_pulp]

--- a/app/models/katello/content_view_puppet_environment_puppet_module.rb
+++ b/app/models/katello/content_view_puppet_environment_puppet_module.rb
@@ -1,7 +1,5 @@
 module Katello
   class ContentViewPuppetEnvironmentPuppetModule < Katello::Model
-    self.include_root_in_json = false
-
     # Do not use active record callbacks in this join model.  Direct INSERTs and DELETEs are done
     belongs_to :content_view_puppet_environment,
                :inverse_of => :content_view_puppet_environment_puppet_modules,

--- a/app/models/katello/content_view_puppet_module.rb
+++ b/app/models/katello/content_view_puppet_module.rb
@@ -1,7 +1,5 @@
 module Katello
   class ContentViewPuppetModule < Katello::Model
-    self.include_root_in_json = false
-
     belongs_to :content_view, :class_name => "Katello::ContentView", :inverse_of => :content_view_versions
 
     validates_lengths_from_database

--- a/app/models/katello/content_view_repository.rb
+++ b/app/models/katello/content_view_repository.rb
@@ -1,7 +1,5 @@
 module Katello
   class ContentViewRepository < Katello::Model
-    self.include_root_in_json = false
-
     ALLOWED_REPOSITORY_TYPES = [Repository::YUM_TYPE,
                                 Repository::DOCKER_TYPE,
                                 Repository::OSTREE_TYPE,

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -1,7 +1,5 @@
 module Katello
   class ContentViewVersion < Katello::Model
-    self.include_root_in_json = false
-
     include Authorization::ContentViewVersion
     include ForemanTasks::Concerns::ActionSubject
 

--- a/app/models/katello/erratum_bugzilla.rb
+++ b/app/models/katello/erratum_bugzilla.rb
@@ -1,7 +1,5 @@
 module Katello
   class ErratumBugzilla < Katello::Model
-    self.include_root_in_json = false
-
     belongs_to :erratum, :inverse_of => :bugzillas, :class_name => 'Katello::Erratum'
   end
 end

--- a/app/models/katello/erratum_cve.rb
+++ b/app/models/katello/erratum_cve.rb
@@ -1,7 +1,5 @@
 module Katello
   class ErratumCve < Katello::Model
-    self.include_root_in_json = false
-
     belongs_to :erratum, :inverse_of => :cves, :class_name => 'Katello::Erratum'
   end
 end

--- a/app/models/katello/erratum_package.rb
+++ b/app/models/katello/erratum_package.rb
@@ -1,7 +1,5 @@
 module Katello
   class ErratumPackage < Katello::Model
-    self.include_root_in_json = false
-
     belongs_to :erratum, :inverse_of => :packages, :class_name => 'Katello::Erratum'
   end
 end

--- a/app/models/katello/gpg_key.rb
+++ b/app/models/katello/gpg_key.rb
@@ -1,7 +1,5 @@
 module Katello
   class GpgKey < Katello::Model
-    self.include_root_in_json = false
-
     include Katello::Authorization::GpgKey
     MAX_CONTENT_LENGTH = 100_000
     MAX_CONTENT_LINE_LENGTH = 65

--- a/app/models/katello/host_collection.rb
+++ b/app/models/katello/host_collection.rb
@@ -1,7 +1,5 @@
 module Katello
   class HostCollection < Katello::Model
-    self.include_root_in_json = false
-
     include Katello::Authorization::HostCollection
 
     has_many :key_host_collections, :class_name => "Katello::KeyHostCollection", :dependent => :destroy

--- a/app/models/katello/host_collection_hosts.rb
+++ b/app/models/katello/host_collection_hosts.rb
@@ -1,7 +1,5 @@
 module Katello
   class HostCollectionHosts < Katello::Model
-    self.include_root_in_json = false
-
     belongs_to :host, :inverse_of => :host_collection_hosts, :class_name => 'Host::Managed'
     belongs_to :host_collection, :inverse_of => :host_collection_hosts
 

--- a/app/models/katello/host_installed_package.rb
+++ b/app/models/katello/host_installed_package.rb
@@ -1,7 +1,5 @@
 module Katello
   class HostInstalledPackage < Katello::Model
-    self.include_root_in_json = false
-
     belongs_to :host, :inverse_of => :host_installed_packages, :class_name => '::Host::Managed'
     belongs_to :installed_package, :inverse_of => :host_installed_packages, :class_name => 'Katello::InstalledPackage'
   end

--- a/app/models/katello/host_tracer.rb
+++ b/app/models/katello/host_tracer.rb
@@ -1,7 +1,5 @@
 module Katello
   class HostTracer < Katello::Model
-    self.include_root_in_json = false
-
     belongs_to :host, :inverse_of => :host_traces, :class_name => '::Host::Managed'
 
     validates :application, :length => {:maximum => 255}, :presence => true

--- a/app/models/katello/key_host_collection.rb
+++ b/app/models/katello/key_host_collection.rb
@@ -1,7 +1,5 @@
 module Katello
   class KeyHostCollection < Katello::Model
-    self.include_root_in_json = false
-
     belongs_to :activation_key, :inverse_of => :key_host_collections
     belongs_to :host_collection, :inverse_of => :key_host_collections
     validates_lengths_from_database

--- a/app/models/katello/kt_environment.rb
+++ b/app/models/katello/kt_environment.rb
@@ -1,7 +1,5 @@
 module Katello
   class KTEnvironment < Katello::Model
-    self.include_root_in_json = false
-
     include ForemanTasks::Concerns::ActionSubject
     include Authorization::LifecycleEnvironment
 

--- a/app/models/katello/pool.rb
+++ b/app/models/katello/pool.rb
@@ -1,7 +1,6 @@
 module Katello
   class Pool < Katello::Model
     include Katello::Authorization::Pool
-
     belongs_to :subscription, :inverse_of => :pools, :class_name => "Katello::Subscription"
 
     has_many :activation_keys, :through => :pool_activation_keys, :class_name => "Katello::ActivationKey"
@@ -9,8 +8,6 @@ module Katello
 
     scope :in_org, ->(org_id) { joins(:subscription).where("#{Katello::Subscription.table_name}.organization_id = ?", org_id) }
     scope :for_activation_key, ->(ak) { joins(:activation_keys).where("#{Katello::ActivationKey.table_name}.id" => ak.id) }
-
-    self.include_root_in_json = false
 
     include Glue::Candlepin::Pool
     include Glue::Candlepin::CandlepinObject

--- a/app/models/katello/product.rb
+++ b/app/models/katello/product.rb
@@ -1,7 +1,5 @@
 module Katello
   class Product < Katello::Model
-    self.include_root_in_json = false
-
     include ForemanTasks::Concerns::ActionSubject
     include Glue::Candlepin::Product if SETTINGS[:katello][:use_cp]
     include Glue::Pulp::Repos if SETTINGS[:katello][:use_pulp]

--- a/app/models/katello/provider.rb
+++ b/app/models/katello/provider.rb
@@ -1,7 +1,5 @@
 module Katello
   class Provider < Katello::Model
-    self.include_root_in_json = false
-
     include ForemanTasks::Concerns::ActionSubject
     include Glue::Provider
     include Glue

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -1,8 +1,6 @@
 module Katello
   # rubocop:disable Metrics/ClassLength
   class Repository < Katello::Model
-    self.include_root_in_json = false
-
     #pulp uses pulp id to sync with 'yum_distributor' on the end
     PULP_ID_MAX_LENGTH = 220
 

--- a/app/models/katello/repository_docker_manifest.rb
+++ b/app/models/katello/repository_docker_manifest.rb
@@ -1,7 +1,5 @@
 module Katello
   class RepositoryDockerManifest < Katello::Model
-    self.include_root_in_json = false
-
     # Do not use active record callbacks in this join model.  Direct INSERTs and DELETEs are done
     belongs_to :repository, :inverse_of => :repository_docker_manifests, :class_name => 'Katello::Repository'
     belongs_to :docker_manifest, :inverse_of => :repository_docker_manifests

--- a/app/models/katello/repository_erratum.rb
+++ b/app/models/katello/repository_erratum.rb
@@ -1,7 +1,5 @@
 module Katello
   class RepositoryErratum < Katello::Model
-    self.include_root_in_json = false
-
     # Do not use active record callbacks in this join model.  Direct INSERTs and DELETEs are done
     belongs_to :repository, :inverse_of => :repository_errata, :class_name => 'Katello::Repository'
     belongs_to :erratum, :inverse_of => :repository_errata, :class_name => 'Katello::Erratum'

--- a/app/models/katello/repository_file.rb
+++ b/app/models/katello/repository_file.rb
@@ -1,7 +1,5 @@
 module Katello
   class RepositoryFile < Katello::Model
-    self.include_root_in_json = false
-
     # Do not use active record callbacks in this join model.  Direct INSERTs and DELETEs are done
     belongs_to :repository, :inverse_of => :repository_files, :class_name => 'Katello::Repository'
     belongs_to :file, :inverse_of => :repository_files, :class_name => 'Katello::FileUnit', :foreign_key => :file_id

--- a/app/models/katello/repository_ostree_branch.rb
+++ b/app/models/katello/repository_ostree_branch.rb
@@ -1,7 +1,5 @@
 module Katello
   class RepositoryOstreeBranch < Katello::Model
-    self.include_root_in_json = false
-
     # Do not use active record callbacks in this join model.  Direct INSERTs and DELETEs are done
     belongs_to :repository, :inverse_of => :repository_ostree_branches, :class_name => 'Katello::Repository'
     belongs_to :ostree_branch, :inverse_of => :repository_ostree_branches

--- a/app/models/katello/repository_package_group.rb
+++ b/app/models/katello/repository_package_group.rb
@@ -1,6 +1,5 @@
 module Katello
   class RepositoryPackageGroup < Katello::Model
-    self.include_root_in_json = false
     # Do not use active record callbacks in this join model.  Direct INSERTs and DELETEs are done
     belongs_to :repository, :inverse_of => :repository_package_groups, :class_name => 'Katello::Repository'
     belongs_to :package_group, :inverse_of => :repository_package_groups, :class_name => 'Katello::PackageGroup'

--- a/app/models/katello/repository_puppet_module.rb
+++ b/app/models/katello/repository_puppet_module.rb
@@ -1,7 +1,5 @@
 module Katello
   class RepositoryPuppetModule < Katello::Model
-    self.include_root_in_json = false
-
     # Do not use active record callbacks in this join model.  Direct INSERTs and DELETEs are done
     belongs_to :repository, :inverse_of => :repository_puppet_modules, :class_name => 'Katello::Repository'
     belongs_to :puppet_module, :inverse_of => :repository_puppet_modules, :class_name => 'Katello::PuppetModule'

--- a/app/models/katello/repository_rpm.rb
+++ b/app/models/katello/repository_rpm.rb
@@ -1,7 +1,5 @@
 module Katello
   class RepositoryRpm < Katello::Model
-    self.include_root_in_json = false
-
     # Do not use active record callbacks in this join model.  Direct INSERTs and DELETEs are done
     belongs_to :repository, :inverse_of => :repository_rpms, :class_name => 'Katello::Repository'
     belongs_to :rpm, :inverse_of => :repository_rpms, :class_name => 'Katello::Rpm'

--- a/app/models/katello/subscription_facet_activation_key.rb
+++ b/app/models/katello/subscription_facet_activation_key.rb
@@ -1,7 +1,5 @@
 module Katello
   class SubscriptionFacetActivationKey < Katello::Model
-    self.include_root_in_json = false
-
     belongs_to :subscription_facet, :inverse_of => :subscription_facet_activation_keys, :class_name => 'Katello::Host::SubscriptionFacet'
     belongs_to :activation_key, :inverse_of => :subscription_facet_activation_keys, :class_name => 'Katello::ActivationKey'
   end

--- a/app/models/katello/subscription_product.rb
+++ b/app/models/katello/subscription_product.rb
@@ -1,6 +1,5 @@
 module Katello
   class SubscriptionProduct < Katello::Model
-    self.include_root_in_json = false
     belongs_to :product, :inverse_of => :subscription_products, :class_name => 'Katello::Product'
     belongs_to :subscription, :inverse_of => :subscription_products, :class_name => 'Katello::Subscription'
   end

--- a/app/models/katello/sync_plan.rb
+++ b/app/models/katello/sync_plan.rb
@@ -2,8 +2,6 @@ require 'time'
 
 module Katello
   class SyncPlan < Katello::Model
-    self.include_root_in_json = false
-
     include Glue
     include Katello::Authorization::SyncPlan
     include ForemanTasks::Concerns::ActionSubject

--- a/app/models/katello/task_status.rb
+++ b/app/models/katello/task_status.rb
@@ -1,7 +1,5 @@
 module Katello
   class TaskStatus < Katello::Model
-    self.include_root_in_json = false
-
     include Util::TaskStatus
 
     serialize :result


### PR DESCRIPTION
in models
This is no longer needed in Rails 4 as it defaults to false [1]

[1] http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html
(section 6.6, 2nd bullet point)