### PR TITLE
Fixes #20293: fix errata environment filter.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/erratum-content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/erratum-content-hosts.controller.js
@@ -61,7 +61,7 @@ angular.module('Bastion.errata').controller('ErratumContentHostsController',
             if ($scope.errata) {
                 errataIds = [$scope.errata['errata_id']];
             } else {
-                errataIds = _.map($scope.table.getSelected(), 'errata_id');
+                errataIds = IncrementalUpdate.getErrataIds();
             }
 
             searchStatements = _.map(errataIds, function(errataId) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.controller.js
@@ -82,7 +82,7 @@ angular.module('Bastion.errata').controller('ErrataController',
         });
 
         $scope.goToNextStep = function () {
-            IncrementalUpdate.setBulkErrata(nutupane.getAllSelectedResults());
+            IncrementalUpdate.setBulkErrata(nutupane.getAllSelectedResults('errata_id'));
             $state.transitionTo('apply-errata.select-content-hosts');
         };
 

--- a/engines/bastion_katello/test/errata/details/erratum-content-hosts.controller.test.js
+++ b/engines/bastion_katello/test/errata/details/erratum-content-hosts.controller.test.js
@@ -1,5 +1,5 @@
 describe('Controller: ErratumContentHostsController', function() {
-    var $scope, translate, Nutupane, ContentHostBulkAction,
+    var $scope, translate, Nutupane, IncrementalUpdate, ContentHostBulkAction,
         CurrentOrganization;
 
     beforeEach(module('Bastion.errata', 'Bastion.test-mocks'));
@@ -44,6 +44,12 @@ describe('Controller: ErratumContentHostsController', function() {
             }
         };
 
+        IncrementalUpdate = {
+            getIncrementalUpdates: function () {},
+            getErrataIds: function () {},
+            setBulkContentHosts: function () {}
+        };
+
         Environment = MockResource.$new();
         CurrentOrganization = 'foo';
         
@@ -56,6 +62,7 @@ describe('Controller: ErratumContentHostsController', function() {
             translate: translate,
             Nutupane: Nutupane,
             Host: Host,
+            IncrementalUpdate: IncrementalUpdate,
             Environment: Environment,
             ContentHostBulkAction: ContentHostBulkAction,
             CurrentOrganization: CurrentOrganization                      
@@ -75,13 +82,14 @@ describe('Controller: ErratumContentHostsController', function() {
 
     it("generates errata search string properly for multiple errata", function () {
         $scope.errata = undefined;
-        $scope.table = {};
-        $scope.table.getSelected = function() {
-            return [{'errata_id': 'foo'},{'errata_id': 'bar'}];
-        };
+
+        spyOn(IncrementalUpdate, 'getErrataIds').and.callFake(function() {
+            return ['foo', 'bar'];
+        });
 
         expect($scope.errataSearchString(false)).toBe('applicable_errata = "foo" or applicable_errata = "bar"');
         expect($scope.errataSearchString(true)).toBe('installable_errata = "foo" or installable_errata = "bar"');
+        expect(IncrementalUpdate.getErrataIds).toHaveBeenCalled();
     });
 
     it("provides a way to filter on environment", function () {


### PR DESCRIPTION
There was a http 500 when attempting to get errata by environment on the
content host selection page because the errata IDs were not being set
correctly.  This change fixes this issue.

http://projects.theforeman.org/issues/20293