### PR TITLE
Fixes #20135 - tests ready for create/edit perms

### DIFF
--- a/db/seeds.d/102-organizations.rb
+++ b/db/seeds.d/102-organizations.rb
@@ -5,9 +5,9 @@
 #
 
 Organization.all.each do |org|
-  User.current = User.anonymous_admin
-  ForemanTasks.sync_task(::Actions::Katello::Organization::Create, org) unless org.library
-  User.current = nil
+  User.as(::User.anonymous_api_admin.login) do
+    ForemanTasks.sync_task(::Actions::Katello::Organization::Create, org) unless org.library
+  end
 end
 
 if ENV['SEED_ORGANIZATION']

--- a/db/seeds.d/103-provisioning_templates.rb
+++ b/db/seeds.d/103-provisioning_templates.rb
@@ -4,41 +4,39 @@
 # !!! PLEASE KEEP THIS SCRIPT IDEMPOTENT !!!
 #
 
-::User.current = ::User.anonymous_api_admin
+User.as(::User.anonymous_api_admin.login) do
+  # Provisioning Templates
 
-# Provisioning Templates
-
-kinds = [:provision, :finish, :user_data].inject({}) do |hash, kind|
-  hash[kind] = TemplateKind.find_by(:name => kind)
-  hash
-end
-
-templates = [{:name => "Katello Kickstart Default",           :source => "kickstart-katello.erb",      :template_kind => kinds[:provision]},
-             {:name => "Katello Kickstart Default User Data", :source => "userdata-katello.erb",       :template_kind => kinds[:user_data]},
-             {:name => "Katello Kickstart Default Finish",    :source => "finish-katello.erb",         :template_kind => kinds[:finish]},
-             {:name => "subscription_manager_registration",   :source => "snippets/_subscription_manager_registration.erb", :snippet => true},
-             {:name => "Katello Atomic Kickstart Default",    :source => "kickstart-katello-atomic.erb", :template_kind => kinds[:provision]}]
-
-templates.each do |template|
-  template[:template] = File.read(File.join(Katello::Engine.root, "app/views/foreman/unattended", template.delete(:source)))
-  ProvisioningTemplate.where(:name => template["name"]).first_or_create do |pt|
-    pt.vendor = "Katello"
-    pt.default = true
-    pt.locked = true
-    pt.name = template[:name]
-    pt.template = template[:template]
-    pt.template_kind = template[:template_kind] if template[:template_kind]
-    pt.snippet = template[:snippet] if template[:snippet]
+  kinds = [:provision, :finish, :user_data].inject({}) do |hash, kind|
+    hash[kind] = TemplateKind.find_by(:name => kind)
+    hash
   end
-  ProvisioningTemplate.find_by(name: template[:name]).update_attributes!(:template => template[:template])
-end
 
-# Ensure all default templates are seeded into the first org and loc
-ProvisioningTemplate.where(:default => true).each do |template|
-  template.organizations << Organization.first unless template.organizations.include?(Organization.first) || Organization.count.zero?
-  if Location.exists? && !template.location_ids.include?(Location.default_location_ids)
-    template.location_ids << Location.default_location_ids
+  templates = [{:name => "Katello Kickstart Default",           :source => "kickstart-katello.erb",      :template_kind => kinds[:provision]},
+               {:name => "Katello Kickstart Default User Data", :source => "userdata-katello.erb",       :template_kind => kinds[:user_data]},
+               {:name => "Katello Kickstart Default Finish",    :source => "finish-katello.erb",         :template_kind => kinds[:finish]},
+               {:name => "subscription_manager_registration",   :source => "snippets/_subscription_manager_registration.erb", :snippet => true},
+               {:name => "Katello Atomic Kickstart Default",    :source => "kickstart-katello-atomic.erb", :template_kind => kinds[:provision]}]
+
+  templates.each do |template|
+    template[:template] = File.read(File.join(Katello::Engine.root, "app/views/foreman/unattended", template.delete(:source)))
+    ProvisioningTemplate.where(:name => template["name"]).first_or_create do |pt|
+      pt.vendor = "Katello"
+      pt.default = true
+      pt.locked = true
+      pt.name = template[:name]
+      pt.template = template[:template]
+      pt.template_kind = template[:template_kind] if template[:template_kind]
+      pt.snippet = template[:snippet] if template[:snippet]
+    end
+    ProvisioningTemplate.find_by(name: template[:name]).update_attributes!(:template => template[:template])
+  end
+
+  # Ensure all default templates are seeded into the first org and loc
+  ProvisioningTemplate.where(:default => true).each do |template|
+    template.organizations << Organization.first unless template.organizations.include?(Organization.first) || Organization.count.zero?
+    if Location.exists? && !template.location_ids.include?(Location.default_location_ids)
+      template.location_ids << Location.default_location_ids
+    end
   end
 end
