### PR TITLE
Fixes #19468 - Displays schema version for Docker

### DIFF
--- a/app/controllers/katello/api/v2/docker_manifests_controller.rb
+++ b/app/controllers/katello/api/v2/docker_manifests_controller.rb
@@ -16,5 +16,9 @@ module Katello
     def custom_index_relation(collection)
       collection.includes(:docker_tags)
     end
+
+    def default_sort
+      lambda { |query| query.default_sort }
+    end
   end
 end

--- a/app/controllers/katello/api/v2/docker_tags_controller.rb
+++ b/app/controllers/katello/api/v2/docker_tags_controller.rb
@@ -7,8 +7,8 @@ module Katello
 
     def auto_complete_name
       page_size = Katello::Concerns::FilteredAutoCompleteSearch::PAGE_SIZE
-      tags = Katello::DockerTag.in_repositories(@repositories)
-      col = "#{Katello::DockerTag.table_name}.name"
+      tags = Katello::DockerMetaTag.in_repositories(@repositories)
+      col = "#{Katello::DockerMetaTag.table_name}.name"
       tags = tags.where("#{Katello::DockerTag.table_name}.name ILIKE ?", "#{params[:term]}%").select(col).group(col).order(col).limit(page_size)
       render :json => tags.pluck(col)
     end
@@ -18,8 +18,7 @@ module Katello
         # group docker tags by name, repo, and product
         repos = Repository.readable
         repos = repos.in_organization(@organization) if @organization
-        collection = Katello::DockerTag.in_repositories(repos).grouped
-
+        collection = Katello::DockerMetaTag.in_repositories(repos, true)
         respond(:collection => scoped_search(collection, "name", "DESC"))
       else
         super
@@ -33,7 +32,7 @@ module Katello
     end
 
     def resource_class
-      DockerTag
+      DockerMetaTag
     end
   end
 end

--- a/app/models/katello/docker_manifest.rb
+++ b/app/models/katello/docker_manifest.rb
@@ -2,7 +2,7 @@ module Katello
   class DockerManifest < Katello::Model
     include Concerns::PulpDatabaseUnit
 
-    has_many :docker_tags, :dependent => :destroy, :class_name => "Katello::DockerTag"
+    has_many :docker_tags, :dependent => :destroy, :class_name => "Katello::DockerTag", :foreign_key => :docker_manifest_id
     has_many :repository_docker_manifests, :dependent => :destroy
     has_many :repositories, :through => :repository_docker_manifests, :inverse_of => :docker_manifests
 
@@ -20,6 +20,10 @@ module Katello
                         :digest => json[:digest],
                         :downloaded => json[:downloaded]
                        )
+    end
+
+    def self.default_sort
+      order(:name).order(:schema_version)
     end
   end
 end

