### PR TITLE
fixes #19063 - uploads packages with correct name

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -366,9 +366,9 @@ module Katello
       upload_ids = uploads.map { |upload| upload['id'] }
       unit_keys = uploads.map do |upload|
         if @repository.file?
-          upload.except('id').except('name')
-        else
           upload.except('id')
+        else
+          upload.except('id').except('name')
         end
       end
 


### PR DESCRIPTION
This commit fixes an issue with the package uploads
The prior logic includes the package name for yum repos
while excludes the name for file repos. What we intend to
happen is the reverse. We need to include the name for file
but exclude for yum since the name is derived from the metadata
for yum, puppet and other types.

This commit also contains a couple of unit tests to handle this.