-
-::User.current = nil

--- a/db/seeds.d/104-proxy.rb
+++ b/db/seeds.d/104-proxy.rb
@@ -9,17 +9,15 @@ def format_errors(model = nil)
   model.errors.full_messages.join(';')
 end
 
-::User.current = ::User.anonymous_api_admin
+User.as(::User.anonymous_api_admin.login) do
+  # Proxy features
+  feature = Feature.where(:name => 'Pulp').first_or_create
+  if feature.nil? || feature.errors.any?
+    fail "Unable to create proxy feature: #{format_errors feature}"
+  end
 
-# Proxy features
-feature = Feature.where(:name => 'Pulp').first_or_create
-if feature.nil? || feature.errors.any?
-  fail "Unable to create proxy feature: #{format_errors feature}"
+  ["Pulp", "Pulp Node"].each do |input|
+    f = Feature.where(:name => input).first_or_create
+    fail "Unable to create proxy feature: #{format_errors f}" if f.nil? || f.errors.any?
+  end
 end
-
-["Pulp", "Pulp Node"].each do |input|
-  f = Feature.where(:name => input).first_or_create
-  fail "Unable to create proxy feature: #{format_errors f}" if f.nil? || f.errors.any?
-end
-
-::User.current = nil

--- a/db/seeds.d/106-mail_notifications.rb
+++ b/db/seeds.d/106-mail_notifications.rb
@@ -3,40 +3,38 @@
 #
 # !!! PLEASE KEEP THIS SCRIPT IDEMPOTENT !!!
 #
-::User.current = ::User.anonymous_api_admin
+User.as(::User.anonymous_api_admin.login) do
+  # The notification names are used as humanized labels. These need to be
+  # translated as well as the description
+  N_('Host errata advisory')
+  N_('Sync errata')
+  N_('Promote errata')
 
-# The notification names are used as humanized labels. These need to be
-# translated as well as the description
-N_('Host errata advisory')
-N_('Sync errata')
-N_('Promote errata')
+  # Mail Notifications
+  notifications = [
+    {:name              => :host_errata_advisory,
+     :description       => N_('A summary of available and applicable errata for your hosts'),
+     :mailer            => 'Katello::ErrataMailer',
+     :method            => 'host_errata',
+     :subscription_type => 'report'
+    },
 
-# Mail Notifications
-notifications = [
-  {:name              => :host_errata_advisory,
-   :description       => N_('A summary of available and applicable errata for your hosts'),
-   :mailer            => 'Katello::ErrataMailer',
-   :method            => 'host_errata',
-   :subscription_type => 'report'
-  },
+    {:name              => :sync_errata,
+     :description       => N_('A summary of new errata after a repository is synchronized'),
+     :mailer            => 'Katello::ErrataMailer',
+     :method            => 'sync_errata',
+     :subscription_type => 'alert'
+    },
 
-  {:name              => :sync_errata,
-   :description       => N_('A summary of new errata after a repository is synchronized'),
-   :mailer            => 'Katello::ErrataMailer',
-   :method            => 'sync_errata',
-   :subscription_type => 'alert'
-  },
+    {:name              => :promote_errata,
+     :description       => N_('A post-promotion summary of hosts with installable errata'),
+     :mailer            => 'Katello::ErrataMailer',
+     :method            => 'promote_errata',
+     :subscription_type => 'alert'
+    }
+  ]
 
-  {:name              => :promote_errata,
-   :description       => N_('A post-promotion summary of hosts with installable errata'),
-   :mailer            => 'Katello::ErrataMailer',
-   :method            => 'promote_errata',
-   :subscription_type => 'alert'
-  }
-]
-
-notifications.each do |notification|
-  ::MailNotification.where(name: notification[:name]).first_or_create!(notification)
+  notifications.each do |notification|
+    ::MailNotification.where(name: notification[:name]).first_or_create!(notification)
+  end
 end
-
-::User.current = nil

--- a/db/seeds.d/107-enable_dynflow.rb
+++ b/db/seeds.d/107-enable_dynflow.rb
@@ -3,7 +3,6 @@
 #
 # !!! PLEASE KEEP THIS SCRIPT IDEMPOTENT !!!
 #