--- a/app/models/katello/docker_meta_tag.rb
+++ b/app/models/katello/docker_meta_tag.rb
@@ -1,0 +1,108 @@
+module Katello
+  class DockerMetaTag < Katello::Model
+    include ScopedSearchExtensions
+    belongs_to :repository, :inverse_of => :docker_meta_tags, :class_name => "Katello::Repository"
+
+    belongs_to :schema1, :class_name => "Katello::DockerTag",
+                          :inverse_of => :schema1_meta_tag
+
+    belongs_to :schema2, :class_name => "Katello::DockerTag",
+                          :inverse_of => :schema2_meta_tag
+
+    def self.delegate_to_tags(*names)
+      names.each do |name|
+        define_method(name) do
+          if schema2
+            schema2.send(name)
+          else
+            schema1.send(name)
+          end
+        end
+      end
+    end
+
+    delegate_to_tags :full_name, :docker_manifest
+    delegate_to_tags :product, :environment, :content_view_version
+
+    def repositories
+      [self.repository]
+    end
+
+    def self.in_repositories(repos, grouped = false)
+      if grouped
+        search_in_tags(DockerTag.in_repositories(repos).grouped)
+      else
+        search_in_tags(DockerTag.in_repositories(repos))
+      end
+    end
+
+    def self.search_in_tags(tags)
+      sql = tags.select("#{::Katello::DockerTag.table_name}.id").to_sql
+      self.where("#{self.table_name}.schema1_id in (#{sql}) or #{self.table_name}.schema2_id in (#{sql})")
+    end
+
+    def schema1_manifest
+      schema1.try(:docker_manifest)
+    end
+
+    def schema2_manifest
+      schema2.try(:docker_manifest)
+    end
+
+    def self.with_identifiers(ids)
+      self.where(:id => ids)
+    end
+
+    def self.cleanup_tags
+      self.where(:schema2_id => nil, :schema1_id => nil).delete_all
+    end
+
+    def self.import_meta_tags(repositories)
+      repositories.each do |repo|
+        tag_table_values = get_tag_table_values(repo)
+        meta_tag_table_values = DockerMetaTag.where(:repository => repo).
+                                  select(:schema1_id, :schema2_id, :name).map do |meta_tag|
+          [meta_tag.schema1_id, meta_tag.schema2_id, meta_tag.name]
+        end
+
+        # Delete [meta_tag_table_values - tag_table_values], insert [tag_table_values - meta_tag_table_values]
+
+        docker_meta_tag_arel_table = ::Katello::DockerMetaTag.arel_table
+        params_to_query_for_delete = (meta_tag_table_values - tag_table_values).map do |schema1, schema2, name|
+          conditional = docker_meta_tag_arel_table[:schema1_id].eq(schema1).and(
+                        docker_meta_tag_arel_table[:schema2_id].eq(schema2)).and(
+                        docker_meta_tag_arel_table[:name].eq(name)).to_sql
+
+          "(#{conditional})"
+        end
+
+        unless params_to_query_for_delete.empty?
+          ::Katello::DockerMetaTag.where(:repository => repo).
+                                   where(params_to_query_for_delete.join(" OR ")).delete_all
+        end
+
+        (tag_table_values - meta_tag_table_values).each do |schema1, schema2, name|
+          DockerMetaTag.where(:schema1_id => schema1,
+                              :schema2_id => schema2,
+                              :name => name,
+                              :repository => repo).create!
+        end
+      end
+    end
+
+    def self.get_tag_table_values(repo)
+      # queries DockerTags for a repo and retuns a [schema1, schema2 , name] tuple combination
+      tags = ::Katello::DockerTag.where(:repository_id => repo.id)
+      dups = tags.group_by(&:name)
+
+      dups.map do |name, values|
+        if values.first.docker_manifest.schema_version == 1
+          schema1, schema2 = values
+        else
+          schema2, schema1 = values
+        end
+        [schema1.try(:id), schema2.try(:id), name]
+      end
+    end
+  end
+end

--- a/app/models/katello/docker_tag.rb
+++ b/app/models/katello/docker_tag.rb
@@ -2,13 +2,21 @@ module Katello
   class DockerTag < Katello::Model
     include Concerns::PulpDatabaseUnit
     include ScopedSearchExtensions
-    belongs_to :docker_manifest, :inverse_of => :docker_tags
+    belongs_to :docker_manifest, :inverse_of => :docker_tags, :class_name => "Katello::DockerManifest"
     belongs_to :repository, :inverse_of => :docker_tags, :class_name => "Katello::Repository"
+
+    has_one :schema1_meta_tag, :class_name => "Katello::DockerMetaTag", :foreign_key => "schema1_id",
+                               :inverse_of => :schema1, :dependent => :nullify
+
+    has_one :schema2_meta_tag, :class_name => "Katello::DockerMetaTag", :foreign_key => "schema2_id",
+                               :inverse_of => :schema2, :dependent => :nullify
 
     scoped_search :on => :name, :complete_value => true, :rename => :tag
     scoped_search :relation => :docker_manifest, :on => :name, :rename => :manifest,
       :complete_value => true, :only_explicit => false
     scoped_search :relation => :docker_manifest, :on => :digest, :rename => :digest,
+      :complete_value => false, :only_explicit => true
+    scoped_search :relation => :docker_manifest, :on => :schema_version, :rename => :schema_version,
       :complete_value => false, :only_explicit => true
     scoped_search :relation => :repository, :on => :name, :rename => :repository,
       :complete_value => true, :only_explicit => true
@@ -28,6 +36,16 @@ module Katello
       self.repository_id ||= ::Katello::Repository.find_by(:pulp_id => json['repo_id']).try(:id)
       self.name = json['name']
       self.save!
+    end
+
+    def self.import_all(uuids = nil, options = {})
+      super
+      if uuids
+        repos = ::Katello::Repository.joins(:docker_tags).where("katello_docker_tags.uuid" => uuids).uniq
+        ::Katello::DockerMetaTag.import_meta_tags(repos)
+      else
+        ::Katello::DockerMetaTag.import_meta_tags(::Katello::Repository.docker_type)
+      end
     end
 
     def self.manage_repository_association

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -62,6 +62,8 @@ module Katello
 
     has_many :docker_tags, :dependent => :destroy, :class_name => "Katello::DockerTag"
 
