### PR TITLE
Fixes #20095: remove reference to nutupane.refreshRows()

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/manifest-import.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/manifest-import.controller.js
@@ -92,7 +92,6 @@ angular.module('Bastion.subscriptions').controller('ManifestImportController',
                 if ($scope.task.result === 'success') {
                     $scope.refreshOrganizationInfo();
                     GlobalNotification.setSuccessMessage(translate("Manifest successfully imported."));
-                    $scope.refreshTable();
                 } else {
                     $scope.handleTaskErrors(task, translate("Error importing manifest."));
                 }
@@ -116,7 +115,6 @@ angular.module('Bastion.subscriptions').controller('ManifestImportController',
                 if ($scope.deleteTask.result === 'success') {
                     $scope.saveSuccess = true;
                     GlobalNotification.setSuccessMessage(translate("Manifest successfully deleted."));
-                    $scope.refreshTable();
                     $scope.refreshOrganizationInfo();
                 } else {
                     $scope.handleTaskErrors(task, translate("Error deleting manifest."));
@@ -149,7 +147,6 @@ angular.module('Bastion.subscriptions').controller('ManifestImportController',
                 if ($scope.refreshTask.result === 'success') {
                     $scope.saveSuccess = true;
                     GlobalNotification.setSuccessMessage(translate("Manifest successfully refreshed."));
-                    $scope.refreshTable();
                     $scope.refreshOrganizationInfo();
                 } else {
                     $scope.handleTaskErrors(task, translate("Error refreshing manifest."));
@@ -174,10 +171,11 @@ angular.module('Bastion.subscriptions').controller('ManifestImportController',
 
             deferred = Organization.update(whitelistedOrganizationObject, function () {
                 GlobalNotification.setSuccessMessage(translate('Repository URL updated'));
-                $scope.refreshTable();
                 $scope.refreshOrganizationInfo();
             }, function (response) {
-                GlobalNotification.setErrorMessage(translate("An error occurred saving the URL: ") + response.data.error.message);
+                angular.forEach(response.data.error['full_messages'], function (message) {
+                    GlobalNotification.setErrorMessage(translate("An error occurred saving the URL: ") + message);
+                });
             });
 
             return deferred.$promise;

--- a/engines/bastion_katello/test/subscriptions/manifest/manifest-import.controller.test.js
+++ b/engines/bastion_katello/test/subscriptions/manifest/manifest-import.controller.test.js
@@ -142,13 +142,11 @@ describe('Controller: ManifestImportController', function() {
 
     it('should set the upload status to success and refresh data if upload status is success', function() {
         $q.all([$scope.organization.$promise]).then(function () {
-            spyOn($scope, 'refreshTable');
             $scope.uploadManifest('<pre>{"status": "success"}</pre>', true);
 
             expect($scope.saveSuccess).toBe(true);
             expect($scope.uploadErrorMessages.length).toBe(0);
             expect(GlobalNotification.setSuccessMessage).toHaveBeenCalled();
-            expect($scope.refreshTable).toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
When migrating away from nutupane this reference was apparently not
removed and thus now causes a JS error.  This commit removes the
reference as well as fixing an issue with the error handling of updating
the CDN url.

http://projects.theforeman.org/issues/20095