### PR TITLE
Fixes #20030 - Incorrect Content Host RAM info fix

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details-info.controller.js
@@ -131,7 +131,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsInfoContro
         };
 
         $scope.convertMemToGB = function (memoryValue) {
-            return (memoryValue / 1024000).toFixed(2);
+            return (memoryValue / 1048576).toFixed(2);
         };
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -112,7 +112,7 @@
         <dd>{{ host.facts["cpu::cpu(s)"] }}</dd>
 
         <dt translate>RAM (GB)</dt>
-        <dd>{{ convertMemtoGB(host.facts["memory::memtotal"]) }}</dd>
+        <dd>{{ convertMemToGB(host.facts["memory::memtotal"]) }}</dd>
       </dl>
 
       <div class="divider"></div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/subscription-content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/subscription-content-hosts.controller.js
@@ -31,6 +31,10 @@ angular.module('Bastion.subscriptions').controller('SubscriptionContentHostsCont
 
         $scope.memory = ContentHostsHelper.memory;
 
+        $scope.convertMemToGB = function (memoryValue) {
+            return (memoryValue / 1048576).toFixed(2);
+        };
+
         $scope.virtual = function (facts) {
             if (angular.isUndefined(facts.virt) || angular.isUndefined(facts.virt['is_guest'])) {
                 return false;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/views/subscription-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/details/views/subscription-content-hosts.html
@@ -54,7 +54,7 @@
         <td bst-table-cell>{{ contentHost.service_level }}</td>
         <td bst-table-cell>{{ contentHost.facts.cpu['cpu_socket(s)'] }}</td>
         <td bst-table-cell>{{ contentHost.facts.cpu['core(s)_per_socket'] }}</td>
-        <td bst-table-cell>{{ contentHost.facts.dmi.memory['size'] }}</td>
+        <td bst-table-cell>{{ convertMemToGB(contentHost.facts.memory['memtotal']) }}</td>
       </tr>
     </tbody>
   </table>

--- a/engines/bastion_katello/test/content-hosts/details/content-host-details-info.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/details/content-host-details-info.controller.test.js
@@ -136,7 +136,7 @@ describe('Controller: ContentHostDetailsInfoController', function() {
         expect($scope.editContentView).toBe(false);
     });
 
-    it('should convert Mem to GB', function() {
-        expect($scope.convertMemToGB(74051368)).toBe('72.32')
+    it('should convert Memory to GB', function() {
+        expect($scope.convertMemToGB(1020120)).toBe('0.97')
     });
 });

--- a/engines/bastion_katello/test/subscriptions/details/subscription-content-hosts.controller.test.js
+++ b/engines/bastion_katello/test/subscriptions/details/subscription-content-hosts.controller.test.js
@@ -34,4 +34,8 @@ describe('Controller: SubscriptionContentHostsController', function() {
         expect($scope.virtual({ })).toBe(false);
     });
 
+    it('should convert Memory to GB', function() {
+        expect($scope.convertMemToGB(1020120)).toBe('0.97')
+    });
+
 });

--- a/engines/bastion_katello/test/subscriptions/details/subscription-details.controller.test.js
+++ b/engines/bastion_katello/test/subscriptions/details/subscription-details.controller.test.js
@@ -45,7 +45,6 @@ describe('Controller: SubscriptionDetailsController', function() {
             var subscription = {sockets: 2, cores: 4};
             expect($scope.subscriptionLimits(subscription)).toBe("Sockets: 2, Cores: 4");
         });
-
     });
 
 });


### PR DESCRIPTION
This fixes the incorrect RAM information for the following web pages 

Hosts >> Content Hosts >> Content Host Properties 
Content >> Red Hat Subscriptions >> Associations >> Hosts