### PR TITLE
Fixes #18845 - Reduce n+1 queries for hosts

### DIFF
--- a/app/models/katello/errata_status.rb
+++ b/app/models/katello/errata_status.rb
@@ -11,7 +11,7 @@ module Katello
 
     def to_label(_options = {})
       installable = Setting[:errata_status_installable]
-      case to_status
+      case status
       when NEEDED_SECURITY_ERRATA
         installable ? N_("Security errata installable") : N_("Security errata applicable")
       when NEEDED_ERRATA
@@ -26,7 +26,7 @@ module Katello
     end
 
     def to_global(_options = {})
-      case to_status
+      case status
       when NEEDED_SECURITY_ERRATA
         ::HostStatus::Global::ERROR
       when NEEDED_ERRATA

--- a/app/views/katello/api/v2/errata/_counts.json.rabl
+++ b/app/views/katello/api/v2/errata/_counts.json.rabl
@@ -1,15 +1,17 @@
-node :security do |presenter|
-  presenter.relation.security.count
+totals = @object.relation.group(:errata_type).count.with_indifferent_access
+
+node :security do |_presenter|
+  totals[:security]
 end
 
-node :bugfix do |presenter|
-  presenter.relation.bugfix.count
+node :bugfix do |_presenter|
+  totals[:bugfix]
 end
 
-node :enhancement do |presenter|
-  presenter.relation.enhancement.count
+node :enhancement do |_presenter|
+  totals[:enhancement]
 end
 
-node :total do |presenter|
-  presenter.relation.count
+node :total do |_presenter|
+  totals.values.inject(:+)
 end

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -246,14 +246,14 @@ Foreman::Plugin.register :katello do
 
   add_controller_action_scope(HostsController, :index) do |base_scope|
     base_scope
-      .preload(:content_view, :lifecycle_environment, :subscription_facet, :applicable_errata)
-      .preload(content_facet: [:bound_repositories, :applicable_errata, :content_view, :lifecycle_environment])
+      .preload(:content_view, :lifecycle_environment, :subscription_facet)
+      .preload(content_facet: [:bound_repositories, :content_view, :lifecycle_environment])
   end
 
   add_controller_action_scope(Api::V2::HostsController, :index) do |base_scope|
     base_scope
-      .preload(:content_view, :lifecycle_environment, :subscription_facet, :applicable_errata)
-      .preload(content_facet: [:bound_repositories, :applicable_errata, :content_view, :lifecycle_environment])
+      .preload(:content_view, :lifecycle_environment, :subscription_facet)
+      .preload(content_facet: [:bound_repositories, :content_view, :lifecycle_environment])
   end
 
   Katello::PermissionCreator.new(self).define


### PR DESCRIPTION
this reduces the number of N+1 queries considerably
via three methods:

1) by fetching errata counts using a group queries
to fetch counts for all types in one query. Note this
also affects content view versions and repos as well.
2) By using the cached status when fetching the
errata status rather than re-computing it at read time
3) By not including :applicable_errata in the 'include'
optimization, as its not needed

This change takes the number of queries for 3 systems (2 with errata)
from 15 queries to 2, 5.8ms to .6ms.

Further improvements could be made to remove all queries, but this
would require caching the data on the host object (or facet), as well
as CVV and repos.  I'm not quite ready to do that yet.