### PR TITLE
fixes #19658 - fix error on sub-mgr register --regenerate

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -137,7 +137,7 @@ module Katello
     #param :date, String, :desc => N_("check-in time")
     def consumer_checkin
       @host.update_attributes(:last_checkin => params[:date])
-      Candlepin::Consumer.new(@host.subscription_facet.uuid).checkin(params[:date])
+      Candlepin::Consumer.new(@host.subscription_facet.uuid, @host.organization.label).checkin(params[:date])
       render :json => Resources::Candlepin::Consumer.get(@host.subscription_facet.uuid)
     end
 
@@ -165,7 +165,7 @@ module Katello
     #desc 'Schedules the consumer identity certificate regeneration'
     def regenerate_identity_certificates
       uuid = @host.subscription_facet.uuid
-      Candlepin::Consumer.new(uuid).regenerate_identity_certificates
+      Candlepin::Consumer.new(uuid, @host.organization.label).regenerate_identity_certificates
       render :json => Resources::Candlepin::Consumer.get(uuid)
     end
 

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -187,7 +187,7 @@ module Katello
     def test_regenerate_indentity_certificates
       consumer_stub = stub(:regenerate_identity_certificates => true)
 
-      Candlepin::Consumer.expects(:new).with(@host.subscription_facet.uuid).returns(consumer_stub)
+      Candlepin::Consumer.expects(:new).with(@host.subscription_facet.uuid, @host.organization.label).returns(consumer_stub)
       Resources::Candlepin::Consumer.expects(:get).with(@host.subscription_facet.uuid)
 
       post :regenerate_identity_certificates, :id => @host.subscription_facet.uuid


### PR DESCRIPTION
The initializer on the candlepin consumer was updated to include
owner to support changes in the candlpein pool apis; however,
the initializer is also used during a
'subscription-manager register --regenerate'
where no owner is supplied.

Error without fix:

> subscription-manager identity --regenerate
wrong number of arguments (1 for 2)