### PR TITLE
[WIP] Fixes #20409 - Correct RBAC for repo content removal

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -6,10 +6,9 @@ module Katello
     before_action :find_environment, :only => [:index, :create, :update]
     before_action :find_optional_organization, :only => [:index, :create, :show]
     before_action :find_content_view, :only => [:index]
-    before_action :find_activation_key, :only => [:show, :update, :destroy, :available_releases, :copy, :product_content,
-                                                  :available_host_collections, :add_host_collections, :remove_host_collections,
-                                                  :content_override, :add_subscriptions, :remove_subscriptions,
-                                                  :subscriptions]
+    before_action :find_activation_key, :only => [:show, :available_releases, :product_content, :available_host_collections]
+    before_action :find_activation_key_write, :only => [:update, :destroy, :copy, :add_host_collections, :remove_host_collections,
+                                                  :content_override, :add_subscriptions, :remove_subscriptions]
     before_action :authorize
 
     wrap_parameters :include => (ActivationKey.attribute_names + %w(host_collection_ids service_level auto_attach content_view_environment))
@@ -247,6 +246,11 @@ module Katello
       @activation_key = ActivationKey.find(params[:id])
       fail HttpErrors::NotFound, _("Couldn't find activation key '%s'") % params[:id] if @activation_key.nil?
       @activation_key
+    end
+
+    def find_activation_key_write
+      find_activation_key
+      return deny_access unless @activation_key.editable?
     end
 
     private

--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -304,6 +304,7 @@ module Katello
     param 'ids', Array, :required => true, :desc => "Array of content ids to remove"
     param 'sync_capsule', :bool, :desc => N_("Whether or not to sync an external capsule after upload. Default: true")
     def remove_content
+      return deny_access unless @repository.editable?
       sync_capsule = ::Foreman::Cast.to_bool(params.fetch(:sync_capsule, true))
       fail _("No content ids provided") if @content.blank?
       respond_for_async :resource => sync_task(::Actions::Katello::Repository::RemoveContent, @repository, @content, sync_capsule: sync_capsule)

--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -462,11 +462,9 @@ module Katello
       query
     end
 
-=begin
-    def resource_class
-      Katello::Product
-    end
-=end
+    #def resource_class
+    #  Katello::Product
+    #end
 
     def controller_permission
       'products'

--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -6,7 +6,7 @@ module Katello
     before_action :find_product, :only => [:index, :auto_complete_search]
     before_action :find_product_for_create, :only => [:create]
     before_action :find_organization_from_product, :only => [:create]
