### PR TITLE
Refs #20317 - correct initializer of models

### DIFF
--- a/app/models/katello/glue/candlepin/product.rb
+++ b/app/models/katello/glue/candlepin/product.rb
@@ -57,7 +57,7 @@ module Katello
     end
 
     module InstanceMethods
-      def initialize(attribs = nil, options = {})
+      def initialize(attribs = nil)
         unless attribs.nil?
           attributes_key = attribs.key?(:attributes) ? :attributes : 'attributes'
           if attribs.key?(attributes_key)

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -85,7 +85,7 @@ module Katello
         last.nil? ? nil : last.to_s
       end
 
-      def initialize(attrs = nil, options = {})
+      def initialize(attrs = nil)
         if attrs.nil?
           super
         else
@@ -97,7 +97,7 @@ module Katello
           attrs_used_by_model = attrs.reject do |k, _v|
             !self.class.column_defaults.keys.member?(k.to_s) && (!respond_to?(:"#{k.to_s}=") rescue true)
           end
-          super(attrs_used_by_model, options)
+          super(attrs_used_by_model)
         end
       end
 

--- a/app/models/katello/product.rb
+++ b/app/models/katello/product.rb
@@ -68,7 +68,7 @@ module Katello
 
     before_create :assign_unique_label
 
-    def initialize(attrs = nil, options = {})
+    def initialize(attrs = nil)
       unless attrs.nil?
         attrs = attrs.with_indifferent_access
 


### PR DESCRIPTION
This corrects these errors as part of rails 5 work:

Katello::ProductCreateTest#test_unique_label_per_organization:
ArgumentError: wrong number of arguments (2 for 0..1)
    /home/vagrant/katello/app/models/katello/glue/candlepin/product.rb:76:in initialize
    /home/vagrant/katello/app/models/katello/product.rb:89:in initialize
    /home/vagrant/katello/test/models/product_test.rb:8:in setup