### PR TITLE
fixes #20303 - Syncplan UI now work with timezones

### DIFF
--- a/app/models/katello/sync_plan.rb
+++ b/app/models/katello/sync_plan.rb
@@ -52,7 +52,7 @@ module Katello
     end
 
     def plan_date_time
-      self.sync_date.strftime('%Y/%m/%d %H:%M:%S %Z')
+      self.sync_date.strftime('%Y/%m/%d %H:%M:%S %z')
     end
 
     def schedule_format
@@ -103,7 +103,7 @@ module Katello
     end
 
     def next_sync
-      next_sync_date.try(:strftime, '%Y/%m/%d %H:%M:%S %Z')
+      next_sync_date.try(:strftime, '%Y/%m/%d %H:%M:%S %z')
     end
 
     def self.humanize_class_name(_name = nil)

--- a/test/models/sync_plan_test.rb
+++ b/test/models/sync_plan_test.rb
@@ -18,7 +18,7 @@ module Katello
     end
 
     def test_sync_date_future
-      sync_date = '5000/11/17 18:26:48 UTC'
+      sync_date = '5000/11/17 18:26:48 +0000'
       @plan.sync_date = sync_date
       @plan.next_sync.to_s.must_equal(sync_date)
     end


### PR DESCRIPTION
Certain time zones were causing "Invalid Date" issues in Javascript.
Timezones like CEST (Prague Time +0200) are not properly recognized.

This fix provides a simple sync_date_with_offset option in the api.
The UI JS then makes a determination on whether to use sync_date or
sync_date_with_offset and behaves appropriately.