### PR TITLE
Fixes #17208 - Env filter UI element clears

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/erratum-content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/erratum-content-hosts.controller.js
@@ -41,8 +41,8 @@ angular.module('Bastion.errata').controller('ErratumContentHostsController',
             if (errataSearchStringAddition) {
                 addition = '( ' + errataSearchStringAddition + ' )';
             }
-            if (angular.isDefined($scope.environmentId)) {
-                addition = addition + ' and lifecycle_environment_id = ' + $scope.environmentId;
+            if (angular.isDefined($scope.environmentFilter)) {
+                addition = addition + ' and lifecycle_environment_id = ' + $scope.environmentFilter;
             }
 
             if (term === "" || angular.isUndefined(term)) {
@@ -77,7 +77,7 @@ angular.module('Bastion.errata').controller('ErratumContentHostsController',
         nutupane.load();
 
         $scope.selectEnvironment = function (environmentId) {
-            $scope.environmentId = environmentId;
+            $scope.environmentFilter = environmentId;
             nutupane.refresh();
         };
 

--- a/engines/bastion_katello/test/errata/details/erratum-content-hosts.controller.test.js
+++ b/engines/bastion_katello/test/errata/details/erratum-content-hosts.controller.test.js
@@ -99,7 +99,7 @@ describe('Controller: ErratumContentHostsController', function() {
         $scope.selectEnvironment('foo');
 
         expect(nutupane.refresh).toHaveBeenCalled();
-        expect($scope.environmentId).toBe('foo');
+        expect($scope.environmentFilter).toBe('foo');
     });
 
     describe("provides a way to go to the next apply step", function () {


### PR DESCRIPTION
Lifecycle environment filter on errata list can be set and then cleared
using the 'x' next to the select dropdown.