### PR TITLE
fixes #20638 - manifest import/refresh as anonymous user

### DIFF
--- a/app/lib/actions/candlepin/owner/import_products.rb
+++ b/app/lib/actions/candlepin/owner/import_products.rb
@@ -8,7 +8,9 @@ module Actions
 
         def run
           organization = ::Organization.find(input[:organization_id])
-          organization.redhat_provider.import_products_from_cp
+          User.as_anonymous_admin do
+            organization.redhat_provider.import_products_from_cp
+          end
         end
       end
     end


### PR DESCRIPTION
This change performs the manifest import/refresh as anonymous user.

Without this change, behavior seen was that doing a new import or
refresh did not result in any changes to Katello DB.  E.g. Product
table was empty after import and no subscriptions could be seen.

While debugging, we found that the save of the products
was failing due to permissions error that resulted from not having
an assigned user.