### PR TITLE
fixes #20014 - Data mismatch between Candlepin and Katello

### DIFF
--- a/app/helpers/katello/concerns/dashboard_helper_extensions.rb
+++ b/app/helpers/katello/concerns/dashboard_helper_extensions.rb
@@ -1,0 +1,30 @@
+module Katello
+  module Concerns
+    module DashboardHelperExtensions
+      def total_host_count
+        total_host_count = ::Host::Managed.authorized('view_hosts', ::Host::Managed).where(:organization => Organization.current).size
+        return total_host_count || 0
+      end
+
+      def partial_consumer_count
+        partial_consumer_count = ::Host::Managed.authorized('view_hosts', ::Host::Managed).where(:organization => Organization.current).search_for("subscription_status = partial").size
+        return partial_consumer_count || 0
+      end
+
+      def valid_consumer_count
+        valid_consumer_count = ::Host::Managed.authorized('view_hosts', ::Host::Managed).where(:organization => Organization.current).search_for("subscription_status = valid").size
+        return valid_consumer_count || 0
+      end
+
+      def invalid_consumer_count
+        invalid_consumer_count = ::Host::Managed.authorized('view_hosts', ::Host::Managed).where(:organization => Organization.current).search_for("subscription_status = invalid").size
+        return invalid_consumer_count || 0
+      end
+
+      def unknown_consumer_count
+        unknown_consumer_count = ::Host::Managed.authorized('view_hosts', ::Host::Managed).where(:organization => Organization.current).search_for("subscription_status = unknown").size
+        return unknown_consumer_count || 0
+      end
+    end
+  end
+end

--- a/app/views/dashboard/_subscription_widget.html.erb
+++ b/app/views/dashboard/_subscription_widget.html.erb
@@ -5,12 +5,14 @@
 <% unless Organization.current.present? %>
   <p class="ca"><%= _("Please select an organization to view subscription status.") %></p>
 <% else %>
-  <% owner_info = Organization.current.owner_info %>
-  <% invalid_consumer_count = owner_info.total_invalid_compliance_consumers %>
-  <% partial_consumer_count = owner_info.total_partial_compliance_consumers %>
-  <% valid_consumer_count = owner_info.total_valid_compliance_consumers %>
-  <% total_count = owner_info.total_consumers %>
-  <% subscription_status_url = '/content_hosts?search='  + ERB::Util.url_encode('subscription_status = ') %>
+  <% total_count = total_host_count() %>
+  <% partial_consumer_count = partial_consumer_count() %>
+  <% valid_consumer_count = valid_consumer_count()%>
+  <% invalid_consumer_count = invalid_consumer_count()%>
+  <% unknown_consumer_count = unknown_consumer_count() %>
+  <% unregistered_consumer_count = total_count-partial_consumer_count-valid_consumer_count-invalid_consumer_count%>
+  <% subscription_status_url = '/content_hosts?search='%>
+  <% registered_subscription_url = subscription_status_url + ERB::Util.url_encode('subscription_status = ') %>
 
   <table class="table table-fixed table-striped table-bordered">
     <thead>
@@ -22,32 +24,52 @@
     <tbody>
       <tr>
         <td>
-          <%= link_to("#{subscription_status_url}" + 'invalid') do %>
+          <%= link_to("#{registered_subscription_url}" + 'invalid') do %>
             <i class="label label-danger" style="margin-right: 6px">&nbsp;</i><%= _("Invalid") %>
           <% end %>
         </td>
         <td style="text-align:right">
-          <%= link_to( "#{invalid_consumer_count}", "#{subscription_status_url}" + 'invalid')%>
+          <%= link_to( "#{invalid_consumer_count}", "#{registered_subscription_url}" + 'invalid')%>
         </td>
       </tr>
       <tr>
         <td>
-          <%= link_to("#{subscription_status_url}" + 'partial') do %>
+          <%= link_to("#{registered_subscription_url}" + 'partial') do %>
             <i class="label label-warning" style="margin-right: 6px">&nbsp;</i><%= _("Partial") %>
           <% end %>
         </td>
         <td style="text-align:right">
-          <%= link_to( "#{partial_consumer_count}", "#{subscription_status_url}" + 'partial')%>
+          <%= link_to( "#{partial_consumer_count}", "#{registered_subscription_url}" + 'partial')%>
         </td>
       </tr>
       <tr>
         <td>
-          <%= link_to("#{subscription_status_url}" + 'valid') do %>
+          <%= link_to("#{registered_subscription_url}" + 'valid') do %>
             <i class="label label-success" style="margin-right: 6px">&nbsp;</i><%= _("Valid") %>
           <% end %>
         </td>
         <td style="text-align:right">
