### PR TITLE
Fixes #19194: show new sync plan on products form in modal.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-details.html
@@ -23,7 +23,7 @@
         </li>
 
         <li role="menuitem" ng-hide="denied('create_sync_plans')">
-          <a ui-sref="product.new-sync-plan">
+          <a ui-sref="openProductModal()">
             <span translate>New Sync Plan</span>
           </a>
         </li>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-new-sync-plan.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/views/product-new-sync-plan.html
@@ -1,2 +1,0 @@
-<h3 translate>New Sync Plan for {{ product.name }}</h3>
-<div ng-include="'sync-plans/new/views/new-sync-plan-form.html'"></div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/new/new-sync-plan-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/new/new-sync-plan-modal.controller.js
@@ -1,0 +1,46 @@
+/**
+ * @ngdoc object
+ * @name  Bastion.proudcts.controller:NewSyncPlanModalController
+ *
+ * @requires $scope
+ * @requires $uibModalInstance
+ * @requires SyncPlan
+ * @requires SyncPlanHelper
+ *
+ * @description
+ *   A controller for creating a new sync plan in a modal.
+ */
+angular.module('Bastion.products').controller('NewSyncPlanModalController',
+    ['$scope', '$uibModalInstance', 'SyncPlan', 'SyncPlanHelper',
+        function ($scope, $uibModalInstance, SyncPlan, SyncPlanHelper) {
+            function success(syncPlan) {
+                $uibModalInstance.close(syncPlan);
+            }
+
+            function error(response) {
+                var form = SyncPlanHelper.getForm();
+
+                angular.forEach(response.data.errors, function (errors, field) {
+                    form[field].$setValidity('server', false);
+                    form[field].$error.messages = errors;
+                });
+            }
+
+            $scope.ok = function (syncPlan) {
+                SyncPlanHelper.createSyncPlan(syncPlan, success, error);
+            };
+
+            $scope.cancel = function () {
+                $uibModalInstance.dismiss('cancel');
+            };
+
+            $scope.isFormDisabled = function () {
+                var form = SyncPlanHelper.getForm();
+                return form && !form.$valid;
+            };
+
+            $scope.intervals = SyncPlanHelper.getIntervals();
+            $scope.syncPlan = new SyncPlan();
+            $scope.syncPlan.interval = $scope.intervals[0].id;
+        }]
+);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/new/product-form.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/new/product-form.controller.js
@@ -4,10 +4,12 @@
  *
  * @requires $scope
  * @requires $q
+ * @requires $uibModal
  * @requires Product
  * @requires GPGKey
  * @requires SyncPlan
  * @requires FormUtils
+ *
  *
  * @description
  *   Provides the functionality specific to Products for use with the Nutupane UI pattern.