-::User.current = ::User.anonymous_api_admin
-
-Setting.find_by(:name => "dynflow_enable_console").update_attributes!(:value => true) if Rails.env.development?
-::User.current = nil
+User.as(::User.anonymous_api_admin.login) do
+  Setting.find_by(:name => "dynflow_enable_console").update_attributes!(:value => true) if Rails.env.development?
+end

--- a/db/seeds.d/108-subcription-bookmarks.rb
+++ b/db/seeds.d/108-subcription-bookmarks.rb
@@ -4,16 +4,18 @@
 # !!! PLEASE KEEP THIS SCRIPT IDEMPOTENT !!!
 #
 
-Bookmark.without_auditing do
-  bookmarks = [
-    {:name => "list hypervisors", :query => 'hypervisor = true', :controller => "hosts"},
-    {:name => "future", :query => 'starts > Today', :controller => "katello_subscriptions"},
-    {:name => "expiring soon", :query => 'expires 30 days from now', :controller => "katello_subscriptions"}
-  ]
+User.as_anonymous_admin do
+  Bookmark.without_auditing do
+    bookmarks = [
+      {:name => "list hypervisors", :query => 'hypervisor = true', :controller => "hosts"},
+      {:name => "future", :query => 'starts > Today', :controller => "katello_subscriptions"},
+      {:name => "expiring soon", :query => 'expires 30 days from now', :controller => "katello_subscriptions"}
+    ]
 
-  bookmarks.each do |input|
-    next if SeedHelper.audit_modified? Bookmark, input[:name], :controller => input[:controller]
-    b = Bookmark.find_or_create_by({ :public => true }.merge(input))
-    fail "Unable to create bookmark: #{format_errors b}" if b.nil? || b.errors.any?
+    bookmarks.each do |input|
+      next if SeedHelper.audit_modified? Bookmark, input[:name], :controller => input[:controller]
+      b = Bookmark.find_or_create_by({ :public => true }.merge(input))
+      fail "Unable to create bookmark: #{format_errors b}" if b.nil? || b.errors.any?
+    end
   end
 end

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -1,7 +1,7 @@
 require 'katello/permission_creator'
 
 Foreman::Plugin.register :katello do
-  requires_foreman '>= 1.15'
+  requires_foreman '>= 1.16'
 
   sub_menu :top_menu, :content_menu, :caption => N_('Content'), :after => :monitor_menu do
     menu :top_menu,

--- a/test/actions/katello/docker_repository_set_test.rb
+++ b/test/actions/katello/docker_repository_set_test.rb
@@ -61,8 +61,10 @@ module ::Actions::Katello::DockerRepositorySet
     let(:expected_relative_path) { "Empty_Organization/library_label/product/x86_64/6Server" }
 
     def repository_already_enabled!
-      katello_repositories(:rhel_6_x86_64).update_attributes!(relative_path: "#{expected_relative_path}",
-                             docker_upstream_name: registry_name)
+      as_admin do
+        katello_repositories(:rhel_6_x86_64).update_attributes!(relative_path: "#{expected_relative_path}",
+                               docker_upstream_name: registry_name)
+      end
     end
   end
 

--- a/test/actions/katello/repository_set_test.rb
+++ b/test/actions/katello/repository_set_test.rb
@@ -32,9 +32,11 @@ module ::Actions::Katello::RepositorySet
     let(:expected_relative_path) { "Empty_Organization/library_label/product/x86_64/6Server" }
 
     def repository_already_enabled!
-      katello_repositories(:rhel_6_x86_64).
-          update_attributes!(:relative_path => "#{expected_relative_path}", :content_id => content.id,
-                            :arch => 'x86_64', :minor => '6Server')
+      as_admin do
+        katello_repositories(:rhel_6_x86_64).
+            update_attributes!(:relative_path => "#{expected_relative_path}", :content_id => content.id,
+                              :arch => 'x86_64', :minor => '6Server')
+      end
     end
   end
 

--- a/test/controllers/api/v2/host_errata_controller_test.rb
+++ b/test/controllers/api/v2/host_errata_controller_test.rb
@@ -81,10 +81,13 @@ module Katello
       bad_perms = [@view_permission, @create_permission, @destroy_permission]
 
       assert_protected_action(:apply, good_perms, bad_perms) do
