### PR TITLE
Fixes #20313: Support subdirectory deployment

### DIFF
--- a/app/assets/javascripts/katello/containers/container.js
+++ b/app/assets/javascripts/katello/containers/container.js
@@ -59,7 +59,7 @@ KT.container = (function(){
             noCapsules = $("#no_capsules"),
             org = getOrg(),
             spinner = $("#load_capsules"),
-            url = "/api/smart_proxies",
+            url = foreman_url("/api/smart_proxies"),
             params = {
                 organization_id: getOrg(),
                 search: "feature = \"Pulp Node\" or feature = \"Pulp\"",
@@ -94,7 +94,7 @@ KT.container = (function(){
         var environmentDropdown = $('#kt_environment_id'),
             org = getOrg(),
             spinner = $("#load_environments"),
-            url = "/katello/api/organizations/" + org + "/environments";
+            url = foreman_url("/katello/api/organizations/" + org + "/environments");
 
         resetEnvironments();
         if (org !== "") {
@@ -120,7 +120,7 @@ KT.container = (function(){
             noCV = $("#no_content_views"),
             env = getEnvironment(),
             spinner = $("#load_content_views"),
-            url = "/katello/api/organizations/" + getOrg() + "/content_views",
+            url = foreman_url("/katello/api/organizations/" + getOrg() + "/content_views");
             params = {
                 environment_id : env
             };
@@ -154,7 +154,7 @@ KT.container = (function(){
             noRepos = $("#no_repositories"),
             cv = getContentView(),
             spinner = $("#load_repositories"),
-            url = "/katello/api/repositories/",
+            url = foreman_url("/katello/api/repositories/"),
             params = {
                 organization_id: getOrg(),
                 content_view_id: cv,
@@ -191,7 +191,7 @@ KT.container = (function(){
         var repo = getRepo(),
             tagsDropdown = $("#tag_id"),
             spinner = $("#load_tags"),
-            url = "/katello/api/repositories/" + repo + "/docker_tags",
+            url = foreman_url("/katello/api/repositories/" + repo + "/docker_tags"),
             params = {};
 
         resetTags();

--- a/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
+++ b/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
@@ -25,7 +25,8 @@ KT.hosts.fetchContentViews = function () {
     select.find('option').remove();
     if (envId) {
         KT.hosts.signalContentViewFetch(true);
-        $.get('/katello/api/v2/content_views/', {environment_id: envId, full_result: true}, function (data) {
+        var url = foreman_url('/katello/api/v2/content_views/');
+        $.get(url, {environment_id: envId, full_result: true}, function (data) {
             select.find('option').remove();
             select.append($("<option />"));
             $.each(data.results, function(index, view) {

--- a/app/assets/javascripts/katello/sync_management/sync_management.js
+++ b/app/assets/javascripts/katello/sync_management/sync_management.js
@@ -95,7 +95,7 @@ KT.content_actions = (function(){
 
             $.ajax({
               type: 'DELETE',
-              url: '/katello/sync_management/' + repo_id,
+              url: foreman_url('/katello/sync_management/' + repo_id),
               dataType: 'json',
               success: function(data) {
               },
@@ -109,7 +109,8 @@ KT.content_actions = (function(){
         if (syncing.length ===0){
             return;
         }
-        updater = $.PeriodicalUpdater('/katello/sync_management/sync_status', {
+        var url = foreman_url('/katello/sync_management/sync_status');
+        updater = $.PeriodicalUpdater(url, {
               data: function(){return {repoids:getSyncing()}},
               method: 'get',
               type: 'json',
@@ -163,7 +164,7 @@ KT.content = (function(){
                 progressBar = $('<a/>').attr('class', 'progress').text(" ");
 
             if(task_id !== undefined) {
-                progressBar.attr('href', '/foreman_tasks/tasks/' + task_id)
+                progressBar.attr('href', foreman_url('/foreman_tasks/tasks/' + task_id));
             }
 
             progress = progress ? progress : 0;
@@ -185,7 +186,8 @@ KT.content = (function(){
         finishRepo = function(repo_id, state, duration, raw_state, error_details, task_id){
             var element = $("#repo-" + repo_id);
             var messages = [];
-            state = '<a href="/foreman_tasks/tasks/' + task_id + '">' + state + '</a>';
+            var url = foreman_url('/foreman_tasks/tasks/' + task_id);
+            state = '<a href="' + url + '">' + state + '</a>';
             element.find(".result .result-info").html(state);
             fadeUpdate(element.find(".duration"), duration);
 
@@ -206,7 +208,7 @@ KT.content = (function(){
             starttime = starttime === null ? katelloI18n.no_start_time : starttime;
 
             if(task_id !== undefined) {
-                pg.attr('href', '/foreman_tasks/tasks/' + task_id);
+                pg.attr('href', foreman_url('/foreman_tasks/tasks/' + task_id));
             }
 
             fadeUpdate(element.find(".start_time"), starttime);
@@ -214,7 +216,7 @@ KT.content = (function(){
             fadeUpdate(element.find(".duration"), '');
             fadeUpdate(element.find(".size"), display_size);
             element.find('.size').data('size', size);
-            element.find('.info-tipsy').attr('href', '/foreman_tasks/tasks/' + task_id);
+            element.find('.info-tipsy').attr('href', foreman_url('/foreman_tasks/tasks/' + task_id));
             progress = progress === 100 ? 99 : progress;
             value.show();
             value.animate({'width': progress },{ queue:false,

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/activation-key.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/activation-key.factory.js
@@ -10,7 +10,7 @@
 angular.module('Bastion.activation-keys').factory('ActivationKey',
     ['BastionResource', function (BastionResource) {
 
-        return BastionResource('/katello/api/v2/activation_keys/:id/:action/:action2', {id: '@id'}, {
+        return BastionResource('katello/api/v2/activation_keys/:id/:action/:action2', {id: '@id'}, {
             get: {method: 'GET', params: {fields: 'full'}},
             update: {method: 'PUT'},
             copy: {method: 'POST', params: {action: 'copy'}},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.factory.js
@@ -10,7 +10,7 @@
 angular.module('Bastion.capsule-content').factory('CapsuleContent',
     ['BastionResource', function (BastionResource) {
 
-        return BastionResource('/katello/api/capsules/:id/content/:action', {id: '@id'}, {
+        return BastionResource('katello/api/capsules/:id/content/:action', {id: '@id'}, {
           syncStatus: {method: 'GET', isArray: false, params: {action: 'sync'}},
           sync: {method: 'post', isArray: false, params: {action: 'sync'}},
           cancelSync: {method: 'delete', isArray: false, params: {action: 'sync'}}

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsules/capsule.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsules/capsule.factory.js
@@ -10,7 +10,7 @@
 angular.module('Bastion.capsules').factory('Capsule',
     ['BastionResource', function (BastionResource) {
 
-        return BastionResource('/katello/api/capsules/:id/:action', {id: '@id'}, {
+        return BastionResource('katello/api/capsules/:id/:action', {id: '@id'}, {
         });
 
     }]

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.js
@@ -106,7 +106,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkErrataModalC
             formData.search = selectedHosts.included.search;
             formData.customize = customize;
 
-            $http.post('/katello/remote_execution', formData, {
+            $http.post('katello/remote_execution', formData, {
                 headers: {'Content-Type': 'application/x-www-form-urlencoded'
             }});
         };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
@@ -5,7 +5,6 @@
  * @requires $scope
  * @requires $q
  * @requires $location
- * @requires $window
  * @requires $uibModal
  * @requires translate
  * @requires Nutupane
@@ -21,8 +20,8 @@
  *   within the table.
  */
 angular.module('Bastion.content-hosts').controller('ContentHostsController',
-    ['$scope', '$q', '$state', '$location', '$window', '$uibModal', 'translate', 'Nutupane', 'Host', 'HostBulkAction', 'Notification', 'CurrentOrganization', 'ContentHostsHelper', 'ContentHostsModalHelper', '$httpParamSerializer',
-    function ($scope, $q, $state, $location, $window, $uibModal, translate, Nutupane, Host, HostBulkAction, Notification, CurrentOrganization, ContentHostsHelper, ContentHostsModalHelper, $httpParamSerializer) {
+    ['$scope', '$q', '$state', '$location', '$uibModal', 'translate', 'Nutupane', 'Host', 'HostBulkAction', 'Notification', 'CurrentOrganization', 'ContentHostsHelper', 'ContentHostsModalHelper', '$httpParamSerializer',
+    function ($scope, $q, $state, $location, $uibModal, translate, Nutupane, Host, HostBulkAction, Notification, CurrentOrganization, ContentHostsHelper, ContentHostsModalHelper, $httpParamSerializer) {
         var nutupane, params, query;
 
         if ($location.search().search) {
@@ -88,7 +87,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsController',
 
             success = function (data) {
                 deferred.resolve(data);
-                $window.location = foreman_url("/foreman_tasks/tasks/" + data.id);
+                $location.path("/foreman_tasks/tasks/" + data.id);
             };
 
             error = function (response) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
@@ -88,7 +88,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsController',
 
             success = function (data) {
                 deferred.resolve(data);
-                $window.location = "/foreman_tasks/tasks/" + data.id;
+                $window.location = foreman_url("/foreman_tasks/tasks/" + data.id);
             };
 
             error = function (response) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/content-view.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/content-view.factory.js
@@ -13,7 +13,7 @@ angular.module('Bastion.content-views').factory('ContentView',
     ['BastionResource', 'translate', 'CurrentOrganization',
     function (BastionResource, translate, CurrentOrganization) {
 
-        return BastionResource('/katello/api/v2/content_views/:id/:action',
+        return BastionResource('katello/api/v2/content_views/:id/:action',
             {id: '@id', 'organization_id': CurrentOrganization},
             {
                 copy: {method: 'POST', params: {action: 'copy'}},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/components/content-view-component.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/components/content-view-component.factory.js
@@ -12,19 +12,19 @@ angular.module('Bastion.content-views').factory('ContentViewComponent',
     ['BastionResource', 'CurrentOrganization',
     function (BastionResource, CurrentOrganization) {
 
-        return BastionResource('/katello/api/v2/content_views/:compositeContentViewId/content_view_components/:id/:action',
+        return BastionResource('katello/api/v2/content_views/:compositeContentViewId/content_view_components/:id/:action',
             {id: '@id', compositeContentViewId: '@compositeContentViewId', 'organization_id': CurrentOrganization},
             {
                 update: {method: 'PUT'},
                 removeComponents: {
                     method: 'PUT',
                     isArray: false,
-                    url: '/katello/api/v2/content_views/:compositeContentViewId/content_view_components/remove'
+                    url: 'katello/api/v2/content_views/:compositeContentViewId/content_view_components/remove'
                 },
                 addComponents: {
                     method: 'PUT',
                     isArray: false,
-                    url: '/katello/api/v2/content_views/:compositeContentViewId/content_view_components/add'
+                    url: 'katello/api/v2/content_views/:compositeContentViewId/content_view_components/add'
                 }
             }
         );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/filter.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/filter.factory.js
@@ -10,7 +10,7 @@
 angular.module('Bastion.content-views').factory('Filter',
     ['BastionResource', function (BastionResource) {
 
-        return BastionResource('/katello/api/v2/content_view_filters/:filterId/:action',
+        return BastionResource('katello/api/v2/content_view_filters/:filterId/:action',
             {filterId: '@id', 'content_view_id': '@content_view.id'},
             {
                 autocomplete: {method: 'GET', isArray: true, params: {filterId: 'auto_complete_search'}},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/rule.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/rule.factory.js
@@ -10,7 +10,7 @@
 angular.module('Bastion.content-views').factory('Rule',
     ['BastionResource', function (BastionResource) {
 
-        return BastionResource('/katello/api/v2/content_view_filters/:filterId/rules/:ruleId',
+        return BastionResource('katello/api/v2/content_view_filters/:filterId/rules/:ruleId',
             {ruleId: '@id', filterId: '@content_view_filter_id'},
             {
                 update: {method: 'PUT'}

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/histories/content-view-history.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/histories/content-view-history.factory.js
@@ -12,7 +12,7 @@ angular.module('Bastion.content-views').factory('ContentViewHistory',
     ['BastionResource', 'CurrentOrganization',
     function (BastionResource, CurrentOrganization) {
 
-        return BastionResource('/katello/api/v2/content_views/:contentViewId/history/:action',
+        return BastionResource('katello/api/v2/content_views/:contentViewId/history/:action',
             {id: '@id', contentViewId: '@contentViewId', 'organization_id': CurrentOrganization},
             {
                 autocomplete: {method: 'GET', isArray: true, params: {action: 'auto_complete_search'}}

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/content-view-puppet-module.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/puppet-modules/content-view-puppet-module.factory.js
@@ -12,7 +12,7 @@ angular.module('Bastion.content-views').factory('ContentViewPuppetModule',
     ['BastionResource', 'CurrentOrganization',
     function (BastionResource, CurrentOrganization) {
 
-        return BastionResource('/katello/api/v2/content_views/:contentViewId/content_view_puppet_modules/:id/:action',
+        return BastionResource('katello/api/v2/content_views/:contentViewId/content_view_puppet_modules/:id/:action',
             {id: '@id', contentViewId: '@contentViewId', 'organization_id': CurrentOrganization},
             {
                 update: {method: 'PUT'},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-version.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-version.factory.js
@@ -11,7 +11,7 @@
 angular.module('Bastion.content-views.versions').factory('ContentViewVersion',
     ['BastionResource', function (BastionResource) {
 
-        return BastionResource('/katello/api/v2/content_view_versions/:id/:action',
+        return BastionResource('katello/api/v2/content_view_versions/:id/:action',
             {id: '@id'},
             {
                 autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-manifests/docker-manifest.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-manifests/docker-manifest.factory.js
@@ -9,7 +9,7 @@
      *   Provides a BastionResource for interacting with Docker Manifests
      */
     function DockerManifest(BastionResource) {
-        return BastionResource('/katello/api/v2/docker_manifests/:id',
+        return BastionResource('katello/api/v2/docker_manifests/:id',
             {'id': '@id'}
         );
     }

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/docker-tags.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/docker-tags.factory.js
@@ -10,7 +10,7 @@
 angular.module('Bastion.docker-tags').factory('DockerTag',
     ['BastionResource', function (BastionResource) {
 
-        return BastionResource('/katello/api/v2/docker_tags/:id/',
+        return BastionResource('katello/api/v2/docker_tags/:id/',
             {id: '@id'},
             {
                 autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/environment.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/environment.factory.js
@@ -12,7 +12,7 @@ angular.module('Bastion.environments').factory('Environment',
     ['BastionResource', 'CurrentOrganization',
     function (BastionResource, CurrentOrganization) {
 
-        return BastionResource('/katello/api/v2/environments/:id/:action',
+        return BastionResource('katello/api/v2/environments/:id/:action',
             {id: '@id', 'organization_id': CurrentOrganization},
             {
                 autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/erratum.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/erratum.factory.js
@@ -10,7 +10,7 @@
 angular.module('Bastion.errata').factory('Erratum',
     ['BastionResource', function (BastionResource) {
 
-        return BastionResource('/katello/api/v2/errata/:id/',
+        return BastionResource('katello/api/v2/errata/:id/',
             {id: '@id', 'sort_by': 'issued', 'sort_order': 'DESC'},
             {
                 autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/files/file.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/files/file.factory.js
@@ -10,7 +10,7 @@
      */
     function File(BastionResource) {
 
-        return BastionResource('/katello/api/v2/files/:id',
+        return BastionResource('katello/api/v2/files/:id',
             {'id': '@id'},
             {
                 autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}}

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/details/gpg-key-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/details/gpg-key-details-info.controller.js
@@ -21,7 +21,7 @@ angular.module('Bastion.gpg-keys').controller('GPGKeyDetailsInfoController',
         });
 
         $scope.gpgKey.$promise.then(function () {
-            $scope.uploadURL = '/katello/api/v2/gpg_keys/' + $scope.gpgKey.id + '/content';
+            $scope.uploadURL = 'katello/api/v2/gpg_keys/' + $scope.gpgKey.id + '/content';
         });
 
         $scope.uploadContent = function (content) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/gpg-key.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/gpg-key.factory.js
@@ -11,7 +11,7 @@ angular.module('Bastion.gpg-keys').factory('GPGKey',
     ['BastionResource', 'CurrentOrganization',
     function (BastionResource, CurrentOrganization) {
 
-        return BastionResource('/katello/api/v2/gpg_keys/:id/:action',
+        return BastionResource('katello/api/v2/gpg_keys/:id/:action',
             {id: '@id', 'organization_id': CurrentOrganization},
             {
                 autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/new/new-gpg-key.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/gpg-keys/new/new-gpg-key.controller.js
@@ -19,7 +19,7 @@ angular.module('Bastion.gpg-keys').controller('NewGPGKeyController',
         $scope.gpgKey = new GPGKey();
         $scope.CurrentOrganization = CurrentOrganization;
         $scope.progress = {uploading: false};
-        $scope.uploadURL = '/katello/api/v2/gpg_keys?organization_id=' + CurrentOrganization;
+        $scope.uploadURL = 'katello/api/v2/gpg_keys?organization_id=' + CurrentOrganization;
 
         $scope.uploadContent = function (response) {
             if (response) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/host-collection.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/host-collection.factory.js
@@ -10,7 +10,7 @@
 angular.module('Bastion.host-collections').factory('HostCollection',
     ['BastionResource', function (BastionResource) {
 
-        return BastionResource('/katello/api/v2/host_collections/:id/:action', {id: '@id'}, {
+        return BastionResource('katello/api/v2/host_collections/:id/:action', {id: '@id'}, {
             get: {method: 'GET', params: {fields: 'full'}},
             update: {method: 'PUT'},
             copy: {method: 'POST', params: {action: 'copy'}},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/host-bulk-action.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/host-bulk-action.factory.js
@@ -10,7 +10,7 @@
 angular.module('Bastion.hosts').factory('HostBulkAction',
     ['BastionResource', function (BastionResource) {
 
-        return BastionResource('/api/v2/hosts/bulk/:action', {}, {
+        return BastionResource('api/v2/hosts/bulk/:action', {}, {
             addHostCollections: {method: 'PUT', params: {action: 'add_host_collections'}},
             removeHostCollections: {method: 'PUT', params: {action: 'remove_host_collections'}},
             updateRepositorySets: {method: 'PUT', params: {action: 'content_overrides'}},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/host-erratum.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/host-erratum.factory.js
@@ -10,7 +10,7 @@
 angular.module('Bastion.hosts').factory('HostErratum',
     ['BastionResource', function (BastionResource) {
 
-        return BastionResource('/api/v2/hosts/:id/errata/:errata_id/:action', {id: '@id'}, {
+        return BastionResource('api/v2/hosts/:id/errata/:errata_id/:action', {id: '@id'}, {
             get: {method: 'GET', isArray: false, transformResponse: function (data) {
                 data = angular.fromJson(data);
                 angular.forEach(data.results, function (errata) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/host-package.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/host-package.factory.js
@@ -10,7 +10,7 @@
 angular.module('Bastion.hosts').factory('HostPackage',
     ['BastionResource', function (BastionResource) {
 
-        return BastionResource('/api/v2/hosts/:id/packages/:action', {id: '@id'}, {
+        return BastionResource('api/v2/hosts/:id/packages/:action', {id: '@id'}, {
             get: {method: 'GET', isArray: false},
             remove: {method: 'PUT', params: {action: 'remove'}},
             install: {method: 'PUT', params: {action: 'install'}},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/host-subscription.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/host-subscription.factory.js
@@ -10,7 +10,7 @@
 angular.module('Bastion.hosts').factory('HostSubscription',
     ['BastionResource', function (BastionResource) {
 
-        return BastionResource('/api/v2/hosts/:id/subscriptions/:action/', {id: '@id'}, {
+        return BastionResource('api/v2/hosts/:id/subscriptions/:action/', {id: '@id'}, {
             events: {method: 'GET', params: {action: 'events'}},
             autoAttach: {method: 'PUT', params: {action: 'auto_attach'}},
             removeSubscriptions: {method: 'put', isArray: false, params: {action: 'remove_subscriptions'}},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/host-traces.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/host-traces.factory.js
@@ -10,7 +10,7 @@
 angular.module('Bastion.hosts').factory('HostTraces',
     ['BastionResource', function (BastionResource) {
 
-        return BastionResource('/api/v2/hosts/:id/traces/:action', {id: '@id'}, {
+        return BastionResource('api/v2/hosts/:id/traces/:action', {id: '@id'}, {
             get: {method: 'GET', isArray: false}
         });
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/host.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/host.factory.js
@@ -9,7 +9,7 @@
  */
 angular.module('Bastion.hosts').factory('Host',
     ['BastionResource', function (BastionResource) {
-        var resource = BastionResource('/api/v2/hosts/:id/:action', {id: '@id'}, {
+        var resource = BastionResource('api/v2/hosts/:id/:action', {id: '@id'}, {
             postIndex: {method: 'POST', params: {action: 'post_index'}},
             update: {method: 'PUT'},
             updateHostCollections: {method: 'PUT', params: {action: 'host_collections'}},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/organization.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/organization.factory.js
@@ -11,7 +11,7 @@
 angular.module('Bastion.organizations').factory('Organization',
     ['BastionResource', 'CurrentOrganization', function (BastionResource, CurrentOrganization) {
 
-        return BastionResource('/katello/api/v2/organizations/:id/:action',
+        return BastionResource('katello/api/v2/organizations/:id/:action',
             {id: '@id'},
             {
                 update: { method: 'PUT' },
@@ -19,13 +19,13 @@ angular.module('Bastion.organizations').factory('Organization',
 
                 select: {
                     method: 'GET',
-                    url: '/organizations/:label/select'
+                    url: 'organizations/:label/select'
                 },
                 repoDiscover: { method: 'POST', params: {action: 'repo_discover'}},
                 cancelRepoDiscover: {method: 'POST', params: {action: 'cancel_repo_discover'}},
                 paths: {
                     method: 'GET',
-                    url: '/katello/api/v2/organizations/:id/environments/paths',
+                    url: 'katello/api/v2/organizations/:id/environments/paths',
                     isArray: true,
                     transformResponse: function (data) {
                         return angular.fromJson(data).results;
@@ -33,7 +33,7 @@ angular.module('Bastion.organizations').factory('Organization',
                 },
                 readableEnvironments: {
                     method: 'GET',
-                    url: '/katello/api/v2/organizations/:id/environments/paths',
+                    url: 'katello/api/v2/organizations/:id/environments/paths',
                     isArray: true,
                     transformResponse: function (data) {
                         // transform [{environments : [{id, name, permissions: {readable : true}}]}]
@@ -48,7 +48,7 @@ angular.module('Bastion.organizations').factory('Organization',
                 },
                 redhatProvider: {
                     method: 'GET',
-                    url: '/katello/api/v2/organizations/:organization_id/redhat_provider',
+                    url: 'katello/api/v2/organizations/:organization_id/redhat_provider',
                     params: {'organization_id': CurrentOrganization}
                 }
             }

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/ostree-branches/ostree-branch.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/ostree-branches/ostree-branch.factory.js
@@ -9,7 +9,7 @@
      *   Provides a BastionResource for interacting with Ostree Branches
      */
     function OstreeBranch(BastionResource) {
-        return BastionResource('/katello/api/v2/ostree_branches/:id',
+        return BastionResource('katello/api/v2/ostree_branches/:id',
             {'id': '@id'},
             {
                 autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}}

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/package-groups/package-group.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/package-groups/package-group.factory.js
@@ -9,7 +9,7 @@
      *   Provides a BastionResource for interacting with Package Groups
      */
     function PackageGroup(BastionResource) {
-        return BastionResource('/katello/api/v2/package_groups/:id',
+        return BastionResource('katello/api/v2/package_groups/:id',
             {'id': '@id'},
             {
               autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}}

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/package.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/package.factory.js
@@ -10,7 +10,7 @@
 angular.module('Bastion.packages').factory('Package',
     ['BastionResource', 'CurrentOrganization', function (BastionResource) {
 
-        return BastionResource('/katello/api/v2/packages/:id',
+        return BastionResource('katello/api/v2/packages/:id',
             {'id': '@id'},
             {
                 'autocomplete': {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/product-bulk-action.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/product-bulk-action.factory.js
@@ -10,7 +10,7 @@
 angular.module('Bastion.products').factory('ProductBulkAction',
     ['BastionResource', function (BastionResource) {
 
-        return BastionResource('/katello/api/v2/products/bulk/:action', {}, {
+        return BastionResource('katello/api/v2/products/bulk/:action', {}, {
             removeProducts: {method: 'PUT', params: {action: 'destroy'}},
             syncProducts: {method: 'PUT', params: {action: 'sync'}},
             updateProductSyncPlan: {method: 'PUT', params: {action: 'sync_plan'}}

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
@@ -24,7 +24,7 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
         $scope.progress = {uploading: false};
 
         $scope.repository.$promise.then(function () {
-            $scope.uploadURL = '/katello/api/v2/repositories/' + $scope.repository.id + '/upload_content';
+            $scope.uploadURL = 'katello/api/v2/repositories/' + $scope.repository.id + '/upload_content';
         });
 
         $scope.gpgKeys = function () {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/repository.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/repository.factory.js
@@ -12,7 +12,7 @@ angular.module('Bastion.repositories').factory('Repository',
     ['BastionResource', 'CurrentOrganization',
     function (BastionResource, CurrentOrganization) {
 
-        return BastionResource('/katello/api/v2/repositories/:id/:action',
+        return BastionResource('katello/api/v2/repositories/:id/:action',
             {id: '@id', 'organization_id': CurrentOrganization},
             {
                 update: { method: 'PUT' },
@@ -41,7 +41,7 @@ angular.module('Bastion.repositories').factory('Repository',
 angular.module('Bastion.repositories').factory('RepositoryBulkAction',
     ['BastionResource', 'CurrentOrganization', function (BastionResource, CurrentOrganization) {
 
-        return BastionResource('/katello/api/v2/repositories/bulk/:action',
+        return BastionResource('katello/api/v2/repositories/bulk/:action',
             {'organization_id': CurrentOrganization},
             {
                 removeRepositories: {method: 'PUT', params: {action: 'destroy'}},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/product.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/product.factory.js
@@ -10,7 +10,7 @@
 angular.module('Bastion.products').factory('Product',
     ['BastionResource', function (BastionResource) {
 
-        return BastionResource('/katello/api/v2/products/:id/:action', {id: '@id'}, {
+        return BastionResource('katello/api/v2/products/:id/:action', {id: '@id'}, {
             update: { method: 'PUT'},
             sync: { method: 'POST', params: { action: 'sync' }},
             updateSyncPlan: { method: 'POST', params: { action: 'sync_plan' }},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/puppet-modules/puppet-module.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/puppet-modules/puppet-module.factory.js
@@ -10,7 +10,7 @@
      */
     function PuppetModule(BastionResource) {
 
-        return BastionResource('/katello/api/v2/puppet_modules/:id',
+        return BastionResource('katello/api/v2/puppet_modules/:id',
             {'id': '@id'},
             {
                 autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}}

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/repository-sets/repository-set.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/repository-sets/repository-set.factory.js
@@ -9,7 +9,7 @@
  */
 angular.module('Bastion.repository-sets').factory('RepositorySet',
     ['BastionResource', function (BastionResource) {
-        return BastionResource('/katello/api/v2/repository_sets/:id/:action', {id: '@id'}, {
+        return BastionResource('katello/api/v2/repository_sets/:id/:action', {id: '@id'}, {
         });
 
     }]

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/settings/setting.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/settings/setting.factory.js
@@ -9,7 +9,7 @@
  */
 angular.module('Bastion.settings').factory('Setting',
     ['BastionResource', function (BastionResource) {
-        var resource = BastionResource('/api/v2/settings/');
+        var resource = BastionResource('api/v2/settings/');
         return resource;
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/manifest-import.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/manifest-import.controller.js
@@ -50,7 +50,7 @@ angular.module('Bastion.subscriptions').controller('ManifestImportController',
 
         $scope.uploadErrorMessages = [];
         $scope.progress = {uploading: false};
-        $scope.uploadURL = '/katello/api/v2/organizations/' + CurrentOrganization + '/subscriptions/upload';
+        $scope.uploadURL = 'katello/api/v2/organizations/' + CurrentOrganization + '/subscriptions/upload';
         $scope.organization = Organization.get({id: CurrentOrganization});
 
         $q.all([$scope.organization.$promise]).then(function () {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/subscriptions.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/subscriptions.factory.js
@@ -11,25 +11,25 @@
 angular.module('Bastion.subscriptions').factory('Subscription', ['BastionResource', 'CurrentOrganization',
 
     function (BastionResource, CurrentOrganization) {
-        return BastionResource('/katello/api/v2/organizations/:org/subscriptions/:id/:action',
+        return BastionResource('katello/api/v2/organizations/:org/subscriptions/:id/:action',
             {org: CurrentOrganization, id: '@id'},
             {
                 autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}},
                 deleteManifest: {
                     method: 'POST',
-                    url: '/katello/api/v2/organizations/:org/subscriptions/delete_manifest',
+                    url: 'katello/api/v2/organizations/:org/subscriptions/delete_manifest',
                     params: {'org': CurrentOrganization}
                 },
 
                 refreshManifest: {
                     method: 'PUT',
-                    url: '/katello/api/v2/organizations/:org/subscriptions/refresh_manifest',
+                    url: 'katello/api/v2/organizations/:org/subscriptions/refresh_manifest',
                     params: {'org': CurrentOrganization}
                 },
 
                 manifestHistory: {
                     method: 'GET',
-                    url: '/katello/api/v2/organizations/:org/subscriptions/:action',
+                    url: 'katello/api/v2/organizations/:org/subscriptions/:action',
                     params: {action: 'manifest_history'},
                     isArray: true
                 }

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/sync-plan.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/sync-plan.factory.js
@@ -12,7 +12,7 @@ angular.module('Bastion.sync-plans').factory('SyncPlan',
     ['BastionResource', 'CurrentOrganization',
     function (BastionResource, CurrentOrganization) {
 
-        return BastionResource('/katello/api/v2/organizations/:organizationId/sync_plans/:id/:action',
+        return BastionResource('katello/api/v2/organizations/:organizationId/sync_plans/:id/:action',
             {id: '@id', organizationId: CurrentOrganization}, {
                 autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}},
                 update: { method: 'PUT' },

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/task.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/task.factory.js
@@ -24,10 +24,10 @@ angular.module('Bastion.tasks').factory('Task',
         var bulkSearchRunning = false, searchIdGenerator = 0,
             searchParamsById = {}, callbackById = {}, pollCount = 0, maxPollInterval = 10000;
 
-        var resource = BastionResource('/katello/api/v2/tasks/:id/:action',
+        var resource = BastionResource('katello/api/v2/tasks/:id/:action',
             {id: '@id', 'organization_id': CurrentOrganization}, {});
 
-        var foremanTasksResource = BastionResource('/foreman_tasks/api/tasks/:id/:action',
+        var foremanTasksResource = BastionResource('foreman_tasks/api/tasks/:id/:action',
             {},
             {
                 bulkSearch: {method: 'POST', isArray: true, params: { action: 'bulk_search'}}

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/tasks.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/tasks.module.js
@@ -28,19 +28,19 @@ angular.module('Bastion.tasks').config(['$stateProvider', function ($stateProvid
         templateUrl: 'tasks/views/tasks.html'
     })
     .state('tasks.index', {
-        url: '/katello_tasks',
+        url: 'katello_tasks',
         permission: 'view_tasks',
         templateUrl: 'tasks/views/tasks-index.html'
     })
     .state('tasks.details', {
-        url: '/katello_tasks/:taskId',
+        url: 'katello_tasks/:taskId',
         permission: 'view_tasks',
         collapsed: true,
         controller: 'TaskDetailsController',
         templateUrl: 'tasks/views/task-details-standalone.html'
     })
     .state('task', {
-        url: '/katello_tasks/single/:taskId',
+        url: 'katello_tasks/single/:taskId',
         controller: 'TaskDetailsController',
         permission: 'view_tasks',
         templateUrl: 'tasks/views/task-details-standalone.html'

--- a/engines/bastion_katello/test/activation-keys/activation-key.factory.test.js
+++ b/engines/bastion_katello/test/activation-keys/activation-key.factory.test.js
@@ -36,7 +36,7 @@ describe('Factory: ActivationKey', function() {
     });
 
     it('ActivationKey.get GET /api/v2/activation_keys/1?fields=full', function() {
-        $httpBackend.expectGET('/katello/api/v2/activation_keys/1?fields=full').respond(activationKeys.results[0]);
+        $httpBackend.expectGET('katello/api/v2/activation_keys/1?fields=full').respond(activationKeys.results[0]);
 
         ActivationKey.get({id: 1}, function(response) {
             expect(response.id).toBe(activationKeys.results[0].id);
@@ -44,7 +44,7 @@ describe('Factory: ActivationKey', function() {
     });
 
     it('ActivationKey.query GET /api/v2/activation_keys', function() {
-        $httpBackend.expectGET('/katello/api/v2/activation_keys').respond(activationKeys);
+        $httpBackend.expectGET('katello/api/v2/activation_keys').respond(activationKeys);
 
         ActivationKey.queryPaged(function(response) {
             expect(response.results.length).toBe(activationKeys.results.length);
@@ -56,7 +56,7 @@ describe('Factory: ActivationKey', function() {
     });
 
     it('ActivationKey.update PUT /api/v2/activation_keys/1', function() {
-        $httpBackend.expectPUT('/katello/api/v2/activation_keys/1').respond(activationKeys.results[0]);
+        $httpBackend.expectPUT('katello/api/v2/activation_keys/1').respond(activationKeys.results[0]);
 
         ActivationKey.update({id: 1}, function(response) {
             expect(response).toBeDefined();
@@ -64,7 +64,7 @@ describe('Factory: ActivationKey', function() {
     });
 
     it('ActivationKey.copy POST /api/v2/activation_keys/1/copy', function() {
-        $httpBackend.expectPOST('/katello/api/v2/activation_keys/1/copy').respond(activationKeys.results[0]);
+        $httpBackend.expectPOST('katello/api/v2/activation_keys/1/copy').respond(activationKeys.results[0]);
 
         ActivationKey.copy({id: 1}, function(response) {
             expect(response).toBeDefined();
@@ -72,7 +72,7 @@ describe('Factory: ActivationKey', function() {
     });
 
     it('ActivationKey.removeSubscriptions PUT /api/v2/activation_keys/1/remove_subscriptions', function() {
-        $httpBackend.expectPUT('/katello/api/v2/activation_keys/1/remove_subscriptions').respond(activationKeys.results[0]);
+        $httpBackend.expectPUT('katello/api/v2/activation_keys/1/remove_subscriptions').respond(activationKeys.results[0]);
 
         ActivationKey.removeSubscriptions({id: 1}, function(response) {
             expect(response).toBeDefined();
@@ -80,7 +80,7 @@ describe('Factory: ActivationKey', function() {
     });
 
     it('ActivationKey.addSubscriptions PUT /api/v2/activation_keys/1/add_subscriptions', function() {
-        $httpBackend.expectPUT('/katello/api/v2/activation_keys/1/add_subscriptions').respond(activationKeys.results[0]);
+        $httpBackend.expectPUT('katello/api/v2/activation_keys/1/add_subscriptions').respond(activationKeys.results[0]);
 
         ActivationKey.addSubscriptions({id: 1}, function(response) {
             expect(response).toBeDefined();
@@ -88,7 +88,7 @@ describe('Factory: ActivationKey', function() {
     });
 
     it('ActivationKey.availableHostCollections GET /api/v2/activation_keys/1/host_collections/available', function() {
-        $httpBackend.expectGET('/katello/api/v2/activation_keys/1/host_collections/available').respond(activationKeys.results[0]);
+        $httpBackend.expectGET('katello/api/v2/activation_keys/1/host_collections/available').respond(activationKeys.results[0]);
 
         ActivationKey.availableHostCollections({id: 1}, function(response) {
             expect(response).toBeDefined();
@@ -96,7 +96,7 @@ describe('Factory: ActivationKey', function() {
     });
 
     it('ActivationKey.removeHostCollections PUT /api/v2/activation_keys/1/host_collections', function() {
-        $httpBackend.expectPUT('/katello/api/v2/activation_keys/1/host_collections').respond(activationKeys.results[0]);
+        $httpBackend.expectPUT('katello/api/v2/activation_keys/1/host_collections').respond(activationKeys.results[0]);
 
         ActivationKey.removeHostCollections({id: 1}, function(response) {
             expect(response).toBeDefined();
@@ -104,7 +104,7 @@ describe('Factory: ActivationKey', function() {
     });
 
     it('ActivationKey.addHostCollections POST /api/v2/activation_keys/1/host_collections', function() {
-        $httpBackend.expectPOST('/katello/api/v2/activation_keys/1/host_collections').respond(activationKeys.results[0]);
+        $httpBackend.expectPOST('katello/api/v2/activation_keys/1/host_collections').respond(activationKeys.results[0]);
 
         ActivationKey.addHostCollections({id: 1}, function(response) {
             expect(response).toBeDefined();
@@ -112,7 +112,7 @@ describe('Factory: ActivationKey', function() {
     });
 
     it('ActivationKey.contentOverride PUT /api/v2/activation_keys/1/content_override', function() {
-        $httpBackend.expectPUT('/katello/api/v2/activation_keys/1/content_override').respond(activationKeys.results[0]);
+        $httpBackend.expectPUT('katello/api/v2/activation_keys/1/content_override').respond(activationKeys.results[0]);
 
         ActivationKey.contentOverride({id: 1},
                         {'content_override': { 'content_label': 'my-repository-label',

--- a/engines/bastion_katello/test/capsules/capsule-content.factory.test.js
+++ b/engines/bastion_katello/test/capsules/capsule-content.factory.test.js
@@ -15,17 +15,17 @@ describe('Factory: CapsuleContent', function () {
     });
 
     it('provides a way to get synchronization status', function () {
-        $httpBackend.expectGET('/katello/api/capsules/1/content/sync').respond({});
+        $httpBackend.expectGET('katello/api/capsules/1/content/sync').respond({});
         CapsuleContent.syncStatus({ id: 1 });
     });
 
     it('provides a way to start synchronization', function () {
-        $httpBackend.expectPOST('/katello/api/capsules/1/content/sync').respond({});
+        $httpBackend.expectPOST('katello/api/capsules/1/content/sync').respond({});
         CapsuleContent.sync({ id: 1 });
     });
 
     it('provides a way to cancel synchronization', function () {
-        $httpBackend.expectDELETE('/katello/api/capsules/1/content/sync').respond({});
+        $httpBackend.expectDELETE('katello/api/capsules/1/content/sync').respond({});
         CapsuleContent.cancelSync({ id: 1 });
     });
 });

--- a/engines/bastion_katello/test/capsules/capsule.factory.test.js
+++ b/engines/bastion_katello/test/capsules/capsule.factory.test.js
@@ -28,7 +28,7 @@ describe('Factory: Capsule', function() {
     });
 
     it('provides a way to get a list of products', function() {
-        $httpBackend.expectGET('/katello/api/capsules?full_result=true').respond(capsules);
+        $httpBackend.expectGET('katello/api/capsules?full_result=true').respond(capsules);
 
         Capsule.queryUnpaged(function(capsules) {
             expect(capsules.records.length).toBe(2);

--- a/engines/bastion_katello/test/content-views/content-view.factory.test.js
+++ b/engines/bastion_katello/test/content-views/content-view.factory.test.js
@@ -33,7 +33,7 @@ describe('Factory: ContentView', function() {
     });
 
     it('provides a way to get a collection of content views', function() {
-        $httpBackend.expectGET('/katello/api/v2/content_views?organization_id=ACME')
+        $httpBackend.expectGET('katello/api/v2/content_views?organization_id=ACME')
                     .respond(contentViews);
 
         ContentView.queryPaged(function (response) {
@@ -47,7 +47,7 @@ describe('Factory: ContentView', function() {
     });
 
     it('provides a way to get a single content view', function() {
-        $httpBackend.expectGET('/katello/api/v2/content_views/1?organization_id=ACME')
+        $httpBackend.expectGET('katello/api/v2/content_views/1?organization_id=ACME')
                     .respond(contentViews.results[0]);
 
         ContentView.get({id: 1}, function (contentView) {
@@ -59,7 +59,7 @@ describe('Factory: ContentView', function() {
     it('provides a way to create a content view', function() {
         var contentView = {id: 1, name: 'Content View'};
 
-        $httpBackend.expectPOST('/katello/api/v2/content_views/1?organization_id=ACME')
+        $httpBackend.expectPOST('katello/api/v2/content_views/1?organization_id=ACME')
                     .respond(contentView);
 
         ContentView.save(contentView, function (contentView) {
@@ -71,7 +71,7 @@ describe('Factory: ContentView', function() {
     it('provides a way to copy a content view', function() {
         var contentView = {id: 1, name: 'New Content View'};
 
-        $httpBackend.expectPOST('/katello/api/v2/content_views/1/copy?organization_id=ACME')
+        $httpBackend.expectPOST('katello/api/v2/content_views/1/copy?organization_id=ACME')
             .respond(contentView);
 
         ContentView.copy(contentView, function (contentView) {
@@ -81,7 +81,7 @@ describe('Factory: ContentView', function() {
     });
 
     it('provides a way to update a content view', function() {
-        $httpBackend.expectPUT('/katello/api/v2/content_views/1?organization_id=ACME')
+        $httpBackend.expectPUT('katello/api/v2/content_views/1?organization_id=ACME')
                     .respond(contentViews.results[0]);
 
         ContentView.update({id: 1, name: 'NewCVName'}, function (contentView) {;

--- a/engines/bastion_katello/test/content-views/details/filters/filter.factory.test.js
+++ b/engines/bastion_katello/test/content-views/details/filters/filter.factory.test.js
@@ -29,7 +29,7 @@ describe('Factory: Filter', function() {
     });
 
     it('provides a way to get a collection of filters', function() {
-        $httpBackend.expectGET('/katello/api/v2/content_view_filters?content_view_id=1')
+        $httpBackend.expectGET('katello/api/v2/content_view_filters?content_view_id=1')
                     .respond(filters);
 
         Filter.queryPaged({'content_view_id': 1}, function (response) {
@@ -43,7 +43,7 @@ describe('Factory: Filter', function() {
     });
 
     it('provides a way to get a single filter', function() {
-        $httpBackend.expectGET('/katello/api/v2/content_view_filters/1?content_view_id=1')
+        $httpBackend.expectGET('katello/api/v2/content_view_filters/1?content_view_id=1')
                     .respond(filters.results[0]);
 
         Filter.get({'content_view_id': 1, filterId: 1}, function (filter) {
@@ -55,7 +55,7 @@ describe('Factory: Filter', function() {
     it('provides a way to create a filter', function() {
         var filter = {id: 1, name: 'Filter'};
 
-        $httpBackend.expectPOST('/katello/api/v2/content_view_filters/1?content_view_id=1')
+        $httpBackend.expectPOST('katello/api/v2/content_view_filters/1?content_view_id=1')
                     .respond(filter);
 
         Filter.save({'content_view_id': 1}, filter, function (filter) {
@@ -65,7 +65,7 @@ describe('Factory: Filter', function() {
     });
 
     it('provides a way to update a filter', function() {
-        $httpBackend.expectPUT('/katello/api/v2/content_view_filters/1?content_view_id=1')
+        $httpBackend.expectPUT('katello/api/v2/content_view_filters/1?content_view_id=1')
                     .respond(filters.results[0]);
 
         Filter.update({'content_view_id': 1}, {id: 1, name: 'New Filter Name'}, function (filter) {
@@ -74,7 +74,7 @@ describe('Factory: Filter', function() {
     });
 
     it('provides a way to get installable errata for a filter', function() {
-        $httpBackend.expectGET('/katello/api/v2/content_view_filters/1/errata?available_for=content_view_filter')
+        $httpBackend.expectGET('katello/api/v2/content_view_filters/1/errata?available_for=content_view_filter')
                     .respond({});
 
         Filter.availableErrata({'filterId': 1}, function (errata) {
@@ -83,7 +83,7 @@ describe('Factory: Filter', function() {
     });
 
     it('provides a way to retrieve current errata on a filter', function() {
-        $httpBackend.expectGET('/katello/api/v2/content_view_filters/1/errata?content_view_id=1')
+        $httpBackend.expectGET('katello/api/v2/content_view_filters/1/errata?content_view_id=1')
                     .respond({});
 
         Filter.errata({'filterId': 1, 'content_view_id': 1}, function (errata) {

--- a/engines/bastion_katello/test/content-views/details/filters/rule.factory.test.js
+++ b/engines/bastion_katello/test/content-views/details/filters/rule.factory.test.js
@@ -29,7 +29,7 @@ describe('Factory: Rule', function() {
     });
 
     it('provides a way to get a collection of rules', function() {
-        $httpBackend.expectGET('/katello/api/v2/content_view_filters/1/rules?full_result=true')
+        $httpBackend.expectGET('katello/api/v2/content_view_filters/1/rules?full_result=true')
                     .respond(rules);
 
         Rule.queryUnpaged({filterId: 1}, function (response) {
@@ -43,7 +43,7 @@ describe('Factory: Rule', function() {
     });
 
     it('provides a way to get a single filter rule', function() {
-        $httpBackend.expectGET('/katello/api/v2/content_view_filters/1/rules/1')
+        $httpBackend.expectGET('katello/api/v2/content_view_filters/1/rules/1')
                     .respond(rules.results[0]);
 
         Rule.get({filterId: 1, ruleId: 1}, function (rule) {
@@ -54,7 +54,7 @@ describe('Factory: Rule', function() {
     it('provides a way to create a filter rule', function() {
         var rule = {id: 1, name: 'Rule'};
 
-        $httpBackend.expectPOST('/katello/api/v2/content_view_filters/1/rules/1')
+        $httpBackend.expectPOST('katello/api/v2/content_view_filters/1/rules/1')
                     .respond(rule);
 
         Rule.save({ruleId: 1, filterId: 1}, rule, function (rule) {
@@ -63,7 +63,7 @@ describe('Factory: Rule', function() {
     });
 
     it('provides a way to update a filter rule', function() {
-        $httpBackend.expectPUT('/katello/api/v2/content_view_filters/1/rules/1')
+        $httpBackend.expectPUT('katello/api/v2/content_view_filters/1/rules/1')
                     .respond(rules.results[0]);
 
         Rule.update({filterId: 1, ruleId: 1}, {id: 1, name: 'New Rule Name'}, function (rule) {

--- a/engines/bastion_katello/test/content-views/details/puppet-modules/content-view-puppet-module.factory.test.js
+++ b/engines/bastion_katello/test/content-views/details/puppet-modules/content-view-puppet-module.factory.test.js
@@ -33,7 +33,7 @@ describe('Factory: ContentViewPuppetModule', function() {
     });
 
     it('provides a way to get a collection of content views', function() {
-        $httpBackend.expectGET('/katello/api/v2/content_views/content_view_puppet_modules?full_result=true&organization_id=ACME')
+        $httpBackend.expectGET('katello/api/v2/content_views/content_view_puppet_modules?full_result=true&organization_id=ACME')
             .respond(ContentViewPuppetModules);
 
         ContentViewPuppetModule.queryUnpaged(function (response) {
@@ -47,7 +47,7 @@ describe('Factory: ContentViewPuppetModule', function() {
     });
 
     it('provides a way to get a single content view', function() {
-        $httpBackend.expectGET('/katello/api/v2/content_views/content_view_puppet_modules/1?organization_id=ACME')
+        $httpBackend.expectGET('katello/api/v2/content_views/content_view_puppet_modules/1?organization_id=ACME')
             .respond(ContentViewPuppetModules.results[0]);
 
         ContentViewPuppetModule.get({id: 1}, function (contentViewPuppetModule) {
@@ -59,7 +59,7 @@ describe('Factory: ContentViewPuppetModule', function() {
     it('provides a way to create a content view', function() {
         var contentViewPuppetModule = {id: 1, name: 'Content View'};
 
-        $httpBackend.expectPOST('/katello/api/v2/content_views/content_view_puppet_modules/1?organization_id=ACME')
+        $httpBackend.expectPOST('katello/api/v2/content_views/content_view_puppet_modules/1?organization_id=ACME')
             .respond(contentViewPuppetModule);
 
         ContentViewPuppetModule.save(contentViewPuppetModule, function (contentViewPuppetModule) {
@@ -69,7 +69,7 @@ describe('Factory: ContentViewPuppetModule', function() {
     });
 
     it('provides a way to update a content view', function() {
-        $httpBackend.expectPUT('/katello/api/v2/content_views/content_view_puppet_modules/1?organization_id=ACME')
+        $httpBackend.expectPUT('katello/api/v2/content_views/content_view_puppet_modules/1?organization_id=ACME')
             .respond(ContentViewPuppetModules.results[0]);
 
         ContentViewPuppetModule.update({id: 1, name: 'NewCVName'}, function (contentViewPuppetModule) {;

--- a/engines/bastion_katello/test/content-views/versions/content-view-version.factory.test.js
+++ b/engines/bastion_katello/test/content-views/versions/content-view-version.factory.test.js
@@ -26,7 +26,7 @@ describe('Factory: ContentViewVersion', function () {
     });
 
     it('provides a way to get a list of repositories', function () {
-        $httpBackend.expectGET('/katello/api/v2/content_view_versions').respond(contentViewVersion);
+        $httpBackend.expectGET('katello/api/v2/content_view_versions').respond(contentViewVersion);
 
         ContentViewVersion.queryPaged(function (contentViewVersion) {
             expect(contentViewVersion.records.length).toBe(1);
@@ -34,7 +34,7 @@ describe('Factory: ContentViewVersion', function () {
     });
 
     it('provides a way to get an incremental update', function () {
-        $httpBackend.expectPOST('/katello/api/v2/content_view_versions/incremental_update').respond({});
+        $httpBackend.expectPOST('katello/api/v2/content_view_versions/incremental_update').respond({});
         ContentViewVersion.incrementalUpdate();
     });
 });

--- a/engines/bastion_katello/test/docker-manifests/docker-manifest.factory.test.js
+++ b/engines/bastion_katello/test/docker-manifests/docker-manifest.factory.test.js
@@ -26,7 +26,7 @@ describe('Factory: DockerManifest', function () {
     });
 
     it('provides a way to get a list of repositories', function () {
-        $httpBackend.expectGET('/katello/api/v2/docker_manifests').respond(dockerManifests);
+        $httpBackend.expectGET('katello/api/v2/docker_manifests').respond(dockerManifests);
 
         DockerManifest.queryPaged(function (dockerManifests) {
             expect(dockerManifests.records.length).toBe(1);

--- a/engines/bastion_katello/test/docker-tags/docker-tag.factory.test.js
+++ b/engines/bastion_katello/test/docker-tags/docker-tag.factory.test.js
@@ -26,7 +26,7 @@ describe('Factory: DockerTag', function () {
     });
 
     it('provides a way to get a list of tags', function () {
-        $httpBackend.expectGET('/katello/api/v2/docker_tags').respond(dockerTags);
+        $httpBackend.expectGET('katello/api/v2/docker_tags').respond(dockerTags);
 
         DockerTag.queryPaged(function (dockerTags) {
             expect(dockerTags.records.length).toBe(1);

--- a/engines/bastion_katello/test/environments/environment.factory.test.js
+++ b/engines/bastion_katello/test/environments/environment.factory.test.js
@@ -23,7 +23,7 @@ describe('Factory: Environment', function() {
     }));
 
     it('provides a way to get a collection of environments', function() {
-        $httpBackend.expectGET('/katello/api/environments').respond(environments.results);
+        $httpBackend.expectGET('katello/api/environments').respond(environments.results);
 
         Environment.query(function (environments) {
             expect(environments.results.length).toBe(2);
@@ -34,7 +34,7 @@ describe('Factory: Environment', function() {
     });
 
     it('provides a way to get a single environment', function() {
-        $httpBackend.expectGET('/katello/api/environments').respond(environments.results[0]);
+        $httpBackend.expectGET('katello/api/environments').respond(environments.results[0]);
 
         Environment.get({ id: 1 }, function (environment) {
             expect(environment).toBeDefined();
@@ -45,7 +45,7 @@ describe('Factory: Environment', function() {
     it('provides a way to update an environment', function() {
         var environment = environments.results[0];
         environment.name = 'NewEnvName';
-        $httpBackend.expectPUT('/katello/api/environments').respond(environment);
+        $httpBackend.expectPUT('katello/api/environments').respond(environment);
 
         Environment.update({ id: 1, name: 'NewEnvName' }, function (environment) {
             expect(environment).toBeDefined();

--- a/engines/bastion_katello/test/errata/erratum.factory.test.js
+++ b/engines/bastion_katello/test/errata/erratum.factory.test.js
@@ -18,7 +18,7 @@ describe('Factory: Erratum', function() {
                 'hosts_applicable': applicable_systems
             };
 
-        $httpBackend.expectGET('/api/v2/errata/1').respond(erratum);
+        $httpBackend.expectGET('api/v2/errata/1').respond(erratum);
 
         Erratum.applicableContentHosts({id: 1}, function (result) {
             expect(result.results).toEqual(applicable_systems);

--- a/engines/bastion_katello/test/files/files.factory.test.js
+++ b/engines/bastion_katello/test/files/files.factory.test.js
@@ -26,7 +26,7 @@ describe('Factory: Files', function () {
     });
 
     it('provides a way to get a list of files', function () {
-        $httpBackend.expectGET('/katello/api/v2/files').respond(files);
+        $httpBackend.expectGET('katello/api/v2/files').respond(files);
 
         File.queryPaged(function (files) {
             expect(files.records.length).toBe(1);
@@ -34,7 +34,7 @@ describe('Factory: Files', function () {
     });
 
     it('provides a way to get autocompleted search terms for files', function () {
-        $httpBackend.expectGET('/katello/api/v2/files/auto_complete_search').respond(files.records);
+        $httpBackend.expectGET('katello/api/v2/files/auto_complete_search').respond(files.records);
 
         File.autocomplete(function (files) {
             expect(files.length).toBe(1);

--- a/engines/bastion_katello/test/gpg-keys/gpg-keys.factory.test.js
+++ b/engines/bastion_katello/test/gpg-keys/gpg-keys.factory.test.js
@@ -28,7 +28,7 @@ describe('Factory: GPGKey', function() {
     });
 
     it('provides a way to get a list of repositorys', function() {
-        $httpBackend.expectGET('/katello/api/v2/gpg_keys?organization_id=ACME').respond(gpgKeys);
+        $httpBackend.expectGET('katello/api/v2/gpg_keys?organization_id=ACME').respond(gpgKeys);
 
         GPGKey.queryPaged(function(gpgKeys) {
             expect(gpgKeys.records.length).toBe(1);

--- a/engines/bastion_katello/test/host-collections/host-collection.factory.test.js
+++ b/engines/bastion_katello/test/host-collections/host-collection.factory.test.js
@@ -21,7 +21,7 @@ describe('Factory: HostCollection', function() {
     });
 
     it('makes a request to get the host collection list from the API.', function() {
-        $httpBackend.expectGET('/katello/api/v2/host_collections').respond(hostCollections);
+        $httpBackend.expectGET('katello/api/v2/host_collections').respond(hostCollections);
 
         HostCollection.queryPaged(function(response) {
             expect(response.results.length).toBe(hostCollections.results.length);
@@ -36,7 +36,7 @@ describe('Factory: HostCollection', function() {
         var hostCollection = hostCollections.results[0];
 
         hostCollection.name = 'NewName';
-        $httpBackend.expectPUT('/katello/api/v2/host_collections/0').respond(hostCollection);
+        $httpBackend.expectPUT('katello/api/v2/host_collections/0').respond(hostCollection);
 
         HostCollection.update({name: hostCollection.name, id: 0}, function(response) {
             expect(response).toBeDefined();
@@ -46,7 +46,7 @@ describe('Factory: HostCollection', function() {
 
     it('provides a way to add hosts', function() {
         var hosts = {test: 'this'};
-        $httpBackend.expectPUT('/katello/api/v2/host_collections/0/add_hosts').respond(hosts);
+        $httpBackend.expectPUT('katello/api/v2/host_collections/0/add_hosts').respond(hosts);
         HostCollection.addHosts({'host_collection': {'host_ids': [1,2]} , id: 0}, function(response) {
             expect(response.test).toBe('this');
         });
@@ -54,7 +54,7 @@ describe('Factory: HostCollection', function() {
 
     it('provides a way to remove hosts', function() {
         var hosts = {test: 'this'};
-        $httpBackend.expectPUT('/katello/api/v2/host_collections/0/remove_hosts').respond(hosts);
+        $httpBackend.expectPUT('katello/api/v2/host_collections/0/remove_hosts').respond(hosts);
         HostCollection.removeHosts({'host_collection': {'host_ids': [1,2]} , id: 0}, function(response) {
             expect(response.test).toBe('this');
         });

--- a/engines/bastion_katello/test/hosts/host-bulk-action.factory.test.js
+++ b/engines/bastion_katello/test/hosts/host-bulk-action.factory.test.js
@@ -27,47 +27,47 @@ describe('Factory: HostBulkAction', function() {
     });
 
     it('provides a way to add host collections to content hosts', function() {
-        $httpBackend.expect('PUT', '/api/v2/hosts/bulk/add_host_collections', hostCollectionParams).respond();
+        $httpBackend.expect('PUT', 'api/v2/hosts/bulk/add_host_collections', hostCollectionParams).respond();
         ContentHostBulkAction.addHostCollections(hostCollectionParams);
     });
 
     it('provides a way to remove host collections from content hosts', function() {
-        $httpBackend.expect('PUT', '/api/v2/hosts/bulk/remove_host_collections', hostCollectionParams).respond();
+        $httpBackend.expect('PUT', 'api/v2/hosts/bulk/remove_host_collections', hostCollectionParams).respond();
         ContentHostBulkAction.removeHostCollections(hostCollectionParams);
     });
 
     it('provides a way to add subscriptions to content hosts', function() {
-        $httpBackend.expect('PUT', '/api/v2/hosts/bulk/add_subscriptions', subscriptionParams).respond();
+        $httpBackend.expect('PUT', 'api/v2/hosts/bulk/add_subscriptions', subscriptionParams).respond();
         ContentHostBulkAction.addSubscriptions(subscriptionParams);
     });
 
     it('provides a way to remove subscriptions from content hosts', function() {
-        $httpBackend.expect('PUT', '/api/v2/hosts/bulk/remove_subscriptions', subscriptionParams).respond();
+        $httpBackend.expect('PUT', 'api/v2/hosts/bulk/remove_subscriptions', subscriptionParams).respond();
         ContentHostBulkAction.removeSubscriptions(subscriptionParams);
     });
 
     it('provides a way to auto attach subscriptions to content hosts', function() {
-        $httpBackend.expect('PUT', '/api/v2/hosts/bulk/auto_attach', subscriptionParams).respond();
+        $httpBackend.expect('PUT', 'api/v2/hosts/bulk/auto_attach', subscriptionParams).respond();
         ContentHostBulkAction.autoAttach(subscriptionParams);
     });
     
     it('provides a way to install content on content hosts', function() {
-        $httpBackend.expect('PUT', '/api/v2/hosts/bulk/install_content', contentHostParams).respond();
+        $httpBackend.expect('PUT', 'api/v2/hosts/bulk/install_content', contentHostParams).respond();
         ContentHostBulkAction.installContent(contentHostParams);
     });
 
     it('provides a way to update content on content hosts', function() {
-        $httpBackend.expect('PUT', '/api/v2/hosts/bulk/update_content', contentHostParams).respond();
+        $httpBackend.expect('PUT', 'api/v2/hosts/bulk/update_content', contentHostParams).respond();
         ContentHostBulkAction.updateContent(contentHostParams);
     });
 
     it('provides a way to remove content from content hosts', function() {
-        $httpBackend.expect('PUT', '/api/v2/hosts/bulk/remove_content', contentHostParams).respond();
+        $httpBackend.expect('PUT', 'api/v2/hosts/bulk/remove_content', contentHostParams).respond();
         ContentHostBulkAction.removeContent(contentHostParams);
     });
 
     it('provides a way to unregister content hosts', function() {
-        $httpBackend.expect('PUT', '/api/v2/hosts/bulk/destroy', contentHostParams).respond();
+        $httpBackend.expect('PUT', 'api/v2/hosts/bulk/destroy', contentHostParams).respond();
         ContentHostBulkAction.destroyHosts(contentHostParams);
     });
 });

--- a/engines/bastion_katello/test/hosts/host-erratum.factory.test.js
+++ b/engines/bastion_katello/test/hosts/host-erratum.factory.test.js
@@ -28,14 +28,14 @@ describe('Factory: HostErratum', function() {
     });
 
     it('provides a way to get a list of errata', function() {
-        $httpBackend.expectGET('/api/v2/hosts/HOST_ID/errata').respond(errata);
+        $httpBackend.expectGET('api/v2/hosts/HOST_ID/errata').respond(errata);
         HostErratum.get({ id: 'HOST_ID' }, function(results) {
             expect(results.total).toBe(2);
         });
     });
 
     it('provides a way to apply a list of errata', function() {
-        $httpBackend.expectPUT('/api/v2/hosts/HOST_ID/errata/apply').respond(task);
+        $httpBackend.expectPUT('api/v2/hosts/HOST_ID/errata/apply').respond(task);
         HostErratum.apply({ id: 'HOST_ID', errata_ids: ['RHSA-1'] }, function(results) {
             expect(results.id).toBe(task.id);
         });

--- a/engines/bastion_katello/test/hosts/host-package.factory.test.js
+++ b/engines/bastion_katello/test/hosts/host-package.factory.test.js
@@ -28,35 +28,35 @@ describe('Factory: HostPackage', function() {
     });
 
     it('provides a way to get a list of packages', function() {
-        $httpBackend.expectGET('/api/v2/hosts/SYS_ID/packages').respond(packages);
+        $httpBackend.expectGET('api/v2/hosts/SYS_ID/packages').respond(packages);
         HostPackage.get({ id: 'SYS_ID' }, function(results) {
             expect(results.total).toBe(2);
         });
     });
 
     it('provides a way to install a list of packages', function() {
-        $httpBackend.expectPUT('/api/v2/hosts/SYS_ID/packages/install').respond(task);
+        $httpBackend.expectPUT('api/v2/hosts/SYS_ID/packages/install').respond(task);
         HostPackage.install({ id: 'SYS_ID', packages: ['kernel'] }, function(results) {
             expect(results.id).toBe(task.id);
         });
     });
 
     it('provides a way to update a list of packages', function() {
-        $httpBackend.expectPUT('/api/v2/hosts/SYS_ID/packages/upgrade').respond(task);
+        $httpBackend.expectPUT('api/v2/hosts/SYS_ID/packages/upgrade').respond(task);
         HostPackage.update({ id: 'SYS_ID', packages: ['kernel'] }, function(results) {
             expect(results.id).toBe(task.id);
         });
     });
 
     it('provides a way to update all of packages', function() {
-        $httpBackend.expectPUT('/api/v2/hosts/SYS_ID/packages/upgrade_all').respond(task);
+        $httpBackend.expectPUT('api/v2/hosts/SYS_ID/packages/upgrade_all').respond(task);
         HostPackage.updateAll({ id: 'SYS_ID', packages: ['kernel'] }, function(results) {
             expect(results.id).toBe(task.id);
         });
     });
 
     it('provides a way to remove a list of packages', function() {
-        $httpBackend.expectPUT('/api/v2/hosts/SYS_ID/packages/remove').respond(task);
+        $httpBackend.expectPUT('api/v2/hosts/SYS_ID/packages/remove').respond(task);
         HostPackage.remove({ id: 'SYS_ID', packages: ['kernel'] }, function(results) {
             expect(results.id).toBe(task.id);
         });

--- a/engines/bastion_katello/test/hosts/host.factory.test.js
+++ b/engines/bastion_katello/test/hosts/host.factory.test.js
@@ -23,13 +23,13 @@ describe('Factory: Host', function() {
     it("provides a way to update the host's host collections", function() {
         var host = hosts.results[0];
 
-        $httpBackend.expectPUT('/api/v2/hosts/1/host_collections').respond(host);
+        $httpBackend.expectPUT('api/v2/hosts/1/host_collections').respond(host);
 
         Host.updateHostCollections({id: 1}, {"host_collection_ids": [1,2]});
     });
 
     it("provides a way to get the host index via a post", function() {
-        $httpBackend.expectPOST('/api/v2/hosts/post_index').respond({});
+        $httpBackend.expectPOST('api/v2/hosts/post_index').respond({});
         Host.postIndex();
     });
 });

--- a/engines/bastion_katello/test/organizations/organization.factory.test.js
+++ b/engines/bastion_katello/test/organizations/organization.factory.test.js
@@ -35,24 +35,24 @@ describe('Factory: Organization', function() {
     });
 
     it('provides a way retrieve an organization', function() {
-        $httpBackend.expectGET('/katello/api/v2/organizations').respond(organizations);
+        $httpBackend.expectGET('katello/api/v2/organizations').respond(organizations);
         Organization.queryPaged(function(organizations) {
             expect(organizations.records.length).toBe(2);
         });
     });
 
     it('provides a way to get repo discover', function() {
-        $httpBackend.expectPOST('/katello/api/v2/organizations/ACME/repo_discover').respond(task);
+        $httpBackend.expectPOST('katello/api/v2/organizations/ACME/repo_discover').respond(task);
         Organization.repoDiscover({ id: 'ACME' , url: '/foo'});
     });
 
     it('provides a way to cancel repo discover', function() {
-        $httpBackend.expectPOST('/katello/api/v2/organizations/ACME/repo_discover').respond(task);
+        $httpBackend.expectPOST('katello/api/v2/organizations/ACME/repo_discover').respond(task);
         Organization.repoDiscover({ id: 'ACME' , url: '/foo'});
     });
 
     it('provides a way to get an org', function() {
-        $httpBackend.expectGET('/katello/api/v2/organizations/ACME').respond(organizations.records[0]);
+        $httpBackend.expectGET('katello/api/v2/organizations/ACME').respond(organizations.records[0]);
 
         Organization.get({ id: 'ACME' }, function(response) {
             expect(response.id).toBe(1);
@@ -116,7 +116,7 @@ describe('Factory: Organization', function() {
         //testing the transform
         // from [{environments : [{id, name, permissions: {readable : true}}]}]
         // to [[{id, name, select: true}]]
-        $httpBackend.expectGET('/katello/api/v2/organizations/ACME/environments/paths').respond(response);
+        $httpBackend.expectGET('katello/api/v2/organizations/ACME/environments/paths').respond(response);
         readableEnvs = Organization.readableEnvironments({"id":"ACME"});
         $httpBackend.flush ();
         flushAfterFunction = false;

--- a/engines/bastion_katello/test/ostree-branches/ostree-branch.factory.test.js
+++ b/engines/bastion_katello/test/ostree-branches/ostree-branch.factory.test.js
@@ -26,7 +26,7 @@ describe('Factory: OstreeBranch', function () {
     });
 
     it('provides a way to get a list of repositories', function () {
-        $httpBackend.expectGET('/katello/api/v2/ostree_branches').respond(ostreeBranches);
+        $httpBackend.expectGET('katello/api/v2/ostree_branches').respond(ostreeBranches);
 
         OstreeBranch.queryPaged(function (ostreeBranches) {
             expect(ostreeBranches.records.length).toBe(1);

--- a/engines/bastion_katello/test/package-groups/package-group.factory.test.js
+++ b/engines/bastion_katello/test/package-groups/package-group.factory.test.js
@@ -26,7 +26,7 @@ describe('Factory: PackageGroup', function () {
     });
 
     it('provides a way to get a list of repositorys', function () {
-        $httpBackend.expectGET('/katello/api/v2/package_groups').respond(packageGroups);
+        $httpBackend.expectGET('katello/api/v2/package_groups').respond(packageGroups);
 
         PackageGroup.queryPaged(function (packageGroups) {
             expect(packageGroups.records.length).toBe(1);

--- a/engines/bastion_katello/test/products/bulk/product-bulk-action.factory.test.js
+++ b/engines/bastion_katello/test/products/bulk/product-bulk-action.factory.test.js
@@ -21,17 +21,17 @@ describe('Factory: ProductBulkAction', function() {
     });
 
     it('provides a way to remove products', function() {
-        $httpBackend.expect('PUT', '/katello/api/v2/products/bulk/destroy', productParams).respond();
+        $httpBackend.expect('PUT', 'katello/api/v2/products/bulk/destroy', productParams).respond();
         ProductBulkAction.removeProducts(productParams);
     });
 
     it('provides a way to sync products', function() {
-        $httpBackend.expect('PUT', '/katello/api/v2/products/bulk/sync', productParams).respond();
+        $httpBackend.expect('PUT', 'katello/api/v2/products/bulk/sync', productParams).respond();
         ProductBulkAction.syncProducts(productParams);
     });
 
     it('provides a way to update product sync plans', function() {
-        $httpBackend.expect('PUT', '/katello/api/v2/products/bulk/sync_plan', productParams).respond();
+        $httpBackend.expect('PUT', 'katello/api/v2/products/bulk/sync_plan', productParams).respond();
         ProductBulkAction.updateProductSyncPlan(productParams);
     });
 });

--- a/engines/bastion_katello/test/products/details/repositories/repository.factory.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/repository.factory.test.js
@@ -28,7 +28,7 @@ describe('Factory: Repository', function() {
     });
 
     it('provides a way to get a list of repositories', function() {
-        $httpBackend.expectGET('/katello/api/v2/repositories?organization_id=ACME&product_id=1')
+        $httpBackend.expectGET('katello/api/v2/repositories?organization_id=ACME&product_id=1')
                     .respond(repositories);
 
         Repository.queryPaged({'product_id': 1}, function(repositories) {
@@ -40,7 +40,7 @@ describe('Factory: Repository', function() {
         var updatedRepository = repositories.records[0];
 
         updatedRepository.name = 'NewRepositoryName';
-        $httpBackend.expectPUT('/katello/api/v2/repositories/1?organization_id=ACME').respond(updatedRepository);
+        $httpBackend.expectPUT('katello/api/v2/repositories/1?organization_id=ACME').respond(updatedRepository);
 
         Repository.update({name: 'NewRepositoryName', id: 1}, function(repository) {
             expect(repository).toBeDefined();
@@ -49,7 +49,7 @@ describe('Factory: Repository', function() {
     });
 
     it('provides a way to sync a repository', function() {
-        $httpBackend.expectPOST('/katello/api/v2/repositories/1/sync?organization_id=ACME').respond({'state': 'running'});
+        $httpBackend.expectPOST('katello/api/v2/repositories/1/sync?organization_id=ACME').respond({'state': 'running'});
 
         Repository.sync({id: 1}, function(task) {
             expect(task).toBeDefined();

--- a/engines/bastion_katello/test/products/product.factory.test.js
+++ b/engines/bastion_katello/test/products/product.factory.test.js
@@ -29,7 +29,7 @@ describe('Factory: Product', function() {
     });
 
     it('provides a way to get a list of products', function() {
-        $httpBackend.expectGET('/katello/api/v2/products').respond(products);
+        $httpBackend.expectGET('katello/api/v2/products').respond(products);
 
         Product.queryPaged(function(products) {
             expect(products.records.length).toBe(2);
@@ -40,7 +40,7 @@ describe('Factory: Product', function() {
         var updatedProduct = products.records[0];
 
         updatedProduct.name = 'NewProductName';
-        $httpBackend.expectPUT('/katello/api/v2/products/1').respond(updatedProduct);
+        $httpBackend.expectPUT('katello/api/v2/products/1').respond(updatedProduct);
 
         Product.update({ id: 1 }, function(product) {
             expect(product).toBeDefined();
@@ -49,7 +49,7 @@ describe('Factory: Product', function() {
     });
 
     it('provides a way to sync a product', function() {
-        $httpBackend.expectPOST('/katello/api/v2/products/1/sync').respond(products[0]);
+        $httpBackend.expectPOST('katello/api/v2/products/1/sync').respond(products[0]);
 
         Product.sync({ id: 1 });
     });
@@ -58,7 +58,7 @@ describe('Factory: Product', function() {
         var updatedProduct = products.records[0];
 
         updatedProduct.sync_plan_id = 2;
-        $httpBackend.expectPOST('/katello/api/v2/products/1/sync_plan').respond(updatedProduct);
+        $httpBackend.expectPOST('katello/api/v2/products/1/sync_plan').respond(updatedProduct);
 
         Product.updateSyncPlan({ id: 1, plan_id: 2 }, function(product) {
             expect(product).toBeDefined();

--- a/engines/bastion_katello/test/puppet-modules/puppet-modules.factory.test.js
+++ b/engines/bastion_katello/test/puppet-modules/puppet-modules.factory.test.js
@@ -26,7 +26,7 @@ describe('Factory: PuppetModules', function () {
     });
 
     it('provides a way to get a list of puppet modules', function () {
-        $httpBackend.expectGET('/katello/api/v2/puppet_modules').respond(puppetModules);
+        $httpBackend.expectGET('katello/api/v2/puppet_modules').respond(puppetModules);
 
         PuppetModule.queryPaged(function (puppetModules) {
             expect(puppetModules.records.length).toBe(1);
@@ -34,7 +34,7 @@ describe('Factory: PuppetModules', function () {
     });
 
     it('provides a way to get autocompleted search terms for puppet modules', function () {
-        $httpBackend.expectGET('/katello/api/v2/puppet_modules/auto_complete_search').respond(puppetModules.records);
+        $httpBackend.expectGET('katello/api/v2/puppet_modules/auto_complete_search').respond(puppetModules.records);
 
         PuppetModule.autocomplete(function (puppetModules) {
             expect(puppetModules.length).toBe(1);

--- a/engines/bastion_katello/test/settings/setting.factory.test.js
+++ b/engines/bastion_katello/test/settings/setting.factory.test.js
@@ -24,7 +24,7 @@ describe('Factory: Setting', function () {
     });
 
     it('provides a way to get a list of settings', function () {
-        $httpBackend.expectGET('/api/v2/settings').respond(setting);
+        $httpBackend.expectGET('api/v2/settings').respond(setting);
 
         Setting.queryPaged(function (setting) {
             expect(setting.results.length).toBeGreaterThan(0);

--- a/engines/bastion_katello/test/subscriptions/subscriptions.factory.test.js
+++ b/engines/bastion_katello/test/subscriptions/subscriptions.factory.test.js
@@ -32,7 +32,7 @@ describe('Factory: Subscription', function() {
     });
 
     it('provides a way to get a list of subscriptions', function() {
-        $httpBackend.expectGET('/katello/api/v2/organizations/ACME/subscriptions').respond(subscriptions);
+        $httpBackend.expectGET('katello/api/v2/organizations/ACME/subscriptions').respond(subscriptions);
 
         Subscription.queryPaged(function(subscriptions) {
             expect(subscriptions.results.length).toBe(2);
@@ -40,14 +40,14 @@ describe('Factory: Subscription', function() {
     });
 
     it('provides a way to get a subscription', function() {
-        $httpBackend.expectGET('/katello/api/v2/organizations/ACME/subscriptions/1').respond(subscription);
+        $httpBackend.expectGET('katello/api/v2/organizations/ACME/subscriptions/1').respond(subscription);
         Subscription.get({ id: 1 }, function(results) {
             expect(results.id).toBe(subscription.id);
         });
     });
 
     it('provides a way to get a manifest history', function() {
-        $httpBackend.expectGET('/katello/api/v2/organizations/ACME/subscriptions/manifest_history').respond([]);
+        $httpBackend.expectGET('katello/api/v2/organizations/ACME/subscriptions/manifest_history').respond([]);
         Subscription.manifestHistory(function(result){
             expect(result).not.toBeUndefined();
         });

--- a/engines/bastion_katello/test/sync-plans/sync-plan.factory.test.js
+++ b/engines/bastion_katello/test/sync-plans/sync-plan.factory.test.js
@@ -40,7 +40,7 @@ describe('Factory: SyncPlan', function() {
     });
 
     it('provides a way to get a list of syncPlans', function() {
-        $httpBackend.expectGET('/katello/api/v2/organizations/ACME/sync_plans?full_result=true').respond(syncPlans);
+        $httpBackend.expectGET('katello/api/v2/organizations/ACME/sync_plans?full_result=true').respond(syncPlans);
 
         SyncPlan.queryUnpaged(function(syncPlans) {
             expect(syncPlans.records.length).toBe(2);
@@ -51,7 +51,7 @@ describe('Factory: SyncPlan', function() {
         var updatedSyncPlan = syncPlans.records[0];
 
         updatedSyncPlan.name = 'NewSyncPlanName';
-        $httpBackend.expectPUT('/katello/api/v2/organizations/ACME/sync_plans/1').respond(updatedSyncPlan);
+        $httpBackend.expectPUT('katello/api/v2/organizations/ACME/sync_plans/1').respond(updatedSyncPlan);
 
         SyncPlan.update({ id: 1 }, function(syncPlan) {
             expect(syncPlan).toBeDefined();
@@ -60,12 +60,12 @@ describe('Factory: SyncPlan', function() {
     });
 
     it('provides a way to add product(s) to a syncPlan', function() {
-        $httpBackend.expectPUT('/katello/api/v2/organizations/ACME/sync_plans/1/add_products').respond(products);
+        $httpBackend.expectPUT('katello/api/v2/organizations/ACME/sync_plans/1/add_products').respond(products);
         SyncPlan.addProducts({id: 1});
     });
 
     it('provides a way to remove product(s) from a syncPlan', function() {
-        $httpBackend.expectPUT('/katello/api/v2/organizations/ACME/sync_plans/1/remove_products').respond(products);
+        $httpBackend.expectPUT('katello/api/v2/organizations/ACME/sync_plans/1/remove_products').respond(products);
         SyncPlan.removeProducts({id: 1});
     });
 });

--- a/engines/bastion_katello/test/tasks/task.factory.test.js
+++ b/engines/bastion_katello/test/tasks/task.factory.test.js
@@ -28,7 +28,7 @@ describe('Factory: Task', function() {
     });
 
     it('provides a way to get a list of tasks', function() {
-        $httpBackend.expectGET('/katello/api/v2/tasks?full_result=true&organization_id=ACME')
+        $httpBackend.expectGET('katello/api/v2/tasks?full_result=true&organization_id=ACME')
                     .respond(tasks);
 
         Task.queryUnpaged(function(tasks) {


### PR DESCRIPTION
The real work for this fix is being done here: https://github.com/Katello/bastion/pull/206

However, Katello needed these changes because all of the factory URLs were relative to the domain which obviously would not work when deployed under a subdir.

*Please* let me know if I may have missed something - I feel there is a high potential even though I looked through the code pretty well.

For testing, pull in the Bastion change above, this code, and start the rails server with:

`rake tmp:clear ; RAILS_RELATIVE_ROOT_URL=/whatever rails s`

The rake task might not be required but I like a clean slate.

I recall seeing odd behaviors switching between present and absent RAILS_RELATIVE_URL_ROOT, so I also opted to **use a new browser session whenever switching things up**.