### PR TITLE
Fixes #20439 - Add csv export to katello pages

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -24,7 +24,16 @@ module Katello
     param_group :search, Api::V2::ApiController
     def index
       activation_key_includes = [:content_view, :environment, :host_collections, :organization]
-      respond(:collection => scoped_search(index_relation.uniq, :name, :asc, :includes => activation_key_includes))
+      activation_keys = scoped_search(index_relation.uniq, :name, :asc, :includes => activation_key_includes)
+      respond_to do |format|
+        format.csv do
+          #Specify columns to export here!
+          csv_response(activation_keys[:results], [:name, :usage_count, 'environment.name', 'content_view.name'], ['Name', 'Host Limit', 'Environment', 'Content View'])
+        end
+        format.any do
+          respond(:collection => activation_keys)
+        end
+      end
     end
 
     api :POST, "/activation_keys", N_("Create an activation key")

--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -4,6 +4,7 @@ module Katello
     include Api::Version2
     include Api::V2::Rendering
     include Api::V2::ErrorHandling
+    include ::Foreman::Controller::CsvResponder
 
     # support for session (thread-local) variables must be the last filter in this class
     include Foreman::ThreadSession::Cleaner

--- a/app/controllers/katello/api/v2/host_collections_controller.rb
+++ b/app/controllers/katello/api/v2/host_collections_controller.rb
@@ -34,7 +34,15 @@ module Katello
     param :available_for, String, :required => false,
           :desc => N_("Interpret specified object to return only Host Collections that can be associated with specified object. The value 'host' is supported.")
     def index
-      respond(:collection => scoped_search(index_relation.uniq, :name, :asc))
+      host_collections = scoped_search(index_relation.uniq, :name, :asc)
+      respond_to do |format|
+        format.csv do
+          csv_response(host_collections[:results])
+        end
+        format.any do
+          respond(:collection => host_collections)
+        end
+      end
     end
 
     def index_relation

--- a/app/controllers/katello/api/v2/products_controller.rb
+++ b/app/controllers/katello/api/v2/products_controller.rb
@@ -1,7 +1,6 @@
 module Katello
   class Api::V2::ProductsController < Api::V2::ApiController
     include Katello::Concerns::FilteredAutoCompleteSearch
-
     before_action :find_activation_key, :only => [:index]
     before_action :find_organization, :only => [:create, :index, :auto_complete_search]
     before_action :find_product, :only => [:update, :destroy, :sync]
@@ -36,7 +35,15 @@ module Katello
     param_group :search, Api::V2::ApiController
     def index
       options = {:includes => [:sync_plan, :provider]}
-      respond(:collection => scoped_search(index_relation.uniq, :name, :asc, options))
+      products = scoped_search(index_relation.uniq, :name, :asc, options)
+      respond_to do |format|
+        format.csv do
+          csv_response(products[:results], [:name, :description, :last_sync_words, 'sync_plan.name'], ['Name', 'Description', 'Days since last sync', 'Sync Plan'])
+        end
+        format.any do
+          respond(:collection => products)
+        end
+      end
     end
 
     def index_relation

--- a/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
+++ b/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
@@ -37,8 +37,16 @@ module Katello
         else
           fail "Unsupported default_sort type"
         end
