### PR TITLE
fixes #19659 - capsule sync via bulk action

### DIFF
--- a/app/controllers/katello/api/v2/capsule_content_controller.rb
+++ b/app/controllers/katello/api/v2/capsule_content_controller.rb
@@ -51,7 +51,7 @@ module Katello
     param :environment_id, Integer, :desc => N_('Id of the environment to limit the synchronization on')
     def sync
       find_environment if params[:environment_id]
-      task = async_task(::Actions::Katello::CapsuleContent::Sync, capsule_content, :environment => @environment)
+      task = async_task(::Actions::Katello::CapsuleContent::Sync, capsule_content.capsule, :environment_id => @environment.try(:id))
       respond_for_async :resource => task
     end
 

--- a/app/lib/actions/katello/capsule_content/sync.rb
+++ b/app/lib/actions/katello/capsule_content/sync.rb
@@ -6,18 +6,30 @@ module Actions
           :link
         end
 
-        def humanized_name
-          _("Synchronize capsule content")
+        input_format do
+          param :name
         end
 
-        def plan(capsule_content, options = {})
+        def humanized_name
+          _("Synchronize smart proxy")
+        end
+
+        def humanized_input
+          ["'#{input['smart_proxy']['name']}'"] + super
+        end
+
+        def plan(smart_proxy, options = {})
+          action_subject(smart_proxy)
+          capsule_content = ::Katello::CapsuleContent.new(smart_proxy)
           capsule_content.ping_pulp
           capsule_content.verify_ueber_certs
-          action_subject(capsule_content.capsule)
 
-          environment = options.fetch(:environment, nil)
-          repository = options.fetch(:repository, nil)
-          content_view = options.fetch(:content_view, nil)
+          environment_id = options.fetch(:environment_id, nil)
+          environment = ::Katello::KTEnvironment.find(environment_id) if environment_id
+          repository_id = options.fetch(:repository_id, nil)
+          repository = ::Katello::Repository.find(repository_id) if repository_id
+          content_view_id = options.fetch(:content_view_id, nil)
+          content_view = ::Katello::ContentView.find(content_view_id) if content_view_id
 
           fail _("Action not allowed for the default capsule.") if capsule_content.default_capsule?
 

--- a/app/lib/actions/katello/content_view/capsule_generate_and_sync.rb
+++ b/app/lib/actions/katello/content_view/capsule_generate_and_sync.rb
@@ -3,15 +3,16 @@ module Actions
     module ContentView
       class CapsuleGenerateAndSync < Actions::Base
         def humanized_name
-          _("Sync Smart proxy with Content View")
+          _("Sync Content View on Smart Proxy(ies)")
         end
 
         def plan(content_view, environment)
           sequence do
             concurrence do
-              ::Katello::CapsuleContent.with_environment(environment).each do |capsule_content|
-                plan_action(Katello::CapsuleContent::Sync, capsule_content, :content_view => content_view,
-                            :environment => environment)
+              smart_proxies = ::Katello::CapsuleContent.with_environment(environment).map { |capsule| capsule.capsule }
+              unless smart_proxies.blank?
+                plan_action(::Actions::BulkAction, ::Actions::Katello::CapsuleContent::Sync, smart_proxies,
+                            :content_view_id => content_view.id, :environment_id => environment.id)
               end
             end
           end

--- a/app/lib/actions/katello/repository/capsule_generate_and_sync.rb
+++ b/app/lib/actions/katello/repository/capsule_generate_and_sync.rb
@@ -3,14 +3,16 @@ module Actions
     module Repository
       class CapsuleGenerateAndSync < Actions::Base
         def humanized_name
-          _("Sync Repository on Smart proxy(ies)")
+          _("Sync Repository on Smart Proxy(ies)")
         end
 
         def plan(repo)
           if repo.node_syncable?
             concurrence do
-              ::Katello::CapsuleContent.with_environment(repo.environment).each do |capsule_content|
-                plan_action(Katello::CapsuleContent::Sync, capsule_content, repository: repo)
+              smart_proxies = ::Katello::CapsuleContent.with_environment(repo.environment).map { |c| c.capsule }
+              unless smart_proxies.blank?
+                plan_action(::Actions::BulkAction, ::Actions::Katello::CapsuleContent::Sync, smart_proxies,
+                            :repository_id => repo.id)
               end
             end
           end

--- a/test/actions/katello/capsule_content_test.rb
+++ b/test/actions/katello/capsule_content_test.rb
@@ -49,7 +49,7 @@ module ::Actions::Katello::CapsuleContent
     it 'plans' do
       capsule_content.add_lifecycle_environment(environment)
       action_class.any_instance.expects(:repos_needing_updates).returns([repository])
-      capsule_content_sync = plan_action(action, capsule_content)
+      capsule_content_sync = plan_action(action, capsule_content.capsule)
 
       synced_repos = synced_repos(capsule_content_sync, capsule_content.repos_available_to_capsule)
 
@@ -64,7 +64,7 @@ module ::Actions::Katello::CapsuleContent
     it 'allows limiting scope of the syncing to one environment' do
       capsule_content.add_lifecycle_environment(dev_environment)
       action_class.any_instance.expects(:repos_needing_updates).returns([])