-    before_action :find_repository, :only => [:show, :update, :destroy, :sync, :export,
+    before_action :find_resource, :only => [:show, :update, :destroy, :sync, :export,
                                               :remove_content, :upload_content, :republish,
                                               :import_uploads, :gpg_key_content]
     before_action :find_content, :only => :remove_content
@@ -304,7 +304,7 @@ module Katello
     param 'ids', Array, :required => true, :desc => "Array of content ids to remove"
     param 'sync_capsule', :bool, :desc => N_("Whether or not to sync an external capsule after upload. Default: true")
     def remove_content
-      return deny_access unless @repository.editable?
+      #return deny_access unless @repository.editable?
       sync_capsule = ::Foreman::Cast.to_bool(params.fetch(:sync_capsule, true))
       fail _("No content ids provided") if @content.blank?
       respond_for_async :resource => sync_task(::Actions::Katello::Repository::RemoveContent, @repository, @content, sync_capsule: sync_capsule)
@@ -460,6 +460,31 @@ module Katello
         query = query.joins(:content_view_repositories).where("#{ContentViewRepository.table_name}.content_view_id" => content_view_id)
       end
       query
+    end
+
+=begin
+    def resource_class
+      Katello::Product
+    end
+=end
+
+    def controller_permission
+      'products'
+    end
+
+    def action_permission
+      case params[:action]
+      when 'upload_content', 'remove_content', 'republish', 'import_uploads'
+        'edit'
+      when 'gpg_key_content', 'show'
+        'view'
+      when 'sync'
+        'sync'
+      when 'export'
+        'export'
+      else
+        super
+      end
     end
   end
 end

--- a/app/controllers/katello/concerns/api/api_controller.rb
+++ b/app/controllers/katello/concerns/api/api_controller.rb
@@ -64,9 +64,11 @@ module Katello
         controller_name
       end
 
+=begin
       def resource_name
         controller_name.singularize
       end
+=end
 
       def respond(options = {})
         method_name = 'respond_for_' + params[:action].to_s

--- a/app/controllers/katello/concerns/api/api_controller.rb
+++ b/app/controllers/katello/concerns/api/api_controller.rb
@@ -64,11 +64,9 @@ module Katello
         controller_name
       end
 
-=begin
-      def resource_name
-        controller_name.singularize
-      end
-=end
+      #def resource_name
+      #  controller_name.singularize
+      #end
 
       def respond(options = {})
         method_name = 'respond_for_' + params[:action].to_s

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -216,6 +216,10 @@ module Katello
       ::Katello::Resources::CDN::CdnResource.ca_file if ::Katello::Resources::CDN::CdnResource.redhat_cdn?(url)
     end
 
+    def self.humanize_class_name(_name = nil)
+      _("Repository")
+    end
+
     def archive?
       self.environment.nil?
     end

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -300,10 +300,10 @@ module Katello
                          :resource_type => 'Katello::Product'
     end
 
-    def repository_permissions
+    def repository_permissions # rubocop:disable Metrics/MethodLength
       @plugin.permission :create_repositories,
                          {
-                           'katello/api/v2/repositories' => [:create],
+                           'katello/api/v2/repositories' => [:create]
                          },
                          :resource_type => 'Katello::Repository'
       @plugin.permission :edit_repositories,
@@ -315,18 +315,18 @@ module Katello
       @plugin.permission :destroy_repositories,
                          {
                            'katello/api/v2/repositories' => [:destroy],
-                           'katello/api/v2/repositories_bulk_actions' => [:destroy_repositories],
+                           'katello/api/v2/repositories_bulk_actions' => [:destroy_repositories]
                          },
                          :resource_type => 'Katello::Repository'
       @plugin.permission :view_repositories,
                          {
-                           'katello/api/v2/repositories' => [:index, :show],
+                           'katello/api/v2/repositories' => [:index, :show]
                          },
                          :resource_type => 'Katello::Repository'
       @plugin.permission :sync_repositories,
                          {
                            'katello/api/v2/repositories' => [:sync],
-                           'katello/api/v2/repositories_bulk_actions' => [:sync_repositories],
+                           'katello/api/v2/repositories_bulk_actions' => [:sync_repositories]
                          },
                          :resource_type => 'Katello::Repository'
       @plugin.permission :export_repositories,

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -12,6 +12,7 @@ module Katello
       host_collections_permissions
       lifecycle_environment_permissions
       product_permissions
+      #repository_permissions
       subscription_permissions
       sync_plan_permissions
       user_permissions
@@ -267,6 +268,11 @@ module Katello
                            'katello/api/v2/organizations' => [:repo_discover, :cancel_repo_discover]
                          },
                          :resource_type => 'Katello::Product'
+      @plugin.permission :edit_products,
+                         {
+                           'katello/api/v2/repositories' => [:update, :remove_content, :import_uploads, :upload_content, :republish]
+                         },
+                         :resource_type => 'Katello::Repository'
       @plugin.permission :destroy_products,
                          {
                            'katello/api/v2/products' => [:destroy],
@@ -292,6 +298,42 @@ module Katello
                            'katello/api/v2/repositories' => [:export]
                          },
                          :resource_type => 'Katello::Product'
+    end
+
+    def repository_permissions
+      @plugin.permission :create_repositories,
+                         {
+                           'katello/api/v2/repositories' => [:create],
+                         },
+                         :resource_type => 'Katello::Repository'
+      @plugin.permission :edit_repositories,
+                         {
+                           'katello/api/v2/repositories' => [:update, :remove_content, :import_uploads, :upload_content, :republish]
+                         },
+                         :resource_type => 'Katello::Repository'
+
+      @plugin.permission :destroy_repositories,
+                         {
+                           'katello/api/v2/repositories' => [:destroy],
+                           'katello/api/v2/repositories_bulk_actions' => [:destroy_repositories],
+                         },
+                         :resource_type => 'Katello::Repository'
+      @plugin.permission :view_repositories,
+                         {
+                           'katello/api/v2/repositories' => [:index, :show],
+                         },
+                         :resource_type => 'Katello::Repository'
+      @plugin.permission :sync_repositories,
+                         {
+                           'katello/api/v2/repositories' => [:sync],
+                           'katello/api/v2/repositories_bulk_actions' => [:sync_repositories],
+                         },
+                         :resource_type => 'Katello::Repository'
+      @plugin.permission :export_repositories,
+                         {
+                           'katello/api/v2/repositories' => [:export]
+                         },
+                         :resource_type => 'Katello::Repository'
     end
 
     def subscription_permissions

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -125,6 +125,15 @@ module Katello
       end
     end
 
