### PR TITLE
fixes #20682 - improve speed on package profile upload

### DIFF
--- a/db/migrate/20170821170915_add_index_to_installed_packages.rb
+++ b/db/migrate/20170821170915_add_index_to_installed_packages.rb
@@ -1,0 +1,5 @@
+class AddIndexToInstalledPackages < ActiveRecord::Migration
+  def change
+    add_index :katello_installed_packages, [:name, :nvra]
+  end
+end


### PR DESCRIPTION
this includes both
- an enhancement to the algorithm to process the profile
- addition of an index to katello_installed_packages

Note: the algorithm improvement was implemented by @jlsherrill and tested both internally and in a user's environment