### PR TITLE
Fixes #19179 - Add force full sync to proxy syncs

### DIFF
--- a/app/controllers/katello/api/v2/capsule_content_controller.rb
+++ b/app/controllers/katello/api/v2/capsule_content_controller.rb
@@ -49,9 +49,14 @@ module Katello
     api :POST, '/capsules/:id/content/sync', N_('Synchronize the content to the smart proxy')
     param :id, Integer, :desc => N_('Id of the smart proxy'), :required => true
     param :environment_id, Integer, :desc => N_('Id of the environment to limit the synchronization on')
+    param :skip_metadata_check, :bool, :desc => N_('Skip metadata check on each repository on the smart proxy')
     def sync
       find_environment if params[:environment_id]
-      task = async_task(::Actions::Katello::CapsuleContent::Sync, capsule_content.capsule, :environment_id => @environment.try(:id))
+      skip_metadata_check = ::Foreman::Cast.to_bool(params[:skip_metadata_check])
+      task = async_task(::Actions::Katello::CapsuleContent::Sync,
+                        capsule_content.capsule,
+                        :environment_id => @environment.try(:id),
+                        :skip_metadata_check => skip_metadata_check)
       respond_for_async :resource => task
     end
 

--- a/app/lib/actions/katello/repository/sync.rb
+++ b/app/lib/actions/katello/repository/sync.rb
@@ -26,7 +26,6 @@ module Actions
           pulp_sync_options = {}
           pulp_sync_options[:download_policy] = ::Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND if validate_contents
           pulp_sync_options[:force_full] = true if skip_metadata_check
-          pulp_sync_options[:auto_publish] = false if skip_metadata_check #skip auto publish, and force it later
           pulp_sync_options[:remove_missing] = false if incremental
 
           fail ::Katello::Errors::InvalidActionOptionError, _("Unable to sync repo. This repository does not have a feed url.") if repo.url.blank? && source_url.blank?

--- a/app/views/foreman/smart_proxies/_content_sync.html.erb
+++ b/app/views/foreman/smart_proxies/_content_sync.html.erb
@@ -21,15 +21,32 @@
   </div>
 
   <br>
-
-  <div>
-    <a ng-show="syncState.is(syncState.SYNCING, syncState.SYNC_TRIGGERED, syncState.CANCEL_TRIGGERED)"
-      ng-click="cancelSync()" class="btn btn-default" ng-disabled="!syncState.is(syncState.SYNCING)">
+  <div ng-show="syncState.is(syncState.SYNCING, syncState.SYNC_TRIGGERED, syncState.CANCEL_TRIGGERED)">
+    <a ng-click="cancelSync()" class="btn btn-default" ng-disabled="!syncState.is(syncState.SYNCING)">
       <span translate>Cancel Sync</span>
     </a>