-
-        respond(:collection => scoped_search(index_relation, sort_options[0], sort_options[1], options))
+        resources = scoped_search(index_relation, sort_options[0], sort_options[1], options)
+        respond_to do |format|
+          format.csv do
+            csv_response(resources[:results])
+            return
+          end
+          format.any do
+            respond(:collection => resources)
+          end
+        end
       end
 
       api :GET, "/:resource_id/:id", N_("Show :a_resource")

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/activation-keys.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/activation-keys.controller.js
@@ -15,8 +15,8 @@
  *   within the table.
  */
 angular.module('Bastion.activation-keys').controller('ActivationKeysController',
-    ['$scope', '$location', 'translate', 'Nutupane', 'ActivationKey', 'CurrentOrganization',
-    function ($scope, $location, translate, Nutupane, ActivationKey, CurrentOrganization) {
+    ['$scope', '$location', 'translate', 'CsvExportUrl', 'Nutupane', 'ActivationKey', 'CurrentOrganization',
+    function ($scope, $location, translate, CsvExportUrl, Nutupane, ActivationKey, CurrentOrganization) {
 
         var params = {
             'organization_id': CurrentOrganization,
@@ -27,8 +27,10 @@ angular.module('Bastion.activation-keys').controller('ActivationKeysController',
         };
 
         var nutupane = new Nutupane(ActivationKey, params);
+        $scope.currentOrganization = CurrentOrganization;
         $scope.controllerName = 'katello_activation_keys';
         nutupane.masterOnly = true;
         $scope.table = nutupane.table;
+        $scope.getCsvLink = CsvExportUrl.getCsvLink;
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/views/activation-keys.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/views/activation-keys.html
@@ -7,6 +7,9 @@
   </div>
 
   <div data-block="list-actions">
+    <a ng-href="{{getCsvLink(table.params)}}" ng-disabled="table.resource.subtotal == 0" class="btn btn-default" target="_self">
+      <span translate>Export</span>
+    </a>
     <button type="button" class="btn btn-primary" ui-sref="activation-keys.new" ng-hide="denied('create_activation_keys')">
       <i class="pficon pficon-add-circle-o"></i>
       {{ "Create Activation Key" | translate }}

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/common/csv-export-url.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/common/csv-export-url.service.js
@@ -1,0 +1,17 @@
+/**
+ * @ngdoc service
+ * @name  Bastion.common.service:CsvExportUrl
+ *
+ * @description
+ *   Helper service that contains functionality common amongst csv urls
+ */
+angular.module('Bastion.common').service('CsvExportUrl', ['$location', '$httpParamSerializer',
+    function ($location, $httpParamSerializer) {
+        this.getCsvLink = function(params) {
+        var tableName = $location.path().split('/').slice(1);
+        return "/katello/api/v2/" + tableName + ".csv?" + $httpParamSerializer(params);
+    };
+
+    }
+
+]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.controller.js
@@ -18,8 +18,8 @@
  *   within the table.
  */
 angular.module('Bastion.errata').controller('ErrataController',
-    ['$scope', '$state', '$location', 'translate', 'Nutupane', 'Erratum', 'IncrementalUpdate', 'Repository', 'CurrentOrganization',
-    function ($scope, $state, $location, translate, Nutupane, Erratum, IncrementalUpdate, Repository, CurrentOrganization) {
+    ['$scope', '$state', '$location', 'translate', 'CsvExportUrl', 'Nutupane', 'Erratum', 'IncrementalUpdate', 'Repository', 'CurrentOrganization',
+    function ($scope, $state, $location, translate, CsvExportUrl, Nutupane, Erratum, IncrementalUpdate, Repository, CurrentOrganization) {
         var nutupane, params = {
             'organization_id': CurrentOrganization,
             'search': $location.search().search || "",
@@ -33,7 +33,7 @@ angular.module('Bastion.errata').controller('ErrataController',
         $scope.controllerName = 'katello_errata';
         $scope.table = nutupane.table;
         $scope.removeRow = nutupane.removeRow;
-
+        $scope.getCsvLink = CsvExportUrl.getCsvLink;
         Erratum.queryPaged({'organization_id': CurrentOrganization}, function (result) {
             $scope.errataCount = result.total;
         });

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/errata.html
@@ -6,6 +6,9 @@
   </div>
 
   <div data-block="list-actions">
+    <a ng-href="{{getCsvLink(table.params)}}" ng-disabled="table.resource.subtotal == 0" class="btn btn-default" target="_self">
+      <span translate>Export</span>
+    </a>
     <button type="button" class="btn btn-primary"
             ng-click="goToNextStep()"
             ng-hide="denied('edit_hosts')"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/host-collection.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/host-collection.factory.js
@@ -9,7 +9,6 @@
  */
 angular.module('Bastion.host-collections').factory('HostCollection',
     ['BastionResource', function (BastionResource) {
-
         return BastionResource('/katello/api/v2/host_collections/:id/:action', {id: '@id'}, {
             get: {method: 'GET', params: {fields: 'full'}},
             update: {method: 'PUT'},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/host-collections.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/host-collections.controller.js
@@ -15,8 +15,9 @@
  *   within the table.
  */
 angular.module('Bastion.host-collections').controller('HostCollectionsController',
-    ['$scope', '$location', 'translate', 'Nutupane', 'HostCollection', 'CurrentOrganization',
-    function ($scope, $location, translate, Nutupane, HostCollection, CurrentOrganization) {
+    ['$scope', '$location', 'translate', 'CsvExportUrl', 'Nutupane', 'HostCollection', 'CurrentOrganization',
+    function ($scope, $location, translate, CsvExportUrl, Nutupane, HostCollection, CurrentOrganization) {
+
         var params = {
             'organization_id': CurrentOrganization,
             'search': $location.search().search || "",
@@ -24,11 +25,10 @@ angular.module('Bastion.host-collections').controller('HostCollectionsController
             'sort_order': 'ASC',
             'paged': true
         };
-
         var nutupane = new Nutupane(HostCollection, params);
         $scope.controllerName = 'katello_host_collections';
         nutupane.masterOnly = true;
-
+        $scope.getCsvLink = CsvExportUrl.getCsvLink;
         $scope.table = nutupane.table;
         $scope.removeRow = nutupane.removeRow;
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/views/host-collections.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/views/host-collections.html
@@ -7,6 +7,10 @@
   </div>
 
   <div data-block="list-actions">
+    <a ng-href="{{getCsvLink(table.params)}}" ng-disabled="table.resource.subtotal == 0" class="btn btn-default" target="_self">
+      <span translate>Export</span>
+    </a>
+
     <button type="button" class="btn btn-primary"
             ui-sref="host-collections.new"
             ng-hide="denied('create_host_collections')">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/packages.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/packages.controller.js
@@ -16,8 +16,8 @@
  *   within the table.
  */
 angular.module('Bastion.packages').controller('PackagesController',
-    ['$scope', '$location', 'translate', 'Nutupane', 'Package', 'Task', 'Repository', 'CurrentOrganization',
-    function ($scope, $location, translate, Nutupane, Package, Task, Repository, CurrentOrganization) {
+    ['$scope', '$location', 'translate', 'CsvExportUrl', 'Nutupane', 'Package', 'Task', 'Repository', 'CurrentOrganization',
+    function ($scope, $location, translate, CsvExportUrl, Nutupane, Package, Task, Repository, CurrentOrganization) {
         var nutupane, params = {
             'organization_id': CurrentOrganization,
             'search': $location.search().search || "",
@@ -31,7 +31,7 @@ angular.module('Bastion.packages').controller('PackagesController',
         $scope.removeRow = nutupane.removeRow;
 
         $scope.repository = {name: translate('All Repositories'), id: 'all'};
-
+        $scope.getCsvLink = CsvExportUrl.getCsvLink;
         Repository.queryUnpaged({'organization_id': CurrentOrganization, 'content_type': 'yum'}, function (response) {
             $scope.repositories = [$scope.repository];
             $scope.repositories = $scope.repositories.concat(response.results);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/views/packages.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/views/packages.html
@@ -6,6 +6,11 @@
     <h2 translate>Packages</h2>
   </header>
 
+  <div data-block="list-actions">
+    <a ng-href="{{getCsvLink(table.params)}}" ng-disabled="table.resource.subtotal == 0" class="btn btn-default" target="_self">
+      <span translate>Export</span>
+    </a>
+  </div>
   <div data-block="search-filter">
     <select class="form-control" ng-model="repository" ng-options="repository.name for (id, repository) in repositories"></select>
   </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.controller.js
@@ -19,8 +19,8 @@
  *   within the table.
  */
 angular.module('Bastion.products').controller('ProductsController',
-    ['$scope', '$state', '$sce', '$location', '$uibModal', 'translate', 'Nutupane', 'Product', 'ProductBulkAction', 'CurrentOrganization', 'GlobalNotification',
-    function ($scope, $state, $sce, $location, $uibModal, translate, Nutupane, Product, ProductBulkAction, CurrentOrganization, GlobalNotification) {
+    ['$scope', '$state', '$sce', '$location', '$uibModal', 'translate', 'CsvExportUrl', 'Nutupane', 'Product', 'ProductBulkAction', 'CurrentOrganization', 'GlobalNotification',
+    function ($scope, $state, $sce, $location, $uibModal, translate, CsvExportUrl, Nutupane, Product, ProductBulkAction, CurrentOrganization, GlobalNotification) {
         var nutupane, taskUrl, taskLink, getBulkParams, bulkError, params;
 
         getBulkParams = function () {
@@ -52,6 +52,7 @@ angular.module('Bastion.products').controller('ProductsController',
         nutupane.masterOnly = true;
 
         $scope.table = nutupane.table;
+        $scope.getCsvLink = CsvExportUrl.getCsvLink;
 
         $scope.$on('productDelete', function (event, taskId) {
             var message;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/products.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/products.html
@@ -7,6 +7,10 @@
   </div>
 
   <div data-block="list-actions">
+    <a ng-href="{{getCsvLink(table.params)}}" ng-disabled="table.resource.subtotal == 0" class="btn btn-default" target="_self">
+      <span translate>Export</span>
+    </a>
+
     <button type="button" class="btn btn-primary"
             ui-sref="products.new.form"
             bst-feature-flag="custom_products"


### PR DESCRIPTION
This is a proposed addition of csv export to several katello pages. This is an extension of the foreman csv export implementation https://github.com/theforeman/foreman/pull/4270 and in line with the PR: https://github.com/Katello/katello/pull/6646
This contains a demo implementation of specifying columns and using the default columns. Need a workaround for derived columns on bastion. One such example would be : [https://goo.gl/urjPSY](url) 

Current PR implements csv export for:
1) Activation Keys
2) Errata
3) Host Collections
4) Packages
5) Products

The identified tables for the first pass for katello would be close to the below list:

a) activation-keys
b) content-hosts
c) content-views
d) docker-tags
e) environments
f) errata
g) files
h) gpg-keys
i) host-collections
j) ostree-branches
k) packages
l) products
m) puppet-modules
n) Subscriptions
o) sync-plans

Opening PR for comments and suggestions.