### PR TITLE
Fixes #20233 - better handle pool/sub import

### DIFF
--- a/app/lib/katello/util/support.rb
+++ b/app/lib/katello/util/support.rb
@@ -76,7 +76,7 @@ module Katello
       #  RecordNotUnique exceptions
       def self.active_record_retry(retries = 3)
         yield
-      rescue ActiveRecord::RecordNotUnique => e
+      rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
         retries -= 1
         if retries == 0
           raise e

--- a/app/models/katello/glue/candlepin/candlepin_object.rb
+++ b/app/models/katello/glue/candlepin/candlepin_object.rb
@@ -33,18 +33,18 @@ module Katello
 
       def import_all(organization = nil)
         organizations = organization ? [organization] : Organization.all
-        candlepin_ids = []
 
         organizations.each do |org|
           import_candlepin_ids(org.label)
-          candlepin_ids.concat(get_candlepin_ids(org.label))
-        end
+          candlepin_ids = get_candlepin_ids(org.label)
 
-        self.all.each do |item|
-          if candlepin_ids.include?(item.cp_id)
-            item.import_data
-          else
-            item.destroy
+          objects = self.in_organization(org) + self.where(:cp_id => candlepin_ids)
+          objects.uniq.each do |item|
+            if candlepin_ids.include?(item.cp_id)
+              item.import_data
+            else
+              item.destroy
+            end
           end
         end
       end

--- a/app/models/katello/glue/candlepin/subscription.rb
+++ b/app/models/katello/glue/candlepin/subscription.rb
@@ -49,7 +49,9 @@ module Katello
         cp_product_ids.each do |cp_id|
           product = ::Katello::Product.where(:cp_id => cp_id, :organization_id => self.organization_id)
           if product.any?
-            ::Katello::SubscriptionProduct.where(:subscription_id => self.id, :product_id => product.first.id).first_or_create
+            ::Katello::Util::Support.active_record_retry do
+              ::Katello::SubscriptionProduct.where(:subscription_id => self.id, :product_id => product.first.id).first_or_create
+            end
           end
         end
       end

--- a/app/models/katello/pool.rb
+++ b/app/models/katello/pool.rb
@@ -6,7 +6,7 @@ module Katello
     has_many :activation_keys, :through => :pool_activation_keys, :class_name => "Katello::ActivationKey"
     has_many :pool_activation_keys, :class_name => "Katello::PoolActivationKey", :dependent => :destroy, :inverse_of => :pool
 
-    scope :in_org, ->(org_id) { joins(:subscription).where("#{Katello::Subscription.table_name}.organization_id = ?", org_id) }
+    scope :in_organization, ->(org_id) { joins(:subscription).where("#{Katello::Subscription.table_name}.organization_id = ?", org_id) }
     scope :for_activation_key, ->(ak) { joins(:activation_keys).where("#{Katello::ActivationKey.table_name}.id" => ak.id) }
 
     include Glue::Candlepin::Pool


### PR DESCRIPTION
the previous commit introduced a bug where it would
delete all subs/pools not being indexed by the current org.
In addition lets use active_record_retry to ensure race conditions
will not result in failed imports