-    <a ng-hide="syncState.is(syncState.SYNCING, syncState.SYNC_TRIGGERED, syncState.CANCEL_TRIGGERED)"
-      ng-click="syncCapsule()" class="btn btn-default">
-      <span translate>Synchronize</span>
-    </a>
+  </div>
+  <div class="dropdown" ng-hide="syncState.is(syncState.SYNCING, syncState.SYNC_TRIGGERED, syncState.CANCEL_TRIGGERED)">
+    <button class="btn btn-default dropdown-toggle" type="button" id="syncDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+      Synchronize
+      <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" aria-labelledby="syncDropdown">
+      <li>
+        <a ng-click="syncCapsule(false)">
+          <span translate>
+            <strong>Optimized Sync</strong>
+            <p>Optimized Sync is a standard sync, optimized for speed by bypassing any unneeded steps.</p>
+          </span>
+        </a>
+      </li>
+      <li>
+        <a ng-click="syncCapsule(true)">
+          <span translate><strong>Complete Sync</strong></span>
+          <p> A Complete Sync will sync repositories even if the upstream metadata appears to have no change.<br>
+              Complete Sync is only relevant for yum repositories and will take longer than an optimized sync.</p>
+        </a>
+      </li>
+    </ul>
   </div>
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.controller.js
@@ -122,13 +122,13 @@ angular.module('Bastion.capsule-content').controller('CapsuleContentController',
 
         $scope.isTaskInProgress = isTaskInProgress;
 
-        $scope.syncCapsule = function () {
+        $scope.syncCapsule = function (skipMetadataCheck) {
             if (!$scope.syncState.is(syncState.SYNCING)) {
 
                 $scope.syncErrorMessages = [];
                 $scope.syncState.set(syncState.SYNC_TRIGGERED);
 
-                CapsuleContent.sync({id: capsuleId}).$promise.then(function (task) {
+                CapsuleContent.sync({id: capsuleId, 'skip_metadata_check': skipMetadataCheck}).$promise.then(function (task) {
                     $scope.syncStatus['active_sync_tasks'].push(task);
                     $scope.syncTask = aggregateTasks($scope.syncStatus['active_sync_tasks']);
                     $scope.syncState.set(syncState.SYNCING);

--- a/engines/bastion_katello/test/capsules/capsule-content.controller.test.js
+++ b/engines/bastion_katello/test/capsules/capsule-content.controller.test.js
@@ -63,23 +63,29 @@ describe('Controller: CapsuleContentController', function() {
         it('has no effect when sync is in progress', function() {
             spyOn(CapsuleContent, 'sync').and.callThrough();
             syncState.set(syncState.SYNCING);
-            $scope.syncCapsule();
+            $scope.syncCapsule(false);
             expect(CapsuleContent.sync).not.toHaveBeenCalled();
         });
 
         it('starts capsule synchronization', function() {
             spyOn(CapsuleContent, 'sync').and.callThrough();
-            $scope.syncCapsule();
-            expect(CapsuleContent.sync).toHaveBeenCalledWith({ id: '83' });
+            $scope.syncCapsule(false);
+            expect(CapsuleContent.sync).toHaveBeenCalledWith({ id: '83', 'skip_metadata_check': false });
+        });
+
+        it('starts capsule synchronization with skip metadata option', function() {
+            spyOn(CapsuleContent, 'sync').and.callThrough();
+            $scope.syncCapsule(true);
+            expect(CapsuleContent.sync).toHaveBeenCalledWith({ id: '83', 'skip_metadata_check': true });
         });
 
         it('sets state to SYNC_TRIGGERED', function() {
-            $scope.syncCapsule();
+            $scope.syncCapsule(false);
             expect(syncState.is(syncState.SYNC_TRIGGERED)).toBeTruthy();
         });
 
         it('sets state to SYNCING when the response is successful', function() {
-            $scope.syncCapsule();
+            $scope.syncCapsule(false);
             deferred.resolve({id: '1'});
             $scope.$apply();
 
@@ -90,7 +96,7 @@ describe('Controller: CapsuleContentController', function() {
         it('adds task to active_sync_tasks when the response is successful', function() {
             var taskCount = $scope.syncStatus['active_sync_tasks'].length;
 
-            $scope.syncCapsule();
+            $scope.syncCapsule(false);
             deferred.resolve({id: '1'});
             $scope.$apply();
 
@@ -98,7 +104,7 @@ describe('Controller: CapsuleContentController', function() {
         });
 
         it('sets state to DEFAULT when there is some error', function() {
-            $scope.syncCapsule();
+            $scope.syncCapsule(false);
             deferred.reject({});
             $scope.$apply();
 

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -294,7 +294,7 @@ module ::Actions::Katello::Repository
       plan_action action, repository, nil, :skip_metadata_check => true
 
       assert_action_planed_with(action, pulp_action_class, pulp_id: repository.pulp_id,
-                                task_id: nil, source_url: nil, options: {force_full: true, auto_publish: false})
+                                task_id: nil, source_url: nil, options: {force_full: true})
       assert_action_planed_with(action, Actions::Katello::Repository::MetadataGenerate, repository, :force => true)
     end
 
@@ -305,7 +305,7 @@ module ::Actions::Katello::Repository
 
       assert_action_planed_with(action, pulp_action_class, source_url: nil,
                                 pulp_id: repository.pulp_id, task_id: nil,
-                                options: {download_policy: 'on_demand', force_full: true, auto_publish: false})
+                                options: {download_policy: 'on_demand', force_full: true})
       assert_action_planed_with(action, Actions::Pulp::Repository::Download, pulp_id: repository.pulp_id,
                                 options: {:verify_all_units => true})
       assert_action_planed_with(action, Actions::Katello::Repository::MetadataGenerate, repository, :force => true)


### PR DESCRIPTION
This allows users to force full syncs on foreman proxies with
content. This is helpful when the packages on the katello
server do not match the packages on the fpc and the user
wants to force a sync of the repos