### PR TITLE
Fixes #19586 - Refactored host info to provider

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -7,7 +7,6 @@ module Katello
 
       included do
         alias_method_chain :validate_media?, :capsule
-        alias_method_chain :info, :katello
         alias_method_chain :smart_proxy_ids, :katello
 
         has_many :host_installed_packages, :class_name => "::Katello::HostInstalledPackage", :foreign_key => :host_id, :dependent => :destroy
@@ -44,36 +43,6 @@ module Katello
         ids = smart_proxy_ids_without_katello
         ids << content_source_id
         ids.uniq.compact
-      end
-
-      #rubocop:disable Metrics/AbcSize
-      def info_with_katello
-        info = info_without_katello
-        info['parameters']['kt_env'] = self.lifecycle_environment.try(:label) #deprecated
-        info['parameters']['kt_cv'] = self.content_view.try(:label) #deprecated
-        info['parameters']['foreman_host_collections'] = self.host_collections.map(&:name)
-        info['parameters']['lifecycle_environment'] = self.lifecycle_environment.try(:label)
-
-        info['parameters']['content_view'] = self.content_view.try(:label)
-        info['parameters']['content_view_info'] = {}
-        info['parameters']['content_view_info']['label'] = self.content_view.try(:label)
-        info['parameters']['content_view_info']['latest-version'] = self.content_view.try(:latest_version)
-        info['parameters']['content_view_info']['version'] = self.content_view.try(:version, self.lifecycle_environment).try(:version)
-        info['parameters']['content_view_info']['published'] = self.content_view.try(:version, self.lifecycle_environment).try(:created_at)
-        info['parameters']['content_view_info']['components'] = {}
-        if self.content_view.try(:composite)
-          self.content_view.try(:version, self.lifecycle_environment).try(:content_view_version_components).each do |cv|
-            cv_label = cv.component_version.content_view.label
-            info['parameters']['content_view_info']['components'][cv_label] = {}
-            info['parameters']['content_view_info']['components'][cv_label]['version'] = cv.component_version.try(:version)
-            info['parameters']['content_view_info']['components'][cv_label]['published'] = cv.component_version.try(:created_at)
-          end
-        end
-
-        if self.content_facet.present?
-          info['parameters']['kickstart_repository'] = self.content_facet.kickstart_repository.try(:label)
-        end
-        info
       end
 
       def correct_puppet_environment

--- a/app/models/katello/host/info_provider.rb
+++ b/app/models/katello/host/info_provider.rb
@@ -1,0 +1,54 @@
+module Katello
+  module Host
+    class InfoProvider < HostInfo::Provider
+      def host_info
+        info = {}
+        info['parameters'] = {
+          'kt_env' => host.lifecycle_environment.try(:label), #deprecated
+          'kt_cv' => host.content_view.try(:label), #deprecated
+          'foreman_host_collections' => host.host_collections.map(&:name),
+          'lifecycle_environment' => host.lifecycle_environment.try(:label),
+
+          'content_view' => host.content_view.try(:label),
+          'content_view_info' => content_view_info
+        }
+
+        if host.content_facet.present?
+          info['parameters']['kickstart_repository'] = host.content_facet.kickstart_repository.try(:label)
+        end
+        info
+      end
+
+      def content_view_info
+        return {} if host.content_view.blank?
+
+        content_view_info = {
+          'label' => host.content_view.try(:label),
+          'latest-version' => host.content_view.try(:latest_version),
+          'version' => content_version.try(:version),
+          'published' => content_version.try(:created_at),
+          'components' => content_view_components
+        }
+
+        content_view_info
+      end
+
+      def content_view_components
+        return {} unless host.content_view.try(:composite)
+
+        components = {}
+        content_version.try(:content_view_version_components).map do |cv|
+          cv_label = cv.component_version.content_view.label
+          components[cv_label] = {}
+          components[cv_label]['version'] = cv.component_version.try(:version)
+          components[cv_label]['published'] = cv.component_version.try(:created_at)
+        end
+        components
+      end
+
+      def content_version
+        host.content_view.try(:version, host.lifecycle_environment)
+      end
+    end
+  end
+end

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -1,7 +1,7 @@
 require 'katello/permission_creator'
 
 Foreman::Plugin.register :katello do
-  requires_foreman '>= 1.15'
+  requires_foreman '>= 1.16'
 
   sub_menu :top_menu, :content_menu, :caption => N_('Content'), :after => :monitor_menu do
     menu :top_menu,
@@ -255,6 +255,8 @@ Foreman::Plugin.register :katello do
       .preload(:content_view, :lifecycle_environment, :subscription_facet)
       .preload(content_facet: [:bound_repositories, :content_view, :lifecycle_environment])
   end
+
+  register_info_provider Katello::Host::InfoProvider
 
   Katello::PermissionCreator.new(self).define
   add_all_permissions_to_default_roles


### PR DESCRIPTION
Depends on https://github.com/theforeman/foreman/pull/3701.
Foreman introduced info providers extension point - refactored `alias_method_chain :info, :katello` to use this extension point.
