### PR TITLE
fixes #20084 - email-notification sync errata

### DIFF
--- a/app/lib/actions/katello/content_view/errata_mail.rb
+++ b/app/lib/actions/katello/content_view/errata_mail.rb
@@ -11,7 +11,7 @@ module Actions
 
           content_view = ::Katello::ContentView.find(input[:content_view])
           environment = ::Katello::KTEnvironment.find(input[:environment])
-          users = ::User.select { |user| user.receives?(:promote_errata) && user.can?(:view_content_views, content_view) }
+          users = ::User.select { |user| user.receives?(:promote_errata) && user.organization_ids.include?(content_view.organization_id) && user.can?(:view_content_views, content_view) }
 
           begin
             MailNotification[:promote_errata].deliver_now(:users => users, :content_view => content_view, :environment => environment) unless users.blank?

--- a/app/lib/actions/katello/repository/errata_mail.rb
+++ b/app/lib/actions/katello/repository/errata_mail.rb
@@ -13,7 +13,7 @@ module Actions
           ::User.current = ::User.anonymous_admin
 
           repo = ::Katello::Repository.find(input[:repo])
-          users = ::User.select { |user| user.receives?(:sync_errata) && user.can?(:view_products, repo.product) }.compact
+          users = ::User.select { |user| user.receives?(:sync_errata) && user.organization_ids.include?(repo.organization.id) && user.can?(:view_products, repo.product) }.compact
           errata = ::Katello::Erratum.where(:id => repo.repository_errata.where('katello_repository_errata.updated_at > ?', input[:last_updated].to_datetime).pluck(:erratum_id))
 
           begin


### PR DESCRIPTION
Email notification - Sync errata - email should be send to only those users who belongs/access to the organization