### PR TITLE
Fixes #20138 - fix host pkgs api

### DIFF
--- a/app/controllers/katello/api/v2/host_packages_controller.rb
+++ b/app/controllers/katello/api/v2/host_packages_controller.rb
@@ -21,7 +21,7 @@ module Katello
     param :host_id, :identifier, :required => true, :desc => N_("ID of the host")
     param_group :search, Api::V2::ApiController
     def index
-      collection = scoped_search(index_relation.uniq, :name, :asc, :resource_class => ::Katello::InstalledPackage)
+      collection = scoped_search(index_relation, :name, :asc, :resource_class => ::Katello::InstalledPackage)
       respond_for_index(:collection => collection)
     end
 

--- a/test/controllers/api/v2/host_packages_controller_test.rb
+++ b/test/controllers/api/v2/host_packages_controller_test.rb
@@ -27,6 +27,12 @@ module Katello
       permissions
     end
 
+    def test_index
+      get :index, :host_id => @host.id
+
+      assert_response :success
+    end
+
     def test_install_package
       assert_async_task ::Actions::Katello::Host::Package::Install do |host, packages|
         host.id == @host.id && packages == %w(foo)


### PR DESCRIPTION
uniq is not needed here, as the scoped_search method handles this
already