+    has_many :docker_meta_tags, :dependent => :destroy, :class_name => "Katello::DockerMetaTag"
+
     has_many :repository_ostree_branches, :class_name => "Katello::RepositoryOstreeBranch", :dependent => :delete_all
     has_many :ostree_branches, :through => :repository_ostree_branches
 
@@ -644,6 +646,10 @@ module Katello
       ::Host.joins(:content_facet => :bound_repositories).where("#{Katello::Repository.table_name}.id" => (self.clones.pluck(:id) + [self.id]))
     end
 
+    def docker_meta_tag_count
+      DockerMetaTag.in_repositories(self.id).count
+    end
+
     protected
 
     def removable_unit_association
@@ -702,7 +708,9 @@ module Katello
 
     def remove_docker_content(manifests)
       self.docker_tags.where(:docker_manifest_id => manifests.map(&:id)).destroy_all
+      DockerMetaTag.cleanup_tags
       self.docker_manifests -= manifests
+
       # destroy any orphan docker manifests
       manifests.each do |manifest|
         manifest.destroy if manifest.repositories.empty?

--- a/app/views/katello/api/v2/docker_tags/_base.json.rabl
+++ b/app/views/katello/api/v2/docker_tags/_base.json.rabl
@@ -1,7 +1,17 @@
 object @resource
 
 attributes :id, :name, :full_name
-attributes :repository_id, :manifest_id
+attributes :repository_id
+
+child :schema1_manifest => :manifest_schema1 do
+  attributes :uuid => :id
+  attributes :name, :schema_version, :digest
+end
+
+child :schema2_manifest => :manifest_schema2 do
+  attributes :uuid => :id
+  attributes :name, :schema_version, :digest
+end
 
 child :docker_manifest => :manifest do
   attributes :uuid => :id

