### PR TITLE
Fixes #20379 unable to select name field

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/common/views/select-action-dropdown.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/common/views/select-action-dropdown.html
@@ -3,7 +3,7 @@
     <span translate>Select Action</span>
   </button>
 
-  <button type="button" class="btn btn-default" uib-dropdown-toggle>
+  <button type="button" class="btn btn-default" ng-click="toggleDropdown($event)">
     <span class="caret"></span>
     <span class="sr-only" translate>Toggle Dropdown</span>
   </button>


### PR DESCRIPTION
The split dropdown was using two methods of opening. One was custom to
allow opening the dropdown with the main button and the other was the
default uib attribute. The bootstrap js seems to create the issue so I
changed both buttons to use the custom dropdown toggle.

http://projects.theforeman.org/issues/20379