### PR TITLE
Fixes #18920 - Use remove_missing on repo sync

### DIFF
--- a/app/lib/actions/pulp/consumer/sync_capsule.rb
+++ b/app/lib/actions/pulp/consumer/sync_capsule.rb
@@ -5,6 +5,7 @@ module Actions
         input_format do
           param :capsule_id, Integer
           param :repo_pulp_id, String
+          param :sync_options
         end
 
         def humanized_name
@@ -12,7 +13,7 @@ module Actions
         end
 
         def invoke_external_task
-          pulp_resources.repository.sync(input[:repo_pulp_id])
+          pulp_resources.repository.sync(input[:repo_pulp_id], override_config: input[:sync_options])
         end
 
         def run_progress

--- a/lib/katello/tasks/delete_orphaned_content.rake
+++ b/lib/katello/tasks/delete_orphaned_content.rake
@@ -1,7 +1,14 @@
 namespace :katello do
   task :delete_orphaned_content => ["environment"] do
     User.current = User.anonymous_admin
-    Katello::Repository.delete_orphaned_content
+    SmartProxy.with_content.reverse.each do |proxy|
+      begin
+        ForemanTasks.async_task(Actions::Katello::CapsuleContent::RemoveOrphans,
+                                :capsule_id => proxy.id)
+      rescue RuntimeError => e
+        Rails.logger.error "Smart proxy with ID #{proxy.id} may be down: #{e}"
+      end
+    end
     puts _("Orphaned content deletion started in background.")
   end
 end


### PR DESCRIPTION
Take advantage of the newly fixed remove_missing option in pulp.