### PR TITLE
fixes #20580 - error listing host collections on a host

### DIFF
--- a/app/controllers/katello/api/v2/host_collections_controller.rb
+++ b/app/controllers/katello/api/v2/host_collections_controller.rb
@@ -34,7 +34,7 @@ module Katello
     param :available_for, String, :required => false,
           :desc => N_("Interpret specified object to return only Host Collections that can be associated with specified object. The value 'host' is supported.")
     def index
-      respond(:collection => scoped_search(index_relation.uniq, :name, :asc))
+      respond(:collection => scoped_search(index_relation.uniq!, :name, :asc))
     end
 
     def index_relation


### PR DESCRIPTION
Without this change, the user will observe an error when listing
the host collections associated with a content host:

2017-08-14T16:45:00 922f5a3b [app] [E] NoMethodError:
  undefined method `order' for #<Array:0x007f494d5162b8>
 | katello/api/v2/api_controller.rb:74:in `scoped_search'
 | katello/api/v2/host_collections_controller.rb:37:in `index'

Similar should also occur for listing host collections associated
with an activation key.

Cause was that the object returned for those cases was
a 'CollectionProxy', which will be converted to an Array
when 'uniq' is invoked on it.