### PR TITLE
Refs #19741 - Last test to use assert_nil

### DIFF
--- a/test/glue/candlepin/owner_test.rb
+++ b/test/glue/candlepin/owner_test.rb
@@ -26,7 +26,7 @@ module Katello
 
     def test_update_candlepin_owner_service_level
       # Without any choices, should not be able to set a service level
-      assert_equal nil, @org.service_level
+      assert_nil @org.service_level
       e = assert_raises(RestClient::BadRequest) do
         @org.service_level = 'Premium'
       end


### PR DESCRIPTION
Sorry, I missed one of the failures: 

http://ci.theforeman.org/job/test_develop_pr_katello/2906/database=postgresql,ruby=2.2,slave=fast/testReport/(root)/Katello__GlueCandlepinOwnerTestSLA/test_update_candlepin_owner_service_level/
http://ci.theforeman.org/job/test_develop_pr_katello/2906/testReport/