--- a/app/views/katello/api/v2/repositories/base.json.rabl
+++ b/app/views/katello/api/v2/repositories/base.json.rabl
@@ -16,7 +16,7 @@ node :content_counts do |repo|
   {
     :ostree_branch => repo.ostree_branches.count,
     :docker_manifest => repo.docker_manifests.count,
-    :docker_tag => repo.docker_tags.count,
+    :docker_tag => repo.docker_meta_tag_count,
     :rpm => repo.rpms.count,
     :package => repo.rpms.count,
     :package_group => repo.package_groups.count,

--- a/db/migrate/20170523182831_create_docker_meta_tag.rb
+++ b/db/migrate/20170523182831_create_docker_meta_tag.rb
@@ -1,0 +1,13 @@
+class CreateDockerMetaTag < ActiveRecord::Migration
+  def change
+    create_table :katello_docker_meta_tags do |t|
+      t.integer  "schema1_id"
+      t.integer  "schema2_id"
+      t.string   :name, :limit => 255
+      t.references :repository, :null => true
+    end
+    add_index :katello_docker_meta_tags, [:schema1_id, :schema2_id], :unique => true
+    add_foreign_key :katello_docker_meta_tags, :katello_repositories,
+                    :name => "katello_docker_meta_tags_repositories_fk", :column => 'repository_id'
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/views/docker-tag-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/views/docker-tag-info.html
@@ -21,22 +21,33 @@
 
   <div data-block="right-column">
     <h4 translate>Docker Manifest</h4>
+    <div ng-if="!_.isEmpty(tag.manifest_schema1)">
+      <h5 translate>Schema Version 1</h5>
+      <dl class="dl-horizontal dl-horizontal-left">
+        <dt translate>Name</dt>
+        <dd>
+          {{ tag.manifest_schema1.name }}
+        </dd>
 
-    <dl class="dl-horizontal dl-horizontal-left">
-      <dt translate>Name</dt>
-      <dd>
-        {{ tag.manifest.name }}
-      </dd>
+        <dt translate>Digest</dt>
+        <dd>
+          {{ tag.manifest_schema1.digest }}
+        </dd>
+      </dl>
+    </div>
+    <div ng-if="!_.isEmpty(tag.manifest_schema2)">
+      <h5 translate>Schema Version 2</h5>
+      <dl class="dl-horizontal dl-horizontal-left">
+        <dt translate>Name</dt>
+        <dd>
+          {{ tag.manifest_schema2.name }}
+        </dd>
 
-      <dt translate>Digest</dt>
-      <dd>
-        {{ tag.manifest.digest }}
-      </dd>
-
-      <dt translate>Schema Version</dt>
-      <dd>
-        {{ tag.manifest.schema_version }}
-      </dd>
-    </dl>
+        <dt translate>Digest</dt>
+        <dd>
+          {{ tag.manifest_schema2.digest }}
+        </dd>
+      </dl>
+    </div>
   </div>
-</div>
+ </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/docker-tags.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/docker-tags.controller.js
@@ -31,5 +31,17 @@ angular.module('Bastion.docker-tags').controller('DockerTagsController',
         $scope.table.closeItem = function () {
             $scope.transitionTo('docker-tags');
         };
+
+        $scope.availableSchemaVersions = function (tag) {
+            var versions = [];
+            if (tag.manifest_schema1) {
+                versions.push(1);
+            }
+
+            if (tag.manifest_schema2) {
+                versions.push(2);
+            }
+            return versions.join(", ");
+        };
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/views/docker-tags.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/views/docker-tags.html
@@ -19,6 +19,7 @@
       <thead>
         <tr bst-table-head>
           <th bst-table-column="name">{{ "Name" | translate }}</th>
+          <th bst-table-column="schema_version">{{ "Available Schema Versions" | translate }}</th>
           <th bst-table-column="product">{{ "Product Name" | translate }}</th>
           <th bst-table-column="repository">{{ "Repository Name" | translate }}</th>
         </tr>
@@ -30,6 +31,9 @@
             <a ui-sref="docker-tag.info({tagId: tag.id})">
               {{ tag.full_name }}
             </a>
+          </td>
+          <td bst-table-cell>
+            {{ availableSchemaVersions(tag) }}
           </td>
           <td bst-table-cell>
             {{ tag.product.name }}

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-manage-docker-manifests.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-manage-docker-manifests.html
@@ -45,6 +45,7 @@
         <tr bst-table-head row-select>
           <th bst-table-column><span translate>Manifest Name</span></th>
           <th bst-table-column><span translate>Tags</span></th>
+          <th bst-table-column><span translate>Schema Version</span></th>
           <th bst-table-column><span translate>Digest</span></th>
         </tr>
       </thead>
@@ -60,6 +61,9 @@
                 {{ tag.name }}
               </a>
             </span>
+          </td>
+          <td bst-table-cell>
+            {{ item.schema_version }}
           </td>
           <td bst-table-cell>
             {{ item.digest }}

--- a/test/controllers/api/v2/docker_tags_controller_test.rb
+++ b/test/controllers/api/v2/docker_tags_controller_test.rb
@@ -6,6 +6,7 @@ module Katello
       @repo = Repository.find(katello_repositories(:redis).id)
       @manifest = @repo.docker_manifests.create!(:name => "abc123", :uuid => "123xyz")
       @tag = @repo.docker_tags.create!(:name => "wat", :docker_manifest => @manifest)
+      @meta_tag = DockerMetaTag.create!(:name => @tag.name, :schema1 => @tag, :repository => @repo)
     end
 
     def setup
@@ -42,7 +43,7 @@ module Katello
     end
 
     def test_show
-      get :show, :repository_id => @repo.id, :id => @tag.id
+      get :show, :repository_id => @repo.id, :id => @meta_tag.id
 
       assert_response :success
       assert_template "katello/api/v2/docker_tags/show"

--- a/test/factories/docker_manifest_factory.rb
+++ b/test/factories/docker_manifest_factory.rb
@@ -3,5 +3,9 @@ FactoryGirl.define do
     sequence(:name) { |n| "2.#{n}" }
     digest { SecureRandom.hex }
     uuid { SecureRandom.hex }
+    schema_version 2
+    trait :schema1 do
+      schema_version 1
+    end
   end
 end

--- a/test/factories/docker_tag_factory.rb
+++ b/test/factories/docker_tag_factory.rb
@@ -4,7 +4,11 @@ FactoryGirl.define do
     repository :docker_repository
     docker_manifest
   end
-
+  trait :schema1 do
+    after(:build) do |tag|
+      tag.docker_manifest.schema_version = 1
+    end
+  end
   trait :latest do
     name "latest"
   end

--- a/test/models/docker_meta_tag_test.rb
+++ b/test/models/docker_meta_tag_test.rb
@@ -1,0 +1,76 @@
+# encoding: utf-8
+
+require 'katello_test_helper'
+
+module Katello
+  class DockerMetaTagTest < ActiveSupport::TestCase
+    extend ActiveRecord::TestFixtures
+
+    def setup
+      @repo = Repository.find(katello_repositories(:busybox).id)
+      @manifest = create(:docker_manifest)
+      @tag_schema2 = create(:docker_tag, :repository => @repo, :name => "latest")
+      @tag_schema1 = create(:docker_tag, :schema1, :repository => @repo, :name => "latest")
+
+      @repo.library_instances_inverse.each do |repo|
+        repo.docker_tags << @tag_schema2.dup
+        repo.docker_tags << @tag_schema1.dup
+      end
+    end
+
+    def test_import_meta_tags
+      assert_empty DockerMetaTag.where(:schema1 => [@tag_schema1.id, @tag_schema2.id])
+      assert_empty DockerMetaTag.where(:schema2 => [@tag_schema1.id, @tag_schema2.id])
+
+      DockerMetaTag.import_meta_tags([@repo])
+
+      assert_equal 1, DockerMetaTag.where(:schema1 => @tag_schema1.id).count
+      assert_equal 1, DockerMetaTag.where(:schema2 => @tag_schema2.id).count
+
+      meta = DockerMetaTag.find_by(:schema1 => @tag_schema1.id)
+      assert_equal @tag_schema2, meta.schema2
+      assert_equal @repo, meta.repository
+
+      DockerTag.where(:id => @tag_schema1.id).delete_all
+      DockerMetaTag.import_meta_tags([@repo])
+      assert_empty DockerMetaTag.where(:schema1 => @tag_schema1.id)
+      assert_equal 1, DockerMetaTag.where(:schema2 => @tag_schema2.id).count
+
+      @tag_schema1 = create(:docker_tag, :schema1, :repository => @repo, :name => "latest")
+      DockerMetaTag.import_meta_tags([@repo])
+      old_meta = meta
+
+      meta = DockerMetaTag.find_by(:schema1 => @tag_schema1.id)
+      assert_equal @tag_schema2, meta.schema2
+      assert_equal @repo, meta.repository
+
+      refute_equal old_meta.id, meta.id
+
+      @tag_schema1.destroy!
+      meta = meta.reload
+      assert_nil meta.schema1
+    end
+
+    def test_in_repositories
+      DockerMetaTag.import_meta_tags([@repo])
+      tags = DockerMetaTag.in_repositories(@repo)
+      assert_equal @tag_schema1.repository, tags.first.repository
+      assert_equal 1, tags.count
+
+      new_tag = create(:docker_tag, :schema1, :repository => @repo)
+      DockerMetaTag.import_meta_tags([@repo])
+
+      tags = DockerMetaTag.in_repositories(@repo, true).pluck(:name)
+      assert_equal tags, DockerMetaTag.where(:name => ["latest", new_tag.name]).pluck(:name)
+    end
+
+    def test_docker_manifest
+      DockerMetaTag.import_meta_tags([@repo])
+      dmt = DockerMetaTag.first
+      assert_equal @tag_schema2.docker_manifest, dmt.docker_manifest
+
+      dmt.schema2 = nil
+      assert_equal @tag_schema1.docker_manifest, dmt.docker_manifest
+    end
+  end
+end

--- a/test/models/docker_tag_test.rb
+++ b/test/models/docker_tag_test.rb
@@ -16,6 +16,11 @@ module Katello
       end
     end
 
+    def test_search_version
+      tags = DockerTag.search_for("schema_version = 2")
+      assert_includes tags, @tag
+    end
+
     def test_import_from_json
       @tag.repository_id = nil
       @tag.docker_manifest_id = nil


### PR DESCRIPTION
Docker V2 has 2 different schema types Schema 1 and 2.
Pulp 2.13 introduces syncing manifests of the 2 different schemas
from a docker registry repo.
This means the same tag in the same repo might point to 2 different
manifests.
Related to this this commit updated the following pages to show the
Schema Version

1) Repository -> Manage Docker Manifests
2) Repository -> Manage Docker Tags
3) Content -> Docker Tags (search page.)

In addition a new DockerMetaTag model got introduced. The role of this
model is to maintain association between the schema v1 version of the
tag and the v2 version of the tag.