### PR TITLE
Fixes #20558 - anon/redhat providers seed idempotency

### DIFF
--- a/app/lib/actions/katello/organization/create.rb
+++ b/app/lib/actions/katello/organization/create.rb
@@ -5,8 +5,8 @@ module Actions
         def plan(organization)
           organization.setup_label_from_name
           organization.create_library
-          organization.create_anonymous_provider
-          organization.create_redhat_provider
+          organization.create_anonymous_provider unless organization.anonymous_provider
+          organization.create_redhat_provider unless organization.redhat_provider
           cp_create = nil
 
           organization.save!


### PR DESCRIPTION
A customer is hitting "ActiveRecord::RecordInvalid: Validation failed: Providers is invalid" during "db/seeds.d/102-organizations.rb". Futher investigation reveals that create_anonymous_provider is called when there is already anonymous provider present. They had anonymous but not redhat, perhaps they run into issues during migration or script during their upgrade.

We don't know how this happened, but this is not important. What's important that the 102-organizations.rb seed script is supposed to be idempotent, there is a big banner at the top, but these lines are definitely not idempotent. My patch will fix that.