### PR TITLE
Fixes #20242 - avoid nil product certs

### DIFF
--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -673,9 +673,10 @@ module Katello
             subscriptions = JSON.parse(subscriptions_json)
 
             product_subscription = subscriptions.find do |sub|
-              sub["product"]["id"] == id ||
+              sub['certificate'] &&
+              (sub["product"]["id"] == id ||
                 sub["providedProducts"].any? { |provided| provided["id"] == id } ||
-                sub["derivedProvidedProducts"].any? { |provided| provided["id"] == id }
+                sub["derivedProvidedProducts"].any? { |provided| provided["id"] == id })
             end
 
             if product_subscription


### PR DESCRIPTION
some situation can occur where a product does not
have product certs but 'provides' a particular product that does
in this case we don't want to use it when trying to select
a product cert to talk to the cdn with