### PR TITLE
Fixes #20582 - Show future dated subs in content host details

### DIFF
--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -158,7 +158,7 @@ module Katello
           end
 
           def available_pools(owner_label, uuid, listall = false)
-            url = Pool.path(nil, owner_label) + "?consumer=#{uuid}&listall=#{listall}"
+            url = Pool.path(nil, owner_label) + "?consumer=#{uuid}&listall=#{listall}&add_future=true"
             response = Candlepin::CandlepinResource.get(url, self.default_headers).body
             JSON.parse(response)
           end


### PR DESCRIPTION
We were missing the necessary Candlepin API parameter in this flow. 

http://www.candlepinproject.org/swagger/?url=candlepin/swagger-2.0.25.json#!/owners/listPools