### PR TITLE
Fixes #20278 - Remove Katello specific support information.

### DIFF
--- a/app/overrides/add_about_page.rb
+++ b/app/overrides/add_about_page.rb
@@ -11,10 +11,3 @@ Deface::Override.new(:virtual_path => "about/index",
                      :insert_bottom => '#about',
                      :partial => 'overrides/about/installed_packages'
                     )
-
-# Add Katello Support information to About page
-Deface::Override.new(:virtual_path => "about/index",
-                     :name => "add_support_documentation",
-                     :insert_bottom => '.col-md-5 .stats-well:first-child',
-                     :partial => 'overrides/about/support_documentation'
-                    )

--- a/app/views/overrides/about/_support_documentation.html.erb
+++ b/app/views/overrides/about/_support_documentation.html.erb
@@ -1,7 +1,0 @@
-<h4><%=_("Katello Support")%></h4>
-<h5><%= _("IRC") %></h5>
-<p><%= _("Katello can be found on the same freenode channels used by Foreman.") %></p>
-<h5><%= _("Mailing lists") %></h5>
-<p><%= _("Katello uses the same mailing lists as Foreman but requests that Katello specific inquiries begin the subject line with [Katello].") %></p>
-<h5><%= _("Issue tracker") %></h5>
-<p><%= _("Katello uses the Foreman Redmine to report and track bugs and feature requests, which can be found here:") %> <%= link_to _("issue tracker"), "http://projects.theforeman.org/projects/katello/issues", :rel => "external" %></p>


### PR DESCRIPTION
This is remnant of katello being not well integrated. I would suggest that
this be removed since katello behaves like the other plugins now.