### PR TITLE
Fixes #19567 - exclude annotation rake file from gem

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |gem|
   gem.files = Dir["{app,vendor,lib,db,ca,config,locale}/**/*"] + ["LICENSE.txt", "README.md"]
   gem.files += Dir["engines/bastion_katello/{app,vendor,lib,config}/**/*"]
   gem.files += Dir["engines/bastion_katello/{README.md}"]
+  gem.files -= ["lib/katello/tasks/annotate_scenarios.rake"]
 
   gem.require_paths = ["lib"]
 


### PR DESCRIPTION
as it depends on test data which is not in the gem