### PR TITLE
Fixes #20532 - acknowledge all candlepin messages

### DIFF
--- a/app/lib/actions/candlepin/listen_on_candlepin_events.rb
+++ b/app/lib/actions/candlepin/listen_on_candlepin_events.rb
@@ -182,6 +182,7 @@ module Actions
           output[:connection] = "Connected"
           Actions::Candlepin::ImportPoolHandler.new(Rails.logger).handle(event)
           output[:last_message] = "#{event.message_id} - #{event.subject}"
+          output[:last_message_time] = DateTime.now.to_s
           output[:messages] = event.message_id
         rescue => e
           output[:last_event_error] = e.message


### PR DESCRIPTION
This solves two different issues, after every 100 messages
recieved that match the subjects we look for, we would
sleep for a second instead of

a) acknowledging the message
b) performing some action on that messsage

This makes two changes to ensure that all messages are
acknowledged and the sleep isn't performed until after
messages are acted upon.