### PR TITLE
Fixes #19433: Mv `trigger` to `triggering_action`

### DIFF
--- a/app/lib/actions/middleware/backend_services_check.rb
+++ b/app/lib/actions/middleware/backend_services_check.rb
@@ -32,8 +32,8 @@ module Actions
 
       def source_action
         parent = self.action
-        until parent.trigger.nil?
-          parent = parent.trigger
+        until parent.triggering_action.nil?
+          parent = parent.triggering_action
         end
         parent
       end


### PR DESCRIPTION
Due to this change: https://github.com/Dynflow/dynflow/pull/229

@iNecas 