### PR TITLE
Fixes #19206: always show message about supersets of errata/packages

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata.html
@@ -22,13 +22,16 @@
     <label class="checkbox-inline" title="{{ 'Only show Errata that are Applicable to one or more Content Hosts' | translate }}">
       <input type="checkbox" ng-model="showApplicable" ng-disabled="showInstallable" ng-change="toggleFilters()"/>
       <span translate>Applicable</span>
-      <i class="fa fa-question-circle" ng-show="showInstallable" title="{{ 'Errata are automatically Applicable if they are Installable' | translate }}"></i>
     </label>
 
     <label class="checkbox-inline" title="{{ 'Only show Errata that are Installable on one or more Content Hosts' | translate }}">
       <input type="checkbox" ng-model="showInstallable" ng-change="toggleFilters()"/>
       <span translate>Installable</span>
     </label>
+
+    <p ng-show="showInstallable" translate>
+      Errata are automatically Applicable if they are Installable
+    </p>
   </div>
 
   <span data-block="no-rows-message">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/views/packages.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/views/packages.html
@@ -14,13 +14,16 @@
     <label class="checkbox-inline" title="{{ 'Only show Packages that are Applicable to one or more Content Hosts' | translate }}">
       <input type="checkbox" ng-model="showApplicable" ng-disabled="showUpgradable" ng-change="toggleFilters()"/>
       <span translate>Applicable</span>
-      <i class="fa fa-question-circle" ng-show="showUpgradable" title="{{ 'Packages are automatically Applicable if they are Upgradable' | translate }}"></i>
     </label>
 
     <label class="checkbox-inline" title="{{ 'Only show Packages that are Upgradable on one or more Content Hosts' | translate }}">
       <input type="checkbox" ng-model="showUpgradable" ng-change="toggleFilters()"/>
       <span translate>Upgradable</span>
     </label>
+
+    <p ng-show="showUpgradable" translate>
+      Packages are automatically Applicable if they are Upgradable
+    </p>
   </div>
 
   <span data-block="no-rows-message">


### PR DESCRIPTION
Always show the message about applicable errata being included in
installable errata and about applicable packages being included in
upgradeable packages.

http://projects.theforeman.org/issues/19206