### PR TITLE
Fixes #20509: ensure no rows message is shown.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-host-collections-table.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/views/activation-key-host-collections-table.html
@@ -29,8 +29,7 @@
     </div>
 
     <div data-block="table">
-      <table ng-show="table.rows.length > 0"
-             ng-class="{'table-mask': table.working}" class="table table-bordered table-striped">
+      <table ng-class="{'table-mask': table.working}" class="table table-bordered table-striped">
         <thead>
           <tr bst-table-head row-select="hostCollection">
             <th bst-table-column="name" translate>Name</th>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-errata-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-errata-modal.html
@@ -61,9 +61,7 @@
       </span>
 
       <div data-block="table">
-        <table class="table table-striped table-bordered"
-               ng-class="{'table-mask': table.working}"
-               ng-show="table.rows.length > 0">
+        <table class="table table-striped table-bordered" ng-class="{'table-mask': table.working}">
          <thead>
            <tr bst-table-head row-select>
              <th bst-table-column="type" translate>Type</th>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
@@ -60,9 +60,7 @@
   </span>
 
   <div data-block="table">
-    <table class="table table-striped table-bordered"
-           ng-class="{'table-mask': table.working}"
-           ng-show="table.rows.length > 0">
+    <table class="table table-striped table-bordered" ng-class="{'table-mask': table.working}">
       <thead>
         <tr bst-table-head row-select>
           <th bst-table-column="name" sortable><span translate>Name</span></th>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filters.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filters.html
@@ -29,8 +29,7 @@
   </span>
 
   <div data-block="table">
-    <table class="table table-striped table-bordered" ng-show="table.rows.length > 0"
-           ng-class="{'table-mask': table.working}">
+    <table class="table table-striped table-bordered" ng-class="{'table-mask': table.working}">
 
       <thead>
         <tr bst-table-head row-select>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/views/docker-tag-environments.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/views/docker-tag-environments.html
@@ -16,10 +16,7 @@
   </span>
 
   <div data-block="table">
-    <table bst-table="table"
-           class="table table-striped table-bordered"
-           ng-class="{'table-mask': table.working}"
-           ng-show="table.rows.length > 0">
+    <table bst-table="table" class="table table-striped table-bordered" ng-class="{'table-mask': table.working}">
       <thead>
         <tr bst-table-head>
           <th bst-table-column="environment" translate>Environment</th>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/erratum-content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/erratum-content-hosts.html
@@ -46,9 +46,7 @@
       <span translate>The Content View or Lifecycle Environment needs to be updated in order to make errata available to these hosts.</span>
     </p>
 
-    <table class="table table-striped table-bordered"
-           ng-class="{'table-mask': table.working}"
-           ng-show="table.rows.length > 0">
+    <table class="table table-striped table-bordered" ng-class="{'table-mask': table.working}">
       <thead>
         <tr bst-table-head row-select>
           <th bst-table-column="name"><span translate>Name</span></th>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/erratum-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/views/erratum-repositories.html
@@ -31,9 +31,7 @@
   </span>
 
   <div data-block="table">
-    <table class="table table-striped table-bordered"
-           ng-class="{'table-mask': table.working}"
-           ng-show="table.rows.length > 0">
+    <table class="table table-striped table-bordered" ng-class="{'table-mask': table.working}">
       <thead>
         <tr bst-table-head>
           <th bst-table-column="name"><span translate>Name</span></th>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/files/details/views/file-content-views.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/files/details/views/file-content-views.html
@@ -12,9 +12,7 @@
   </span>
 
   <div data-block="table">
-    <table class="table table-striped table-bordered"
-           ng-class="{'table-mask': table.working}"
-           ng-show="table.rows.length > 0">
+    <table class="table table-striped table-bordered" ng-class="{'table-mask': table.working}">
       <thead>
         <tr bst-table-head>
           <th bst-table-column="name"><span translate>Name</span></th>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/files/details/views/file-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/files/details/views/file-repositories.html
@@ -12,9 +12,7 @@
   </span>
 
   <div data-block="table">
-    <table class="table table-striped table-bordered"
-           ng-class="{'table-mask': table.working}"
-           ng-show="table.rows.length > 0">
+    <table class="table table-striped table-bordered" ng-class="{'table-mask': table.working}">
       <thead>
         <tr bst-table-head>
           <th bst-table-column="name"><span translate>Name</span></th>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/views/gpg-keys.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/views/gpg-keys.html
@@ -20,11 +20,7 @@
   </span>
 
   <div data-block="table">
-    <table bst-table="table"
-           type="button"
-           class="table table-striped table-bordered"
-           ng-class="{'table-mask': table.working}"
-           ng-show="table.rows.length > 0">
+    <table bst-table="table" class="table table-striped table-bordered" ng-class="{'table-mask': table.working}">
       <thead>
       <tr bst-table-head>
         <th bst-table-column="name" sortable><span translate>Name</span></th>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-add-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-add-hosts.html
@@ -22,9 +22,7 @@
   </span>
 
   <div data-block="table">
-    <table ng-class="{'table-mask': table.working}"
-           class="table table-bordered table-striped"
-           ng-show="table.rows.length > 0">
+    <table ng-class="{'table-mask': table.working}" class="table table-bordered table-striped">
       <thead>
         <tr bst-table-head row-select>
           <th bst-table-column="name" translate>Name</th>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-hosts-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-hosts-list.html
@@ -22,9 +22,7 @@
   </span>
 
   <div data-block="table">