-      capsule_content_sync = plan_action(action, capsule_content, :environment => dev_environment)
+      capsule_content_sync = plan_action(action, capsule_content.capsule, :environment_id => dev_environment.id)
       synced_repos = synced_repos(capsule_content_sync, capsule_content.repos_available_to_capsule)
 
       assert_equal synced_repos.uniq.count, 7
@@ -73,7 +73,7 @@ module ::Actions::Katello::CapsuleContent
     it 'fails when trying to sync to the default capsule' do
       Katello::CapsuleContent.any_instance.stubs(:default_capsule?).returns(true)
       assert_raises(RuntimeError) do
-        plan_action(action, capsule_content, :environment => dev_environment)
+        plan_action(action, capsule_content.capsule, :environment_id => dev_environment.id)
       end
     end
 
@@ -82,7 +82,7 @@ module ::Actions::Katello::CapsuleContent
 
       Katello::CapsuleContent.any_instance.stubs(:lifecycle_environments).returns([])
       assert_raises(RuntimeError) do
-        plan_action(action, capsule_content, :environment => staging_environment)
+        plan_action(action, capsule_content.capsule, :environment_id => staging_environment.id)
       end
     end
   end

--- a/test/actions/katello/content_view_test.rb
+++ b/test/actions/katello/content_view_test.rb
@@ -281,13 +281,16 @@ module ::Actions::Katello::ContentView
       katello_environments(:library)
     end
 
-    before do
-      capsule_content.add_lifecycle_environment(library)
-    end
-
     it 'plans' do
+      capsule_content_1 = new_capsule_content(:three)
+      capsule_content_2 = new_capsule_content(:four)
+      capsule_content_1.add_lifecycle_environment(library)
+      capsule_content_2.add_lifecycle_environment(library)
+
       plan_action(action, content_view, library)
-      assert_action_planed_with(action, ::Actions::Katello::CapsuleContent::Sync, capsule_content, :content_view => content_view, :environment => library)
+      assert_action_planned_with(action, ::Actions::BulkAction, ::Actions::Katello::CapsuleContent::Sync,
+                                 [capsule_content_1.capsule, capsule_content_2.capsule],
+                                 :content_view_id => content_view.id, :environment_id => library.id)
     end
   end
 

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -438,13 +438,15 @@ module ::Actions::Katello::Repository
 
     let(:action_class) { ::Actions::Katello::Repository::CapsuleGenerateAndSync }
 
-    before do
-      capsule_content.add_lifecycle_environment(repository.environment)
-    end
-
     it 'plans' do
+      capsule_content_1 = new_capsule_content(:three)
+      capsule_content_2 = new_capsule_content(:four)
+      capsule_content_1.add_lifecycle_environment(repository.environment)
+      capsule_content_2.add_lifecycle_environment(repository.environment)
+
       plan_action(action, repository)
-      assert_action_planed_with(action, ::Actions::Katello::CapsuleContent::Sync, capsule_content, :repository => repository)
+      assert_action_planned_with(action, ::Actions::BulkAction, ::Actions::Katello::CapsuleContent::Sync,
+                                 [capsule_content_1.capsule, capsule_content_2.capsule], :repository_id => repository.id)
     end
   end
 

--- a/test/controllers/api/v2/capsule_content_controller_test.rb
+++ b/test/controllers/api/v2/capsule_content_controller_test.rb
@@ -71,9 +71,9 @@ module Katello
     end
 
     def test_sync
-      assert_async_task ::Actions::Katello::CapsuleContent::Sync do |capsule_content, options|
-        capsule_content.capsule.id.must_equal proxy_with_pulp.id
-        options[:environment].id.must_equal environment.id
+      assert_async_task ::Actions::Katello::CapsuleContent::Sync do |capsule, options|
+        capsule.id.must_equal proxy_with_pulp.id
+        options[:environment_id].must_equal environment.id
       end
 
       post :sync, :id => proxy_with_pulp.id, :environment_id => environment.id

--- a/test/support/capsule_support.rb
+++ b/test/support/capsule_support.rb
@@ -4,8 +4,9 @@ module Support
       @pulp_feature ||= Feature.create(name: SmartProxy::PULP_NODE_FEATURE)
     end
 
-    def proxy_with_pulp
-      @proxy_with_pulp ||= smart_proxies(:four).tap do |proxy|
+    def proxy_with_pulp(proxy_resource = nil)
+      proxy_resource = :four unless proxy_resource
+      smart_proxies(proxy_resource).tap do |proxy|
         unless proxy.features.include?(pulp_feature)
           proxy.features << pulp_feature
         end
@@ -13,7 +14,13 @@ module Support
     end
 
     def capsule_content
+      # This helper is useful for tests that only need a single capsule
       @capsule_content ||= Katello::CapsuleContent.new(proxy_with_pulp)
+    end
+
+    def new_capsule_content(proxy_resource)
+      # This helper is useful for tests involving multiple capsules
+      Katello::CapsuleContent.new(proxy_with_pulp(proxy_resource))
     end
   end
 end


### PR DESCRIPTION
Moving the capsule sync to a bulk action.
This will ensure that if one capsule is down, that
the remaining syncs continue.