### PR TITLE
Fixes #19548 - use numerical product cp ids

### DIFF
--- a/app/lib/actions/katello/product/create.rb
+++ b/app/lib/actions/katello/product/create.rb
@@ -7,7 +7,7 @@ module Actions
             product.provider = organization.anonymous_provider
             product.organization = organization
             product.setup_label_from_name
-            product.cp_id = unused_product_id(organization.label, product.label)
+            product.cp_id = ::Katello::Product.unused_product_id
             product.save!
 
             plan_action(::Actions::Candlepin::Product::Create,
@@ -29,17 +29,6 @@ module Actions
             plan_self
             plan_action Katello::Product::ReindexSubscriptions, product, subscription_id
           end
-        end
-
-        def unused_product_id(owner, product_label)
-          id = ::Katello::Util::Data.md5hash("#{owner}-#{product_label}")
-
-          count = 0
-          while ::Katello::Product.find_by(:cp_id => id)
-            id = ::Katello::Util::Data.md5hash("#{owner}-#{product_label}#{count}")
-            count += 1
-          end
-          id
         end
 
         def finalize

--- a/app/models/katello/product.rb
+++ b/app/models/katello/product.rb
@@ -248,5 +248,14 @@ module Katello
     def self.humanize_class_name(_name = nil)
       _("Product and Repositories")
     end
+
+    def self.unused_product_id
+      id = SecureRandom.random_number(999_999_999_999)
+      if ::Katello::Product.find_by(:cp_id => id)
+        unused_product_id
+      else
+        id
+      end
+    end
   end
 end

--- a/test/actions/katello/product_test.rb
+++ b/test/actions/katello/product_test.rb
@@ -81,13 +81,13 @@ module ::Actions::Katello::Product
       end
       product.expects(:save!).returns([])
       product.organization.label = 'somelabel'
+      Katello::Product.expects(:unused_product_id).returns(3)
 
-      Katello::Util::Data.expects(:md5hash).returns('foobar')
       plan_action(action, product, product.organization)
 
       assert_action_planed_with(action,
                                 ::Actions::Candlepin::Product::Create,
-                                :id => 'foobar',
+                                :id => '3',
                                 :name => product.name,
                                 :owner => product.organization.label,
                                 :multiplier => 1,

--- a/test/glue/pulp/repository_test.rb
+++ b/test/glue/pulp/repository_test.rb
@@ -60,8 +60,7 @@ module Katello
 
   class GluePulpNonVcrTests < GluePulpRepoTestBase
     def test_importer_feed_url
-      proxy = FactoryGirl.build(:bmc_smart_proxy)
-
+      proxy = SmartProxy.new(:url => 'http://foo.com/foo')
       pulp_host = URI.parse(SETTINGS[:katello][:pulp][:url]).host
       repo = ::Katello::Repository.new(:url => 'http://zodiak.com/ted', :unprotected => false, :relative_path => '/elbow')
 
@@ -74,7 +73,7 @@ module Katello
 
     def test_importer_ssl_options
       ::Cert::Certs.stubs(:ueber_cert).returns(:cert => 'foo', :key => 'bar')
-      proxy = FactoryGirl.build(:bmc_smart_proxy)
+      proxy = SmartProxy.new(:url => 'http://foo.com/foo')
       assert @fedora_17_x86_64.importer_ssl_options(proxy).key?(:ssl_validation)
       refute @cvpe_one.importer_ssl_options(proxy).key?(:ssl_validation)
     end

--- a/test/support/scenario_support.rb
+++ b/test/support/scenario_support.rb
@@ -18,6 +18,7 @@ class ScenarioSupport
   end
 
   def create_product(product, org)
+    Katello::Product.expects(:unused_product_id).returns('7c825013cab01349ae8cb8db187de391')
     record("product_create") { ForemanTasks.sync_task(::Actions::Katello::Product::Create, product, org, Time.utc(2017, "jan", 1, 20, 15, 1).iso8601) }
   end
 


### PR DESCRIPTION
candlepin does not work properly when product ids
have alphabetical characters in it.  This is intentional
on their side, even if it is unexpected