@@ -15,8 +17,8 @@
  *   within the table.
  */
 angular.module('Bastion.products').controller('ProductFormController',
-    ['$scope', '$q', 'Product', 'GPGKey', 'SyncPlan', 'FormUtils', 'GlobalNotification',
-    function ($scope, $q, Product, GPGKey, SyncPlan, FormUtils, GlobalNotification) {
+    ['$scope', '$q', '$uibModal', 'Product', 'GPGKey', 'SyncPlan', 'FormUtils', 'GlobalNotification',
+    function ($scope, $q, $uibModal, Product, GPGKey, SyncPlan, FormUtils, GlobalNotification) {
 
         function fetchGpgKeys() {
             return GPGKey.queryUnpaged(function (gpgKeys) {
@@ -62,5 +64,16 @@ angular.module('Bastion.products').controller('ProductFormController',
         $q.all([fetchSyncPlans().$promise, fetchGpgKeys().$promise]).finally(function () {
             $scope.page.loading = false;
         });
+
+        $scope.openSyncPlanModal = function () {
+            $uibModal.open({
+                templateUrl: 'products/new/views/new-sync-plan-modal.html',
+                controller: 'NewSyncPlanModalController'
+            }).result.then(function ($value) {
+                fetchSyncPlans().$promise.then(function () {
+                    $scope.product['sync_plan_id'] = $value.id;
+                });
+            });
+        };
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/new/views/new-sync-plan-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/new/views/new-sync-plan-modal.html
@@ -1,0 +1,18 @@
+<div data-extend-template="components/views/bst-modal.html" ng-controller="NewSyncPlanController">
+  <h4 data-block="modal-header" translate>
+    New Sync Plan
+  </h4>
+
+  <div data-block="modal-body">
+    <div ng-include="'sync-plans/new/views/new-sync-plan-form.html'"></div>
+  </div>
+
+  <span data-block="modal-confirm-button">
+    <button class="btn btn-primary" ng-click="ok(syncPlan)"
+            ng-disabled="isFormDisabled()">
+      <span translate>Save</span>
+    </button>
+  </span>
+</div>
+
+

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/new/views/product-new-form.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/new/views/product-new-form.html
@@ -27,18 +27,18 @@
       </select>
     </div>
 
-    <div bst-form-group label="{{ 'Sync Plan' | translate }}">
-      <select id="sync_plan_id"
-              name="sync_plan_id"
-              ng-model="product.sync_plan_id"
-              ng-options="syncPlan.id as syncPlan.name for syncPlan in syncPlans">
-        <option value=""></option>
-      </select>
-      <a ui-sref="products.new.sync-plan" translate>
-        <i class="pficon pficon-add-circle-o"></i>
-        Create Sync Plan
-      </a>
-    </div>
+  <div bst-form-group label="{{ 'Sync Plan' | translate }}">
+    <select id="sync_plan_id"
+            name="sync_plan_id"
+            ng-model="product.sync_plan_id"
+            ng-options="syncPlan.id as syncPlan.name for syncPlan in syncPlans">
+      <option value=""></option>
+    </select>
+    <a ng-click="openSyncPlanModal()">
+      <i class="pficon pficon-add-circle-o"></i>
+      <span translate>Create Sync Plan</span>
+    </a>
+  </div>
 
     <div bst-form-group label="{{ 'Description' | translate }}">
       <textarea id="description"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.routes.js
@@ -40,15 +40,6 @@ angular.module('Bastion.products').config(['$stateProvider', function ($statePro
         ncyBreadcrumb: {
             label: "{{ 'New Product' | translate }}"
         }
-    })
-    .state('products.new.sync-plan', {
-        url: '/new/sync-plan',
-        permission: 'create_sync_plans',
-        controller: 'NewSyncPlanController',
-        templateUrl: 'sync-plans/new/views/new-sync-plan-form.html',
-        ncyBreadcrumb: {
-            label: "{{ 'New Sync Plan' | translate }}"
-        }
     });
 
     $stateProvider.state("product-discovery", {
@@ -92,16 +83,6 @@ angular.module('Bastion.products').config(['$stateProvider', function ($statePro
         ncyBreadcrumb: {
             label: "{{ product.name }}",
             parent: 'products'
-        }
-    })
-    .state('product.new-sync-plan', {
-        url: '/sync-plan/new',
-        permission: 'create_sync_plans',
-        controller: 'NewSyncPlanController',
-        templateUrl: 'products/details/views/product-new-sync-plan.html',
-        ncyBreadcrumb: {
-            label: "{{ 'New Sync Plan'  | translate}}",
-            parent: 'product.info'
         }
     });
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/new/new-sync-plan.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/new/new-sync-plan.controller.js
@@ -5,51 +5,43 @@
  * @requires $scope
  * @requires translate
  * @requires SyncPlan
+ * @requires SyncPlanHelper
+ * @requires GlobalNotification
  *
  * @description
  *   Controls the creation of an empty SyncPlan object for use by sub-controllers.
  */
 angular.module('Bastion.sync-plans').controller('NewSyncPlanController',
-    ['$scope', 'translate', 'SyncPlan', 'GlobalNotification',
-        function ($scope, translate, SyncPlan, GlobalNotification) {
-            $scope.intervals = [
-                {id: 'hourly', value: translate('hourly')},
-                {id: 'daily', value: translate('daily')},
-                {id: 'weekly', value: translate('weekly')}
-            ];
+    ['$scope', '$rootScope', 'translate', 'SyncPlan', 'SyncPlanHelper', 'GlobalNotification',
+        function ($scope, $rootScope, translate, SyncPlan, SyncPlanHelper, GlobalNotification) {
+            $scope.intervals = SyncPlanHelper.getIntervals();
 
             $scope.syncPlan = new SyncPlan();
             $scope.syncPlan.interval = $scope.intervals[0].id;
 
             function success(syncPlan) {
                 $scope.working = false;
+                $scope.$state.go('sync-plan.info', {syncPlanId: syncPlan.id});
                 GlobalNotification.setSuccessMessage(translate('New sync plan successfully created.'));
-                if ($scope.product) {
-                    $scope.product['sync_plan_id'] = syncPlan.id;
-                    $scope.$state.go('product.info', {productId: $scope.product.id});
-                } else {
-                    $scope.$state.go('sync-plan.info', {syncPlanId: syncPlan.id});
-                }
             }
 
             function error(response) {
-                $scope.working = false;
+                var form = SyncPlanHelper.getForm();
+
                 angular.forEach(response.data.errors, function (errors, field) {
-                    $scope.syncPlanForm[field].$setValidity('server', false);
-                    $scope.syncPlanForm[field].$error.messages = errors;
+                    form[field].$setValidity('server', false);
+                    form[field].$error.messages = errors;
                 });
+
+                $scope.working = false;
             }
 
             $scope.createSyncPlan = function (syncPlan) {
-                var GMT_OFFSET_MILLISECONDS = syncPlan.startDate.getTimezoneOffset() * 60000,
-                    syncDate = new Date(syncPlan.startDate.getTime() + GMT_OFFSET_MILLISECONDS),
-                    syncTime = new Date(syncPlan.startTime || new Date());
-                syncDate.setHours(syncTime.getHours());
-                syncDate.setMinutes(syncTime.getMinutes());
-                syncDate.setSeconds(0);
+                SyncPlanHelper.createSyncPlan(syncPlan, success, error);
+            };
 
-                syncPlan['sync_date'] = syncDate.toString();
-                syncPlan.$save(success, error);
+            $scope.setForm = function (form) {
+                SyncPlanHelper.setForm(form);
             };
         }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/new/views/new-sync-plan-form.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/new/views/new-sync-plan-form.html
@@ -1,65 +1,69 @@
-<form ng-controller="NewSyncPlanController" name="syncPlanForm" class="col-sm-5" novalidate role="form">
- <div bst-form-group label="{{ 'Name' | translate }}">
-   <input id="name"
-          name="name"
-          ng-model="syncPlan.name"
-          type="text"
-          tabindex="1"
-          autofocus
-          required/>
- </div>
+<div ng-form name="syncPlanForm" novalidate role="form">
+  <div bst-form-group label="{{ 'Name' | translate }}">
+    <input id="name"
+           name="name"
+           ng-model="syncPlan.name"
+           type="text"
+           tabindex="1"
+           autofocus
+           required/>
+  </div>
 
- <div bst-form-group label="{{ 'Description' | translate }}">
+  <div bst-form-group label="{{ 'Description' | translate }}">
    <textarea id="description"
              name="description"
              ng-model="syncPlan.description"
              tabindex="2">
    </textarea>
- </div>
+  </div>
 
- <div bst-form-group label="{{ 'Interval' | translate }}">
-   <select id="interval"
-           name="interval"
-           ng-model="syncPlan.interval"
-           ng-options="interval.id as interval.value for interval in intervals"
-           tabindex="3"
-           required>
+  <div bst-form-group label="{{ 'Interval' | translate }}">
+    <select id="interval"
+            name="interval"
+            ng-model="syncPlan.interval"
+            ng-options="interval.id as interval.value for interval in intervals"
+            tabindex="3"
+            required>
       <option value="" translate>-- select an interval --</option>
-   </select>
- </div>
+    </select>
+  </div>
 
- <div bst-form-group label="{{ 'Start Date' | translate }}">
-   <div class="input-group">
-     <input type="text" uib-datepicker-popup
-            id="startDate"
-            name="startDate"
-            is-open="isOpen"
-            ng-model="syncPlan.startDate"
-            show-weeks="false"
-            tabindex="4"
-            required/>
+  <div bst-form-group label="{{ 'Start Date' | translate }}">
+    <div class="input-group">
+      <input type="text" uib-datepicker-popup
+             id="startDate"
+             name="startDate"
+             is-open="isOpen"
+             ng-model="syncPlan.startDate"
+             show-weeks="false"
+             tabindex="4"
+             required/>
 
      <span class="input-group-btn">
        <button type="button" class="btn btn-default" ng-click="isOpen = !isOpen">
          <i class="fa fa-calendar"></i>
        </button>
      </span>
-   </div>
- </div>
+    </div>
+  </div>
 
- <div bst-form-group label="{{ 'Start Time' | translate }}">
-   <div uib-timepicker show-meridian="false"
-          id="startTime"
-          name="startTime"
-          ng-model="syncPlan.startTime"
-          tabindex="5">
-   </div>
-   <p class="help-block" translate>The time the sync should happen in your current time zone.</p>
- </div>
+  <div bst-form-group label="{{ 'Start Time' | translate }}">
+    <div uib-timepicker show-meridian="false"
+         id="startTime"
+         name="startTime"
+         ng-model="syncPlan.startTime"
+         tabindex="5">
+    </div>
+    <p class="help-block" translate>The time the sync should happen in your current time zone.</p>
+  </div>
 
- <div bst-form-buttons
-      on-cancel="transitionBack()"
-      on-save="createSyncPlan(syncPlan)"
-      working="working">
- </div>
-</form>
+  <div ng-init="setForm(syncPlanForm);"></div>
+
+  <div ng-show="isState('sync-plans.new')">
+    <div bst-form-buttons
+         on-cancel="transitionBack()"
+         on-save="createSyncPlan(syncPlan)"
+         working="working">
+    </div>
+  </div>
+</div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/new/views/new-sync-plan.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/new/views/new-sync-plan.html
@@ -6,6 +6,8 @@
   </header>
 
   <div data-block="content">
-    <div ng-include="'sync-plans/new/views/new-sync-plan-form.html'"></div>
+    <div class="row">
+      <div class="col-sm-5" ng-include="'sync-plans/new/views/new-sync-plan-form.html'"></div>
+    </div>
   </div>
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/sync-plan-helper.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/sync-plan-helper.service.js
@@ -1,0 +1,66 @@
+(function () {
+
+    /**
+     * @ngdoc service
+     * @name Bastion.sync-plans.service:SyncPlanHelper
+     *
+     * @description
+     *   Provides a helper service for Sync Plans
+     *
+     */
+    function SyncPlanHelper(translate) {
+
+        /**
+         * Get the set form.  Allows the sharing of form data across controllers
+         *
+         * @param form the form to set
+         */
+        this.setForm = function (form) {
+            this.form = form;
+        };
+
+        /**
+         * Set the form.  Allows the sharing of form data across controllers
+         *
+         * @returns {form|*} the stored form
+         */
+        this.getForm = function () {
+            return this.form;
+        };
+
+        /**
+         * Returns the valid sync plan intervals.
+         *
+         * @returns {{id: string, value: *}[]}
+         */
+        this.getIntervals = function () {
+            return [
+                {id: 'hourly', value: translate('hourly')},
+                {id: 'daily', value: translate('daily')},
+                {id: 'weekly', value: translate('weekly')}
+            ];
+
+        };
+
+        /**
+         * Create a sync plan, including setting the dates correctly.
+         *
+         * @returns $resource sync plan
+         */
+        this.createSyncPlan = function (syncPlan, success, error) {
+            var GMT_OFFSET_MILLISECONDS = syncPlan.startDate.getTimezoneOffset() * 60000,
+                syncDate = new Date(syncPlan.startDate.getTime() + GMT_OFFSET_MILLISECONDS),
+                syncTime = new Date(syncPlan.startTime || new Date());
+            syncDate.setHours(syncTime.getHours());
+            syncDate.setMinutes(syncTime.getMinutes());
+            syncDate.setSeconds(0);
+
+            syncPlan['sync_date'] = syncDate.toString();
+            syncPlan.$save(success, error);
+            return syncPlan;
+        };
+    }
+
+    angular.module('Bastion.sync-plans').service('SyncPlanHelper', SyncPlanHelper);
+    SyncPlanHelper.$inject = ['translate'];
+})();

--- a/engines/bastion_katello/test/products/new/product-form.controller.test.js
+++ b/engines/bastion_katello/test/products/new/product-form.controller.test.js
@@ -7,7 +7,8 @@ describe('Controller: ProductFormController', function() {
     beforeEach(module('Bastion.products', 'Bastion.test-mocks'));
 
     beforeEach(inject(function($injector) {
-        var $controller = $injector.get('$controller'),
+        var $uibModal,
+            $controller = $injector.get('$controller'),
             $http = $injector.get('$http'),
             $q = $injector.get('$q'),
             Product = $injector.get('MockResource').$new(),
@@ -23,10 +24,23 @@ describe('Controller: ProductFormController', function() {
         $scope.productForm = $injector.get('MockForm');
         $scope.panel = {};
 
+        $uibModal = {
+            open: function () {
+                return {
+                    result: {
+                        then: function (callback) {
+                            callback();
+                        }
+                    }
+                }
+            }
+        };
+
         $controller('ProductFormController', {
             $scope: $scope,
             $http: $http,
             $q: $q,
+            $uibModal: $uibModal,
             Product: Product,
             Provider: Provider,
             GPGKey: GPGKey,

--- a/engines/bastion_katello/test/sync-plans/sync-plan-helper.service.test.js
+++ b/engines/bastion_katello/test/sync-plans/sync-plan-helper.service.test.js
@@ -1,0 +1,78 @@
+describe('Service: SyncPlanHelper', function() {
+    var SyncPlanHelper;
+
+    beforeEach(module('Bastion.sync-plans'));
+
+    beforeEach(module(function($provide) {
+        var translate = function (string) {
+            return string
+        };
+
+        $provide.value('translate', translate);
+    }));
+
+    beforeEach(inject(function($injector) {
+        SyncPlanHelper = $injector.get('SyncPlanHelper');
+    }));
+
+    it("should allow setting of the form", function () {
+        var form = {name: 'blah'};
+        SyncPlanHelper.setForm(form);
+        expect(SyncPlanHelper.form).toBe(form);
+    });
+
+    it("should allow getting of the form", function () {
+        var form = {name: 'blah'};
+        SyncPlanHelper.form = form;
+        expect(SyncPlanHelper.getForm()).toBe(form);
+    });
+
+    it("returns the list of valid sync plan intervals", function () {
+        var intervals = SyncPlanHelper.getIntervals();
+        expect(intervals.length).toBe(3);
+        expect(intervals[0].id).toBeDefined();
+        expect(intervals[0].value).toBeDefined();
+    });
+
+    describe('creates a sync plan', function() {
+        it('should save a sync date in MM/DD/YYYY HH:MM:SS format', function() {
+            var syncPlan = {};
+            syncPlan.startDate = new Date('08/05/2015 00:00:00');
+            syncPlan.startTime = new Date('09/09/1999 13:00:00');
+
+            syncPlan.$save = function() {};
+            spyOn(syncPlan, '$save').and.callThrough();
+
+            SyncPlanHelper.createSyncPlan(syncPlan);
+
+            var syncDate = new Date(syncPlan['sync_date']);
+
+            expect(syncDate.getHours()).toBe(13);
+            expect(syncDate.getMinutes()).toBe(0);
+            expect(syncDate.getDate()).toBe(5);
+            expect(syncDate.getMonth()).toBe(7);
+            expect(syncDate.getFullYear()).toBe(2015);
+            expect(syncPlan.$save).toHaveBeenCalled();
+        });
+
+        it('should save a sync date in YYYY-MM-DD HH:MM:SS format', function() {
+            var syncPlan = {};
+            syncPlan.startDate = new Date('2015-08-05T00:00:00');
+            syncPlan.startTime = new Date('09/09/1999 13:00:00');
+
+            syncPlan.$save = function() {};
+            spyOn(syncPlan, '$save').and.callThrough();
+
+            SyncPlanHelper.createSyncPlan(syncPlan);
+
+            var syncDate = new Date(syncPlan['sync_date']);
+
+            expect(syncDate.getHours()).toBe(13);
+            expect(syncDate.getMinutes()).toBe(0);
+            expect(syncDate.getDate()).toBe(5);
+            expect(syncDate.getMonth()).toBe(7);
+            expect(syncDate.getFullYear()).toBe(2015);
+            expect(syncPlan.$save).toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
Instead of redirecting to another page for the new sync plan when
creating a new product we should show the new sync plan form in a modal.

http://projects.theforeman.org/issues/19194