### PR TITLE
fixes #19971 - allow repo create by non-admin and fix delete

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -52,7 +52,7 @@ module Katello
         scope :with_content, -> { with_features(PULP_FEATURE, PULP_NODE_FEATURE) }
 
         def self.default_capsule
-          with_features(PULP_FEATURE).first
+          unscoped.with_features(PULP_FEATURE).first
         end
 
         def self.default_capsule!

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details.controller.js
@@ -98,12 +98,12 @@
             var readOnlyReason = null;
 
             if (repo.$resolved && product.$resolved) {
-                if ($scope.denied('destroy_products', product)) {
-                    readOnlyReason = 'permissions';
-                } else if (repo.promoted) {
+                if (repo.promoted) {
                     readOnlyReason = 'published';
                 } else if (repo['product_type'] === "redhat") {
                     readOnlyReason = 'redhat';
+                } else if ($scope.denied('deletable', repo)) {
+                    readOnlyReason = 'permissions';
                 }
             }
             return readOnlyReason;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-details.html
@@ -46,12 +46,13 @@
           </span>
         </li>
 
-        <li class="divider" bst-feature-flag="custom_products" ng-hide="denied('delete_repositories')"></li>
+        <li class="divider" bst-feature-flag="custom_products"></li>
         <li role="menuitem" ng-show="canRemove(repository, product)">
           <a ng-click="openModal()" translate>
             Remove Repository
           </a>
-
+        </li>
+        <li>
           <span class="disabled" ng-hide="canRemove(repository, product)">
             <span translate>Cannot Remove</span>
 

--- a/engines/bastion_katello/test/products/details/repositories/details/repository-details.controller.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/details/repository-details.controller.test.js
@@ -71,7 +71,7 @@ describe('Controller: RepositoryDetailsController', function() {
             repository = {id: 200, $resolved: true};
 
         $scope.denied = function (perm, prod) {
-            expect(perm).toBe("destroy_products");
+            expect(perm).toBe("deletable");
             return true;
         };
         expect($scope.getRepoNonDeletableReason(repository, product)).toBe("permissions");


### PR DESCRIPTION
Attempting to create a repository as a non-admin user would
generate the following error:

RuntimeError: Could not find a smart proxy with pulp feature.
 | .../smart_proxy_extensions.rb:60:in `default_capsule!'

Since we do not want to now require the user to have
an additional permission on smart proxies, we chose
to treat the default capsule as an unscoped query.

Also, observed that the UI behavior for the repository
deletion permissions was incorrect.  It was treating the
repo behavior based upon the product, which is determined
by all repos in that product vs the one the user is
working with.