### PR TITLE
fixes #19338 - puppet classes not imported during cv publish

### DIFF
--- a/app/lib/katello/foreman.rb
+++ b/app/lib/katello/foreman.rb
@@ -7,21 +7,23 @@ module Katello
     end
 
     def self.update_puppet_environment(content_view, environment)
-      content_view_puppet_env = content_view.version(environment).puppet_env(environment)
-      if !content_view.default? && content_view_puppet_env
-        foreman_environment = content_view_puppet_env.puppet_environment
+      User.as_anonymous_admin do
+        content_view_puppet_env = content_view.version(environment).puppet_env(environment)
+        if !content_view.default? && content_view_puppet_env
+          foreman_environment = content_view_puppet_env.puppet_environment
 
-        # Associate the puppet environment with the locations that are currently
-        # associated with the capsules that have the target lifecycle environment.
-        capsule_contents = Katello::CapsuleContent.with_environment(environment, true)
-        unless capsule_contents.blank?
-          locations = capsule_contents.map(&:capsule).map(&:locations).compact.flatten.uniq
-          foreman_environment.locations = locations
-          foreman_environment.save!
-        end
+          # Associate the puppet environment with the locations that are currently
+          # associated with the capsules that have the target lifecycle environment.
+          capsule_contents = Katello::CapsuleContent.with_environment(environment, true)
+          unless capsule_contents.blank?
+            locations = capsule_contents.map(&:capsule).map(&:locations).compact.flatten.uniq
+            foreman_environment.locations = locations
+            foreman_environment.save!
+          end
 
-        if (foreman_smart_proxy = SmartProxy.default_capsule)
-          PuppetClassImporter.new(:url => foreman_smart_proxy.url, :env => foreman_environment.name).update_environment
+          if (foreman_smart_proxy = SmartProxy.default_capsule)
+            PuppetClassImporter.new(:url => foreman_smart_proxy.url, :env => foreman_environment.name).update_environment
+          end
         end
       end
     end


### PR DESCRIPTION
After 5f606e11cf39719bf62f8b1f3396861b32387905 merged into foreman
publishing a content view containing puppet modules is no longer importing
the puppet classes.  In order to address it, we'll 'keep' the current
user on the action.  Another alternative is to use 'unscoped' queries;
however, there are multiple foreman resources needed to support the flow
and this will address them all.

Test scenario:
- create a cv
- add a puppet module
- publish the cv
- go to Configure -> Classes
- observe that the puppet classes exist for the modules included