### PR TITLE
[WIP] Fixes #18704 - Add index to katello_rpms

### DIFF
--- a/db/migrate/20170504190050_add_indexes_to_katello_rpms.rb
+++ b/db/migrate/20170504190050_add_indexes_to_katello_rpms.rb
@@ -1,0 +1,5 @@
+class AddIndexesToKatelloRpms < ActiveRecord::Migration
+  def change
+    add_index "katello_repository_rpms", "rpm_id", :name => 'index_katello_repository_rpms_on_rpm_ids'
+  end
+end


### PR DESCRIPTION
This speeds up our packages endpoint, which currently
does not scale too well.

On a machine with 68,266 packages, the response time
went from 3.6572951642 seconds to 1.8027665101 seconds
when this index was added. The benchmark script
used can be found [here](https://gist.github.com/johnpmitsch/181b429f260731206350632ba0da113f)