### PR TITLE
fixes #20011 -Host Collection/Copy page missing validation

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-copy.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-copy.controller.js
@@ -16,7 +16,7 @@
             HostCollection.copy({id: $scope.$stateParams.hostCollectionId, 'host_collection': {name: newName}}, function (response) {
                 $scope.transitionTo('host-collection.info', {hostCollectionId: response.id});
             }, function (response) {
-                $scope.errorMessages.push(response.data.displayMessage);
+                $scope.$parent.errorMessages.push(response.data.displayMessage);
             });
         };
     }


### PR DESCRIPTION
The errors on the Host Collections/ Copy need to be pushed to the parent scope.