### PR TITLE
Fixes #20280: Run package profile update and applicability in sequence

### DIFF
--- a/app/lib/actions/katello/host/upload_package_profile.rb
+++ b/app/lib/actions/katello/host/upload_package_profile.rb
@@ -7,8 +7,10 @@ module Actions
         def plan(host, profile_string)
           action_subject host
 
-          plan_self(:host_id => host.id, :hostname => host.name, :profile_string => profile_string)
-          plan_action(GenerateApplicability, [host])
+          sequence do
+            plan_self(:host_id => host.id, :hostname => host.name, :profile_string => profile_string)
+            plan_action(GenerateApplicability, [host])
+          end
         end
 
         def humanized_name


### PR DESCRIPTION
I could not see a way to write a test to ensure the sequence was respected.