### PR TITLE
Fixes #20308 - use large timeout on manifest refresh

### DIFF
--- a/app/lib/actions/katello/repository/refresh_repository.rb
+++ b/app/lib/actions/katello/repository/refresh_repository.rb
@@ -2,11 +2,11 @@ module Actions
   module Katello
     module Repository
       class RefreshRepository < Actions::Base
-        def plan(repo)
+        def plan(repo, options = {})
           User.as_anonymous_admin do
             repo = ::Katello::Repository.find(repo.id)
-            plan_action(Pulp::Repository::Refresh, repo, :capsule_id => SmartProxy.default_capsule!.id)
-            plan_self(:name => repo.name)
+            plan_action(Pulp::Repository::Refresh, repo, :capsule_id => SmartProxy.default_capsule!.id, :dependency => options[:dependency])
+            plan_self(:name => repo.name, :dependency => options[:dependency])
           end
         end
       end

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -306,7 +306,9 @@ module Katello
                                    :ssl_client_cert => OpenSSL::X509::Certificate.new(client_cert),
                                    :ssl_client_key => OpenSSL::PKey::RSA.new(client_key),
                                    :ssl_ca_file => ca_file,
-                                   :verify_ssl => ca_file ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
+                                   :verify_ssl => ca_file ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE,
+                                   :open_timeout => Setting[:manifest_refresh_timeout],
+                                   :timeout => Setting[:manifest_refresh_timeout]
                                   )
         end
 

--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -28,6 +28,7 @@ class Setting::Content < Setting
                  'Discovery Red Hat kexec', N_('Default synced OS kexec template')),
         self.set('katello_default_atomic_provision', N_("Default provisioning template for new Atomic Operating Systems created from synced content"),
                  'Katello Atomic Kickstart Default', N_('Default synced OS Atomic template')),
+        self.set('manifest_refresh_timeout', N_('Timeout when refreshing a manifest (in seconds)'), 60 * 20, N_("Manifest refresh timeout")),
         self.set('content_action_accept_timeout', N_("Time in seconds to wait for a Host to pickup a remote action"),
                  20, N_('Accept action timeout')),
         self.set('content_action_finish_timeout', N_("Time in seconds to wait for a Host to finish a remote action"),

--- a/test/actions/katello/organization_test.rb
+++ b/test/actions/katello/organization_test.rb
@@ -100,34 +100,39 @@ module ::Actions::Katello::Organization
       action.stubs(:rand).returns('1234')
       plan_action(action, organization)
 
-      assert_action_planned_with(action,
-                                 ::Actions::Candlepin::Owner::UpstreamRegenerateCertificates,
-                                 organization_id: organization.id,
-                                 upstream: upstream
-                                )
-      assert_action_planned_with(action,
+      found = assert_action_planned_with(action,
+                                         ::Actions::Candlepin::Owner::UpstreamRegenerateCertificates,
+                                         organization_id: organization.id,
+                                         upstream: upstream
+                                        )
+      found = assert_action_planned_with(action,
                                  ::Actions::Candlepin::Owner::UpstreamUpdate,
                                  organization_id: organization.id,
-                                 upstream: upstream
-                                )
-      assert_action_planned_with(action,
+                                 upstream: upstream,
+                                 dependency: found.first.output
+                                        )
+      found = assert_action_planned_with(action,
                                  ::Actions::Candlepin::Owner::UpstreamExport,
                                  organization_id: organization.id,
                                  upstream: upstream,
-                                 path: "/tmp/1234.zip"
-                                )
-      assert_action_planned_with(action,
+                                 path: "/tmp/1234.zip",
+                                 dependency: found.first.output
+                                        )
+      found = assert_action_planned_with(action,
                                  ::Actions::Candlepin::Owner::Import,
                                  label: organization.label,
-                                 path: "/tmp/1234.zip"
-                                )
-      assert_action_planned_with(action,
+                                 path: "/tmp/1234.zip",
+                                 dependency: found.first.output
+                                        )
+      found = assert_action_planned_with(action,
                                  ::Actions::Candlepin::Owner::ImportProducts,
-                                 organization_id: organization.id
-                                )
+                                 organization_id: organization.id,
+                                 dependency: found.first.output
+                                        )
       assert_action_planned_with(action,
                                  ::Actions::Katello::Repository::RefreshRepository,
-                                 rhel7
+                                 rhel7,
+                                 dependency: found.first.output
                                 )
     end
   end


### PR DESCRIPTION
when regenerating certs on the cdn, large manifests
can take several minutes to refresh (over five minutes).
The default two minute timeout is not long enough