### PR TITLE
fixes #19960 - Host Collection/Host views not filtering correctly

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-associations.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-associations.controller.js
@@ -16,7 +16,7 @@
 angular.module('Bastion.activation-keys').controller('ActivationKeyAssociationsController',
     ['$scope', '$location', 'translate', 'Nutupane', 'ActivationKey', 'ContentHostsHelper', 'CurrentOrganization', 'Host',
     function ($scope, $location, translate, Nutupane, ActivationKey, ContentHostsHelper, CurrentOrganization, Host) {
-        var contentHostsNutupane, params = {
+        var contentHostsNutupane, nutupaneParams, params = {
             'organization_id': CurrentOrganization,
             'search': $location.search().search || "",
             'page': 1,
@@ -25,7 +25,11 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyAssociationsC
             'paged': true
         };
 
-        contentHostsNutupane = new Nutupane(Host, params);
+        nutupaneParams = {
+            'disableAutoLoad': true
+        };
+
+        contentHostsNutupane = new Nutupane(Host, params, undefined, nutupaneParams);
         $scope.controllerName = 'hosts';
         contentHostsNutupane.searchTransform = function (term) {
             var searchQuery, addition = "activation_key_id=" + $scope.$stateParams.activationKeyId;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-add-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-add-hosts.controller.js
@@ -16,7 +16,7 @@
 angular.module('Bastion.host-collections').controller('HostCollectionAddHostsController',
     ['$scope', '$state', '$location', 'translate', 'Nutupane', 'CurrentOrganization', 'Host', 'HostCollection',
     function ($scope, $state, $location, translate, Nutupane, CurrentOrganization, Host, HostCollection) {
-        var contentNutupane, params;
+        var contentNutupane, params, nutupaneParams;
 
         params = {
             'organization_id': CurrentOrganization,
@@ -27,7 +27,10 @@ angular.module('Bastion.host-collections').controller('HostCollectionAddHostsCon
             'paged': true
         };
 
-        contentNutupane = new Nutupane(Host, params);
+        nutupaneParams = {
+            'disableAutoLoad': true
+        };
+        contentNutupane = new Nutupane(Host, params, undefined, nutupaneParams);
         $scope.controllerName = 'hosts';
         contentNutupane.searchTransform = function (term) {
             var addition = "-host_collection_id=" + $scope.$stateParams.hostCollectionId;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-hosts.controller.js
@@ -16,7 +16,7 @@
 angular.module('Bastion.host-collections').controller('HostCollectionHostsController',
     ['$scope', '$location', 'translate', 'Nutupane', 'CurrentOrganization', 'Host', 'HostCollection',
     function ($scope, $location, translate, Nutupane, CurrentOrganization, Host, HostCollection) {
-        var params;
+        var params, nutupaneParams;
 
         params = {
             'organization_id': CurrentOrganization,
@@ -27,7 +27,11 @@ angular.module('Bastion.host-collections').controller('HostCollectionHostsContro
             'paged': true
         };
 
-        $scope.contentNutupane = new Nutupane(Host, params);
+        nutupaneParams = {
+            'disableAutoLoad': true
+        };
+
+        $scope.contentNutupane = new Nutupane(Host, params, undefined, nutupaneParams);
         $scope.controllerName = 'hosts';
         $scope.contentNutupane.searchTransform = function (term) {
             var addition = "host_collection_id=" + $scope.$stateParams.hostCollectionId;


### PR DESCRIPTION
1) Adding a new optional key : overrideAutoLoad to Nutupane factory params to control the initial loading behavior of the table on Katello pages.This is required as in few use cases, we want to be able to set table parameters and adjust query parameters before loading the table.
2) Making the value true for Host collection/Host> List/Remove and Add pages

Depends on PR: https://github.com/Katello/bastion/pull/197 in bastion.