+    def test_update_protected_and_filtered
+      permission = { :name => :edit_activation_keys, :search => 'name = foo' }
+      User.current = setup_user_with_permissions(permission, User.find(users(:restricted).id))
+
+      put :update, :id => @activation_key.id, :organization_id => @organization.id,
+          :activation_key => {:name => 'New Name'}
+      assert_response(403)
+    end
+
     def test_update_limit_below_consumed
       subscription_facet1 = Host::SubscriptionFacet.find(katello_subscription_facets(:one).id)
       subscription_facet2 = Host::SubscriptionFacet.find(katello_subscription_facets(:two).id)
@@ -156,6 +165,14 @@ module Katello
       assert_protected_action(:destroy, allowed_perms, denied_perms) do
         delete :destroy, :organization_id => @organization.id, :id => @activation_key.id
       end
+    end
+
+    def test_destroy_protected_and_filtered
+      permission = { :name => @destroy_permission, :search => 'name = foo' }
+      User.current = setup_user_with_permissions(permission, User.find(users(:restricted).id))
+
+      delete :destroy, :organization_id => @organization.id, :id => @activation_key.id
+      assert_response(403)
     end
 
     def test_copy

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -20,6 +20,14 @@ module Katello
     end
 
     def permissions
+=begin
+      @read_permission = :view_repositories
+      @create_permission = :create_repositories
+      @update_permission = :edit_repositories
+      @destroy_permission = :destroy_repositories
+      @sync_permission = :sync_repositories
+      @export_permission = :export_repositories
+=end
       @read_permission = :view_products
       @create_permission = :create_products
       @update_permission = :edit_products
@@ -661,11 +669,11 @@ module Katello
     end
 
     def test_remove_content_protected_and_filtered
-      permission = { :name => :edit_products, :search => 'name = foo' }
+      permission = { :name => @update_permission, :search => 'name = foo' }
       User.current = setup_user_with_permissions(permission, User.find(users(:restricted).id))
 
       put :remove_content, :id => @repository.id, :ids => %w(foo)
-      assert_response(403)
+      assert_response(404)
     end
 
     def test_destroy
@@ -717,7 +725,7 @@ module Katello
     def test_sync_with_url_override
       assert_async_task ::Actions::Katello::Repository::Sync do |repo, pulp_task_id, options|
         repo.id.must_equal(@repository.id)
-        pulp_task_id.must_equal(nil)
+        assert_nil pulp_task_id
         options[:source_url].must_equal('file:///tmp/')
       end
       post :sync, :id => @repository.id, :source_url => 'file:///tmp/'
@@ -726,7 +734,7 @@ module Katello
 
     def test_sync_with_incremental_flag
       assert_async_task ::Actions::Katello::Repository::Sync do |repo, pulp_task_id, options|
-        repo.id.must_equal(@repository.id)
+        assert_equal repo.id @repository.id
         pulp_task_id.must_equal(nil)
         options[:source_url].must_equal('file:///tmp/')
         options[:incremental].must_equal true

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -660,6 +660,14 @@ module Katello
       end
     end
 
+    def test_remove_content_protected_and_filtered
+      permission = { :name => :edit_products, :search => 'name = foo' }
+      User.current = setup_user_with_permissions(permission, User.find(users(:restricted).id))
+
+      put :remove_content, :id => @repository.id, :ids => %w(foo)
+      assert_response(403)
+    end
+
     def test_destroy
       assert_sync_task(::Actions::Katello::Repository::Destroy) do |repo|
         repo.id == @repository.id

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -20,14 +20,12 @@ module Katello
     end
 
     def permissions
-=begin
-      @read_permission = :view_repositories
-      @create_permission = :create_repositories
-      @update_permission = :edit_repositories
-      @destroy_permission = :destroy_repositories
-      @sync_permission = :sync_repositories
-      @export_permission = :export_repositories
-=end
+      #@read_permission = :view_repositories
+      #@create_permission = :create_repositories
+      #@update_permission = :edit_repositories
+      #@destroy_permission = :destroy_repositories
+      #@sync_permission = :sync_repositories
+      #@export_permission = :export_repositories
       @read_permission = :view_products
       @create_permission = :create_products
       @update_permission = :edit_products


### PR DESCRIPTION
We were not actually checking whether a user was able to modify a repo before allowing them to remove content from it. Now we do! Let me know if I've missed something such as including a more suitable message in the response.

Testing pending.