### PR TITLE
Fixes #20398 - Add support for rhel5 rhsm facts

### DIFF
--- a/app/models/katello/rhsm_fact_parser.rb
+++ b/app/models/katello/rhsm_fact_parser.rb
@@ -1,8 +1,9 @@
 module Katello
   class RhsmFactParser < ::FactParser
     def architecture
-      name = facts['lscpu.architecture']
+      name = facts['lscpu.architecture'] || facts['uname.machine']
       name = "x86_64" if name == "amd64"
+      name = "i386" if name == "i686"
       Architecture.where(:name => name).first_or_create unless name.blank?
     end
 

--- a/test/models/rhsm_fact_parser_test.rb
+++ b/test/models/rhsm_fact_parser_test.rb
@@ -66,5 +66,12 @@ module Katello
 
       refute @parser.operatingsystem
     end
+
+    def test_uname_architecture
+      @facts['uname.machine'] = 'i686'
+      @parser = RhsmFactParser.new(@facts)
+
+      assert 'i386', @parser.architecture.name
+    end
   end
 end


### PR DESCRIPTION
RHEL5 reports its architecture using `uname.machine` fact instead of `lscpu.architecture`. Added support for reading thearchitecture from that node.

In addition added architecture translation from `i686` to the default `i386`.