### PR TITLE
Fixes #16509 - Keep state of Content View for Container creation

### DIFF
--- a/app/assets/javascripts/katello/containers/container.js
+++ b/app/assets/javascripts/katello/containers/container.js
@@ -1,6 +1,7 @@
 var KT = KT ? KT : {};
 
 KT.container = (function(){
+    var pre_selection = {};
     var setup = function() {
         var orgDropdown = $('#organization_id'),
             envDropdown = $('#kt_environment_id'),
@@ -136,6 +137,7 @@ KT.container = (function(){
                                     $('<option></option>').val(cv["id"]).html(cv["name"]));
                             });
                             enableContentViews(true);
+                            contentViewDropdown.val(pre_selection.content_view_id).trigger('change')
                         } else {
                             noCV.removeClass("hide");
                         }
@@ -173,6 +175,7 @@ KT.container = (function(){
                                     $('<option></option>').val(repo["id"]).html(repo["name"]));
                             });
                             enableRepositories(true);
+                            reposDropdown.val(pre_selection.repository_id).trigger('change');
                         } else {
                             noRepos.removeClass("hide");
                         }
@@ -204,6 +207,7 @@ KT.container = (function(){
                                 $('<option></option>').val(tag["id"]).html(tag["name"]));
                         });
                         enableTags(true);
+                        tagsDropdown.val(pre_selection.tag_id).trigger('change')
                 })
                 .fail(function(resp) {
                     $("#error_tags").removeClass("hide")
@@ -278,9 +282,14 @@ KT.container = (function(){
             spinner.addClass("hide")
         }
     };
-
+    setSelection = function(selection) {
+      pre_selection = selection;
+      $('#kt_environment_id').val(selection.environment_id)
+                             .trigger('change')
+    }
     return {
         setup: setup,
+        setSelection: setSelection,
         enableNext: enableNext
     };
 })();

--- a/app/controllers/katello/concerns/containers/steps_controller_extensions.rb
+++ b/app/controllers/katello/concerns/containers/steps_controller_extensions.rb
@@ -31,10 +31,18 @@ module Katello
             if params[:capsule] && params[:capsule][:id]
               capsule_id = params[:capsule][:id]
             end
+
+            katello_content = {
+              organization_id: params[:organization_id],
+              environment_id: params.fetch(:kt_environment, {})[:id],
+              content_view_id: params.fetch(:content_view, {})[:id],
+              repository_id: repo.try(:id),
+              tag_id: tag.try(:id)
+            }
             @docker_container_wizard_states_image = @state.build_image(:repository_name => repo.try(:pulp_id),
                                 :tag => tag.try(:name),
                                 :capsule_id => capsule_id,
-                                :katello => true)
+                                :katello => true, :katello_content => katello_content)
           else
             build_state_without_katello
           end

--- a/app/models/katello/concerns/docker_container_wizard_state_image_extensions.rb
+++ b/app/models/katello/concerns/docker_container_wizard_state_image_extensions.rb
@@ -1,0 +1,26 @@
+module Katello
+  module Concerns
+    module DockerContainerWizardStateImageExtensions
+      extend ActiveSupport::Concern
+
+      included do
+        alias_method :orig_image_exists, :image_exists
+        def image_exists
+          orig_image_exists unless katello
+        end
+
+        serialize :katello_content, Hash
+        validate :katello_content_completed
+      end
+
+      def katello_content_completed
+        empty_values = katello_content.map do |key, value|
+          key if value.blank?
+        end
+        return true if empty_values.compact.empty?
+        error_msg = _("Content View not completelly set")
+        errors.add(:katello_content, error_msg)
+      end
+    end
+  end
+end

--- a/app/views/foreman_docker/containers/steps/_katello_container.html.erb
+++ b/app/views/foreman_docker/containers/steps/_katello_container.html.erb
@@ -2,6 +2,16 @@
 <%= stylesheet "katello/containers/container" %>
 <div>
   <div class="form-group">
+    <% model_for("katello").errors.messages.select {|field, _| field == :katello_content }.each do |field, field_errors| %>
+    <div class="alert alert-danger">
+      <span class="pficon pficon-error-circle-o"></span>
+      <ul>
+        <% field_errors.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
     <%= hidden_field_tag :katello, true %>
     <% if Organization.current -%>
       <%= hidden_field_tag :organization_id, Organization.current.id%>
@@ -33,6 +43,10 @@
       <span id="no_capsules" class="hide"> <%= _("Selected organization has no smart proxies with Pulp or Pulp Node features. Please choose a different organization.")-%></span>
       <span id="error_capsules" class="hide"> <%= _("Unable to fetch any smart proxies. Please try again.")-%></span>
     </div>
-
+    <script type="text/javascript">
+      $(document).ready(function() {
+        KT.container.setSelection(<%= @state.image.try(:katello_content).to_json.html_safe %>)
+      })
+    </script>
   </div>
 </div>

--- a/db/migrate/20170822104447_add_katello_content_to_image.rb
+++ b/db/migrate/20170822104447_add_katello_content_to_image.rb
@@ -1,0 +1,5 @@
+class AddKatelloContentToImage < ActiveRecord::Migration
+  def change
+    add_column :docker_container_wizard_states_images, :katello_content, :text
+  end
+end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -193,6 +193,7 @@ module Katello
       ::Setting.send :include, Katello::Concerns::SettingExtensions
       ::Container.send :include, Katello::Concerns::ContainerExtensions
       ::DockerContainerWizardState.send :include, Katello::Concerns::DockerContainerWizardStateExtensions
+      ::DockerContainerWizardStates::Image.send :include, Katello::Concerns::DockerContainerWizardStateImageExtensions
 
       #Controller extensions
       ::HostsController.send :include, Katello::Concerns::HostsControllerExtensions

--- a/test/controllers/foreman/containers/steps_controller_test.rb
+++ b/test/controllers/foreman/containers/steps_controller_test.rb
@@ -45,7 +45,14 @@ module Containers
       @state.expects(:build_image).with(:repository_name => repo.pulp_id,
                                         :tag => tag.name,
                                         :capsule_id => capsule_id.to_s,
-                                        :katello => true).returns(image)
+                                        :katello => true,
+                                        :katello_content => {
+                                          :organization_id => nil,
+                                          :environment_id => nil,
+                                          :content_view_id => nil,
+                                          :repository_id => 100,
+                                          :tag_id => 200
+                                        }).returns(image)
 
       put :update, :wizard_state_id => @state.id,
                    :id => :image,


### PR DESCRIPTION
This implements keeping the state of the content view when creating a container as well as validates that all fields are set:

![container_content_view_demo](https://user-images.githubusercontent.com/7757/29570578-2391dd1e-8757-11e7-96cf-bda0c6b4d943.gif)

Since this is primarily a change for the UI, it would be good to test this with an integration test, but there are non yet (or anymore).