-          <%= link_to( "#{valid_consumer_count}", "#{subscription_status_url}" + 'valid')%>
+          <%= link_to( "#{valid_consumer_count}", "#{registered_subscription_url}" + 'valid')%>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <%= link_to("#{registered_subscription_url}" + 'unknown') do %>
+              <i class="label label-warning" style="margin-right: 6px">&nbsp;</i><%= _("Unknown") %>
+          <% end %>
+        </td>
+        <td style="text-align:right">
+          <%= link_to( "#{unknown_consumer_count}", "#{registered_subscription_url}" + 'unknown')%>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <%= link_to("#{subscription_status_url}" + 'null? subscription_uuid') do %>
+              <i class="label label-danger" style="margin-right: 6px">&nbsp;</i><%= _("Unregistered") %>
+          <% end %>
+        </td>
+        <td style="text-align:right">
+          <%= link_to( "#{unregistered_consumer_count}", "#{subscription_status_url}" + 'null? subscription_uuid')%>
         </td>
       </tr>
       <tr>

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -212,6 +212,9 @@ module Katello
         helper Katello::Concerns::SmartProxyHelperExtensions
       end
 
+      ::DashboardController.class_eval do
+        helper Katello::Concerns::DashboardHelperExtensions
+      end
       #Handle Smart Proxy items separately
       begin
         ::SmartProxy.send :include, Katello::Concerns::SmartProxyExtensions

--- a/test/actions/katello/host/register_test.rb
+++ b/test/actions/katello/host/register_test.rb
@@ -14,6 +14,7 @@ module Katello::Host
       @activation_key = katello_activation_keys(:library_dev_staging_view_key)
       @host_collection = katello_host_collections(:simple_host_collection)
       Dynflow::Testing::DummyPlannedAction.any_instance.stubs(:error).returns(nil)
+      Dynflow::Testing::DummyPlannedAction.any_instance.stubs(:input).returns(response: {:uuid => ' '})
     end
 
     let(:action_class) { ::Actions::Katello::Host::Register }

--- a/test/helpers/dashboard_helper_test.rb
+++ b/test/helpers/dashboard_helper_test.rb
@@ -1,0 +1,68 @@
+require 'test_helper'
+require 'katello_test_helper'
+
+class DashboardHelperTest < ActiveSupport::TestCase
+  include ApplicationHelper
+  include ::Katello::Concerns::DashboardHelperExtensions
+
+  def setup
+    User.current = User.anonymous_api_admin
+    @library = katello_environments(:library)
+    @host =  FactoryGirl.build(:host, :with_content, :with_subscription,
+                               :content_view => katello_content_views(:library_dev_view),
+                               :lifecycle_environment => katello_environments(:library), :id => 101)
+    @host.organization = taxonomies(:organization1)
+    @host.save!
+    Organization.current = @host.organization
+  end
+
+  def test_total_host_count
+    total = total_host_count
+    assert !total.nil?
+    assert_equal 1, total
+  end
+
+  def test_partial_consumer_count
+    @host.subscription_facet.update_subscription_status('partial')
+    partial = partial_consumer_count
+    assert_equal 1, partial
+  end
+
+  def test_valid_consumer_count
+    @host.subscription_facet.update_subscription_status('valid')
+    valid = valid_consumer_count
+    assert_equal 1, valid
+  end
+
+  def test_invalid_consumer_count
+    @host.subscription_facet.update_subscription_status('invalid')
+    invalid = invalid_consumer_count
+    assert_equal 1, invalid
+  end
+
+  def test_unknown_consumer_count
+    @host.subscription_facet.update_subscription_status('unknown')
+    unknown = unknown_consumer_count
+    assert_equal 1, unknown
+  end
+
+  def test_partial_consumer_count_nil
+    partial = partial_consumer_count
+    assert !partial.nil?
+  end
+
+  def test_valid_consumer_count_nil
+    valid = valid_consumer_count
+    assert !valid.nil?
+  end
+
+  def test_invalid_consumer_count_nil
+    invalid = invalid_consumer_count
+    assert !invalid.nil?
+  end
+
+  def test_unknown_consumer_count_nil
+    unknown = unknown_consumer_count
+    assert !unknown.nil?
+  end
+end


### PR DESCRIPTION
**[BUG]** "Dashboard content host subscription status" widget shows incorrect information
**Root Cause:** Data mismatch between Candlepin consumer and Katello hosts

**Steps to Reproduce:**

- Set up a host
- Induce an error while registering the host with subscription manager.
- No candlepin consumer should get created

This PR fixes the issue where there was an issue when the content facets and subscription facets did not get updated with UUIDs but the candlepin consumer remained in place, causing a mismatch between katello and candlepin.

Fix: Adding rollback in the candlepin consumer table if there are issues with updating UUID in content facet or subscription facet.

**[To-Do]**
Another cause for mismatch is the subscription handling of virt-machines, which is the intended design. Therefore, the suggestion is to move the subscription widget to point to katello DB instead of Candlepin counts.

**Update**
The Subscription widget now points to katello DB.