### PR TITLE
fixes #19932 - fix repository checksum options

### DIFF
--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -86,7 +86,7 @@ module Katello
 
     validates :product_id, :presence => true
     validates :pulp_id, :presence => true, :uniqueness => true, :if => proc { |r| r.name.present? }
-    validates :checksum_type, :inclusion => {:in => CHECKSUM_TYPES, :allow_blank => true}
+    validates :checksum_type, :inclusion => {:in => CHECKSUM_TYPES}, :allow_blank => true
     validates :docker_upstream_name, :allow_blank => true, :if => :docker?, :length => { :maximum => 255 }, :format => {
       :with => /\A([a-z0-9]+[a-z0-9\-\_\.]*)+(\/[a-z0-9]+[a-z0-9\-\_\.]*)?\z/,
       :message => _("must be a valid docker name")

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/product-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/product-repositories.controller.js
@@ -16,8 +16,8 @@
  *   Provides the functionality for manipulating repositories attached to a product.
  */
 angular.module('Bastion.products').controller('ProductRepositoriesController',
-    ['$scope', '$state', '$location', 'ApiErrorHandler', 'Product', 'Repository', 'RepositoryBulkAction', 'CurrentOrganization', 'Nutupane', 'translate',
-    function ($scope, $state, $location, ApiErrorHandler, Product, Repository, RepositoryBulkAction, CurrentOrganization, Nutupane, translate) {
+    ['$scope', '$state', '$location', 'ApiErrorHandler', 'Product', 'Repository', 'RepositoryBulkAction', 'CurrentOrganization', 'Nutupane',
+    function ($scope, $state, $location, ApiErrorHandler, Product, Repository, RepositoryBulkAction, CurrentOrganization, Nutupane) {
         var repositoriesNutupane = new Nutupane(Repository, {
             'product_id': $scope.$stateParams.productId,
             'search': $location.search().search || "",
@@ -53,7 +53,6 @@ angular.module('Bastion.products').controller('ProductRepositoriesController',
 
         $scope.removingTasks = [];
 
-        $scope.checksums = [{name: translate('Default'), id: null}, {id: 'sha256', name: 'sha256'}, {id: 'sha1', name: 'sha1'}];
         $scope.table = repositoriesNutupane.table;
 
         $scope.syncSelectedRepositories = function () {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/checksum.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/checksum.service.js
@@ -1,0 +1,22 @@
+/**
+ * @ngdoc service
+ * @name  Bastion.repository.service:checksum
+ *
+ * @requires translate
+ *
+ * @description
+ *   Provides a checksum for repositories
+ */
+angular.module('Bastion.repositories').service('Checksum',
+    ['translate', function (translate) {
+
+        this.checksums = [{name: translate('Default'), id: null}, {id: 'sha256', name: 'sha256'}, {id: 'sha1', name: 'sha1'}];
+
+        this.checksumType = function (checksum) {
+            if (checksum === null) {
+                checksum = translate('Default');
+            }
+            return checksum;
+        };
+    }]
+);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
@@ -7,6 +7,7 @@
  * @requires translate
  * @requires GPGKey
  * @requires CurrentOrganization
+ * @requires Checksum
  * @requires DownloadPolicy
  * @requires OstreeUpstreamSyncPolicy
  *
@@ -14,8 +15,8 @@
  *   Provides the functionality for the repository details info page.
  */
 angular.module('Bastion.repositories').controller('RepositoryDetailsInfoController',
-    ['$scope', '$q', 'translate', 'GPGKey', 'CurrentOrganization', 'DownloadPolicy', 'OstreeUpstreamSyncPolicy',
-    function ($scope, $q, translate, GPGKey, CurrentOrganization, DownloadPolicy, OstreeUpstreamSyncPolicy) {
+    ['$scope', '$q', 'translate', 'GPGKey', 'CurrentOrganization', 'Checksum', 'DownloadPolicy', 'OstreeUpstreamSyncPolicy',
+    function ($scope, $q, translate, GPGKey, CurrentOrganization, Checksum, DownloadPolicy, OstreeUpstreamSyncPolicy) {
         $scope.successMessages = [];
         $scope.errorMessages = [];
         $scope.uploadSuccessMessages = [];
@@ -94,14 +95,13 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
             $scope.progress.uploading = false;
         };
 
-        $scope.checksumTypeDisplay = function (checksum) {
-            if (checksum === null) {
-                checksum = translate('Default');
-            }
-            return checksum;
-        };
+        $scope.checksums = Checksum.checksums;
         $scope.downloadPolicies = DownloadPolicy.downloadPolicies;
         $scope.ostreeUpstreamSyncPolicies = OstreeUpstreamSyncPolicy.syncPolicies;
+
+        $scope.checksumTypeDisplay = function (checksum) {
+            return Checksum.checksumType(checksum);
+        };
 
         $scope.downloadPolicyDisplay = function (downloadPolicy) {
             return DownloadPolicy.downloadPolicyName(downloadPolicy);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/new-repository.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/new-repository.controller.js
@@ -11,6 +11,7 @@
  * @requires GlobalNotification
  * @requires ApiErrorHandler
  * @requires BastionConfig
+ * @requires Checksum
  * @requires DownloadPolicy
  * @requires OstreeUpstreamSyncPolicy
  *
@@ -18,8 +19,8 @@
  *   Controls the creation of an empty Repository object for use by sub-controllers.
  */
 angular.module('Bastion.repositories').controller('NewRepositoryController',
-    ['$scope', 'Repository', 'Product', 'GPGKey', 'FormUtils', 'translate', 'GlobalNotification', 'ApiErrorHandler', 'BastionConfig', 'DownloadPolicy', 'OstreeUpstreamSyncPolicy',
-    function ($scope, Repository, Product, GPGKey, FormUtils, translate, GlobalNotification, ApiErrorHandler, BastionConfig, DownloadPolicy, OstreeUpstreamSyncPolicy) {
+    ['$scope', 'Repository', 'Product', 'GPGKey', 'FormUtils', 'translate', 'GlobalNotification', 'ApiErrorHandler', 'BastionConfig', 'Checksum', 'DownloadPolicy', 'OstreeUpstreamSyncPolicy',
+    function ($scope, Repository, Product, GPGKey, FormUtils, translate, GlobalNotification, ApiErrorHandler, BastionConfig, Checksum, DownloadPolicy, OstreeUpstreamSyncPolicy) {
 
         function success() {
             GlobalNotification.setSuccessMessage(translate('Repository %s successfully created.').replace('%s', $scope.repository.name));
@@ -74,6 +75,7 @@ angular.module('Bastion.repositories').controller('NewRepositoryController',
             $scope.repositoryTypes = data;
         });
 
+        $scope.checksums = Checksum.checksums;
         $scope.downloadPolicies = DownloadPolicy.downloadPolicies;
         $scope.ostreeUpstreamSyncPolicies = OstreeUpstreamSyncPolicy.syncPolicies;
 

--- a/engines/bastion_katello/test/products/details/repositories/checksum.service.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/checksum.service.test.js
@@ -1,0 +1,20 @@
+describe('Service: Checksum', function() {
+    var Checksum;
+
+    beforeEach(module('Bastion.repositories'));
+
+    beforeEach(module(function ($provide) {
+        $provide.value('translate', function (string) { return string; });
+    }));
+
+    beforeEach(inject(function($injector) {
+        Checksum = $injector.get('Checksum');
+    }));
+
+    it("provides a method to convert a checksum to human readable version", function() {
+        expect(Checksum.checksumType(null)).toBe('Default');
+        expect(Checksum.checksumType('sha256')).toBe('sha256');
+        expect(Checksum.checksumType('sha1')).toBe('sha1');
+    });
+
+});


### PR DESCRIPTION
Convert checksums to be a service, similar to download
policy and other types.  This change will allow for
repository create/update to offer the user a set
of valid options for the checksum (e.g. Default,
sha256, sha1).