### PR TITLE
fixes #20844 - adding LABEL search on the content view

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -65,6 +65,7 @@ module Katello
 
     scoped_search :on => :name, :complete_value => true
     scoped_search :on => :organization_id, :complete_value => true, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
+    scoped_search :on => :label, :complete_value => true
     scoped_search :on => :composite, :complete_value => {true: true, false: false}
 
     def self.in_environment(env)

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -395,6 +395,10 @@ module Katello
       assert_equal @library_view, ContentView.search_for("name = \"#{@library_view.name}\"").first
     end
 
+    def test_search_label
+      assert_equal @library_view, ContentView.search_for("label = \"#{@library_view.label}\"").first
+    end
+
     def test_search_organization_id
       assert_includes ContentView.search_for("organization_id = #{@library_view.organization_id}"), @library_view
     end


### PR DESCRIPTION
Changes done for adding 'label' as a search attribute through API call and webUI search.