-    <table ng-class="{'table-mask': table.working}"
-           class="table table-bordered table-striped"
-           ng-show="table.rows.length > 0">
+    <table ng-class="{'table-mask': table.working}" class="table table-bordered table-striped">
       <thead>
         <tr bst-table-head row-select>
           <th bst-table-column="name" translate>Name</th>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/views/host-collections.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/views/host-collections.html
@@ -23,9 +23,7 @@
   </span>
 
   <div data-block="table">
-    <table class="table table-striped table-bordered"
-           ng-class="{'table-mask': table.working}"
-           ng-show="table.rows.length > 0">
+    <table class="table table-striped table-bordered" ng-class="{'table-mask': table.working}">
       <thead>
       <tr bst-table-head>
         <th bst-table-column="name" sortable><span translate>Name</span></th>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/ostree-branches/details/views/ostree-branch-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/ostree-branches/details/views/ostree-branch-repositories.html
@@ -31,9 +31,7 @@
   </span>
 
   <div data-block="table">
-    <table class="table table-striped table-bordered"
-           ng-class="{'table-mask': table.working}"
-           ng-show="table.rows.length > 0">
+    <table class="table table-striped table-bordered" ng-class="{'table-mask': table.working}">
       <thead>
         <tr bst-table-head>
           <th bst-table-column="name"><span translate>Name</span></th>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/views/package-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/views/package-repositories.html
@@ -32,9 +32,7 @@
   </span>
 
   <div data-block="table">
-    <table class="table table-striped table-bordered"
-           ng-class="{'table-mask': table.working}"
-           ng-show="table.rows.length > 0">
+    <table class="table table-striped table-bordered" ng-class="{'table-mask': table.working}">
       <thead>
         <tr bst-table-head>
           <th bst-table-column="name"><span translate>Name</span></th>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/views/product-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/views/product-repositories.html
@@ -88,8 +88,7 @@
   </span>
 
   <div data-block="table">
-    <table class="table table-striped table-bordered"
-           ng-show="table.rows.length > 0">
+    <table class="table table-striped table-bordered">
       <thead>
         <tr bst-table-head row-select>
           <th bst-table-column="name" translate>Name</th>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery-create.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery-create.html
@@ -123,9 +123,7 @@
   </span>
 
   <div data-block="table">
-    <table bst-table="table"
-           class="table table-full table-bordered"
-           ng-show="table.rows.length > 0">
+    <table bst-table="table" class="table table-full table-bordered">
       <thead>
         <tr bst-table-head>
           <th bst-table-column="task" translate>Create Status</th>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery.html
@@ -93,10 +93,7 @@
   </span>
 
   <div data-block="table">
-    <table bst-table="table"
-           class="table table-full table-bordered"
-           ng-class="{'table-mask': discovery.working}"
-           ng-show="table.rows.length > 0">
+    <table bst-table="table" class="table table-full table-bordered" ng-class="{'table-mask': discovery.working}">
       <thead>
         <tr bst-table-head row-select>
           <th bst-table-column="path" translate>Discovered Repository</th>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/puppet-modules/details/views/puppet-module-content-views.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/puppet-modules/details/views/puppet-module-content-views.html
@@ -12,9 +12,7 @@
   </span>
 
   <div data-block="table">
-    <table class="table table-striped table-bordered"
-           ng-class="{'table-mask': table.working}"
-           ng-show="table.rows.length > 0">
+    <table class="table table-striped table-bordered" ng-class="{'table-mask': table.working}">
       <thead>
         <tr bst-table-head>
           <th bst-table-column="name"><span translate>Name</span></th>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/puppet-modules/details/views/puppet-module-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/puppet-modules/details/views/puppet-module-repositories.html
@@ -12,9 +12,7 @@
   </span>
 
   <div data-block="table">
-    <table class="table table-striped table-bordered"
-           ng-class="{'table-mask': table.working}"
-           ng-show="table.rows.length > 0">
+    <table class="table table-striped table-bordered" ng-class="{'table-mask': table.working}">
       <thead>
         <tr bst-table-head>
           <th bst-table-column="name"><span translate>Name</span></th>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/subscriptions.html
@@ -23,7 +23,7 @@
    </span>
 
   <div data-block="table">
-    <table class="table table-bordered" ng-class="{'table-mask': table.working}" ng-show="table.rows.length > 0">
+    <table class="table table-bordered" ng-class="{'table-mask': table.working}">
       <thead>
         <tr bst-table-head>
           <th bst-table-column="consumed" class="align-center"><span translate>Consumed</span></th>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/views/sync-plan-products.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/views/sync-plan-products.html
@@ -49,8 +49,7 @@
   </span>
 
   <div data-block="table">
-    <table ng-show="table.rows.length > 0"
-           ng-class="{'table-mask': table.working}" class="table table-bordered table-striped">
+    <table ng-class="{'table-mask': table.working}" class="table table-bordered table-striped">
       <thead>
         <tr bst-table-head row-select="product">
           <th bst-table-column="name" translate>Name</th>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/views/sync-plans.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/views/sync-plans.html
@@ -21,9 +21,7 @@
   </span>
 
   <div data-block="table">
-    <table class="table table-striped table-bordered"
-           ng-class="{'table-mask': syncPlanTable.working}"
-           ng-show="syncPlanTable.rows.length > 0">
+    <table class="table table-striped table-bordered" ng-class="{'table-mask': syncPlanTable.working}">
       <thead>
         <tr bst-table-head>
           <th bst-table-column="name" sortable><span translate>Name</span></th>


### PR DESCRIPTION
We moved the no rows messages into the table but in katello we are often
hiding the table if there are no rows.  This PR ensures the table is
shown regardless and thus also the no rows message.

http://projects.theforeman.org/issues/20509