-        @host.update_attribute(:organization, taxonomies(:organization1))
-        @host.update_attribute(:location, taxonomies(:location1))
-        User.current.update_attribute(:organizations, [@host.organization])
-        User.current.update_attribute(:locations, [@host.location])
+        user = User.current
+        as_admin do
+          @host.update_attribute(:organization, taxonomies(:organization1))
+          @host.update_attribute(:location, taxonomies(:location1))
+          user.organizations = [@host.organization]
+          user.locations = [@host.location]
+        end
         put :apply, :host_id => @host.id, :errata_ids => %w(RHSA-1999-1231)
       end
     end

--- a/test/controllers/api/v2/host_packages_controller_test.rb
+++ b/test/controllers/api/v2/host_packages_controller_test.rb
@@ -104,10 +104,14 @@ module Katello
       bad_perms = [@update_permission, @create_permission, @destroy_permission]
 
       assert_protected_action(:index, good_perms, bad_perms) do
-        User.current.update_attribute(:organizations, [taxonomies(:organization1)])
-        @host.update_attribute(:organization, taxonomies(:organization1))
-        User.current.update_attribute(:locations, [taxonomies(:location1)])
-        @host.update_attribute(:location, taxonomies(:location1))
+        user = User.current
+        as_admin do
+          user.update_attribute(:organizations, [taxonomies(:organization1)])
+          @host.update_attribute(:organization, taxonomies(:organization1))
+          user.update_attribute(:locations, [taxonomies(:location1)])
+          @host.update_attribute(:location, taxonomies(:location1))
+        end
+
         get :index, :host_id => @host.id
       end
     end

--- a/test/controllers/api/v2/sync_plans_controller_test.rb
+++ b/test/controllers/api/v2/sync_plans_controller_test.rb
@@ -94,7 +94,7 @@ module Katello
       allowed_perms = [@update_permission]
       denied_perms = [@view_permission, @create_permission, @destroy_permission]
 
-      assert_protected_action(:destroy, allowed_perms, denied_perms) do
+      assert_protected_action(:destroy, allowed_perms, denied_perms, [@organization]) do
         put :update, :id => @sync_plan.id, :organization_id => @organization.id,
             :sync_plan => {:description => 'new description.'}
       end

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -4,7 +4,7 @@ module Katello
   class ProductCreateTest < ActiveSupport::TestCase
     def setup
       super
-      User.current = @admin
+      User.current = @@admin
       @product = build(:katello_product,
                        :organization => get_organization,
                        :provider => katello_providers(:anonymous)

--- a/test/support/auth_support.rb
+++ b/test/support/auth_support.rb
@@ -48,23 +48,25 @@ module Katello
     # [{:name => :view_lifecycle_environments, :search => 'name=Dev'}, ..] OR
     # :view_lifecycle_environments
     def setup_user_with_permissions(permissions, user)
-      actual_permissions =  if permissions.is_a?(Hash)
-                              [permissions]
-                            elsif permissions.is_a?(Array)
-                              permissions.collect do |perm|
-                                if perm.is_a?(Hash)
-                                  perm
-                                else
-                                  {:name => perm}
-                                end
-                              end
-                            else
-                              [{:name => permissions}]
-                            end
+      as_admin do
+        actual_permissions = if permissions.is_a?(Hash)
+                               [permissions]
+                             elsif permissions.is_a?(Array)
+                               permissions.collect do |perm|
+                                 if perm.is_a?(Hash)
+                                   perm
+                                 else
+                                   {:name => perm}
+                                 end
+                               end
+                             else
+                               [{:name => permissions}]
+                             end
 
-      role = create_role_with_permissions(actual_permissions)
-      user.roles = [role]
-      user
+        role = create_role_with_permissions(actual_permissions)
+        user.roles = [role]
+        user
+      end
     end
 
     def setup_current_user_with_permissions(permissions)

--- a/test/support/controller_support.rb
+++ b/test/support/controller_support.rb
@@ -8,8 +8,8 @@ module ControllerSupport
 
     permissions.each do |permission|
       user = User.unscoped.find(users(:restricted).id)
-      user.organizations = params[:organizations] if params[:organizations].present?
       as_admin do
+        user.organizations = params[:organizations] if params[:organizations].present?
         setup_user_with_permissions(permission, user)
       end
 


### PR DESCRIPTION
This should fix all test failures introduced by https://github.com/theforeman/foreman/pull/4030, note that also foreman tasks with https://github.com/theforeman/foreman-tasks/pull/261 merged is required. Once foreman-tasks is released with it, we should probably bump the dependency on gemspec.