### PR TITLE
fixes #20266 - allow serviceLevel updates from sub-mgr

### DIFF
--- a/app/lib/actions/candlepin/consumer/update.rb
+++ b/app/lib/actions/candlepin/consumer/update.rb
@@ -9,6 +9,7 @@ module Actions
 
         def run
           ::Katello::Resources::Candlepin::Consumer.update(input[:uuid], input[:consumer_params])
+          output[:uuid] = input[:uuid]
         end
 
         def finalize

--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -28,7 +28,7 @@ module Katello
         update_guests(consumer_params)
 
         self.autoheal = consumer_params['autoheal'] unless consumer_params['autoheal'].blank?
-        self.service_level = consumer_params['serviceLevel'] unless consumer_params['serviceLevel'].blank?
+        self.service_level = consumer_params['serviceLevel'] unless consumer_params['serviceLevel'].nil?
         self.registered_at = consumer_params['created'] unless consumer_params['created'].blank?
         self.last_checkin = consumer_params['lastCheckin'] unless consumer_params['lastCheckin'].blank?
 


### PR DESCRIPTION
This commit will allow a user to set the serviceLevel from
a client via subscription-manager and have it reflected
in the Katello UI (Hosts -> Content Host -> [myhost]).

e.g.

subscription-manager service-level --set Self-Support
subscription-manager service-level --unset