### PR TITLE
Refs #20122 - Match container JS file with digest

### DIFF
--- a/test/controllers/foreman/containers/steps_controller_test.rb
+++ b/test/controllers/foreman/containers/steps_controller_test.rb
@@ -25,7 +25,7 @@ module Containers
       # Only match the container.js part - as the response.body will contain
       # something like "digest+container.js" on Sprockets 3.x, even on the
       # test environment
-      assert_match(/container.js/, response.body)
+      assert_match(/container.*\.js/, response.body)
       docker_image = @controller.instance_eval do
         @docker_container_wizard_states_image
       end


### PR DESCRIPTION
As it can be seen here 

http://ci.theforeman.org/job/test_develop_pr_katello/3166/database=postgresql,ruby=2.2,slave=fast/testReport/junit/(root)/Containers__StepsControllerTest/test_show_image_loads_katello/

the test didn't pass because my previous PR #6841 didn't match the digest in between the container and the .js file, sorry! See the Jenkins link above, the change here should make it pass.
