### PR TITLE
Fixes #19741 - Undefined method split for nil on tests

### DIFF
--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -208,7 +208,7 @@ module Katello
       assert_equal '1.3.0', results.first['version']
       use_latest_rec = results.last
       assert_equal 'Always Use Latest (currently 1.3.0)', use_latest_rec['version']
-      assert_equal nil, use_latest_rec['uuid']
+      assert_nil use_latest_rec['uuid']
     end
 
     def test_available_puppet_modules_when_latest_module_already_selected

--- a/test/glue/candlepin/owner_test.rb
+++ b/test/glue/candlepin/owner_test.rb
@@ -31,15 +31,15 @@ module Katello
         @org.service_level = 'Premium'
       end
       refute_nil JSON.parse(e.response)['displayMessage']
-      assert_equal nil, @org.service_level
+      assert_nil @org.service_level
 
       # Should be able to set clear the default
       @org.service_level = ''
-      assert_equal nil, @org.service_level
+      assert_nil @org.service_level
 
       # ...with a nil too
       @org.service_level = nil
-      assert_equal nil, @org.service_level
+      assert_nil @org.service_level
     end
   end
 end

--- a/test/lib/capsule_content_test.rb
+++ b/test/lib/capsule_content_test.rb
@@ -83,7 +83,7 @@ module Katello
 
       test "last sync time is nil when there's no successful sync" do
         @tasks[:successful].destroy
-        assert_equal(nil, capsule_content.last_sync_time)
+        assert_nil capsule_content.last_sync_time
       end
 
       test "last failed sync tasks" do

--- a/test/models/activation_key_test.rb
+++ b/test/models/activation_key_test.rb
@@ -49,12 +49,12 @@ module Katello
 
     test "key can be copied" do
       new_key = @dev_key.copy("new key name")
-      assert_equal new_key.name, "new key name"
-      assert_equal new_key.description, @dev_key.description
-      assert_equal new_key.host_collections, @dev_key.host_collections
-      assert_equal new_key.content_view, @dev_key.content_view
-      assert_equal new_key.organization, @dev_key.organization
-      assert_equal new_key.max_hosts, @dev_key.max_hosts
+      assert new_key.name == "new key name"
+      assert new_key.description == @dev_key.description
+      assert new_key.host_collections == @dev_key.host_collections
+      assert new_key.content_view == @dev_key.content_view
+      assert new_key.organization == @dev_key.organization
+      assert new_key.max_hosts == @dev_key.max_hosts
     end
 
     test "unlimited hosts requires no max hosts" do

--- a/test/models/concerns/hostgroup_extensions_test.rb
+++ b/test/models/concerns/hostgroup_extensions_test.rb
@@ -48,16 +48,16 @@ module Katello
       @child.content_view = @view
       @child.save!
 
-      assert_equal @view, @child.content_view
-      assert_equal nil, @root.content_view
+      assert @view == @child.content_view
+      assert_nil @root.content_view
     end
 
     def test_inherited_lifecycle_environment_with_ancestry_nil
       @child.lifecycle_environment = @library
       @child.save!
 
-      assert_equal @library, @child.lifecycle_environment
-      assert_equal nil, @root.lifecycle_environment
+      assert @library == @child.lifecycle_environment
+      assert_nil @root.lifecycle_environment
     end
 
     def test_content_and_puppet_match?

--- a/test/models/content_view_puppet_module_test.rb
+++ b/test/models/content_view_puppet_module_test.rb
@@ -56,7 +56,7 @@ module Katello
         :uuid => nil,
         :content_view => @library_view
       )
-      assert_equal nil, content_view_puppet_module.computed_version
+      assert_nil content_view_puppet_module.computed_version
     end
 
     def test_latest_in_modules_by_author

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -108,15 +108,15 @@ module Katello
       count = ContentView.count
       new_view = @library_dev_view.copy("new view name")
 
-      assert_equal count + 1, ContentView.count
-      assert_equal new_view.name, "new view name"
-      assert_equal new_view.description, @library_dev_view.description
-      assert_equal new_view.organization_id, @library_dev_view.organization_id
-      assert_equal new_view.default, @library_dev_view.default
-      assert_equal new_view.composite, @library_dev_view.composite
-      assert_equal new_view.components, @library_dev_view.components
-      assert_equal new_view.repositories, @library_dev_view.repositories
-      assert_equal new_view.filters, @library_dev_view.filters
+      assert count + 1 == ContentView.count
+      assert new_view.name == "new view name"
+      assert new_view.description == @library_dev_view.description
+      assert new_view.organization_id == @library_dev_view.organization_id
+      assert new_view.default == @library_dev_view.default
+      assert new_view.composite ==  @library_dev_view.composite
+      assert new_view.components == @library_dev_view.components
+      assert new_view.repositories == @library_dev_view.repositories
+      assert new_view.filters == @library_dev_view.filters
     end
 
     def test_delete

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -671,7 +671,7 @@ module Katello
       new_repo.url = nil
       assert new_repo.save
       assert new_repo.persisted?
-      assert_equal nil, new_repo.reload.url
+      assert_nil new_repo.reload.url
       refute new_repo.url?
     end
 
@@ -728,8 +728,8 @@ module Katello
 
     def test_capsule_download_policy
       proxy = SmartProxy.new(:download_policy => 'on_demand')
-      assert_equal @content_view_puppet_environment.capsule_download_policy(proxy), nil
-      assert_equal @puppet_forge.capsule_download_policy(proxy), nil
+      assert_nil @content_view_puppet_environment.capsule_download_policy(proxy)
+      assert_nil @puppet_forge.capsule_download_policy(proxy)
       assert_not_nil @fedora_17_x86_64.download_policy
     end
   end

--- a/test/models/sync_plan_test.rb
+++ b/test/models/sync_plan_test.rb
@@ -32,7 +32,7 @@ module Katello
     def test_sync_date_if_bad_interval
       @plan.sync_date = '1999-11-17 18:26:48 UTC'
       @plan.interval = 'blah'
-      @plan.next_sync.must_equal(nil)
+      assert_nil @plan.next_sync
     end
 
     def test_next_run_hourly


### PR DESCRIPTION
Due to a bug on minitest that is being currently fixed, our tests are
broken when they run as the "test_develop_pr_katello" job in Jenkins.

The fix is published as https://github.com/seattlerb/minitest/pull/696
however there is no version of minitest with it yet. A possible
workaround is to prevent these assertions like this PR does.