### PR TITLE
Fixes #19204: correct links to products pages.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/views/docker-tag-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/views/docker-tag-info.html
@@ -5,14 +5,14 @@
     <dl class="dl-horizontal dl-horizontal-left">
       <dt translate>Product</dt>
       <dd>
-        <a ui-sref="products.details.info({productId: tag.product.id})">
+        <a ui-sref="product.info({productId: tag.product.id})">
           {{ tag.product.name }}
         </a>
       </dd>
 
       <dt translate>Repository</dt>
       <dd>
-        <a ui-sref="products.details.repositories.manage-content.docker-manifests({productId: tag.product.id, repositoryId: tag.repository.id})">
+        <a ui-sref="product.repository.manage-content.docker-manifests({productId: tag.product.id, repositoryId: tag.repository.id})">
           {{ tag.repository.name }}
         </a>
       </dd>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/ostree-branches/details/views/ostree-branch-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/ostree-branches/details/views/ostree-branch-repositories.html
@@ -51,7 +51,7 @@
             </a>
           </td>
           <td bst-table-cell>
-            <a ui-sref="products.details.repositories.index({productId: repository.product.id})">
+            <a ui-sref="product.repositories({productId: repository.product.id})">
               {{ repository.product.name }}
             </a>
           </td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/views/sync-plan-products.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/views/sync-plan-products.html
@@ -63,7 +63,7 @@
       <tbody>
         <tr bst-table-row ng-repeat="product in table.rows" row-select="product">
           <td bst-table-cell>
-            <a ui-sref="products.details.info({productId: product.id})">
+            <a ui-sref="product.info({productId: product.id})">
               {{ product.name }}
             </a>
           </td>


### PR DESCRIPTION
There were several ui-sref links pointing to the old products.details
state which no longer exists.  This commit fixes the links.

http://projects.theforeman.org/issues/19204