### PR TITLE
Fixes #20478 - fixes API doc related to hosts bulk installable errata

### DIFF
--- a/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
@@ -6,9 +6,9 @@ module Katello
     before_action :find_host_collections, :only => [:bulk_add_host_collections, :bulk_remove_host_collections]
     before_action :find_environment, :only => [:environment_content_view]
     before_action :find_content_view, :only => [:environment_content_view]
-    before_action :find_editable_hosts, :except => [:destroy_hosts, :applicable_errata]
+    before_action :find_editable_hosts, :except => [:destroy_hosts, :installable_errata]
     before_action :find_deletable_hosts, :only => [:destroy_hosts]
-    before_action :find_readable_hosts, :only => [:applicable_errata, :available_incremental_updates]
+    before_action :find_readable_hosts, :only => [:installable_errata, :available_incremental_updates]
     before_action :find_errata, :only => [:available_incremental_updates]
 
     before_action :validate_content_action, :only => [:install_content, :update_content, :remove_content]
@@ -91,8 +91,8 @@ module Katello
                        :resource => { 'displayMessages' => display_messages }
     end
 
-    api :POST, "/hosts/bulk/applicable_errata",
-        N_("Fetch applicable errata for a host.")
+    api :POST, "/hosts/bulk/installable_errata",
+        N_("Fetch installable errata for a host.")
     param_group :bulk_params
     def installable_errata
       respond_for_index(:collection => scoped_search(Katello::Erratum.installable_for_hosts(@hosts), 'updated', 'desc',


### PR DESCRIPTION
API doc POST /api/hosts/bulk/applicable_errata  has incorrect references to `applicable errata` which should be `installable errata`