### PR TITLE
Fixes #19749 - Hammer content-view ignores nondefault

### DIFF
--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -40,7 +40,7 @@ module Katello
       content_views = ContentView.readable
       content_views = content_views.where(:organization_id => @organization.id) if @organization
       content_views = content_views.in_environment(@environment) if @environment
-      content_views = content_views.non_default if params[:nondefault]
+      content_views = ::Foreman::Cast.to_bool(params[:nondefault]) ? content_views.non_default : content_views.default if params[:nondefault]
       content_views = ::Foreman::Cast.to_bool(params[:noncomposite]) ? content_views.non_composite : content_views.composite if params[:noncomposite]
       content_views = ::Foreman::Cast.to_bool(params[:composite]) ? content_views.composite : content_views.non_composite if params[:composite]
       content_views = content_views.where(:name => params[:name]) if params[:name]


### PR DESCRIPTION
After fixing this issue the Boolean values (0/1, true/false , yes/no) will work for --nondefault option

$ hammer content-view list --organization-id=1 --nondefault No
----------------|---------------------------|---------------------------|-----------|---------------
CONTENT VIEW ID | NAME                      | LABEL                     | COMPOSITE | REPOSITORY IDS
----------------|---------------------------|---------------------------|-----------|---------------
1               | Default Organization View | Default_Organization_View |           |               
----------------|---------------------------|---------------------------|-----------|---------------
