### PR TITLE
Fixes #5477 - Restrict a certain repo based on architecture

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -143,11 +143,11 @@ module Katello
         gpg_key = @gpg_key
       end
       repo_params[:label] = labelize_params(repo_params)
+      repo_params[:arch] = repo_params[:arch] || 'noarch'
       repo_params[:url] = nil if repo_params[:url].blank?
-      unprotected =  repo_params.key?(:unprotected) ? repo_params[:unprotected] : true
-      repository = @product.add_repo(repo_params[:label], repo_params[:name], repo_params[:url],
-                                     repo_params[:content_type], unprotected,
-                                     gpg_key, repository_params[:checksum_type], repo_params[:download_policy])
+      repo_params[:unprotected] = repo_params.key?(:unprotected) ? repo_params[:unprotected] : true
+      repo_params[:gpg_key] = gpg_key
+      repository = @product.add_repo(Hash[repo_params.slice(:label, :name, :url, :content_type, :arch, :unprotected, :gpg_key, :checksum_type, :download_policy).map { |k, v| [k.to_sym, v] }])
       repository.docker_upstream_name = repo_params[:docker_upstream_name] if repo_params[:docker_upstream_name]
       repository.mirror_on_sync = ::Foreman::Cast.to_bool(repo_params[:mirror_on_sync]) if repo_params.key?(:mirror_on_sync)
       repository.verify_ssl_on_sync = ::Foreman::Cast.to_bool(repo_params[:verify_ssl_on_sync]) if repo_params.key?(:verify_ssl_on_sync)
@@ -417,7 +417,7 @@ module Katello
     end
 
     def repository_params
-      keys = [:download_policy, :mirror_on_sync, :verify_ssl_on_sync, :upstream_password, :upstream_username,
+      keys = [:download_policy, :mirror_on_sync, :arch, :verify_ssl_on_sync, :upstream_password, :upstream_username,
               :ostree_upstream_sync_depth, :ostree_upstream_sync_policy
              ]
       keys += [:label, :content_type] if params[:action] == "create"

--- a/app/lib/actions/candlepin/product/content_create.rb
+++ b/app/lib/actions/candlepin/product/content_create.rb
@@ -5,6 +5,7 @@ module Actions
         input_format do
           param :name
           param :type
+          param :arches
           param :label
           param :content_url
           param :owner
@@ -16,6 +17,7 @@ module Actions
                      name: input[:name],
                      contentUrl: input[:content_url],
                      type: input[:type],
+                     arches: input[:arches],
                      label: input[:label],
                      metadataExpire: 1,
                      vendor: ::Katello::Provider::CUSTOM)

--- a/app/lib/actions/candlepin/product/content_update.rb
+++ b/app/lib/actions/candlepin/product/content_update.rb
@@ -6,6 +6,7 @@ module Actions
           param :content_id
           param :name
           param :type
+          param :arches
           param :label
           param :content_url
           param :gpg_key_url
@@ -20,6 +21,7 @@ module Actions
                      contentUrl: input[:content_url],
                      gpgUrl: input[:gpg_key_url],
                      type: input[:type],
+                     arches: input[:arches],
                      label: input[:label],
                      metadataExpire: 1,
                      vendor: ::Katello::Provider::CUSTOM)

--- a/app/lib/actions/katello/product/content_create.rb
+++ b/app/lib/actions/katello/product/content_create.rb
@@ -11,11 +11,11 @@ module Actions
                                            owner:       repository.product.organization.label,
                                            name:        repository.name,
                                            type:        repository.content_type,
+                                           arches:      repository.arch == "noarch" ? nil : repository.arch,
                                            label:       repository.custom_content_label,
                                            content_url: content_url(repository))
               content_id = content_create.output[:response][:id]
-              plan_action(Candlepin::Product::ContentAdd,
-                                    owner: repository.product.organization.label,
+              plan_action(Candlepin::Product::ContentAdd, owner: repository.product.organization.label,
                                     product_id: repository.product.cp_id,
                                     content_id: content_id)
 
@@ -29,13 +29,13 @@ module Actions
                           content_id:  content_id,
                           name:        repository.name,
                           type:        repository.content_type,
+                          arches:      repository.arch == "noarch" ? "" : repository.arch,
                           label:       repository.custom_content_label,
                           content_url: content_url(repository),
                           gpg_key_url: repository.yum_gpg_key_url)
             end
 
-            plan_self(repository_id: repository.id,
-                      content_id: content_id)
+            plan_self(repository_id: repository.id, content_id: content_id)
           end
         end
 

--- a/app/lib/actions/katello/repository/update.rb
+++ b/app/lib/actions/katello/repository/update.rb
@@ -18,7 +18,8 @@ module Actions
                         :content_url => ::Katello::Glue::Pulp::Repos.custom_content_path(repository.product, repository.label),
                         :gpg_key_url => repository.yum_gpg_key_url,
                         :label => repository.content.label,
-                        :type => repository.content_type)
+                        :type => repository.content_type,
+                        :arches => repository.arch == "noarch" ? nil : repository.arch)
           end
 
           if SETTINGS[:katello][:use_pulp] && repository.pulp_update_needed?

--- a/app/models/katello/glue/pulp/repos.rb
+++ b/app/models/katello/glue/pulp/repos.rb
@@ -213,30 +213,30 @@ module Katello
         end
       end
 
-      def add_repo(label, name, url, repo_type, unprotected = false, gpg = nil, checksum_type = nil, download_policy = nil)
-        unprotected = unprotected.nil? ? false : unprotected
+      def add_repo(repo_param)
+        repo_param[:unprotected] = repo_param[:unprotected].nil? ? false : repo_param[:unprotected]
 
-        if download_policy.blank? && repo_type == Repository::YUM_TYPE
-          download_policy = Setting[:default_download_policy]
+        if repo_param[:download_policy].blank? && repo_param[:content_type] == Repository::YUM_TYPE
+          repo_param[:download_policy] = Setting[:default_download_policy]
         end
 
-        rel_path = if repo_type == 'docker'
-                     Glue::Pulp::Repos.custom_docker_repo_path(self.library, self, label)
+        rel_path = if repo_param[:content_type] == 'docker'
+                     Glue::Pulp::Repos.custom_docker_repo_path(self.library, self, repo_param[:label])
                    else
-                     Glue::Pulp::Repos.custom_repo_path(self.library, self, label)
+                     Glue::Pulp::Repos.custom_repo_path(self.library, self, repo_param[:label])
                    end
         Repository.new(:environment => self.organization.library,
                        :product => self,
                        :relative_path => rel_path,
-                       :arch => arch,
-                       :name => name,
-                       :label => label,
-                       :url => url,
-                       :gpg_key => gpg,
-                       :unprotected => unprotected,
-                       :content_type => repo_type,
-                       :checksum_type => checksum_type,
-                       :download_policy => download_policy,
+                       :arch => repo_param[:arch],
+                       :name => repo_param[:name],
+                       :label => repo_param[:label],
+                       :url => repo_param[:url],
+                       :gpg_key => repo_param[:gpg_key],
+                       :unprotected => repo_param[:unprotected],
+                       :content_type => repo_param[:content_type],
+                       :checksum_type => repo_param[:checksum_type],
+                       :download_policy => repo_param[:download_policy],
                        :content_view_version => self.organization.library.default_content_view_version)
       end
 

--- a/app/views/katello/api/v2/repositories/base.json.rabl
+++ b/app/views/katello/api/v2/repositories/base.json.rabl
@@ -2,7 +2,7 @@ object @resource
 
 extends 'katello/api/v2/common/identifier'
 
-attributes :content_type, :url, :relative_path
+attributes :content_type, :url, :relative_path, :arch
 attributes :pulp_id => :backend_identifier
 
 child :product do |_product|

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/architectures/architecture.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/architectures/architecture.factory.js
@@ -1,0 +1,15 @@
+/**
+ * @ngdoc service
+ * @name  Bastion.architectures.factory:Architecture
+ *
+ * @requires BastionResource
+ *
+ * @description
+ *   Provides a BastionResource for architectures.
+ */
+angular.module('Bastion.architectures').factory('Architecture',
+    ['BastionResource', function (BastionResource) {
+        var resource = BastionResource('/api/v2/architectures/');
+        return resource;
+    }]
+);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/architectures/architectures.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/architectures/architectures.module.js
@@ -1,0 +1,14 @@
+/**
+ * @ngdoc module
+ * @name  Bastion.architectures
+ *
+ * @description
+ *    Module for architectures
+ */
+angular.module('Bastion.architectures', [
+    'ngResource',
+    'ui.router',
+    'Bastion',
+    'Bastion.i18n',
+    'Bastion.common'
+]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/bastion-katello-bootstrap.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/bastion-katello-bootstrap.js
@@ -1,6 +1,7 @@
 BASTION_MODULES.push(
     'Bastion.capsule-content',
     'Bastion.activation-keys',
+    'Bastion.architectures' ,
     'Bastion.common',
     'Bastion.content-views',
     'Bastion.content-views.versions',

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/bastion_katello.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/bastion_katello.js
@@ -82,6 +82,9 @@
 //= require "bastion_katello/settings/settings.module.js"
 //= require_tree "./settings"
 
+//= require "bastion_katello/architectures/architectures.module.js"
+//= require_tree "./architectures"
+
 //= require "bastion_katello/i18n/translations.js"
 
 //= require "bastion_katello/bastion-katello-bootstrap.js"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
@@ -11,13 +11,14 @@
  * @requires Checksum
  * @requires DownloadPolicy
  * @requires OstreeUpstreamSyncPolicy
+ * @requires Architecture
  *
  * @description
  *   Provides the functionality for the repository details info page.
  */
 angular.module('Bastion.repositories').controller('RepositoryDetailsInfoController',
-    ['$scope', '$q', 'translate', 'GlobalNotification', 'GPGKey', 'CurrentOrganization', 'Checksum', 'DownloadPolicy', 'OstreeUpstreamSyncPolicy',
-    function ($scope, $q, translate, GlobalNotification, GPGKey, CurrentOrganization, Checksum, DownloadPolicy, OstreeUpstreamSyncPolicy) {
+    ['$scope', '$q', 'translate', 'GlobalNotification', 'GPGKey', 'CurrentOrganization', 'Checksum', 'DownloadPolicy', 'OstreeUpstreamSyncPolicy', 'Architecture',
+    function ($scope, $q, translate, GlobalNotification, GPGKey, CurrentOrganization, Checksum, DownloadPolicy, OstreeUpstreamSyncPolicy, Architecture) {
         $scope.organization = CurrentOrganization;
 
         $scope.progress = {uploading: false};
@@ -36,6 +37,23 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
                 deferred.resolve(results);
             });
 
+            return deferred.promise;
+        };
+
+        $scope.architectures = function () {
+            var deferred = $q.defer();
+            Architecture.queryUnpaged(function (architectures) {
+                var results = architectures.results;
+                results.map(function(i) {
+                    i.id = i.name;
+                });
+                results.unshift({
+                    id: 'noarch',
+                    name: translate('Default'),
+                    value: null
+                });
+                deferred.resolve(results);
+            });
             return deferred.promise;
         };
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -20,6 +20,13 @@
       <dt translate>Type</dt>
       <dd>{{ repository.content_type }}</dd>
 
+      <dt ng-show="repository.content_type === 'yum'" translate>Restrict to architecture</dt>
+      <dd bst-edit-select="repository.arch==='noarch'?'Default':repository.arch"
+          selector="repository.arch"
+          options="architectures()"
+          on-save="save(repository)">
+      </dd>
+
       <dt ng-show="repository.content_type !== 'docker'" translate>URL</dt>
       <dt ng-show="repository.content_type === 'docker'" translate>Registry URL</dt>
       <dd bst-edit-text="repository.url"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/new-repository.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/new-repository.controller.js
@@ -14,13 +14,14 @@
  * @requires Checksum
  * @requires DownloadPolicy
  * @requires OstreeUpstreamSyncPolicy
+ * @requires Architecture
  *
  * @description
  *   Controls the creation of an empty Repository object for use by sub-controllers.
  */
 angular.module('Bastion.repositories').controller('NewRepositoryController',
-    ['$scope', 'Repository', 'Product', 'GPGKey', 'FormUtils', 'translate', 'GlobalNotification', 'ApiErrorHandler', 'BastionConfig', 'Checksum', 'DownloadPolicy', 'OstreeUpstreamSyncPolicy',
-    function ($scope, Repository, Product, GPGKey, FormUtils, translate, GlobalNotification, ApiErrorHandler, BastionConfig, Checksum, DownloadPolicy, OstreeUpstreamSyncPolicy) {
+    ['$scope', 'Repository', 'Product', 'GPGKey', 'FormUtils', 'translate', 'GlobalNotification', 'ApiErrorHandler', 'BastionConfig', 'Checksum', 'DownloadPolicy', 'OstreeUpstreamSyncPolicy', 'Architecture',
+    function ($scope, Repository, Product, GPGKey, FormUtils, translate, GlobalNotification, ApiErrorHandler, BastionConfig, Checksum, DownloadPolicy, OstreeUpstreamSyncPolicy, Architecture) {
 
         function success() {
             GlobalNotification.setSuccessMessage(translate('Repository %s successfully created.').replace('%s', $scope.repository.name));
@@ -61,7 +62,7 @@ angular.module('Bastion.repositories').controller('NewRepositoryController',
 
         $scope.repository = new Repository({'product_id': $scope.$stateParams.productId, unprotected: true,
             'checksum_type': null, 'mirror_on_sync': true, 'verify_ssl_on_sync': true,
-            'download_policy': BastionConfig.defaultDownloadPolicy,
+            'download_policy': BastionConfig.defaultDownloadPolicy, 'arch': null,
             'ostree_upstream_sync_policy': 'latest'});
 
         $scope.product = Product.get({id: $scope.$stateParams.productId}, function () {
@@ -90,12 +91,30 @@ angular.module('Bastion.repositories').controller('NewRepositoryController',
             $scope.gpgKeys = gpgKeys.results;
         });
 
+        Architecture.queryUnpaged(function (architecture) {
+            var results = architecture.results;
+            var noarch = {
+                id: 'noarch',
+                name: translate('Default'),
+                value: null
+            };
+            results.map(function(i) {
+                i.id = i.name;
+            });
+            results.unshift(noarch);
+            $scope.architecture = results;
+            $scope.repository.arch = results[0].id;
+        });
+
         $scope.save = function (repository) {
             if (repository.content_type === 'ostree') {
                 repository.unprotected = false;
             }
             if (repository.content_type !== 'yum') {
                 repository['download_policy'] = '';
+            }
+            if (repository.arch === 'Default') {
+                repository.arch = null;
             }
             repository.$save(success, error);
         };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -32,6 +32,17 @@
                 ng-options="type.name as type.name for type in repositoryTypes">
         </select>
       </div>
+
+      <div bst-form-group label="{{ 'Restrict to Architecture' | translate }}" ng-show="repository.content_type === 'yum'">
+        <select id="architecture_restricted"
+                name="architecture_restricted"
+                ng-model="repository.arch"
+                ng-options="arch.id as arch.name for arch in architecture">
+        </select>
+        <p class="help-block" translate>
+          Choose <b>Default</b> to enable the repository for all architectures
+        </p>
+      </div>
     </div>
     <div ng-show="repository.content_type !== undefined">
       <h4 translate> Sync Information </h4>
@@ -121,7 +132,7 @@
         <p class="help-block" translate>
           For On Demand synchronization, only the metadata is downloaded during sync and packages are fetched and stored on the filesystem when clients request them.
           For Background synchronization, a background task will download all packages after the initial sync.
-          The Immediate option will download all metadata and packages immediately during the sync. 
+          The Immediate option will download all metadata and packages immediately during the sync.
         </p>
       </div>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.module.js
@@ -11,6 +11,7 @@ angular.module('Bastion.products', [
     'Bastion',
     'Bastion.components',
     'Bastion.gpg-keys',
+    'Bastion.architectures',
     'Bastion.i18n',
     'Bastion.sync-plans',
     'Bastion.tasks',

--- a/engines/bastion_katello/test/architecture/architecture.factory.test.js
+++ b/engines/bastion_katello/test/architecture/architecture.factory.test.js
@@ -1,0 +1,35 @@
+describe('Factory: Architecture', function() {
+    var $httpBackend,
+        architecture;
+
+    beforeEach(module('Bastion.architectures', 'Bastion.test-mocks'));
+
+    beforeEach(module(function($provide) {
+        architecture = {
+            records: [
+                { name: 'Architecture1', id: 1 }
+            ],
+            total: 2,
+            subtotal: 1
+        };
+    }));
+
+    beforeEach(inject(function($injector) {
+        $httpBackend = $injector.get('$httpBackend');
+        Architecture = $injector.get('Architecture');
+    }));
+
+    afterEach(function() {
+        $httpBackend.flush();
+        $httpBackend.verifyNoOutstandingExpectation();
+        $httpBackend.verifyNoOutstandingRequest();
+    });
+
+    it('provides a way to get a list of architectures', function() {
+         $httpBackend.expectGET('/api/v2/architectures?full_result=true').respond(architecture);
+
+         Architecture.queryUnpaged(function(architecture) {
+             expect(architecture.records.length).toBe(1);
+         });
+    });
+});

--- a/engines/bastion_katello/test/products/details/repositories/new/new-repository.controller.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/new/new-repository.controller.test.js
@@ -14,7 +14,8 @@ describe('Controller: NewRepositoryController', function() {
             Repository = $injector.get('MockResource').$new(),
             Product = $injector.get('MockResource').$new(),
             Setting = $injector.get('MockResource').$new(),
-            GPGKey = $injector.get('MockResource').$new();
+            GPGKey = $injector.get('MockResource').$new(),
+            Architecture = $injector.get('MockResource').$new();
 
         DownloadPolicy = $injector.get('DownloadPolicy');
         OstreeUpstreamSyncPolicy = $injector.get('OstreeUpstreamSyncPolicy');
@@ -42,6 +43,7 @@ describe('Controller: NewRepositoryController', function() {
             Repository: Repository,
             Product: Product,
             GPGKey: GPGKey,
+            Architecture: Architecture,
             GlobalNotification: GlobalNotification,
             Setting: Setting
         });
@@ -58,6 +60,10 @@ describe('Controller: NewRepositoryController', function() {
 
     it('should fetch available GPG Keys', function() {
         expect($scope.gpgKeys).toBeDefined();
+    });
+
+    it('should fetch available Architectures', function() {
+        expect($scope.architecture).toBeDefined();
     });
 
     it('should save a new repository resource', function() {

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -228,14 +228,13 @@ module Katello
     def test_create
       product = mock
       product.expects(:add_repo).with(
-        'Fedora_Repository',
-        'Fedora Repository',
-        'http://www.google.com',
-        'yum',
-        true,
-        nil,
-        nil,
-        nil
+        :label => 'Fedora_Repository',
+        :name => 'Fedora Repository',
+        :url => 'http://www.google.com',
+        :content_type => 'yum',
+        :arch => 'noarch',
+        :unprotected => true,
+        :gpg_key => nil
       ).returns(@repository)
 
       product.expects(:gpg_key).returns(nil)
@@ -248,7 +247,33 @@ module Katello
                     :product_id => @product.id,
                     :url => 'http://www.google.com',
                     :content_type => 'yum'
+      assert_response :success
+      assert_template 'api/v2/repositories/show'
+    end
 
+    def test_create_with_arch
+      product = mock
+      product.expects(:add_repo).with(
+          :label => 'Fedora_Repository',
+          :name => 'Fedora Repository',
+          :url => 'http://www.google.com',
+          :content_type => 'yum',
+          :arch => 'x86_64',
+          :unprotected => true,
+          :gpg_key => nil
+      ).returns(@repository)
+
+      product.expects(:gpg_key).returns(nil)
+      product.expects(:organization).returns(@organization)
+      product.expects(:redhat?).returns(false)
+      assert_sync_task(::Actions::Katello::Repository::Create, @repository, false, true)
+
+      Product.stubs(:find).returns(product)
+      post :create, :name => 'Fedora Repository',
+           :product_id => @product.id,
+           :url => 'http://www.google.com',
+           :content_type => 'yum',
+           :arch => 'x86_64'
       assert_response :success
       assert_template 'api/v2/repositories/show'
     end
@@ -256,14 +281,13 @@ module Katello
     def test_create_with_empty_string_url
       product = mock
       product.expects(:add_repo).with(
-        'Fedora_Repository',
-        'Fedora Repository',
-        nil,
-        'yum',
-        true,
-        nil,
-        nil,
-        nil
+        :label => 'Fedora_Repository',
+        :name => 'Fedora Repository',
+        :url => nil,
+        :content_type => 'yum',
+        :arch => 'noarch',
+        :unprotected => true,
+        :gpg_key => nil
       ).returns(@repository)
 
       product.expects(:gpg_key).returns(nil)
@@ -277,7 +301,6 @@ module Katello
                       :product_id => @product.id,
                       :url => '',
                       :content_type => 'yum'
-
       assert_response :success
       assert_template 'api/v2/repositories/show'
     end
@@ -286,14 +309,13 @@ module Katello
       key = GpgKey.find(katello_gpg_keys('fedora_gpg_key').id)
       product = mock
       product.expects(:add_repo).with(
-        'Fedora_Repository',
-        'Fedora Repository',
-        'http://www.google.com',
-        'yum',
-        true,
-        key,
-        nil,
-        nil
+        :label => 'Fedora_Repository',
+        :name => 'Fedora Repository',
+        :url => 'http://www.google.com',
+        :content_type => 'yum',
+        :arch => 'noarch',
+        :unprotected => true,
+        :gpg_key => key
       ).returns(@repository)
 
       product.expects(:gpg_key).returns(key)
@@ -315,14 +337,14 @@ module Katello
     def test_create_with_checksum
       product = mock
       product.expects(:add_repo).with(
-        'Fedora_Repository',
-        'Fedora Repository',
-        nil,
-        'yum',
-        true,
-        nil,
-        'sha256',
-        nil
+        :label => 'Fedora_Repository',
+        :name => 'Fedora Repository',
+        :url => nil,
+        :content_type => 'yum',
+        :arch => 'noarch',
+        :unprotected => true,
+        :gpg_key => nil,
+        :checksum_type => 'sha256'
       ).returns(@repository)
 
       product.expects(:gpg_key).returns(nil)
@@ -344,14 +366,14 @@ module Katello
     def test_create_with_download_policy
       product = mock
       product.expects(:add_repo).with(
-        'Fedora_Repository',
-        'Fedora Repository',
-        nil,
-        'yum',
-        true,
-        nil,
-        nil,
-        'on_demand'
+        :label => 'Fedora_Repository',
+        :name => 'Fedora Repository',
+        :url => nil,
+        :content_type => 'yum',
+        :arch => 'noarch',
+        :unprotected => true,
+        :gpg_key => nil,
+        :download_policy => 'on_demand'
       ).returns(@repository)
 
       product.expects(:gpg_key).returns(nil)
@@ -373,14 +395,13 @@ module Katello
     def test_create_with_protected_true
       product = mock
       product.expects(:add_repo).with(
-        'Fedora_Repository',
-        'Fedora Repository',
-        'http://www.google.com',
-        'yum',
-        false,
-        nil,
-        nil,
-        nil
+          :label => 'Fedora_Repository',
+          :name => 'Fedora Repository',
+          :url => 'http://www.google.com',
+          :content_type => 'yum',
+          :arch => 'noarch',
+          :unprotected => false,
+          :gpg_key => nil
       ).returns(@repository)
 
       product.expects(:gpg_key).returns(nil)
@@ -403,14 +424,13 @@ module Katello
       mirror_on_sync = true
       product = mock
       product.expects(:add_repo).with(
-        'Fedora_Repository',
-        'Fedora Repository',
-        'http://www.google.com',
-        'yum',
-        false,
-        nil,
-        nil,
-        nil
+          :label => 'Fedora_Repository',
+          :name => 'Fedora Repository',
+          :url => 'http://www.google.com',
+          :content_type => 'yum',
+          :arch => 'noarch',
+          :unprotected => false,
+          :gpg_key => nil
       ).returns(@repository)
 
       product.expects(:gpg_key).returns(nil)
@@ -434,14 +454,13 @@ module Katello
       verify_ssl_on_sync = true
       product = mock
       product.expects(:add_repo).with(
-        'Fedora_Repository',
-        'Fedora Repository',
-        'http://www.google.com',
-        'yum',
-        false,
-        nil,
-        nil,
-        nil
+          :label => 'Fedora_Repository',
+          :name => 'Fedora Repository',
+          :url => 'http://www.google.com',
+          :content_type => 'yum',
+          :arch => 'noarch',
+          :unprotected => false,
+          :gpg_key => nil
       ).returns(@repository)
 
       product.expects(:gpg_key).returns(nil)
@@ -467,14 +486,13 @@ module Katello
       upstream_password = "genius_password"
       product = mock
       product.expects(:add_repo).with(
-        'Fedora_Repository',
-        'Fedora Repository',
-        'http://www.google.com',
-        'yum',
-        false,
-        nil,
-        nil,
-        nil
+          :label => 'Fedora_Repository',
+          :name => 'Fedora Repository',
+          :url => 'http://www.google.com',
+          :content_type => 'yum',
+          :arch => 'noarch',
+          :unprotected => false,
+          :gpg_key => nil
       ).returns(@repository)
 
       product.expects(:gpg_key).returns(nil)
@@ -500,21 +518,19 @@ module Katello
     def test_create_with_protected_docker
       product = mock
       product.expects(:add_repo).with(
-        'Fedora_Repository',
-        'Fedora Repository',
-        'http://hub.registry.com',
-        'docker',
-        true,
-        nil,
-        nil,
-        nil
+          :label => 'Fedora_Repository',
+          :name => 'Fedora Repository',
+          :url => 'http://hub.registry.com',
+          :content_type => 'docker',
+          :arch => 'noarch',
+          :unprotected => true,
+          :gpg_key => nil
       ).returns(@repository)
 
       product.expects(:gpg_key).returns(nil)
       product.expects(:organization).returns(@organization)
       product.expects(:redhat?).returns(false)
       assert_sync_task(::Actions::Katello::Repository::Create, @repository, false, true)
-
       Product.stubs(:find).returns(product)
       post :create, :name => 'Fedora Repository',
                     :product_id => @product.id,
@@ -532,14 +548,13 @@ module Katello
       sync_policy = "custom"
       product = mock
       product.expects(:add_repo).with(
-        'Fedora_Repository',
-        'Fedora Repository',
-        'http://hub.registry.com',
-        'ostree',
-        true,
-        nil,
-        nil,
-        nil
+          :label => 'Fedora_Repository',
+          :name => 'Fedora Repository',
+          :url => 'http://hub.registry.com',
+          :content_type => 'ostree',
+          :arch => 'noarch',
+          :unprotected => true,
+          :gpg_key => nil
       ).returns(repository)
 
       product.expects(:gpg_key).returns(nil)

--- a/test/fixtures/vcr_cassettes/scenarios/org_create.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/org_create.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://dev.example.com:8443/candlepin/owners/
+    uri: https://centos7-devl2.example.com:8443/candlepin/owners/
     body:
       encoding: UTF-8
       base64_string: |
@@ -17,9 +17,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp",
-        oauth_nonce="tpaBANJkmSEHzvkuCZzmUYLOABGgFUNXlNgeTUbvg", oauth_signature="l02fC78ghctge2cltMZplN7y2%2BI%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1493910073", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="BuwYxVLAM5Q5nfZ5j6auFWWZnaZdQsif",
+        oauth_nonce="rdqX829iOSQkVcRetymM9tAxouNGucxP1Vu41zv4w", oauth_signature="qou469h3TY%2FT9xSwHC7iCOGhvrU%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1502315591", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -36,32 +36,32 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - f46a48ee-a198-4388-a3c0-aab544179dfb
+      - 9c0ece0b-2b53-4640-9158-ad3ad8e32533
       X-Version:
-      - 2.0.26-1
+      - 2.0.35-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 04 May 2017 15:01:13 GMT
+      - Wed, 09 Aug 2017 21:53:11 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiI0MDI4Zjk1MTViY2JkZjE0MDE1
-        YmQzZmFiMTMxMDAwMCIsImtleSI6InNjZW5hcmlvX3Rlc3QiLCJkaXNwbGF5
+        eyJwYXJlbnRPd25lciI6bnVsbCwiaWQiOiI0MDI4Zjk3NTVkYzg3NWNkMDE1
+        ZGM4ZmNiN2VhMDAxMSIsImtleSI6InNjZW5hcmlvX3Rlc3QiLCJkaXNwbGF5
         TmFtZSI6InNjZW5hcmlvX3Rlc3QiLCJjb250ZW50UHJlZml4IjoiL3NjZW5h
         cmlvX3Rlc3QvJGVudiIsImRlZmF1bHRTZXJ2aWNlTGV2ZWwiOm51bGwsInVw
         c3RyZWFtQ29uc3VtZXIiOm51bGwsImxvZ0xldmVsIjpudWxsLCJhdXRvYmlu
         ZERpc2FibGVkIjpudWxsLCJjb250ZW50QWNjZXNzTW9kZSI6bnVsbCwiY29u
         dGVudEFjY2Vzc01vZGVMaXN0IjpudWxsLCJocmVmIjoiL293bmVycy9zY2Vu
-        YXJpb190ZXN0IiwiY3JlYXRlZCI6IjIwMTctMDUtMDRUMTU6MDE6MTMrMDAw
-        MCIsInVwZGF0ZWQiOiIyMDE3LTA1LTA0VDE1OjAxOjEzKzAwMDAifQ==
+        YXJpb190ZXN0IiwiY3JlYXRlZCI6IjIwMTctMDgtMDlUMjE6NTM6MTErMDAw
+        MCIsInVwZGF0ZWQiOiIyMDE3LTA4LTA5VDIxOjUzOjExKzAwMDAifQ==
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:13 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:11 GMT
 - request:
     method: post
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/environments
+    uri: https://centos7-devl2.example.com:8443/candlepin/owners/scenario_test/environments
     body:
       encoding: UTF-8
       base64_string: |
@@ -75,9 +75,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp",
-        oauth_nonce="4iFjN8AW2KGUjBczDRtrxrBoo17p5aU2YQHMAF8OI", oauth_signature="dTMq7ThSjsOSpJZzBPocmdw82ZU%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1493910073", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="BuwYxVLAM5Q5nfZ5j6auFWWZnaZdQsif",
+        oauth_nonce="kJzxiaKWY8eMv4t1gTu3CAMIsZYSaB4OZRZoAlzGE", oauth_signature="NdRA%2BbnP5zifzMEG5q2iJjRd2SY%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1502315591", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -94,30 +94,30 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 594000a8-4464-485e-9cc9-22047d97001a
+      - 7ba88277-2b5d-4ab2-a01e-5af08bf8f56a
       X-Version:
-      - 2.0.26-1
+      - 2.0.35-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 04 May 2017 15:01:13 GMT
+      - Wed, 09 Aug 2017 21:53:11 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJvd25lciI6eyJpZCI6IjQwMjhmOTUxNWJjYmRmMTQwMTViZDNmYWIxMzEw
-        MDAwIiwia2V5Ijoic2NlbmFyaW9fdGVzdCIsImRpc3BsYXlOYW1lIjoic2Nl
+        eyJvd25lciI6eyJpZCI6IjQwMjhmOTc1NWRjODc1Y2QwMTVkYzhmY2I3ZWEw
+        MDExIiwia2V5Ijoic2NlbmFyaW9fdGVzdCIsImRpc3BsYXlOYW1lIjoic2Nl
         bmFyaW9fdGVzdCIsImhyZWYiOiIvb3duZXJzL3NjZW5hcmlvX3Rlc3QifSwi
         bmFtZSI6IkxpYnJhcnkiLCJkZXNjcmlwdGlvbiI6bnVsbCwiaWQiOiIxMTlj
         NDc1M2ZmNmQzYjdiZDBiNzZkZTZkNWE1Zjk0YSIsImVudmlyb25tZW50Q29u
-        dGVudCI6W10sImNyZWF0ZWQiOiIyMDE3LTA1LTA0VDE1OjAxOjEzKzAwMDAi
-        LCJ1cGRhdGVkIjoiMjAxNy0wNS0wNFQxNTowMToxMyswMDAwIn0=
+        dGVudCI6W10sImNyZWF0ZWQiOiIyMDE3LTA4LTA5VDIxOjUzOjExKzAwMDAi
+        LCJ1cGRhdGVkIjoiMjAxNy0wOC0wOVQyMTo1MzoxMSswMDAwIn0=
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:13 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:11 GMT
 - request:
     method: get
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/uebercert
+    uri: https://centos7-devl2.example.com:8443/candlepin/owners/scenario_test/uebercert
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -129,9 +129,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
       Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="3dm00qw0vkrSN64EYnGrxPRyVcOiHqLjhibRAnBdU",
-        oauth_signature="rPBMqzQlTXiojJhoAXExOnzKTR8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1493910073", oauth_version="1.0"
+      - OAuth oauth_consumer_key="BuwYxVLAM5Q5nfZ5j6auFWWZnaZdQsif", oauth_nonce="HtwmjVKlQ6HDB3KPCorcwg8LIwwWX1SpK4az7qU48",
+        oauth_signature="oJflACDl4Zo3Px1gi%2Bu5ZeqtBYo%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1502315591", oauth_version="1.0"
       Cp-User:
       - foreman_admin
   response:
@@ -142,28 +142,28 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 49f8b599-2467-4272-82a7-c0590d6e56c8
+      - e86f4a2e-dc14-48c4-aa7a-37495c139e8d
       X-Version:
-      - 2.0.26-1
-      - 2.0.26-1
+      - 2.0.35-1
+      - 2.0.35-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 04 May 2017 15:01:13 GMT
+      - Wed, 09 Aug 2017 21:53:11 GMT
     body:
       encoding: UTF-8
       base64_string: |
         eyJkaXNwbGF5TWVzc2FnZSI6InViZXIgY2VydGlmaWNhdGUgZm9yIG93bmVy
         IHNjZW5hcmlvX3Rlc3Qgd2FzIG5vdCBmb3VuZC4gUGxlYXNlIGdlbmVyYXRl
-        IG9uZS4iLCJyZXF1ZXN0VXVpZCI6IjQ5ZjhiNTk5LTI0NjctNDI3Mi04MmE3
-        LWMwNTkwZDZlNTZjOCJ9
+        IG9uZS4iLCJyZXF1ZXN0VXVpZCI6ImU4NmY0YTJlLWRjMTQtNDhjNC1hYTdh
+        LTM3NDk1YzEzOWU4ZCJ9
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:13 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:11 GMT
 - request:
     method: post
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/uebercert
+    uri: https://centos7-devl2.example.com:8443/candlepin/owners/scenario_test/uebercert
     body:
       encoding: UTF-8
       base64_string: |
@@ -176,9 +176,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp",
-        oauth_nonce="Iexb6IcbZT3LWV3M2dq1VqA5dX4hCvKMiSiK4l7g0", oauth_signature="cY38mc85S1ZOHFPi%2BzaNujXE8T4%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1493910073", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="BuwYxVLAM5Q5nfZ5j6auFWWZnaZdQsif",
+        oauth_nonce="Y5nHw77gBkb30OUqr4fFRYkBmYO4zVBCVeACSATg", oauth_signature="HLQJU1%2B2kZZja8U77xHOL6aQl90%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1502315591", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -195,122 +195,123 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - f24b3a8b-d0df-4f1d-96be-0891d10a5f4b
+      - 6a110cb4-9a71-469a-bc4e-6e05fa104e01
       X-Version:
-      - 2.0.26-1
+      - 2.0.35-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 04 May 2017 15:01:14 GMT
+      - Wed, 09 Aug 2017 21:53:12 GMT
     body:
       encoding: UTF-8
       base64_string: |
         eyJrZXkiOiItLS0tLUJFR0lOIFJTQSBQUklWQVRFIEtFWS0tLS0tXG5NSUlF
-        b3dJQkFBS0NBUUVBcWxJRVkxTE83aVpIRWlqcUZTbXoyVnQ1QmZaNHNraEhy
-        eFNueS9iTTJvaEVlTVVjXG5CaDQxejB0dU00RnZLdnMyaEpPZERROFpqcWYz
-        c29pV2FCR1ozM1hFRXgzSVkwSXcwSGFvNEZLaGpqRGgxYzQ1XG5pVFRNakE0
-        UEFQK1BzSWwrQkQ4SW1qanBucDJvRWdVSE03VEVldUhKL2hqS2h2K3FVUFBx
-        ZitkWlVJZExiYjVUXG5lMkRoNlF5NCs1bllwWjNxSkpxZjhyZUw1eE4renZD
-        dVgzZXNXWjBzMjlZVVB0RUVsdHRaZEFBdjFjSTFLNm83XG5BUjVrdGNiNE52
-        K05yUWo1bFNCY2U0SFlPVk80S2xEdzhOWktka1kyazN0TUFRYTVFekE2VmxZ
-        L0lEclRhTVcyXG5rejVhZjFVR2U1WjZnNTI4bmczRkVJcTFRMEQxQ2MvZEI2
-        d1dYd0lEQVFBQkFvSUJBREFrd09MR2ZJR3F4am9tXG40SXdjM3A2WkVhdVMw
-        T2tzTHo4Wktwa242UjM0bU1vK2hUNWhlYnBmeXdXNkY0OWh0VFppZDJsQ2xH
-        blRwdHVMXG5hbUIrWVMxZUg0OTd3ckh6K3RKaVNEZ29nMHdyR3hzUmtRZnNx
-        Y2tKREVxdThwSG5PM3k5eUpPM2RLb0dUSVRUXG5jUWEzbVRaVzduN3B5UTNC
-        NVFXKy9ORXN0djFnMkxFRHc1VkRTWGdCL1hwdytYeXY3REI3WGRzQXFucWVN
-        RElJXG53bkVBeEpzY1kvMVdpVXdFQWVKZmo2czZvT1VVRVdycDJ0U0R2RWhz
-        d3N0QktOV2FtNkNUVlR2Y2tPTWdETUx4XG5sNFh4eThUMnRrcFhSUTlWQXIy
-        WTVNT2VRZFU5VmY0Z3ZZU3lwekNlZG8ya0JvdDVTaXVYNjB2RUUwU01BSjMz
-        XG5zQk9RcmlrQ2dZRUEvYlVBWldGd2JLSXRoWW92Z25DUXE4RFNsd083Z0pK
-        NXdOTWVvZmdDTS90S2pyUFptL2Y2XG43NVRqNjRPdWdJQzk4UVZQY2Rnejhp
-        dTY2c0FyY1kyMS9BZ2luWVA3bVZ0M1dmMHhDeElJNjdqOUR6d09vMURDXG5C
-        U3lpejRRbTdGcUVOZmtqMHF5Rkc5RmY4c2xINCtjTm5Pbmt6RzFpSXp0TUFU
-        enJFOEhkOEJNQ2dZRUFxOXdWXG54UzZ5alUzbVJRZGpkSzdqdnhpS3pDcGl6
-        QUhVRDhNdEp0RGF6NytxT3RyK0ROM1ZoRkRYRkFVMXBPT01TNUlyXG5BSzRj
-        WklZL0IwbHJYNGtYQnFDZGJkVDNKcy9Pdm1ZeFgycVFtT3ZnbUNrUk5rVjVF
-        QUsvb1pERHY2eWRpemRMXG5tN2U4Y0VsYnptUllWNU5SKytaZ3JZVk4wQWR4
-        R2Zna3VoVDR3Z1VDZ1lFQXo3U2RyR0pIZmtpUDZDSW5ueXkwXG41RWdxb0lQ
-        bnYrMHJUSmdMSGlOQytuZWlwSTNOZkFsYklVWE9Dd1IxbXJMTHprVEFzNzJE
-        V2FJL2x1elpKRkFXXG5TMDRGdU50UzRreWx1OEN6cEJLUnh4cGQ0MWtSeXRi
-        VTRST1gvemg3L1VobHNTSlZGNmN5R29JaGdVMFVWQnJYXG5aRDJBbVhSN3dj
-        aE1Bejl5WFd4OFhJMENnWUJpQkhvZUpnNEw3WHdCcnI4WWs0NnROTkFrdFov
-        M2ZxdDErZmxNXG5oQjNvRXdhQjN0aTZlZU1IUGh3TS9ST2xZV3BveDRyakxt
-        cGZJdm5ickJJalFNcnpLclBmS25Gem4xM28xZHdlXG44V1phOFZ6OUs1NzNk
-        eFFlLzVKUUVZS3pWVDNkWXNJcW85WkRySE5CK1pVeERZTGF5b0FsTnp3MEE2
-        cU1CeXpiXG5QSTdNQ1FLQmdHMGx4bUdvNzFCbjQ4Y01qdWNhN2tzbHJyaWN5
-        YzdmbWg1Y05waUlQS2dKVHRBZFhrei9iTzFDXG56L203ajZUMzdXT25BT2tG
-        czh3U0xYRGRjSzc3ZTA3aHdHWEVVbDhTUDJHV2lIcjIxU3BiYU5IZ0lFY1Bw
-        cnVqXG5lL0dQRHhtYWU4d2QrREtTWjVTdklsa0J1ZnNSTlBKZE1jSHlnam9F
-        UTlqYXFQdDd3Qk9sXG4tLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLVxu
-        IiwiY2VydCI6Ii0tLS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0tLVxuTUlJRzFq
-        Q0NCYjZnQXdJQkFnSUlHOHltSGx6NlFCRXdEUVlKS29aSWh2Y05BUUVGQlFB
-        d2VqRUxNQWtHQTFVRVxuQmhNQ1ZWTXhGekFWQmdOVkJBZ1REazV2Y25Sb0lF
-        TmhjbTlzYVc1aE1SQXdEZ1lEVlFRSEV3ZFNZV3hsYVdkb1xuTVJBd0RnWURW
-        UVFLRXdkTFlYUmxiR3h2TVJRd0VnWURWUVFMRXd0VGIyMWxUM0puVlc1cGRE
-        RVlNQllHQTFVRVxuQXhNUFpHVjJMbVY0WVcxd2JHVXVZMjl0TUI0WERURTNN
-        RFV3TkRFMU1ERXhNMW9YRFRRNU1USXdNVEV6TURBd1xuTUZvd0dERVdNQlFH
-        QTFVRUNnd05jMk5sYm1GeWFXOWZkR1Z6ZERDQ0FTSXdEUVlKS29aSWh2Y05B
-        UUVCQlFBRFxuZ2dFUEFEQ0NBUW9DZ2dFQkFLcFNCR05TenU0bVJ4SW82aFVw
-        czlsYmVRWDJlTEpJUjY4VXA4djJ6TnFJUkhqRlxuSEFZZU5jOUxiak9CYnly
-        N05vU1RuUTBQR1k2bjk3S0lsbWdSbWQ5MXhCTWR5R05DTU5CMnFPQlNvWTR3
-        NGRYT1xuT1lrMHpJd09Ed0QvajdDSmZnUS9DSm80Nlo2ZHFCSUZCek8weEhy
-        aHlmNFl5b2IvcWxEejZuL25XVkNIUzIyK1xuVTN0ZzRla011UHVaMktXZDZp
-        U2FuL0szaStjVGZzN3dybDkzckZtZExOdldGRDdSQkpiYldYUUFMOVhDTlN1
-        cVxuT3dFZVpMWEcrRGIvamEwSStaVWdYSHVCMkRsVHVDcFE4UERXU25aR05w
-        TjdUQUVHdVJNd09sWldQeUE2MDJqRlxudHBNK1duOVZCbnVXZW9PZHZKNE54
-        UkNLdFVOQTlRblAzUWVzRmw4Q0F3RUFBYU9DQThBd2dnTzhNQkVHQ1dDR1xu
-        U0FHRytFSUJBUVFFQXdJRm9EQUxCZ05WSFE4RUJBTUNCTEF3Z2F3R0ExVWRJ
-        d1NCcERDQm9ZQVV2V3UwYU9qU1xudUxRT2ZQSk9XRnNyV1ZtanFnYWhmcVI4
-        TUhveEN6QUpCZ05WQkFZVEFsVlRNUmN3RlFZRFZRUUlFdzVPYjNKMFxuYUNC
-        RFlYSnZiR2x1WVRFUU1BNEdBMVVFQnhNSFVtRnNaV2xuYURFUU1BNEdBMVVF
-        Q2hNSFMyRjBaV3hzYnpFVVxuTUJJR0ExVUVDeE1MVTI5dFpVOXlaMVZ1YVhR
-        eEdEQVdCZ05WQkFNVEQyUmxkaTVsZUdGdGNHeGxMbU52YllJSlxuQU5ENWRE
-        d2xkdFNNTUIwR0ExVWREZ1FXQkJSSFUrTFIrNEFMMHc1NGh5RDcrcmozNkNC
-        eTdEQVRCZ05WSFNVRVxuRERBS0JnZ3JCZ0VGQlFjREFqQXhCaEFyQmdFRUFa
-        SUlDUUdydlovcTVRNEJCQjBNRzNOalpXNWhjbWx2WDNSbFxuYzNSZmRXVmla
-        WEpmY0hKdlpIVmpkREFXQmhBckJnRUVBWklJQ1FHcnZaL3E1UTREQkFJTUFE
-        QVdCaEFyQmdFRVxuQVpJSUNRR3J2Wi9xNVE0Q0JBSU1BREFXQmhBckJnRUVB
-        WklJQ1FHcnZaL3E1UTRGQkFJTUFEQVpCaEFyQmdFRVxuQVpJSUNRS3J2Wi9x
-        NVE4QkJBVU1BM2wxYlRBa0JoRXJCZ0VFQVpJSUNRS3J2Wi9xNVE4QkFRUVBE
-        QTExWldKbFxuY2w5amIyNTBaVzUwTURJR0VTc0dBUVFCa2dnSkFxdTluK3Js
-        RHdFQ0JCME1HekUwT1RNNU1UQXdOek01T1RoZlxuZFdWaVpYSmZZMjl1ZEdW
-        dWREQWRCaEVyQmdFRUFaSUlDUUtydlovcTVROEJCUVFJREFaRGRYTjBiMjB3
-        SlFZUlxuS3dZQkJBR1NDQWtDcTcyZjZ1VVBBUVlFRUF3T0wzTmpaVzVoY21s
-        dlgzUmxjM1F3RndZUkt3WUJCQUdTQ0FrQ1xucTcyZjZ1VVBBUWNFQWd3QU1C
-        Z0dFU3NHQVFRQmtnZ0pBcXU5bitybER3RUlCQU1NQVRFd0t3WUtLd1lCQkFH
-        U1xuQ0FrRUFRUWREQnR6WTJWdVlYSnBiMTkwWlhOMFgzVmxZbVZ5WDNCeWIy
-        UjFZM1F3RUFZS0t3WUJCQUdTQ0FrRVxuQWdRQ0RBQXdIUVlLS3dZQkJBR1ND
-        QWtFQXdRUERBMHhORGt6T1RFd01EY3pPVGs0TUJFR0Npc0dBUVFCa2dnSlxu
-        QkFVRUF3d0JNVEFrQmdvckJnRUVBWklJQ1FRR0JCWU1GREl3TVRjdE1EVXRN
-        RFJVTVRVNk1ERTZNVE5hTUNRR1xuQ2lzR0FRUUJrZ2dKQkFjRUZnd1VNakEw
-        T1MweE1pMHdNVlF4TXpvd01Eb3dNRm93RVFZS0t3WUJCQUdTQ0FrRVxuREFR
-        RERBRXdNQkFHQ2lzR0FRUUJrZ2dKQkFvRUFnd0FNQkFHQ2lzR0FRUUJrZ2dK
-        QkEwRUFnd0FNQkVHQ2lzR1xuQVFRQmtnZ0pCQTRFQXd3Qk1EQVJCZ29yQmdF
-        RUFaSUlDUVFMQkFNTUFURXdOQVlLS3dZQkJBR1NDQWtGQVFRbVxuRENRNE16
-        WmhaVGcxTVMwMU0yWXdMVFEzT1RJdFltVTVZaTAwTVRaaU9XVmtORFZsWXpj
-        d0RRWUpLb1pJaHZjTlxuQVFFRkJRQURnZ0VCQUd6ZURhaHdVZHhNMDFob2xa
-        YThCeHZWSHp2ZGFZbjVWNEpFNjA0MStFVG5WV0NLcFkxZFxuUXoyaHJ0alF3
-        a3J6c1MybW9PeEJWZXhVTTUyZUZCa2ZPNW9aZWdjbmtQbjlXQkw0aklQdFgz
-        Y2lqMHdGWDkrbVxuMlFYTUcrTEViVnVqeVNWRFRST3RMbk1rTzRaR3lPTUNK
-        b0xyWnFoVmxjY2t0VVdsZVNrMC9KRmNpZmo2Y1dPNFxucm44OFpaNWY3T2lH
-        ZjBzSVh3S0lWNS9YSG1SS2J6NHIxUGpqTFFVeDJJejJCV0xGc2FMUno1WVRj
-        SmtBYlpCUVxuYXM4UC9sa09yU2MzVEFrak1GZVFua3lTSTdTeDBMa3pTcTUr
-        ZjNKUmIxMnQ1bzE5S20yb0hMVWh5eG5GVGdKSFxuL2twSFJzK2NVSmV5eEVh
-        SnlMUmZnS1Z0QlM5ZEJYRkh1N3M9XG4tLS0tLUVORCBDRVJUSUZJQ0FURS0t
-        LS0tXG4iLCJpZCI6IjQwMjhmOTUxNWJjYmRmMTQwMTViZDNmYWIzZTQwMDAz
-        Iiwic2VyaWFsIjp7ImlkIjoyMDAzMTU4NTgzNjEyMTYyMDY1LCJyZXZva2Vk
-        IjpmYWxzZSwiY29sbGVjdGVkIjpmYWxzZSwiZXhwaXJhdGlvbiI6IjIwNDkt
-        MTItMDFUMTM6MDA6MDArMDAwMCIsInNlcmlhbCI6MjAwMzE1ODU4MzYxMjE2
-        MjA2NSwiY3JlYXRlZCI6IjIwMTctMDUtMDRUMTU6MDE6MTMrMDAwMCIsInVw
-        ZGF0ZWQiOiIyMDE3LTA1LTA0VDE1OjAxOjEzKzAwMDAifSwib3duZXIiOnsi
-        aWQiOiI0MDI4Zjk1MTViY2JkZjE0MDE1YmQzZmFiMTMxMDAwMCIsImtleSI6
-        InNjZW5hcmlvX3Rlc3QiLCJkaXNwbGF5TmFtZSI6InNjZW5hcmlvX3Rlc3Qi
-        LCJocmVmIjoiL293bmVycy9zY2VuYXJpb190ZXN0In0sImNyZWF0ZWQiOiIy
-        MDE3LTA1LTA0VDE1OjAxOjEzKzAwMDAiLCJ1cGRhdGVkIjoiMjAxNy0wNS0w
-        NFQxNTowMToxNCswMDAwIn0=
+        b2dJQkFBS0NBUUVBcEcvdWpVdDFxNlh5QXdkZVR4bjdzVXkrUEV2Q3FSNHll
+        d2pFRUxvTmJzZ0JBSzdOXG5nenQrbUpIUElYSXREOHpPTEE5RUpWTnVXdEVT
+        UWZ1eUx2Yk9Za2ZlbDR0VHc3WEdHV3oxdTlxU2tTUE1PaktaXG5DeXkzTHBD
+        SVJLdHdZaVUxVmg0K2dHbzBkdmVGdlFqb09TeUNFanNIekhJQkxFbkUxeTRK
+        Mjc1WlVPQmsySWxBXG52TWl1RXl3RW1QamZaYWltblZEZXdnQVl6MitRVUov
+        aG02aWswOU8yTlVoakY4N1c1N1ZlK2Y2QTRmTnAzZDEwXG51S1JqVzRsbWx5
+        TWZzQ1RjUG03elkwQnEySkpPS0tHUmZRQ0ZFaVRoSjZRR21UN0hpcnYxVkVw
+        UU9DNStGcGlFXG5YWDhlL0lCQ1lKR0pzYk9YdjQ1SU4wZ1drR3YzblE5bjZM
+        SEFwd0lEQVFBQkFvSUJBRTlDV0lTb2U2WnB6VllpXG5aaFhRbTEzaGRNeVJZ
+        OW1xWVlDbVFBTWorcmVNRmRlamFoRzRTcFAxckJZZDk1Um5EblYwUWsrUGdH
+        Q3I1NVlBXG5ZT2w4TXd4eVFkdGYzOWMwdGJDcHNXU0R2U1BTVW0wMjJFZm5u
+        TUFJRUhhdy8vRitwOC9Ec2pLcGZuSmRhb3dzXG5UK3JIQmtjTlJ2d0hjNE5L
+        WjJPa29FSFg1U3N5eDBVcTFVbFpOcXA1MkVsUVJFdldFZ3oxenlPenBtUFVL
+        cnlLXG4xRWlBenhST2g0STRjRktFLzl3dDA3b0dIU3MxVU1tcFNuSFdJSVpR
+        SUErcTJRd3hNS1lnOGZiQTRSaEhqd3dsXG5MZHpGZ0QxU2RjczJqSFF2L2ph
+        MHMrY3I0VVhEN3VxeXVlbHZsZnZnbWkyYS9XdU9BQTJjRTVla0dOWURXMDR4
+        XG5vazdGMVFFQ2dZRUEzNEFOOEpFSGtoM1hFN1pNWlNiU0Z6WUx6b3lOVkEx
+        YW9TYTdDTVYzRjdYczgyb05TTW5uXG4xR3RYRVFvVjRxL0M4bnlOL2xQZWJQ
+        R214K0dWNUpuYUt1Umh3M052Sy9nb3lQN0J6NDJnUU02VzVzSjU4M2JmXG5W
+        NWRJMHZZM2lNL2hUU3ZHTG5OUTZjMUl4UFBZWGhqYzhOcmhjMklZMlRFSXlj
+        Y05vS1lnMVlFQ2dZRUF2RmszXG41RDlRUkkzaEJhT0RuSjB5K3VkamI4YXhB
+        K3owdTJ2aGhJVGlielkzZ3ZPdjJJZ28rVkdTdnlzczFpc2FPSHdIXG5hSDU5
+        dEI1ZHQ4OHBUVGN4UTNFSnVkN3I3d0Jla2FOZVlrUkhsTjVhYTBGZHB0KzRu
+        cG04K1VmZ3hldE5hNnF5XG5ab3NFcmRPRHB0VzhGbXFvY2hMd3Q3bWtLV0VC
+        dFdlZkpjWlNPaWNDZ1lCUnJ1dHBVSmdEdndRc0lDUXJrOVNVXG54eHZwa1ZU
+        VnMwdThPZnVCYVNudGNILzVObmxFY1FaWmpDRjJDTW1XMzhYUCtkV3JiZHVN
+        MVlTdTZMTnZxUXNqXG5RZlM1Q2lkSFdwc05XbzVhM05nRTEzd3ZPa1IzeHFv
+        NXlRREVtVmdTbUdjdlhTQkJPY1FJcnc0NWJTVld2cCtCXG5KMzNlUGF2M05R
+        U1JPajZ3eUFhWUFRS0JnQWxZbEFGcmN0d3ovaHA5aHFaYTFwREVzcFoxVVl0
+        VVVzQ0tGZUt4XG5oVnJuWWRISnJjd2MxWXVwbEpLUDNlV3l0ZFpmc1M1cU9H
+        cWJweUxiMEx6WUpFV29ja2NhM0xJN1huWHptVmRlXG44LzViR2ptQVFObHEr
+        SXBHTHE1ZjlyTmJmYmY5L0dSQ09iVTJiYTMxcFNPbm56d3AzSEFCY2pmcmJG
+        NUlDZ21oXG4wYXE1QW9HQVJTVG5YRU1kTDZSakl0aTNzT3JTME1ObEw2MDNZ
+        eWlqNXlTVEg1bWwwUWpVMmluNlN3TGw5OW1zXG5wVWQwaTBvYXZQcEFTQUtE
+        TFA4ZTU3Y0lnVXlha2JxZkpxNEVOclZYZURWT1VGNE9sZng1ZzgxTUV3QXRL
+        Vzk4XG5kbVBRd1JWdXBRVlZLTDNpd052TFllM1RSZHVuMXhxOE5vay9Wc2sz
+        b29CMks3M255d2c9XG4tLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLVxu
+        IiwiY2VydCI6Ii0tLS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0tLVxuTUlJRzdq
+        Q0NCZGFnQXdJQkFnSUlVRHFpWmp6RzlFY3dEUVlKS29aSWh2Y05BUUVGQlFB
+        d2dZUXhDekFKQmdOVlxuQkFZVEFsVlRNUmN3RlFZRFZRUUlFdzVPYjNKMGFD
+        QkRZWEp2YkdsdVlURVFNQTRHQTFVRUJ4TUhVbUZzWldsblxuYURFUU1BNEdB
+        MVVFQ2hNSFMyRjBaV3hzYnpFVU1CSUdBMVVFQ3hNTFUyOXRaVTl5WjFWdWFY
+        UXhJakFnQmdOVlxuQkFNVEdXTmxiblJ2Y3pjdFpHVjJiREl1WlhoaGJYQnNa
+        UzVqYjIwd0hoY05NVGN3T0RBNU1qRTFNekV4V2hjTlxuTkRreE1qQXhNVE13
+        TURBd1dqQVlNUll3RkFZRFZRUUtEQTF6WTJWdVlYSnBiMTkwWlhOME1JSUJJ
+        akFOQmdrcVxuaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUFwRy91
+        alV0MXE2WHlBd2RlVHhuN3NVeStQRXZDcVI0eVxuZXdqRUVMb05ic2dCQUs3
+        Tmd6dCttSkhQSVhJdEQ4ek9MQTlFSlZOdVd0RVNRZnV5THZiT1lrZmVsNHRU
+        dzdYR1xuR1d6MXU5cVNrU1BNT2pLWkN5eTNMcENJUkt0d1lpVTFWaDQrZ0dv
+        MGR2ZUZ2UWpvT1N5Q0Vqc0h6SElCTEVuRVxuMXk0SjI3NVpVT0JrMklsQXZN
+        aXVFeXdFbVBqZlphaW1uVkRld2dBWXoyK1FVSi9obTZpazA5TzJOVWhqRjg3
+        V1xuNTdWZStmNkE0Zk5wM2QxMHVLUmpXNGxtbHlNZnNDVGNQbTd6WTBCcTJK
+        Sk9LS0dSZlFDRkVpVGhKNlFHbVQ3SFxuaXJ2MVZFcFFPQzUrRnBpRVhYOGUv
+        SUJDWUpHSnNiT1h2NDVJTjBnV2tHdjNuUTluNkxIQXB3SURBUUFCbzRJRFxu
+        elRDQ0E4a3dFUVlKWUlaSUFZYjRRZ0VCQkFRREFnV2dNQXNHQTFVZER3UUVB
+        d0lFc0RDQnVRWURWUjBqQklHeFxuTUlHdWdCUXV0WWZnN3d5SkhDYy9UeWxz
+        RU9ObmswaFloNkdCaXFTQmh6Q0JoREVMTUFrR0ExVUVCaE1DVlZNeFxuRnpB
+        VkJnTlZCQWdURGs1dmNuUm9JRU5oY205c2FXNWhNUkF3RGdZRFZRUUhFd2RT
+        WVd4bGFXZG9NUkF3RGdZRFxuVlFRS0V3ZExZWFJsYkd4dk1SUXdFZ1lEVlFR
+        TEV3dFRiMjFsVDNKblZXNXBkREVpTUNBR0ExVUVBeE1aWTJWdVxuZEc5ek55
+        MWtaWFpzTWk1bGVHRnRjR3hsTG1OdmJZSUpBS05jYkttSGJ6N21NQjBHQTFV
+        ZERnUVdCQlNnSlhpdFxuS2ViRFp1eGFWeklWOVVEYnF0M2RIVEFUQmdOVkhT
+        VUVEREFLQmdnckJnRUZCUWNEQWpBeEJoQXJCZ0VFQVpJSVxuQ1FHcjNNZnk4
+        UndCQkIwTUczTmpaVzVoY21sdlgzUmxjM1JmZFdWaVpYSmZjSEp2WkhWamRE
+        QVdCaEFyQmdFRVxuQVpJSUNRR3IzTWZ5OFJ3REJBSU1BREFXQmhBckJnRUVB
+        WklJQ1FHcjNNZnk4UndDQkFJTUFEQVdCaEFyQmdFRVxuQVpJSUNRR3IzTWZ5
+        OFJ3RkJBSU1BREFaQmhBckJnRUVBWklJQ1FLcjNNZnk4UjBCQkFVTUEzbDFi
+        VEFrQmhFclxuQmdFRUFaSUlDUUtyM01meThSMEJBUVFQREExMVpXSmxjbDlq
+        YjI1MFpXNTBNRElHRVNzR0FRUUJrZ2dKQXF2Y1xueC9MeEhRRUNCQjBNR3pF
+        MU1ESXpNVFUxT1RFNE16WmZkV1ZpWlhKZlkyOXVkR1Z1ZERBZEJoRXJCZ0VF
+        QVpJSVxuQ1FLcjNNZnk4UjBCQlFRSURBWkRkWE4wYjIwd0pRWVJLd1lCQkFH
+        U0NBa0NxOXpIOHZFZEFRWUVFQXdPTDNOalxuWlc1aGNtbHZYM1JsYzNRd0Z3
+        WVJLd1lCQkFHU0NBa0NxOXpIOHZFZEFRY0VBZ3dBTUJnR0VTc0dBUVFCa2dn
+        SlxuQXF2Y3gvTHhIUUVJQkFNTUFURXdLd1lLS3dZQkJBR1NDQWtFQVFRZERC
+        dHpZMlZ1WVhKcGIxOTBaWE4wWDNWbFxuWW1WeVgzQnliMlIxWTNRd0VBWUtL
+        d1lCQkFHU0NBa0VBZ1FDREFBd0hRWUtLd1lCQkFHU0NBa0VBd1FQREEweFxu
+        TlRBeU16RTFOVGt4T0RNMk1CRUdDaXNHQVFRQmtnZ0pCQVVFQXd3Qk1UQWtC
+        Z29yQmdFRUFaSUlDUVFHQkJZTVxuRkRJd01UY3RNRGd0TURsVU1qRTZOVE02
+        TVRGYU1DUUdDaXNHQVFRQmtnZ0pCQWNFRmd3VU1qQTBPUzB4TWkwd1xuTVZR
+        eE16b3dNRG93TUZvd0VRWUtLd1lCQkFHU0NBa0VEQVFEREFFd01CQUdDaXNH
+        QVFRQmtnZ0pCQW9FQWd3QVxuTUJBR0Npc0dBUVFCa2dnSkJBMEVBZ3dBTUJF
+        R0Npc0dBUVFCa2dnSkJBNEVBd3dCTURBUkJnb3JCZ0VFQVpJSVxuQ1FRTEJB
+        TU1BVEV3TkFZS0t3WUJCQUdTQ0FrRkFRUW1EQ1JoWmpWbE9ETm1NaTAwWVRO
+        a0xUUmtOVGN0T1dObFxuTlMwNE1EVm1PVEZsTWpaak9EQXdEUVlKS29aSWh2
+        Y05BUUVGQlFBRGdnRUJBQUZGRGVVaW9sNVB2WFhmZE10NlxuZGdSeFpla1hX
+        ejlmQ3lBdGxncmt4OFVIM21uS2NFZ3hPSGlFVFJpcjJ4WVgvVm5wRm1aR280
+        YTBESFkvQkM4OVxuS2IzT1BqeTRKa3BVSEozQmtRWTVabVBGckJ2RDZmMmxX
+        Q2xtUU1kOVhtaTRBUmJoNGVWOUxIM2FBY2pSQUhmUlxuNm9PRzFER2NBSVkz
+        cnRlS01oQk12UFpCbkJXZVBUU0hIQW00UVJOSUMvcURMckkwMkN3TzIwSWJz
+        Uk11THExMVxuQmFFald3UEhUaTFyNVBTWFRRMWMrNEJCZGZSNFJ2UXZJdDMw
+        KzREaVdUZkJ1Zkl4R0VrNjdDeEJlU1d5TENxRVxuc1p5Z1ZMRjljczdnMW1H
+        Nk55WVRoVmZUbURIalNGQlhnSXlIZ1dsdkR3SWRXWVZpVDMxTU9qUTBXeDBP
+        eXZDRVxudS9ZPVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLVxuIiwic2Vy
+        aWFsIjp7ImlkIjo1NzgxMTExNjMxNjczNDg4NDU1LCJyZXZva2VkIjpmYWxz
+        ZSwiY29sbGVjdGVkIjpmYWxzZSwiZXhwaXJhdGlvbiI6IjIwNDktMTItMDFU
+        MTM6MDA6MDArMDAwMCIsInNlcmlhbCI6NTc4MTExMTYzMTY3MzQ4ODQ1NSwi
+        Y3JlYXRlZCI6IjIwMTctMDgtMDlUMjE6NTM6MTErMDAwMCIsInVwZGF0ZWQi
+        OiIyMDE3LTA4LTA5VDIxOjUzOjExKzAwMDAifSwiaWQiOiI0MDI4Zjk3NTVk
+        Yzg3NWNkMDE1ZGM4ZmNiYTViMDAxNCIsIm93bmVyIjp7ImlkIjoiNDAyOGY5
+        NzU1ZGM4NzVjZDAxNWRjOGZjYjdlYTAwMTEiLCJrZXkiOiJzY2VuYXJpb190
+        ZXN0IiwiZGlzcGxheU5hbWUiOiJzY2VuYXJpb190ZXN0IiwiaHJlZiI6Ii9v
+        d25lcnMvc2NlbmFyaW9fdGVzdCJ9LCJjcmVhdGVkIjoiMjAxNy0wOC0wOVQy
+        MTo1MzoxMSswMDAwIiwidXBkYXRlZCI6IjIwMTctMDgtMDlUMjE6NTM6MTIr
+        MDAwMCJ9
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:14 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:12 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/organization_destroy.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/organization_destroy.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/?include=productContent.content.name
+    uri: https://centos7-devl2.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/?include=productContent.content.name
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -14,9 +14,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
       Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="w2LhsNrw4JohS98LMqjA1M244vj1AC2oRyZa0URFU",
-        oauth_signature="%2B3eIsC2Ii7HGb4ph7LHG98ofp4Q%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1493910099", oauth_version="1.0"
+      - OAuth oauth_consumer_key="BuwYxVLAM5Q5nfZ5j6auFWWZnaZdQsif", oauth_nonce="37LEW7Am7txHsY0iiITLm7vMKBQRcpPbOMCRdxAvBk",
+        oauth_signature="PoCC1zdaeTE3zWuufD5noykoeVI%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1502315616", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -31,31 +31,31 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 40f2f383-49d0-45dd-b821-78588d79b2e4
+      - 7d79cbdf-9e5b-4351-8773-c0590a351838
       X-Version:
-      - 2.0.26-1
+      - 2.0.35-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 04 May 2017 15:01:40 GMT
+      - Wed, 09 Aug 2017 21:53:36 GMT
     body:
       encoding: UTF-8
       base64_string: |
         eyJuYW1lIjoiU2NlbmFyaW8gUHJvZHVjdCIsImF0dHJpYnV0ZXMiOlt7Im5h
         bWUiOiJhcmNoIiwidmFsdWUiOiJBTEwifV0sInByb2R1Y3RDb250ZW50Ijpb
-        eyJjb250ZW50Ijp7ImlkIjoiMTQ5MzkxMDA3NTkzMyIsInR5cGUiOiJ5dW0i
+        eyJjb250ZW50Ijp7ImlkIjoiMTUwMjMxNTU5MzU4MSIsInR5cGUiOiJ5dW0i
         LCJsYWJlbCI6InNjZW5hcmlvX3Rlc3RfU2NlbmFyaW9fUHJvZHVjdF9TY2Vu
         YXJpb195dW1fcHJvZHVjdCIsIm5hbWUiOiJTY2VuYXJpbyB5dW0gcHJvZHVj
         dCIsImNvbnRlbnRVcmwiOiIvY3VzdG9tL1NjZW5hcmlvX1Byb2R1Y3QvU2Nl
         bmFyaW9feXVtX3Byb2R1Y3QiLCJtb2RpZmllZFByb2R1Y3RJZHMiOltdfSwi
         ZW5hYmxlZCI6dHJ1ZX1dfQ==
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:40 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:36 GMT
 - request:
     method: delete
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/repositories/scenario_test/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -74,7 +74,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:40 GMT
+      - Wed, 09 Aug 2017 21:53:36 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -87,14 +87,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2ZmYzUxNzQzLTVjY2QtNDk3NC05MmFhLTA4MDhiYmRlNjBhNS8iLCAi
-        dGFza19pZCI6ICJmZmM1MTc0My01Y2NkLTQ5NzQtOTJhYS0wODA4YmJkZTYw
-        YTUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzRiMGQzZDcwLWU5YWUtNDNlMi04YzE5LTQ4YjczOTgxYjE4Yi8iLCAi
+        dGFza19pZCI6ICI0YjBkM2Q3MC1lOWFlLTQzZTItOGMxOS00OGI3Mzk4MWIx
+        OGIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:40 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:36 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/ffc51743-5ccd-4974-92aa-0808bbde60a5/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/tasks/4b0d3d70-e9ae-43e2-8c19-48b73981b18b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -113,13 +113,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:40 GMT
+      - Wed, 09 Aug 2017 21:53:36 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '553'
+      - '571'
       Connection:
       - close
       Content-Type:
@@ -129,74 +129,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mZmM1MTc0My01Y2NkLTQ5NzQtOTJhYS0wODA4YmJkZTYw
-        YTUvIiwgInRhc2tfaWQiOiAiZmZjNTE3NDMtNWNjZC00OTc0LTkyYWEtMDgw
-        OGJiZGU2MGE1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUi
-        OiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBu
-        dWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwg
-        InByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJz
-        dGF0ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTkw
-        YjQyNTQzZjdhZDU5MzI4NTEzNzkxIn0sICJpZCI6ICI1OTBiNDI1NDNmN2Fk
-        NTkzMjg1MTM3OTEifQ==
-    http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:40 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/ffc51743-5ccd-4974-92aa-0808bbde60a5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 May 2017 15:01:40 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '649'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mZmM1MTc0My01Y2NkLTQ5NzQtOTJhYS0wODA4YmJkZTYw
-        YTUvIiwgInRhc2tfaWQiOiAiZmZjNTE3NDMtNWNjZC00OTc0LTkyYWEtMDgw
-        OGJiZGU2MGE1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy80YjBkM2Q3MC1lOWFlLTQzZTItOGMxOS00OGI3Mzk4MWIx
+        OGIvIiwgInRhc2tfaWQiOiAiNGIwZDNkNzAtZTlhZS00M2UyLThjMTktNDhi
+        NzM5ODFiMThiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUi
         OiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAi
-        MjAxNy0wNS0wNFQxNTowMTo0MFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNw
+        MjAxNy0wOC0wOVQyMTo1MzozNloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNw
         YXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVl
-        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2LmV4YW1wbGUu
-        Y29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2LmV4YW1wbGUuY29tIiwg
-        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNTkwYjQyNTQzZjdhZDU5MzI4NTEzNzkxIn0sICJpZCI6ICI1OTBiNDI1
-        NDNmN2FkNTkzMjg1MTM3OTEifQ==
+        dWUiOiAiTm9uZS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9u
+        YW1lIjogbnVsbCwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNTk4Yjg0NjBiYmM2ZjRiOTM2NWY5MGY0In0sICJp
+        ZCI6ICI1OThiODQ2MGJiYzZmNGI5MzY1ZjkwZjQifQ==
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:40 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:36 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/ffc51743-5ccd-4974-92aa-0808bbde60a5/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/tasks/4b0d3d70-e9ae-43e2-8c19-48b73981b18b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -215,13 +163,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:40 GMT
+      - Wed, 09 Aug 2017 21:53:36 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '649'
+      - '669'
       Connection:
       - close
       Content-Type:
@@ -231,24 +179,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mZmM1MTc0My01Y2NkLTQ5NzQtOTJhYS0wODA4YmJkZTYw
-        YTUvIiwgInRhc2tfaWQiOiAiZmZjNTE3NDMtNWNjZC00OTc0LTkyYWEtMDgw
-        OGJiZGU2MGE1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy80YjBkM2Q3MC1lOWFlLTQzZTItOGMxOS00OGI3Mzk4MWIx
+        OGIvIiwgInRhc2tfaWQiOiAiNGIwZDNkNzAtZTlhZS00M2UyLThjMTktNDhi
+        NzM5ODFiMThiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUi
         OiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAi
-        MjAxNy0wNS0wNFQxNTowMTo0MFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNw
+        MjAxNy0wOC0wOVQyMTo1MzozNloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNw
         YXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVl
-        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2LmV4YW1wbGUu
-        Y29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2LmV4YW1wbGUuY29tIiwg
-        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNTkwYjQyNTQzZjdhZDU5MzI4NTEzNzkxIn0sICJpZCI6ICI1OTBiNDI1
-        NDNmN2FkNTkzMjg1MTM3OTEifQ==
+        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAY2VudG9zNy1kZXZs
+        Mi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczct
+        ZGV2bDIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjog
+        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1OThiODQ2MGJiYzZmNGI5MzY1Zjkw
+        ZjQifSwgImlkIjogIjU5OGI4NDYwYmJjNmY0YjkzNjVmOTBmNCJ9
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:40 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:36 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/ffc51743-5ccd-4974-92aa-0808bbde60a5/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/tasks/4b0d3d70-e9ae-43e2-8c19-48b73981b18b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -267,13 +215,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:40 GMT
+      - Wed, 09 Aug 2017 21:53:36 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '668'
+      - '688'
       Connection:
       - close
       Content-Type:
@@ -283,24 +231,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mZmM1MTc0My01Y2NkLTQ5NzQtOTJhYS0wODA4YmJkZTYw
-        YTUvIiwgInRhc2tfaWQiOiAiZmZjNTE3NDMtNWNjZC00OTc0LTkyYWEtMDgw
-        OGJiZGU2MGE1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy80YjBkM2Q3MC1lOWFlLTQzZTItOGMxOS00OGI3Mzk4MWIx
+        OGIvIiwgInRhc2tfaWQiOiAiNGIwZDNkNzAtZTlhZS00M2UyLThjMTktNDhi
+        NzM5ODFiMThiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUi
-        OiAiMjAxNy0wNS0wNFQxNTowMTo0MFoiLCAiX25zIjogInRhc2tfc3RhdHVz
-        IiwgInN0YXJ0X3RpbWUiOiAiMjAxNy0wNS0wNFQxNTowMTo0MFoiLCAidHJh
+        OiAiMjAxNy0wOC0wOVQyMTo1MzozNloiLCAiX25zIjogInRhc2tfc3RhdHVz
+        IiwgInN0YXJ0X3RpbWUiOiAiMjAxNy0wOC0wOVQyMTo1MzozNloiLCAidHJh
         Y2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNz
         X3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVk
-        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
-        QGRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU5MGI0MjU0M2Y3YWQ1OTMyODUxMzc5
-        MSJ9LCAiaWQiOiAiNTkwYjQyNTQzZjdhZDU5MzI4NTEzNzkxIn0=
+        a2VyLTFAY2VudG9zNy1kZXZsMi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6
+        ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBjZW50b3M3LWRldmwyLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTk4
+        Yjg0NjBiYmM2ZjRiOTM2NWY5MGY0In0sICJpZCI6ICI1OThiODQ2MGJiYzZm
+        NGI5MzY1ZjkwZjQifQ==
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:40 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:36 GMT
 - request:
     method: delete
-    uri: https://dev.example.com:8443/candlepin/environments/119c4753ff6d3b7bd0b76de6d5a5f94a
+    uri: https://centos7-devl2.example.com:8443/candlepin/environments/119c4753ff6d3b7bd0b76de6d5a5f94a
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -312,9 +261,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
       Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="laefQES5AwOOD4GAUi1cfEowQTs3ekpbcoNbB6zbjsc",
-        oauth_signature="b2HoYYbphi9ZmV62bsTfSPCOIwI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1493910100", oauth_version="1.0"
+      - OAuth oauth_consumer_key="BuwYxVLAM5Q5nfZ5j6auFWWZnaZdQsif", oauth_nonce="Mjc32GESjAGRfluGXQ5Lx8pZsBypGhgxjqT01TMGk",
+        oauth_signature="nYw%2FXtCh4uwpJZSWf8GhRrp4KlY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1502315616", oauth_version="1.0"
       Cp-User:
       - foreman_admin
   response:
@@ -325,19 +274,19 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - fe4d6ed1-a73f-46c5-9dfd-309b27d5e466
+      - 8b0476b5-755f-4381-8795-0211c39896b8
       X-Version:
-      - 2.0.26-1
+      - 2.0.35-1
       Date:
-      - Thu, 04 May 2017 15:01:40 GMT
+      - Wed, 09 Aug 2017 21:53:36 GMT
     body:
       encoding: UTF-8
       base64_string: ''
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:40 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:36 GMT
 - request:
     method: delete
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test
+    uri: https://centos7-devl2.example.com:8443/candlepin/owners/scenario_test
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -349,9 +298,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
       Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="XsEZm71Ped8AKgzIM4vakmWPtcsW2OO1rz9Gct3ImM",
-        oauth_signature="1aGAGqAYXBRFiVkZ%2F1GxMbq5zZM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1493910100", oauth_version="1.0"
+      - OAuth oauth_consumer_key="BuwYxVLAM5Q5nfZ5j6auFWWZnaZdQsif", oauth_nonce="AjdA6KbxTwyEzJrt15CTq8t43tlbxrjIcrUG3WTsLU",
+        oauth_signature="ItO8TOxNKnUU%2F%2Fb1rzI1FarC5OY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1502315616", oauth_version="1.0"
       Cp-User:
       - foreman_admin
   response:
@@ -362,14 +311,14 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - d7700031-9b49-4e1a-b6fa-46514eb29e47
+      - bc87e527-4525-4782-a559-30b1b20e8d85
       X-Version:
-      - 2.0.26-1
+      - 2.0.35-1
       Date:
-      - Thu, 04 May 2017 15:01:40 GMT
+      - Wed, 09 Aug 2017 21:53:36 GMT
     body:
       encoding: UTF-8
       base64_string: ''
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:40 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:37 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/product_create.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/product_create.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/products/
+    uri: https://centos7-devl2.example.com:8443/candlepin/owners/scenario_test/products/
     body:
       encoding: UTF-8
       base64_string: |
@@ -17,9 +17,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp",
-        oauth_nonce="OaEWcUtBz2dcMoyYIgyxULArhObhYzEylk1tT7gFMQ", oauth_signature="EHTOxwUJq0n42PlItJ%2FHumqGkMU%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1496252350", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="BuwYxVLAM5Q5nfZ5j6auFWWZnaZdQsif",
+        oauth_nonce="YGIrPZqMgsqxs4SsyGW0X3aBtLCNGxjPgf23kk", oauth_signature="GL9a1MCRJuRX%2F7NWzkzm74R0QNE%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1502315592", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -36,7 +36,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 232768f9-94cb-4bd8-863b-02130b712a18
+      - b7d95dab-f28c-419a-9077-92aa66c26aa6
       X-Version:
       - 2.0.35-1
       Content-Type:
@@ -44,23 +44,23 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Wed, 31 May 2017 17:39:10 GMT
+      - Wed, 09 Aug 2017 21:53:12 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxNy0wNS0zMVQxNzozOToxMCswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTctMDUtMzFUMTc6Mzk6MTArMDAwMCIsInV1aWQiOiI0MDI4Zjk1
-        MTVjNDYyZmY2MDE1YzVmOTcwMDI1MDFkOSIsImlkIjoiN2M4MjUwMTNjYWIw
+        eyJjcmVhdGVkIjoiMjAxNy0wOC0wOVQyMTo1MzoxMiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTctMDgtMDlUMjE6NTM6MTIrMDAwMCIsInV1aWQiOiI0MDI4Zjk3
+        NTVkYzg3NWNkMDE1ZGM4ZmNiYjhhMDAxNSIsImlkIjoiN2M4MjUwMTNjYWIw
         MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVj
         dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
         IiwidmFsdWUiOiJBTEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJo
-        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOTUxNWM0NjJmZjYwMTVjNWY5NzAwMjUw
-        MWQ5IiwicHJvZHVjdENvbnRlbnQiOltdfQ==
+        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOTc1NWRjODc1Y2QwMTVkYzhmY2JiOGEw
+        MDE1IiwicHJvZHVjdENvbnRlbnQiOltdfQ==
     http_version: 
-  recorded_at: Wed, 31 May 2017 17:39:10 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:12 GMT
 - request:
     method: post
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/subscriptions
+    uri: https://centos7-devl2.example.com:8443/candlepin/owners/scenario_test/subscriptions
     body:
       encoding: UTF-8
       base64_string: |
@@ -77,9 +77,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp",
-        oauth_nonce="iGe47NWUC4JuCCMM6k802QWuC4ae5q3Klp0uVvUq1w", oauth_signature="BC5%2BaLBM%2FdELopNjLkvjKZ%2FfL%2Bs%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1496252350", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="BuwYxVLAM5Q5nfZ5j6auFWWZnaZdQsif",
+        oauth_nonce="6eyXO5bdFm54MqvkhfKbMxjY6mafGiZf3g7XTFjSavQ", oauth_signature="ZjLJZbANYUPt2Wo4oTADeTuml%2F0%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1502315592", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -96,7 +96,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 9f1afeb3-d527-4928-bd70-1c82a3a08dd6
+      - 1baf1747-8e78-4e49-998c-6a443b62ed88
       X-Version:
       - 2.0.35-1
       Content-Type:
@@ -104,13 +104,13 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Wed, 31 May 2017 17:39:10 GMT
+      - Wed, 09 Aug 2017 21:53:12 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjpudWxsLCJ1cGRhdGVkIjpudWxsLCJpZCI6IjQ4MjEwMzhk
-        ZjNjMDRiNDJhMTVjZjYwOTExNGQ2YTU0Iiwib3duZXIiOnsiaWQiOiI0MDI4
-        Zjk1MTVjNDYyZmY2MDE1YzVmOTZmY2IxMDFkNSIsImtleSI6InNjZW5hcmlv
+        eyJjcmVhdGVkIjpudWxsLCJ1cGRhdGVkIjpudWxsLCJpZCI6ImJjODMzYWJk
+        Y2Q3YzQ0ODk4ZmIwNDk1MGU1MmVlZTkyIiwib3duZXIiOnsiaWQiOiI0MDI4
+        Zjk3NTVkYzg3NWNkMDE1ZGM4ZmNiN2VhMDAxMSIsImtleSI6InNjZW5hcmlv
         X3Rlc3QiLCJkaXNwbGF5TmFtZSI6InNjZW5hcmlvX3Rlc3QiLCJocmVmIjoi
         L293bmVycy9zY2VuYXJpb190ZXN0In0sInByb2R1Y3QiOnsiY3JlYXRlZCI6
         bnVsbCwidXBkYXRlZCI6bnVsbCwidXVpZCI6bnVsbCwiaWQiOiI3YzgyNTAx
@@ -127,10 +127,10 @@ http_interactions:
         bnN1bWVySWQiOm51bGwsImNkbiI6bnVsbCwic3RhY2tlZCI6ZmFsc2UsInN0
         YWNrSWQiOm51bGwsImNlcnRpZmljYXRlIjpudWxsfQ==
     http_version: 
-  recorded_at: Wed, 31 May 2017 17:39:10 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:12 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/events/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/events/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -149,13 +149,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 31 May 2017 17:39:10 GMT
+      - Wed, 09 Aug 2017 21:53:12 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '338'
+      - '280'
       Connection:
       - close
       Content-Type:
@@ -163,104 +163,18 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2V2ZW50cy81OTI1YWE5YzQxOGE4
-        YTZmOWJhY2FjNDkvIiwgIm5vdGlmaWVyX2NvbmZpZyI6IHsidXJsIjogImh0
-        dHBzOi8vZGV2LmV4YW1wbGUuY29tL2thdGVsbG8vYXBpL3YyL3JlcG9zaXRv
-        cmllcy9zeW5jX2NvbXBsZXRlP3Rva2VuPXRlc3QifSwgIl9ucyI6ICJldmVu
-        dF9saXN0ZW5lcnMiLCAiZXZlbnRfdHlwZXMiOiBbInJlcG8uc3luYy5maW5p
-        c2giXSwgIl9pZCI6IHsiJG9pZCI6ICI1OTI1YWE5YzQxOGE4YTZmOWJhY2Fj
-        NDkifSwgImlkIjogIjU5MjVhYTljNDE4YThhNmY5YmFjYWM0OSIsICJub3Rp
-        Zmllcl90eXBlX2lkIjogImh0dHAifV0=
+        W3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2V2ZW50cy81OThiODJlMmQwMzVj
+        YTAzZDE1MTI3NWMvIiwgIm5vdGlmaWVyX2NvbmZpZyI6IHsidXJsIjogImh0
+        dHA6Ly9mb29iYXIuY29tLyJ9LCAiX25zIjogImV2ZW50X2xpc3RlbmVycyIs
+        ICJldmVudF90eXBlcyI6IFsicmVwby5zeW5jLmZpbmlzaCJdLCAiX2lkIjog
+        eyIkb2lkIjogIjU5OGI4MmUyZDAzNWNhMDNkMTUxMjc1YyJ9LCAiaWQiOiAi
+        NTk4YjgyZTJkMDM1Y2EwM2QxNTEyNzVjIiwgIm5vdGlmaWVyX3R5cGVfaWQi
+        OiAiaHR0cCJ9XQ==
     http_version: 
-  recorded_at: Wed, 31 May 2017 17:39:10 GMT
-- request:
-    method: delete
-    uri: https://dev.example.com/pulp/api/v2/events/5925aa9c418a8a6f9bacac49/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 31 May 2017 17:39:10 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '4'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        bnVsbA==
-    http_version: 
-  recorded_at: Wed, 31 May 2017 17:39:10 GMT
-- request:
-    method: post
-    uri: https://dev.example.com/pulp/api/v2/events/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJub3RpZmllcl90eXBlX2lkIjoiaHR0cCIsIm5vdGlmaWVyX2NvbmZpZyI6
-        eyJ1cmwiOiJodHRwOi8vZm9vYmFyLmNvbS8ifSwiZXZlbnRfdHlwZXMiOlsi
-        cmVwby5zeW5jLmZpbmlzaCJdfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '109'
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Wed, 31 May 2017 17:39:10 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '278'
-      Location:
-      - https://dev.example.com/pulp/api/v2/events/592effbe418a8a2b068f2a62/
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJfaHJlZiI6ICIvcHVscC9hcGkvdjIvZXZlbnRzLzU5MmVmZmJlNDE4YThh
-        MmIwNjhmMmE2Mi8iLCAibm90aWZpZXJfY29uZmlnIjogeyJ1cmwiOiAiaHR0
-        cDovL2Zvb2Jhci5jb20vIn0sICJfbnMiOiAiZXZlbnRfbGlzdGVuZXJzIiwg
-        ImV2ZW50X3R5cGVzIjogWyJyZXBvLnN5bmMuZmluaXNoIl0sICJfaWQiOiB7
-        IiRvaWQiOiAiNTkyZWZmYmU0MThhOGEyYjA2OGYyYTYyIn0sICJpZCI6ICI1
-        OTJlZmZiZTQxOGE4YTJiMDY4ZjJhNjIiLCAibm90aWZpZXJfdHlwZV9pZCI6
-        ICJodHRwIn0=
-    http_version: 
-  recorded_at: Wed, 31 May 2017 17:39:10 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:12 GMT
 - request:
     method: get
-    uri: https://dev.example.com:8443/candlepin/subscriptions/4821038df3c04b42a15cf609114d6a54
+    uri: https://centos7-devl2.example.com:8443/candlepin/subscriptions/bc833abdcd7c44898fb04950e52eee92
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -272,9 +186,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
       Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="UArzBjEFgVnikQoop86O5eBVaiy2gTL0eCL3IflbXwc",
-        oauth_signature="7D5yC3lrKztTftTWgmy8OgL0Y0w%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1496252350", oauth_version="1.0"
+      - OAuth oauth_consumer_key="BuwYxVLAM5Q5nfZ5j6auFWWZnaZdQsif", oauth_nonce="5YZAuao8prgjSU0xdrL7hYyKijHlWT2lrokEXtwl14",
+        oauth_signature="o3ziLPX%2FFy2UIs%2FKsQwWlrUxzaQ%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1502315592", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -289,7 +203,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 77bbbca8-106a-49e2-a829-ea708ee0ed85
+      - c2faed50-611d-4e05-947a-0cfdcbed182c
       X-Version:
       - 2.0.35-1
       Content-Type:
@@ -297,38 +211,38 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Wed, 31 May 2017 17:39:10 GMT
+      - Wed, 09 Aug 2017 21:53:12 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxNy0wNS0zMVQxNzozOToxMCswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTctMDUtMzFUMTc6Mzk6MTArMDAwMCIsImlkIjoiNDgyMTAzOGRm
-        M2MwNGI0MmExNWNmNjA5MTE0ZDZhNTQiLCJvd25lciI6eyJpZCI6IjQwMjhm
-        OTUxNWM0NjJmZjYwMTVjNWY5NmZjYjEwMWQ1Iiwia2V5Ijoic2NlbmFyaW9f
+        eyJjcmVhdGVkIjoiMjAxNy0wOC0wOVQyMTo1MzoxMiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTctMDgtMDlUMjE6NTM6MTIrMDAwMCIsImlkIjoiYmM4MzNhYmRj
+        ZDdjNDQ4OThmYjA0OTUwZTUyZWVlOTIiLCJvd25lciI6eyJpZCI6IjQwMjhm
+        OTc1NWRjODc1Y2QwMTVkYzhmY2I3ZWEwMDExIiwia2V5Ijoic2NlbmFyaW9f
         dGVzdCIsImRpc3BsYXlOYW1lIjoic2NlbmFyaW9fdGVzdCIsImhyZWYiOiIv
         b3duZXJzL3NjZW5hcmlvX3Rlc3QifSwicHJvZHVjdCI6eyJjcmVhdGVkIjoi
-        MjAxNy0wNS0zMVQxNzozOToxMCswMDAwIiwidXBkYXRlZCI6IjIwMTctMDUt
-        MzFUMTc6Mzk6MTArMDAwMCIsInV1aWQiOiI0MDI4Zjk1MTVjNDYyZmY2MDE1
-        YzVmOTcwMDI1MDFkOSIsImlkIjoiN2M4MjUwMTNjYWIwMTM0OWFlOGNiOGRi
+        MjAxNy0wOC0wOVQyMTo1MzoxMiswMDAwIiwidXBkYXRlZCI6IjIwMTctMDgt
+        MDlUMjE6NTM6MTIrMDAwMCIsInV1aWQiOiI0MDI4Zjk3NTVkYzg3NWNkMDE1
+        ZGM4ZmNiYjhhMDAxNSIsImlkIjoiN2M4MjUwMTNjYWIwMTM0OWFlOGNiOGRi
         MTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVjdCIsIm11bHRpcGxp
         ZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNoIiwidmFsdWUiOiJB
         TEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJocmVmIjoiL3Byb2R1
-        Y3RzLzQwMjhmOTUxNWM0NjJmZjYwMTVjNWY5NzAwMjUwMWQ5IiwicHJvZHVj
+        Y3RzLzQwMjhmOTc1NWRjODc1Y2QwMTVkYzhmY2JiOGEwMDE1IiwicHJvZHVj
         dENvbnRlbnQiOltdfSwiZGVyaXZlZFByb2R1Y3QiOm51bGwsInByb3ZpZGVk
         UHJvZHVjdHMiOltdLCJkZXJpdmVkUHJvdmlkZWRQcm9kdWN0cyI6W10sImJy
         YW5kaW5nIjpbXSwicXVhbnRpdHkiOi0xLCJzdGFydERhdGUiOiIyMDE3LTAx
         LTAxVDIwOjE1OjAxKzAwMDAiLCJlbmREYXRlIjoiMjA0Ni0xMi0yNVQyMDox
         NTowMSswMDAwIiwiY29udHJhY3ROdW1iZXIiOm51bGwsImFjY291bnROdW1i
-        ZXIiOm51bGwsIm1vZGlmaWVkIjoiMjAxNy0wNS0zMVQxNzozOToxMCswMDAw
+        ZXIiOm51bGwsIm1vZGlmaWVkIjoiMjAxNy0wOC0wOVQyMTo1MzoxMiswMDAw
         Iiwib3JkZXJOdW1iZXIiOm51bGwsInVwc3RyZWFtUG9vbElkIjpudWxsLCJ1
         cHN0cmVhbUVudGl0bGVtZW50SWQiOm51bGwsInVwc3RyZWFtQ29uc3VtZXJJ
         ZCI6bnVsbCwiY2RuIjpudWxsLCJzdGFja2VkIjpmYWxzZSwic3RhY2tJZCI6
         bnVsbCwiY2VydGlmaWNhdGUiOm51bGx9
     http_version: 
-  recorded_at: Wed, 31 May 2017 17:39:10 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:12 GMT
 - request:
     method: get
-    uri: https://dev.example.com:8443/candlepin/subscriptions/4821038df3c04b42a15cf609114d6a54
+    uri: https://centos7-devl2.example.com:8443/candlepin/subscriptions/bc833abdcd7c44898fb04950e52eee92
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -340,9 +254,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
       Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="RrXLuckBhopvK1gEmwWAyiKiN2dajgPV3mJ0Dk",
-        oauth_signature="%2ByzH0MoafI%2F4diQsDcUWdNFaCBk%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1496252350", oauth_version="1.0"
+      - OAuth oauth_consumer_key="BuwYxVLAM5Q5nfZ5j6auFWWZnaZdQsif", oauth_nonce="z57kP3jscXNpIcQnc8lhhhejSXLK1SGTmrNjSwKZ4c",
+        oauth_signature="tXPv2Hv5w3ijj5eObi9spsKmzbs%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1502315592", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -357,7 +271,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - eeace53a-be32-40df-b5f9-c409b21a8c97
+      - 7e280d09-f7bc-4091-8067-0e9d51f1a8c5
       X-Version:
       - 2.0.35-1
       Content-Type:
@@ -365,38 +279,38 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Wed, 31 May 2017 17:39:10 GMT
+      - Wed, 09 Aug 2017 21:53:12 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxNy0wNS0zMVQxNzozOToxMCswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTctMDUtMzFUMTc6Mzk6MTArMDAwMCIsImlkIjoiNDgyMTAzOGRm
-        M2MwNGI0MmExNWNmNjA5MTE0ZDZhNTQiLCJvd25lciI6eyJpZCI6IjQwMjhm
-        OTUxNWM0NjJmZjYwMTVjNWY5NmZjYjEwMWQ1Iiwia2V5Ijoic2NlbmFyaW9f
+        eyJjcmVhdGVkIjoiMjAxNy0wOC0wOVQyMTo1MzoxMiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTctMDgtMDlUMjE6NTM6MTIrMDAwMCIsImlkIjoiYmM4MzNhYmRj
+        ZDdjNDQ4OThmYjA0OTUwZTUyZWVlOTIiLCJvd25lciI6eyJpZCI6IjQwMjhm
+        OTc1NWRjODc1Y2QwMTVkYzhmY2I3ZWEwMDExIiwia2V5Ijoic2NlbmFyaW9f
         dGVzdCIsImRpc3BsYXlOYW1lIjoic2NlbmFyaW9fdGVzdCIsImhyZWYiOiIv
         b3duZXJzL3NjZW5hcmlvX3Rlc3QifSwicHJvZHVjdCI6eyJjcmVhdGVkIjoi
-        MjAxNy0wNS0zMVQxNzozOToxMCswMDAwIiwidXBkYXRlZCI6IjIwMTctMDUt
-        MzFUMTc6Mzk6MTArMDAwMCIsInV1aWQiOiI0MDI4Zjk1MTVjNDYyZmY2MDE1
-        YzVmOTcwMDI1MDFkOSIsImlkIjoiN2M4MjUwMTNjYWIwMTM0OWFlOGNiOGRi
+        MjAxNy0wOC0wOVQyMTo1MzoxMiswMDAwIiwidXBkYXRlZCI6IjIwMTctMDgt
+        MDlUMjE6NTM6MTIrMDAwMCIsInV1aWQiOiI0MDI4Zjk3NTVkYzg3NWNkMDE1
+        ZGM4ZmNiYjhhMDAxNSIsImlkIjoiN2M4MjUwMTNjYWIwMTM0OWFlOGNiOGRi
         MTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVjdCIsIm11bHRpcGxp
         ZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNoIiwidmFsdWUiOiJB
         TEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJocmVmIjoiL3Byb2R1
-        Y3RzLzQwMjhmOTUxNWM0NjJmZjYwMTVjNWY5NzAwMjUwMWQ5IiwicHJvZHVj
+        Y3RzLzQwMjhmOTc1NWRjODc1Y2QwMTVkYzhmY2JiOGEwMDE1IiwicHJvZHVj
         dENvbnRlbnQiOltdfSwiZGVyaXZlZFByb2R1Y3QiOm51bGwsInByb3ZpZGVk
         UHJvZHVjdHMiOltdLCJkZXJpdmVkUHJvdmlkZWRQcm9kdWN0cyI6W10sImJy
         YW5kaW5nIjpbXSwicXVhbnRpdHkiOi0xLCJzdGFydERhdGUiOiIyMDE3LTAx
         LTAxVDIwOjE1OjAxKzAwMDAiLCJlbmREYXRlIjoiMjA0Ni0xMi0yNVQyMDox
         NTowMSswMDAwIiwiY29udHJhY3ROdW1iZXIiOm51bGwsImFjY291bnROdW1i
-        ZXIiOm51bGwsIm1vZGlmaWVkIjoiMjAxNy0wNS0zMVQxNzozOToxMCswMDAw
+        ZXIiOm51bGwsIm1vZGlmaWVkIjoiMjAxNy0wOC0wOVQyMTo1MzoxMiswMDAw
         Iiwib3JkZXJOdW1iZXIiOm51bGwsInVwc3RyZWFtUG9vbElkIjpudWxsLCJ1
         cHN0cmVhbUVudGl0bGVtZW50SWQiOm51bGwsInVwc3RyZWFtQ29uc3VtZXJJ
         ZCI6bnVsbCwiY2RuIjpudWxsLCJzdGFja2VkIjpmYWxzZSwic3RhY2tJZCI6
         bnVsbCwiY2VydGlmaWNhdGUiOm51bGx9
     http_version: 
-  recorded_at: Wed, 31 May 2017 17:39:10 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:12 GMT
 - request:
     method: get
-    uri: https://dev.example.com:8443/candlepin/subscriptions/4821038df3c04b42a15cf609114d6a54
+    uri: https://centos7-devl2.example.com:8443/candlepin/subscriptions/bc833abdcd7c44898fb04950e52eee92
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -408,9 +322,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
       Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="XEUX0oGoSUluGn4Odid2ZlOHimqUPtWc3m67ovoFI",
-        oauth_signature="hORVwKO9WQ7aLxzWDm6P%2F1EEd0w%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1496252350", oauth_version="1.0"
+      - OAuth oauth_consumer_key="BuwYxVLAM5Q5nfZ5j6auFWWZnaZdQsif", oauth_nonce="B2dzCDfZFDN5CyGW6Q4wVeTXVGK0sLQjS4AkDxc7f7s",
+        oauth_signature="Wq%2FyT047EEOr3g2oYLFjxhl9eIY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1502315592", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -425,7 +339,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 7df3899f-5ede-4028-a3e7-4cf62115b6cf
+      - 755068f9-7b5c-4b40-a287-307272937970
       X-Version:
       - 2.0.35-1
       Content-Type:
@@ -433,38 +347,38 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Wed, 31 May 2017 17:39:10 GMT
+      - Wed, 09 Aug 2017 21:53:12 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxNy0wNS0zMVQxNzozOToxMCswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTctMDUtMzFUMTc6Mzk6MTArMDAwMCIsImlkIjoiNDgyMTAzOGRm
-        M2MwNGI0MmExNWNmNjA5MTE0ZDZhNTQiLCJvd25lciI6eyJpZCI6IjQwMjhm
-        OTUxNWM0NjJmZjYwMTVjNWY5NmZjYjEwMWQ1Iiwia2V5Ijoic2NlbmFyaW9f
+        eyJjcmVhdGVkIjoiMjAxNy0wOC0wOVQyMTo1MzoxMiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTctMDgtMDlUMjE6NTM6MTIrMDAwMCIsImlkIjoiYmM4MzNhYmRj
+        ZDdjNDQ4OThmYjA0OTUwZTUyZWVlOTIiLCJvd25lciI6eyJpZCI6IjQwMjhm
+        OTc1NWRjODc1Y2QwMTVkYzhmY2I3ZWEwMDExIiwia2V5Ijoic2NlbmFyaW9f
         dGVzdCIsImRpc3BsYXlOYW1lIjoic2NlbmFyaW9fdGVzdCIsImhyZWYiOiIv
         b3duZXJzL3NjZW5hcmlvX3Rlc3QifSwicHJvZHVjdCI6eyJjcmVhdGVkIjoi
-        MjAxNy0wNS0zMVQxNzozOToxMCswMDAwIiwidXBkYXRlZCI6IjIwMTctMDUt
-        MzFUMTc6Mzk6MTArMDAwMCIsInV1aWQiOiI0MDI4Zjk1MTVjNDYyZmY2MDE1
-        YzVmOTcwMDI1MDFkOSIsImlkIjoiN2M4MjUwMTNjYWIwMTM0OWFlOGNiOGRi
+        MjAxNy0wOC0wOVQyMTo1MzoxMiswMDAwIiwidXBkYXRlZCI6IjIwMTctMDgt
+        MDlUMjE6NTM6MTIrMDAwMCIsInV1aWQiOiI0MDI4Zjk3NTVkYzg3NWNkMDE1
+        ZGM4ZmNiYjhhMDAxNSIsImlkIjoiN2M4MjUwMTNjYWIwMTM0OWFlOGNiOGRi
         MTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVjdCIsIm11bHRpcGxp
         ZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNoIiwidmFsdWUiOiJB
         TEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJocmVmIjoiL3Byb2R1
-        Y3RzLzQwMjhmOTUxNWM0NjJmZjYwMTVjNWY5NzAwMjUwMWQ5IiwicHJvZHVj
+        Y3RzLzQwMjhmOTc1NWRjODc1Y2QwMTVkYzhmY2JiOGEwMDE1IiwicHJvZHVj
         dENvbnRlbnQiOltdfSwiZGVyaXZlZFByb2R1Y3QiOm51bGwsInByb3ZpZGVk
         UHJvZHVjdHMiOltdLCJkZXJpdmVkUHJvdmlkZWRQcm9kdWN0cyI6W10sImJy
         YW5kaW5nIjpbXSwicXVhbnRpdHkiOi0xLCJzdGFydERhdGUiOiIyMDE3LTAx
         LTAxVDIwOjE1OjAxKzAwMDAiLCJlbmREYXRlIjoiMjA0Ni0xMi0yNVQyMDox
         NTowMSswMDAwIiwiY29udHJhY3ROdW1iZXIiOm51bGwsImFjY291bnROdW1i
-        ZXIiOm51bGwsIm1vZGlmaWVkIjoiMjAxNy0wNS0zMVQxNzozOToxMCswMDAw
+        ZXIiOm51bGwsIm1vZGlmaWVkIjoiMjAxNy0wOC0wOVQyMTo1MzoxMiswMDAw
         Iiwib3JkZXJOdW1iZXIiOm51bGwsInVwc3RyZWFtUG9vbElkIjpudWxsLCJ1
         cHN0cmVhbUVudGl0bGVtZW50SWQiOm51bGwsInVwc3RyZWFtQ29uc3VtZXJJ
         ZCI6bnVsbCwiY2RuIjpudWxsLCJzdGFja2VkIjpmYWxzZSwic3RhY2tJZCI6
         bnVsbCwiY2VydGlmaWNhdGUiOm51bGx9
     http_version: 
-  recorded_at: Wed, 31 May 2017 17:39:10 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:12 GMT
 - request:
     method: get
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/pools?add_future=true
+    uri: https://centos7-devl2.example.com:8443/candlepin/owners/scenario_test/pools?add_future=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -476,9 +390,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
       Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="hBEgUkL5yhEp7ag3wYAUxrtSPgD3BNkAWJxqI9EJAk8",
-        oauth_signature="tjhaafejDJk1KiSghOMecv7UXI0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1496252350", oauth_version="1.0"
+      - OAuth oauth_consumer_key="BuwYxVLAM5Q5nfZ5j6auFWWZnaZdQsif", oauth_nonce="QDWfI6jopzRz96DhUZ9GNtNMUiTkat2mKemhFEJSM",
+        oauth_signature="8RhFqs0%2F2F03DouV8W3qPRhE1bs%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1502315592", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -493,7 +407,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 91e30fa7-1198-45c2-a730-7cf2de417233
+      - ac17e8aa-7391-4e08-91bc-4f8641a21b3d
       X-Version:
       - 2.0.35-1
       Content-Type:
@@ -501,35 +415,35 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Wed, 31 May 2017 17:39:10 GMT
+      - Wed, 09 Aug 2017 21:53:12 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        W3siaWQiOiI0MDI4Zjk1MTVjNDYyZmY2MDE1YzVmOTcwMDY2MDFkYSIsInR5
-        cGUiOiJOT1JNQUwiLCJvd25lciI6eyJpZCI6IjQwMjhmOTUxNWM0NjJmZjYw
-        MTVjNWY5NmZjYjEwMWQ1Iiwia2V5Ijoic2NlbmFyaW9fdGVzdCIsImRpc3Bs
+        W3siaWQiOiI0MDI4Zjk3NTVkYzg3NWNkMDE1ZGM4ZmNiYmNlMDAxNiIsInR5
+        cGUiOiJOT1JNQUwiLCJvd25lciI6eyJpZCI6IjQwMjhmOTc1NWRjODc1Y2Qw
+        MTVkYzhmY2I3ZWEwMDExIiwia2V5Ijoic2NlbmFyaW9fdGVzdCIsImRpc3Bs
         YXlOYW1lIjoic2NlbmFyaW9fdGVzdCIsImhyZWYiOiIvb3duZXJzL3NjZW5h
         cmlvX3Rlc3QifSwiYWN0aXZlU3Vic2NyaXB0aW9uIjp0cnVlLCJxdWFudGl0
         eSI6LTEsInN0YXJ0RGF0ZSI6IjIwMTctMDEtMDFUMjA6MTU6MDErMDAwMCIs
         ImVuZERhdGUiOiIyMDQ2LTEyLTI1VDIwOjE1OjAxKzAwMDAiLCJhdHRyaWJ1
         dGVzIjpbXSwiY29uc3VtZWQiOjAsImV4cG9ydGVkIjowLCJicmFuZGluZyI6
         W10sImNhbGN1bGF0ZWRBdHRyaWJ1dGVzIjp7ImNvbXBsaWFuY2VfdHlwZSI6
-        IlN0YW5kYXJkIn0sInByb2R1Y3RJZCI6IjdjODI1MDEzY2FiMDEzNDlhZThj
-        YjhkYjE4N2RlMzkxIiwicHJvZHVjdEF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJh
-        cmNoIiwidmFsdWUiOiJBTEwifV0sImRlcml2ZWRQcm9kdWN0QXR0cmlidXRl
-        cyI6W10sInByb2R1Y3ROYW1lIjoiU2NlbmFyaW8gUHJvZHVjdCIsInN0YWNr
-        ZWQiOmZhbHNlLCJkZXZlbG9wbWVudFBvb2wiOmZhbHNlLCJocmVmIjoiL3Bv
-        b2xzLzQwMjhmOTUxNWM0NjJmZjYwMTVjNWY5NzAwNjYwMWRhIiwiY3JlYXRl
-        ZCI6IjIwMTctMDUtMzFUMTc6Mzk6MTArMDAwMCIsInVwZGF0ZWQiOiIyMDE3
-        LTA1LTMxVDE3OjM5OjEwKzAwMDAiLCJwcm92aWRlZFByb2R1Y3RzIjpbXSwi
+        IlN0YW5kYXJkIn0sInByb2R1Y3RBdHRyaWJ1dGVzIjpbeyJuYW1lIjoiYXJj
+        aCIsInZhbHVlIjoiQUxMIn1dLCJkZXJpdmVkUHJvZHVjdEF0dHJpYnV0ZXMi
+        OltdLCJwcm9kdWN0SWQiOiI3YzgyNTAxM2NhYjAxMzQ5YWU4Y2I4ZGIxODdk
+        ZTM5MSIsImhyZWYiOiIvcG9vbHMvNDAyOGY5NzU1ZGM4NzVjZDAxNWRjOGZj
+        YmJjZTAwMTYiLCJwcm9kdWN0TmFtZSI6IlNjZW5hcmlvIFByb2R1Y3QiLCJz
+        dGFja2VkIjpmYWxzZSwiZGV2ZWxvcG1lbnRQb29sIjpmYWxzZSwiY3JlYXRl
+        ZCI6IjIwMTctMDgtMDlUMjE6NTM6MTIrMDAwMCIsInVwZGF0ZWQiOiIyMDE3
+        LTA4LTA5VDIxOjUzOjEyKzAwMDAiLCJwcm92aWRlZFByb2R1Y3RzIjpbXSwi
         ZGVyaXZlZFByb3ZpZGVkUHJvZHVjdHMiOltdLCJzdWJzY3JpcHRpb25JZCI6
-        IjQ4MjEwMzhkZjNjMDRiNDJhMTVjZjYwOTExNGQ2YTU0Iiwic3Vic2NyaXB0
+        ImJjODMzYWJkY2Q3YzQ0ODk4ZmIwNDk1MGU1MmVlZTkyIiwic3Vic2NyaXB0
         aW9uU3ViS2V5IjoibWFzdGVyIn1d
     http_version: 
-  recorded_at: Wed, 31 May 2017 17:39:11 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:13 GMT
 - request:
     method: get
-    uri: https://dev.example.com:8443/candlepin/pools/4028f9515c462ff6015c5f97006601da
+    uri: https://centos7-devl2.example.com:8443/candlepin/pools/4028f9755dc875cd015dc8fcbbce0016
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -541,9 +455,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
       Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="SYtwvpyf6lgavRZlPqXnKE8kCPWeAdcTwDip02GIVHg",
-        oauth_signature="OaE4ZhPEnDRrCAXvWs8Q%2FB5Pto0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1496252351", oauth_version="1.0"
+      - OAuth oauth_consumer_key="BuwYxVLAM5Q5nfZ5j6auFWWZnaZdQsif", oauth_nonce="lEGx54lFyiJY4XhBek2VR4lJUOC9A0Dvl5SxQa2QA",
+        oauth_signature="OcuodXh9b2nzlLT2BuRi6UYgpZo%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1502315593", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -558,7 +472,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 90f5f075-e575-4dbb-afd4-97efd87747ee
+      - 24935bb4-b443-41d0-9fe3-57c99127cb5a
       X-Version:
       - 2.0.35-1
       Content-Type:
@@ -566,35 +480,35 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Wed, 31 May 2017 17:39:10 GMT
+      - Wed, 09 Aug 2017 21:53:12 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJpZCI6IjQwMjhmOTUxNWM0NjJmZjYwMTVjNWY5NzAwNjYwMWRhIiwidHlw
-        ZSI6Ik5PUk1BTCIsIm93bmVyIjp7ImlkIjoiNDAyOGY5NTE1YzQ2MmZmNjAx
-        NWM1Zjk2ZmNiMTAxZDUiLCJrZXkiOiJzY2VuYXJpb190ZXN0IiwiZGlzcGxh
+        eyJpZCI6IjQwMjhmOTc1NWRjODc1Y2QwMTVkYzhmY2JiY2UwMDE2IiwidHlw
+        ZSI6Ik5PUk1BTCIsIm93bmVyIjp7ImlkIjoiNDAyOGY5NzU1ZGM4NzVjZDAx
+        NWRjOGZjYjdlYTAwMTEiLCJrZXkiOiJzY2VuYXJpb190ZXN0IiwiZGlzcGxh
         eU5hbWUiOiJzY2VuYXJpb190ZXN0IiwiaHJlZiI6Ii9vd25lcnMvc2NlbmFy
         aW9fdGVzdCJ9LCJhY3RpdmVTdWJzY3JpcHRpb24iOnRydWUsInF1YW50aXR5
         IjotMSwic3RhcnREYXRlIjoiMjAxNy0wMS0wMVQyMDoxNTowMSswMDAwIiwi
         ZW5kRGF0ZSI6IjIwNDYtMTItMjVUMjA6MTU6MDErMDAwMCIsImF0dHJpYnV0
         ZXMiOltdLCJjb25zdW1lZCI6MCwiZXhwb3J0ZWQiOjAsImJyYW5kaW5nIjpb
         XSwiY2FsY3VsYXRlZEF0dHJpYnV0ZXMiOnsiY29tcGxpYW5jZV90eXBlIjoi
-        U3RhbmRhcmQifSwicHJvZHVjdElkIjoiN2M4MjUwMTNjYWIwMTM0OWFlOGNi
-        OGRiMTg3ZGUzOTEiLCJwcm9kdWN0QXR0cmlidXRlcyI6W3sibmFtZSI6ImFy
-        Y2giLCJ2YWx1ZSI6IkFMTCJ9XSwiZGVyaXZlZFByb2R1Y3RBdHRyaWJ1dGVz
-        IjpbXSwicHJvZHVjdE5hbWUiOiJTY2VuYXJpbyBQcm9kdWN0Iiwic3RhY2tl
-        ZCI6ZmFsc2UsImRldmVsb3BtZW50UG9vbCI6ZmFsc2UsImhyZWYiOiIvcG9v
-        bHMvNDAyOGY5NTE1YzQ2MmZmNjAxNWM1Zjk3MDA2NjAxZGEiLCJjcmVhdGVk
-        IjoiMjAxNy0wNS0zMVQxNzozOToxMCswMDAwIiwidXBkYXRlZCI6IjIwMTct
-        MDUtMzFUMTc6Mzk6MTArMDAwMCIsInByb3ZpZGVkUHJvZHVjdHMiOltdLCJk
+        U3RhbmRhcmQifSwicHJvZHVjdEF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
+        IiwidmFsdWUiOiJBTEwifV0sImRlcml2ZWRQcm9kdWN0QXR0cmlidXRlcyI6
+        W10sInByb2R1Y3RJZCI6IjdjODI1MDEzY2FiMDEzNDlhZThjYjhkYjE4N2Rl
+        MzkxIiwiaHJlZiI6Ii9wb29scy80MDI4Zjk3NTVkYzg3NWNkMDE1ZGM4ZmNi
+        YmNlMDAxNiIsInByb2R1Y3ROYW1lIjoiU2NlbmFyaW8gUHJvZHVjdCIsInN0
+        YWNrZWQiOmZhbHNlLCJkZXZlbG9wbWVudFBvb2wiOmZhbHNlLCJjcmVhdGVk
+        IjoiMjAxNy0wOC0wOVQyMTo1MzoxMiswMDAwIiwidXBkYXRlZCI6IjIwMTct
+        MDgtMDlUMjE6NTM6MTIrMDAwMCIsInByb3ZpZGVkUHJvZHVjdHMiOltdLCJk
         ZXJpdmVkUHJvdmlkZWRQcm9kdWN0cyI6W10sInN1YnNjcmlwdGlvbklkIjoi
-        NDgyMTAzOGRmM2MwNGI0MmExNWNmNjA5MTE0ZDZhNTQiLCJzdWJzY3JpcHRp
+        YmM4MzNhYmRjZDdjNDQ4OThmYjA0OTUwZTUyZWVlOTIiLCJzdWJzY3JpcHRp
         b25TdWJLZXkiOiJtYXN0ZXIifQ==
     http_version: 
-  recorded_at: Wed, 31 May 2017 17:39:11 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:13 GMT
 - request:
     method: get
-    uri: https://dev.example.com:8443/candlepin/activation_keys/?include=pools.pool.id
+    uri: https://centos7-devl2.example.com:8443/candlepin/activation_keys/?include=pools.pool.id
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -606,9 +520,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
       Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="5cJ8VI7TJIYC86F3MbFJiF6hY0pkN4zaDvoMsflvEoM",
-        oauth_signature="0K6iaUkF7jt0Ley2KhEnltxTgWE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1496252351", oauth_version="1.0"
+      - OAuth oauth_consumer_key="BuwYxVLAM5Q5nfZ5j6auFWWZnaZdQsif", oauth_nonce="KqjyfYPhk8lC7BkThrFeKYfq4ec866CxDB1BUSA1o",
+        oauth_signature="Tk1UsHnBGFvOIWYPxBFtXXqhquU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1502315593", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -623,7 +537,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - a3517c67-9254-448a-b615-810c660effc6
+      - 1ffddba3-536c-4b4d-a3f1-703915ac14be
       X-Version:
       - 2.0.35-1
       Content-Type:
@@ -631,13 +545,11 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Wed, 31 May 2017 17:39:10 GMT
+      - Wed, 09 Aug 2017 21:53:12 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        W3siaWQiOiI0MDI4Zjk1MTVjMjFkODE4MDE1YzIyNTdlNTIyMDAzZiIsInBv
-        b2xzIjpbeyJwb29sIjp7ImlkIjoiNDAyOGY5NTE1YzFjOGIyMjAxNWMxYzlj
-        NGE0MjEwOWIifX1dfV0=
+        W10=
     http_version: 
-  recorded_at: Wed, 31 May 2017 17:39:11 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:13 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/repo_create.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/repo_create.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -43,13 +43,13 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:15 GMT
+      - Wed, 09 Aug 2017 21:53:13 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
       - '332'
       Location:
-      - https://dev.example.com/pulp/api/v2/repositories/scenario_test/
+      - https://centos7-devl2.example.com/pulp/api/v2/repositories/scenario_test/
       Connection:
       - close
       Content-Type:
@@ -62,22 +62,22 @@ http_interactions:
         X2FkZGVkIjogbnVsbCwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
         ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3Vu
         aXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lkIjogeyIkb2lk
-        IjogIjU5MGI0MjNiNDE4YThhMDdiNmE4YzlkOCJ9LCAiaWQiOiAic2NlbmFy
+        IjogIjU5OGI4NDQ5ZDAzNWNhMDNkMzY2OGE1YiJ9LCAiaWQiOiAic2NlbmFy
         aW9fdGVzdCIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVz
         L3NjZW5hcmlvX3Rlc3QvIn0=
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:15 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:13 GMT
 - request:
     method: post
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/content/
+    uri: https://centos7-devl2.example.com:8443/candlepin/owners/scenario_test/content/
     body:
       encoding: UTF-8
       base64_string: |
         eyJuYW1lIjoiU2NlbmFyaW8geXVtIHByb2R1Y3QiLCJjb250ZW50VXJsIjoi
         L2N1c3RvbS9TY2VuYXJpb19Qcm9kdWN0L1NjZW5hcmlvX3l1bV9wcm9kdWN0
-        IiwidHlwZSI6Inl1bSIsImxhYmVsIjoic2NlbmFyaW9fdGVzdF9TY2VuYXJp
-        b19Qcm9kdWN0X1NjZW5hcmlvX3l1bV9wcm9kdWN0IiwibWV0YWRhdGFFeHBp
-        cmUiOjEsInZlbmRvciI6IkN1c3RvbSJ9
+        IiwidHlwZSI6Inl1bSIsImFyY2hlcyI6bnVsbCwibGFiZWwiOiJzY2VuYXJp
+        b190ZXN0X1NjZW5hcmlvX1Byb2R1Y3RfU2NlbmFyaW9feXVtX3Byb2R1Y3Qi
+        LCJtZXRhZGF0YUV4cGlyZSI6MSwidmVuZG9yIjoiQ3VzdG9tIn0=
     headers:
       Accept:
       - application/json
@@ -86,9 +86,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp",
-        oauth_nonce="VltBCcz0vkkq8p1ItXETThPNVFf95nJTVb4HIxAh3A", oauth_signature="eduWubUwPDK0WoMeBVsFAXx8u8Y%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1493910075", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="BuwYxVLAM5Q5nfZ5j6auFWWZnaZdQsif",
+        oauth_nonce="vRdP9I35dUz3LhTN1c6htDXyATmy4BFWrKtsxUb0", oauth_signature="1alNwQ6jEeKnrQRsAL3fZrXzLT4%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1502315593", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -96,7 +96,7 @@ http_interactions:
       Cp-User:
       - foreman_admin
       Content-Length:
-      - '204'
+      - '218'
   response:
     status:
       code: 200
@@ -105,22 +105,22 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - deebf167-2447-44f7-8f2c-28e7e07a1836
+      - 077a97b8-ca2e-4804-82aa-deabd417bde8
       X-Version:
-      - 2.0.26-1
+      - 2.0.35-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 04 May 2017 15:01:15 GMT
+      - Wed, 09 Aug 2017 21:53:13 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxNy0wNS0wNFQxNTowMToxNSswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTctMDUtMDRUMTU6MDE6MTUrMDAwMCIsInV1aWQiOiI0MDI4Zjk1
-        MTViY2JkZjE0MDE1YmQzZmFiYTI5MDAwOSIsImlkIjoiMTQ5MzkxMDA3NTkz
-        MyIsInR5cGUiOiJ5dW0iLCJsYWJlbCI6InNjZW5hcmlvX3Rlc3RfU2NlbmFy
+        eyJjcmVhdGVkIjoiMjAxNy0wOC0wOVQyMTo1MzoxMyswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTctMDgtMDlUMjE6NTM6MTMrMDAwMCIsInV1aWQiOiI0MDI4Zjk3
+        NTVkYzg3NWNkMDE1ZGM4ZmNiZjY5MDAxOSIsImlkIjoiMTUwMjMxNTU5MzU4
+        MSIsInR5cGUiOiJ5dW0iLCJsYWJlbCI6InNjZW5hcmlvX3Rlc3RfU2NlbmFy
         aW9fUHJvZHVjdF9TY2VuYXJpb195dW1fcHJvZHVjdCIsIm5hbWUiOiJTY2Vu
         YXJpbyB5dW0gcHJvZHVjdCIsInZlbmRvciI6IkN1c3RvbSIsImNvbnRlbnRV
         cmwiOiIvY3VzdG9tL1NjZW5hcmlvX1Byb2R1Y3QvU2NlbmFyaW9feXVtX3By
@@ -128,10 +128,10 @@ http_interactions:
         YWRhdGFFeHBpcmUiOjEsIm1vZGlmaWVkUHJvZHVjdElkcyI6W10sImFyY2hl
         cyI6bnVsbCwicmVsZWFzZVZlciI6bnVsbH0=
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:15 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:13 GMT
 - request:
     method: post
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/content/1493910075933?enabled=true
+    uri: https://centos7-devl2.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/content/1502315593581?enabled=true
     body:
       encoding: UTF-8
       base64_string: ''
@@ -143,9 +143,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp",
-        oauth_nonce="9oG9lOFr2OKQal7ONmG1AnLrhzvVMtuhVvJWTzVpVY", oauth_signature="sn5dgnkXTEPn8ej3dBucvFnf2K4%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1493910075", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="BuwYxVLAM5Q5nfZ5j6auFWWZnaZdQsif",
+        oauth_nonce="77O9ZRLMCON783OqZhDSMjInNSh60SGt0FsoQXMTHm4", oauth_signature="gOKAMWZEi4UpH%2B2wRjKEQvX7jDw%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1502315593", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -160,43 +160,41 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 9091d18a-8a39-4b62-a457-e4f75759a5c7
+      - 22a67d3a-fc97-499c-8d8a-7df914bcdc28
       X-Version:
-      - 2.0.26-1
+      - 2.0.35-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 04 May 2017 15:01:15 GMT
+      - Wed, 09 Aug 2017 21:53:13 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxNy0wNS0wNFQxNTowMToxNCswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTctMDUtMDRUMTU6MDE6MTYrMDAwMCIsInV1aWQiOiI0MDI4Zjk1
-        MTViY2JkZjE0MDE1YmQzZmFiYTdjMDAwYSIsImlkIjoiN2M4MjUwMTNjYWIw
+        eyJjcmVhdGVkIjoiMjAxNy0wOC0wOVQyMTo1MzoxMiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTctMDgtMDlUMjE6NTM6MTMrMDAwMCIsInV1aWQiOiI0MDI4Zjk3
+        NTVkYzg3NWNkMDE1ZGM4ZmNiZmFlMDAxYSIsImlkIjoiN2M4MjUwMTNjYWIw
         MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVj
-        dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7ImNyZWF0ZWQiOiIy
-        MDE3LTA1LTA0VDE1OjAxOjE0KzAwMDAiLCJ1cGRhdGVkIjoiMjAxNy0wNS0w
-        NFQxNTowMToxNiswMDAwIiwibmFtZSI6ImFyY2giLCJ2YWx1ZSI6IkFMTCJ9
-        XSwiZGVwZW5kZW50UHJvZHVjdElkcyI6W10sImhyZWYiOiIvcHJvZHVjdHMv
-        NDAyOGY5NTE1YmNiZGYxNDAxNWJkM2ZhYmE3YzAwMGEiLCJwcm9kdWN0Q29u
-        dGVudCI6W3siY29udGVudCI6eyJjcmVhdGVkIjoiMjAxNy0wNS0wNFQxNTow
-        MToxNSswMDAwIiwidXBkYXRlZCI6IjIwMTctMDUtMDRUMTU6MDE6MTUrMDAw
-        MCIsInV1aWQiOiI0MDI4Zjk1MTViY2JkZjE0MDE1YmQzZmFiYTI5MDAwOSIs
-        ImlkIjoiMTQ5MzkxMDA3NTkzMyIsInR5cGUiOiJ5dW0iLCJsYWJlbCI6InNj
-        ZW5hcmlvX3Rlc3RfU2NlbmFyaW9fUHJvZHVjdF9TY2VuYXJpb195dW1fcHJv
-        ZHVjdCIsIm5hbWUiOiJTY2VuYXJpbyB5dW0gcHJvZHVjdCIsInZlbmRvciI6
-        IkN1c3RvbSIsImNvbnRlbnRVcmwiOiIvY3VzdG9tL1NjZW5hcmlvX1Byb2R1
-        Y3QvU2NlbmFyaW9feXVtX3Byb2R1Y3QiLCJyZXF1aXJlZFRhZ3MiOm51bGws
-        ImdwZ1VybCI6bnVsbCwibWV0YWRhdGFFeHBpcmUiOjEsIm1vZGlmaWVkUHJv
-        ZHVjdElkcyI6W10sImFyY2hlcyI6bnVsbCwicmVsZWFzZVZlciI6bnVsbH0s
-        ImVuYWJsZWQiOnRydWV9XX0=
+        dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
+        IiwidmFsdWUiOiJBTEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJo
+        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOTc1NWRjODc1Y2QwMTVkYzhmY2JmYWUw
+        MDFhIiwicHJvZHVjdENvbnRlbnQiOlt7ImNvbnRlbnQiOnsiY3JlYXRlZCI6
+        IjIwMTctMDgtMDlUMjE6NTM6MTMrMDAwMCIsInVwZGF0ZWQiOiIyMDE3LTA4
+        LTA5VDIxOjUzOjEzKzAwMDAiLCJ1dWlkIjoiNDAyOGY5NzU1ZGM4NzVjZDAx
+        NWRjOGZjYmY2OTAwMTkiLCJpZCI6IjE1MDIzMTU1OTM1ODEiLCJ0eXBlIjoi
+        eXVtIiwibGFiZWwiOiJzY2VuYXJpb190ZXN0X1NjZW5hcmlvX1Byb2R1Y3Rf
+        U2NlbmFyaW9feXVtX3Byb2R1Y3QiLCJuYW1lIjoiU2NlbmFyaW8geXVtIHBy
+        b2R1Y3QiLCJ2ZW5kb3IiOiJDdXN0b20iLCJjb250ZW50VXJsIjoiL2N1c3Rv
+        bS9TY2VuYXJpb19Qcm9kdWN0L1NjZW5hcmlvX3l1bV9wcm9kdWN0IiwicmVx
+        dWlyZWRUYWdzIjpudWxsLCJncGdVcmwiOm51bGwsIm1ldGFkYXRhRXhwaXJl
+        IjoxLCJtb2RpZmllZFByb2R1Y3RJZHMiOltdLCJhcmNoZXMiOm51bGwsInJl
+        bGVhc2VWZXIiOm51bGx9LCJlbmFibGVkIjp0cnVlfV19
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:16 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:13 GMT
 - request:
     method: get
-    uri: https://dev.example.com:8443/candlepin/environments/119c4753ff6d3b7bd0b76de6d5a5f94a
+    uri: https://centos7-devl2.example.com:8443/candlepin/environments/119c4753ff6d3b7bd0b76de6d5a5f94a
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -208,9 +206,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
       Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="WJRG6urdTqcUFbE4v0wQLcvyaaO2Lt8JGwfq1pqlqBE",
-        oauth_signature="DxMUeejwce38yudLbj24JpsfRRQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1493910076", oauth_version="1.0"
+      - OAuth oauth_consumer_key="BuwYxVLAM5Q5nfZ5j6auFWWZnaZdQsif", oauth_nonce="XPqnLf9kTa2Z4e2Q69s2v3B042RVXtCyaVC2TorqO4",
+        oauth_signature="q7T6piAfjxSaUfIMLEM%2FXtxFUCY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1502315593", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -225,34 +223,34 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - dc0b0d98-b644-4369-aae0-f80679302a63
+      - a3ae00a7-5055-4eab-9cb6-f9babc927398
       X-Version:
-      - 2.0.26-1
+      - 2.0.35-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 04 May 2017 15:01:15 GMT
+      - Wed, 09 Aug 2017 21:53:13 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJvd25lciI6eyJpZCI6IjQwMjhmOTUxNWJjYmRmMTQwMTViZDNmYWIxMzEw
-        MDAwIiwia2V5Ijoic2NlbmFyaW9fdGVzdCIsImRpc3BsYXlOYW1lIjoic2Nl
+        eyJvd25lciI6eyJpZCI6IjQwMjhmOTc1NWRjODc1Y2QwMTVkYzhmY2I3ZWEw
+        MDExIiwia2V5Ijoic2NlbmFyaW9fdGVzdCIsImRpc3BsYXlOYW1lIjoic2Nl
         bmFyaW9fdGVzdCIsImhyZWYiOiIvb3duZXJzL3NjZW5hcmlvX3Rlc3QifSwi
         bmFtZSI6IkxpYnJhcnkiLCJkZXNjcmlwdGlvbiI6bnVsbCwiaWQiOiIxMTlj
         NDc1M2ZmNmQzYjdiZDBiNzZkZTZkNWE1Zjk0YSIsImVudmlyb25tZW50Q29u
-        dGVudCI6W10sImNyZWF0ZWQiOiIyMDE3LTA1LTA0VDE1OjAxOjEzKzAwMDAi
-        LCJ1cGRhdGVkIjoiMjAxNy0wNS0wNFQxNTowMToxMyswMDAwIn0=
+        dGVudCI6W10sImNyZWF0ZWQiOiIyMDE3LTA4LTA5VDIxOjUzOjExKzAwMDAi
+        LCJ1cGRhdGVkIjoiMjAxNy0wOC0wOVQyMTo1MzoxMSswMDAwIn0=
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:16 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:13 GMT
 - request:
     method: post
-    uri: https://dev.example.com:8443/candlepin/environments/119c4753ff6d3b7bd0b76de6d5a5f94a/content
+    uri: https://centos7-devl2.example.com:8443/candlepin/environments/119c4753ff6d3b7bd0b76de6d5a5f94a/content
     body:
       encoding: UTF-8
       base64_string: |
-        W3siY29udGVudElkIjoiMTQ5MzkxMDA3NTkzMyJ9XQ==
+        W3siY29udGVudElkIjoiMTUwMjMxNTU5MzU4MSJ9XQ==
     headers:
       Accept:
       - application/json
@@ -261,9 +259,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp",
-        oauth_nonce="6M0hRRzpLr8Qg4XnbXQoton4i4JVqNUzWxQe1i4NGa4", oauth_signature="dfeCh4i%2BbcVH7QhqVNFajGLJVlM%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1493910076", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="BuwYxVLAM5Q5nfZ5j6auFWWZnaZdQsif",
+        oauth_nonce="kl0M4L8zOBGbnAGgAYJ8Qlzcw5NRHKRwHVzvJoMLUY", oauth_signature="4O8OYV3LDPhfPom1YDnBL2zCxSY%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1502315593", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -280,33 +278,34 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 3dab1b29-7211-4e53-acc8-e8262d022f75
+      - d9e0a5c7-ef7e-4a37-9fd6-9dfe3282f6d5
       X-Version:
-      - 2.0.26-1
+      - 2.0.35-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 04 May 2017 15:01:15 GMT
+      - Wed, 09 Aug 2017 21:53:13 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJpZCI6InJlZ2VuX2VudGl0bGVtZW50X2NlcnRfb2ZfZW52ZGE2NjgyZmEt
-        MDQ2MS00MGM3LThmZTItNDA0ODBjZWE4MzhhIiwic3RhdGUiOiJDUkVBVEVE
+        eyJpZCI6InJlZ2VuX2VudGl0bGVtZW50X2NlcnRfb2ZfZW52NTMwMjA5NjUt
+        YjJlOC00YWI5LTlmZTUtODNiZDRiZjUxZTM2Iiwic3RhdGUiOiJDUkVBVEVE
         Iiwic3RhcnRUaW1lIjpudWxsLCJmaW5pc2hUaW1lIjpudWxsLCJyZXN1bHQi
         Om51bGwsInByaW5jaXBhbE5hbWUiOiJmb3JlbWFuX2FkbWluIiwidGFyZ2V0
-        VHlwZSI6bnVsbCwidGFyZ2V0SWQiOm51bGwsIm93bmVySWQiOm51bGwsInJl
-        c3VsdERhdGEiOm51bGwsInN0YXR1c1BhdGgiOiIvam9icy9yZWdlbl9lbnRp
-        dGxlbWVudF9jZXJ0X29mX2VudmRhNjY4MmZhLTA0NjEtNDBjNy04ZmUyLTQw
-        NDgwY2VhODM4YSIsImRvbmUiOmZhbHNlLCJncm91cCI6ImFzeW5jIGdyb3Vw
-        IiwiY3JlYXRlZCI6IjIwMTctMDUtMDRUMTU6MDE6MTYrMDAwMCIsInVwZGF0
-        ZWQiOiIyMDE3LTA1LTA0VDE1OjAxOjE2KzAwMDAifQ==
+        VHlwZSI6bnVsbCwidGFyZ2V0SWQiOm51bGwsIm93bmVySWQiOm51bGwsImNv
+        cnJlbGF0aW9uSWQiOm51bGwsInJlc3VsdERhdGEiOm51bGwsInN0YXR1c1Bh
+        dGgiOiIvam9icy9yZWdlbl9lbnRpdGxlbWVudF9jZXJ0X29mX2VudjUzMDIw
+        OTY1LWIyZTgtNGFiOS05ZmU1LTgzYmQ0YmY1MWUzNiIsImRvbmUiOmZhbHNl
+        LCJncm91cCI6ImFzeW5jIGdyb3VwIiwiY3JlYXRlZCI6IjIwMTctMDgtMDlU
+        MjE6NTM6MTMrMDAwMCIsInVwZGF0ZWQiOiIyMDE3LTA4LTA5VDIxOjUzOjEz
+        KzAwMDAifQ==
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:16 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:13 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/?details=true
+    uri: https://centos7-devl2.example.com/pulp/api/v2/repositories/scenario_test/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -325,7 +324,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:16 GMT
+      - Wed, 09 Aug 2017 21:53:13 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -342,59 +341,59 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiU2NlbmFyaW8g
         eXVtIHByb2R1Y3QiLCAiZGVzY3JpcHRpb24iOiBudWxsLCAiZGlzdHJpYnV0
         b3JzIjogW3sicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgImxhc3RfdXBk
-        YXRlZCI6ICIyMDE3LTA1LTA0VDE1OjAxOjE1WiIsICJfaHJlZiI6ICIvcHVs
+        YXRlZCI6ICIyMDE3LTA4LTA5VDIxOjUzOjEzWiIsICJfaHJlZiI6ICIvcHVs
         cC9hcGkvdjIvcmVwb3NpdG9yaWVzL3NjZW5hcmlvX3Rlc3QvZGlzdHJpYnV0
         b3JzL3NjZW5hcmlvX3Rlc3RfY2xvbmUvIiwgImxhc3Rfb3ZlcnJpZGVfY29u
         ZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxsLCAiZGlzdHJpYnV0b3Jf
         dHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJs
         aXNoIjogZmFsc2UsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19k
-        aXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjU5MGI0MjNiNDE4YThh
-        MDdiNmE4YzlkYyJ9LCAiY29uZmlnIjogeyJkZXN0aW5hdGlvbl9kaXN0cmli
+        aXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjU5OGI4NDQ5ZDAzNWNh
+        MDNkMzY2OGE1ZiJ9LCAiY29uZmlnIjogeyJkZXN0aW5hdGlvbl9kaXN0cmli
         dXRvcl9pZCI6ICJzY2VuYXJpb190ZXN0In0sICJpZCI6ICJzY2VuYXJpb190
         ZXN0X2Nsb25lIn0sIHsicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgImxh
-        c3RfdXBkYXRlZCI6ICIyMDE3LTA1LTA0VDE1OjAxOjE1WiIsICJfaHJlZiI6
+        c3RfdXBkYXRlZCI6ICIyMDE3LTA4LTA5VDIxOjUzOjEzWiIsICJfaHJlZiI6
         ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL3NjZW5hcmlvX3Rlc3QvZGlz
         dHJpYnV0b3JzL3NjZW5hcmlvX3Rlc3QvIiwgImxhc3Rfb3ZlcnJpZGVfY29u
         ZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxsLCAiZGlzdHJpYnV0b3Jf
         dHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjog
         dHJ1ZSwgInNjcmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1
-        dG9ycyIsICJfaWQiOiB7IiRvaWQiOiAiNTkwYjQyM2I0MThhOGEwN2I2YThj
-        OWRhIn0sICJjb25maWciOiB7InByb3RlY3RlZCI6IHRydWUsICJodHRwIjog
+        dG9ycyIsICJfaWQiOiB7IiRvaWQiOiAiNTk4Yjg0NDlkMDM1Y2EwM2QzNjY4
+        YTVkIn0sICJjb25maWciOiB7InByb3RlY3RlZCI6IHRydWUsICJodHRwIjog
         ZmFsc2UsICJodHRwcyI6IHRydWUsICJyZWxhdGl2ZV91cmwiOiAic2NlbmFy
         aW9fdGVzdCJ9LCAiaWQiOiAic2NlbmFyaW9fdGVzdCJ9LCB7InJlcG9faWQi
-        OiAic2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxNy0wNS0w
-        NFQxNTowMToxNVoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRv
+        OiAic2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxNy0wOC0w
+        OVQyMTo1MzoxM1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRv
         cmllcy9zY2VuYXJpb190ZXN0L2Rpc3RyaWJ1dG9ycy9leHBvcnRfZGlzdHJp
         YnV0b3IvIiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1
         Ymxpc2giOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJleHBvcnRf
         ZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNo
         cGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjog
-        eyIkb2lkIjogIjU5MGI0MjNiNDE4YThhMDdiNmE4YzlkYiJ9LCAiY29uZmln
+        eyIkb2lkIjogIjU5OGI4NDQ5ZDAzNWNhMDNkMzY2OGE1ZSJ9LCAiY29uZmln
         IjogeyJodHRwIjogZmFsc2UsICJyZWxhdGl2ZV91cmwiOiAic2NlbmFyaW9f
         dGVzdCIsICJodHRwcyI6IGZhbHNlfSwgImlkIjogImV4cG9ydF9kaXN0cmli
         dXRvciJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3RlcyI6IHsi
         X3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3JlbW92ZWQi
         OiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25zIjogInJl
         cG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAic2NlbmFyaW9fdGVz
-        dCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxNy0wNS0wNFQxNTowMToxNVoiLCAi
+        dCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxNy0wOC0wOVQyMTo1MzoxM1oiLCAi
         X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJpb190
         ZXN0L2ltcG9ydGVycy95dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBvX2lt
         cG9ydGVycyIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIs
         ICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjogbnVs
-        bCwgInNjcmF0Y2hwYWQiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU5MGI0
-        MjNiNDE4YThhMDdiNmE4YzlkOSJ9LCAiY29uZmlnIjogeyJmZWVkIjogImZp
+        bCwgInNjcmF0Y2hwYWQiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU5OGI4
+        NDQ5ZDAzNWNhMDNkMzY2OGE1YyJ9LCAiY29uZmlnIjogeyJmZWVkIjogImZp
         bGU6Ly8vdmFyL3d3dy90ZXN0X3JlcG9zL3pvbyIsICJzc2xfdmFsaWRhdGlv
         biI6IHRydWUsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9w
         b2xpY3kiOiAiaW1tZWRpYXRlIn0sICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0s
         ICJsb2NhbGx5X3N0b3JlZF91bml0cyI6IDAsICJfaWQiOiB7IiRvaWQiOiAi
-        NTkwYjQyM2I0MThhOGEwN2I2YThjOWQ4In0sICJ0b3RhbF9yZXBvc2l0b3J5
+        NTk4Yjg0NDlkMDM1Y2EwM2QzNjY4YTViIn0sICJ0b3RhbF9yZXBvc2l0b3J5
         X3VuaXRzIjogMCwgImlkIjogInNjZW5hcmlvX3Rlc3QiLCAiX2hyZWYiOiAi
         L3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJpb190ZXN0LyJ9
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:16 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:13 GMT
 - request:
     method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/actions/publish/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/repositories/scenario_test/actions/publish/
     body:
       encoding: UTF-8
       base64_string: |
@@ -417,7 +416,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:16 GMT
+      - Wed, 09 Aug 2017 21:53:14 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -430,14 +429,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzRhYzVlYjUxLTE3MzItNGEzNi04NDQ0LTJjYTVhZWUzMzVkNS8iLCAi
-        dGFza19pZCI6ICI0YWM1ZWI1MS0xNzMyLTRhMzYtODQ0NC0yY2E1YWVlMzM1
-        ZDUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzI0Zjc0ZDEyLTZlY2UtNDYwNS1iMDM2LTg0ZTNjMGRiMTYwMi8iLCAi
+        dGFza19pZCI6ICIyNGY3NGQxMi02ZWNlLTQ2MDUtYjAzNi04NGUzYzBkYjE2
+        MDIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:16 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:14 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/4ac5eb51-1732-4a36-8444-2ca5aee335d5/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/tasks/24f74d12-6ece-4605-b036-84e3c0db1602/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -456,13 +455,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:16 GMT
+      - Wed, 09 Aug 2017 21:53:14 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '560'
+      - '578'
       Connection:
       - close
       Content-Type:
@@ -472,274 +471,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80YWM1ZWI1MS0xNzMyLTRhMzYtODQ0NC0yY2E1
-        YWVlMzM1ZDUvIiwgInRhc2tfaWQiOiAiNGFjNWViNTEtMTczMi00YTM2LTg0
-        NDQtMmNhNWFlZTMzNWQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy8yNGY3NGQxMi02ZWNlLTQ2MDUtYjAzNi04NGUz
+        YzBkYjE2MDIvIiwgInRhc2tfaWQiOiAiMjRmNzRkMTItNmVjZS00NjA1LWIw
+        MzYtODRlM2MwZGIxNjAyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
         aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogbnVsbCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
-        IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIk5vbmUu
-        ZHEiLCAic3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6IG51bGws
-        ICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjU5MGI0MjNjM2Y3YWQ1OTMyODUxMzc3ZiJ9LCAiaWQiOiAiNTkwYjQy
-        M2MzZjdhZDU5MzI4NTEzNzdmIn0=
-    http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:16 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/4ac5eb51-1732-4a36-8444-2ca5aee335d5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 May 2017 15:01:16 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '560'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80YWM1ZWI1MS0xNzMyLTRhMzYtODQ0NC0yY2E1
-        YWVlMzM1ZDUvIiwgInRhc2tfaWQiOiAiNGFjNWViNTEtMTczMi00YTM2LTg0
-        NDQtMmNhNWFlZTMzNWQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogbnVsbCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
-        IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIk5vbmUu
-        ZHEiLCAic3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6IG51bGws
-        ICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjU5MGI0MjNjM2Y3YWQ1OTMyODUxMzc3ZiJ9LCAiaWQiOiAiNTkwYjQy
-        M2MzZjdhZDU5MzI4NTEzNzdmIn0=
-    http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:16 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/4ac5eb51-1732-4a36-8444-2ca5aee335d5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 May 2017 15:01:16 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '560'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80YWM1ZWI1MS0xNzMyLTRhMzYtODQ0NC0yY2E1
-        YWVlMzM1ZDUvIiwgInRhc2tfaWQiOiAiNGFjNWViNTEtMTczMi00YTM2LTg0
-        NDQtMmNhNWFlZTMzNWQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogbnVsbCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
-        IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIk5vbmUu
-        ZHEiLCAic3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6IG51bGws
-        ICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjU5MGI0MjNjM2Y3YWQ1OTMyODUxMzc3ZiJ9LCAiaWQiOiAiNTkwYjQy
-        M2MzZjdhZDU5MzI4NTEzNzdmIn0=
-    http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:16 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/4ac5eb51-1732-4a36-8444-2ca5aee335d5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 May 2017 15:01:16 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '560'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80YWM1ZWI1MS0xNzMyLTRhMzYtODQ0NC0yY2E1
-        YWVlMzM1ZDUvIiwgInRhc2tfaWQiOiAiNGFjNWViNTEtMTczMi00YTM2LTg0
-        NDQtMmNhNWFlZTMzNWQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogbnVsbCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
-        IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIk5vbmUu
-        ZHEiLCAic3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6IG51bGws
-        ICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjU5MGI0MjNjM2Y3YWQ1OTMyODUxMzc3ZiJ9LCAiaWQiOiAiNTkwYjQy
-        M2MzZjdhZDU5MzI4NTEzNzdmIn0=
-    http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:16 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/4ac5eb51-1732-4a36-8444-2ca5aee335d5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 May 2017 15:01:16 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '560'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80YWM1ZWI1MS0xNzMyLTRhMzYtODQ0NC0yY2E1
-        YWVlMzM1ZDUvIiwgInRhc2tfaWQiOiAiNGFjNWViNTEtMTczMi00YTM2LTg0
-        NDQtMmNhNWFlZTMzNWQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogbnVsbCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
-        IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIk5vbmUu
-        ZHEiLCAic3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6IG51bGws
-        ICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjU5MGI0MjNjM2Y3YWQ1OTMyODUxMzc3ZiJ9LCAiaWQiOiAiNTkwYjQy
-        M2MzZjdhZDU5MzI4NTEzNzdmIn0=
-    http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:16 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/4ac5eb51-1732-4a36-8444-2ca5aee335d5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 May 2017 15:01:16 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '656'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80YWM1ZWI1MS0xNzMyLTRhMzYtODQ0NC0yY2E1
-        YWVlMzM1ZDUvIiwgInRhc2tfaWQiOiAiNGFjNWViNTEtMTczMi00YTM2LTg0
-        NDQtMmNhNWFlZTMzNWQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTctMDUtMDRUMTU6MDE6MTZaIiwgInRyYWNlYmFjayI6IG51
+        aW1lIjogIjIwMTctMDgtMDlUMjE6NTM6MTRaIiwgInRyYWNlYmFjayI6IG51
         bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGRldi5l
-        eGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9u
-        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGRldi5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjU5MGI0MjNjM2Y3YWQ1OTMyODUxMzc3ZiJ9LCAiaWQiOiAi
-        NTkwYjQyM2MzZjdhZDU5MzI4NTEzNzdmIn0=
+        fSwgInF1ZXVlIjogIk5vbmUuZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3
+        b3JrZXJfbmFtZSI6IG51bGwsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU5OGI4NDRhYmJjNmY0YjkzNjVmOTBl
+        MiJ9LCAiaWQiOiAiNTk4Yjg0NGFiYmM2ZjRiOTM2NWY5MGUyIn0=
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:16 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:14 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/4ac5eb51-1732-4a36-8444-2ca5aee335d5/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/tasks/24f74d12-6ece-4605-b036-84e3c0db1602/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -758,13 +505,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:16 GMT
+      - Wed, 09 Aug 2017 21:53:14 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '656'
+      - '3773'
       Connection:
       - close
       Content-Type:
@@ -774,266 +521,93 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80YWM1ZWI1MS0xNzMyLTRhMzYtODQ0NC0yY2E1
-        YWVlMzM1ZDUvIiwgInRhc2tfaWQiOiAiNGFjNWViNTEtMTczMi00YTM2LTg0
-        NDQtMmNhNWFlZTMzNWQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy8yNGY3NGQxMi02ZWNlLTQ2MDUtYjAzNi04NGUz
+        YzBkYjE2MDIvIiwgInRhc2tfaWQiOiAiMjRmNzRkMTItNmVjZS00NjA1LWIw
+        MzYtODRlM2MwZGIxNjAyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
         aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTctMDUtMDRUMTU6MDE6MTZaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGRldi5l
-        eGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9u
-        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGRldi5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjU5MGI0MjNjM2Y3YWQ1OTMyODUxMzc3ZiJ9LCAiaWQiOiAi
-        NTkwYjQyM2MzZjdhZDU5MzI4NTEzNzdmIn0=
-    http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:16 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/4ac5eb51-1732-4a36-8444-2ca5aee335d5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 May 2017 15:01:16 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3766'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80YWM1ZWI1MS0xNzMyLTRhMzYtODQ0NC0yY2E1
-        YWVlMzM1ZDUvIiwgInRhc2tfaWQiOiAiNGFjNWViNTEtMTczMi00YTM2LTg0
-        NDQtMmNhNWFlZTMzNWQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTctMDUtMDRUMTU6MDE6MTZaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogImE4NWVjZmExLWJhODktNDc5Zi04ZTNiLWNmNmJmZGUzOGU4OSIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
-        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAi
-        c3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICIxNTIyNzEwNi0wN2ZmLTQ3YWMtOTI5Mi0wN2RiYTVhNTQ4MTciLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJkYTgyZjFmYy05MDMxLTRkYzAtYmQ0ZC0y
-        MDMyOGZhOWFlZGIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBN
-        cyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        OTNiMGViZjctYTQ1Zi00NjI3LWI5NjAtYjU3ZjA3NzFlZWMzIiwgIm51bV9w
-        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
-        biI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRh
-        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjJhZjZhYTI3LTdiMDItNGM2Ni1iYzFi
-        LWM4YWU3YzYyODY3MyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
-        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBm
-        aWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI0OGRiM2Q4Mi01MDAzLTQ2ZWYtYmU1OC1lMjgwNDk0NjU3NzAiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJt
-        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RB
-        UlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4OWMyMDA2Ni1mMGZjLTRj
-        OTEtOTNlZC00NTU4YzMyZmI4ZjkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
-        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVw
-        byBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0
-        YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmMzZkNDg0Zi1mY2E5LTRjODQtODMy
-        Yy0yZmIzMWIyYzQyYmIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRl
-        IGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiZDU0MmEyYjgtZTFiMS00OTIxLWJmYjItYTllNmM4
-        NThkZTFiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
-        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAi
-        c3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM5
-        MzZhMzkwLTIzOWItNGIwZi05NmE3LWZiMzNkNzVhMjJlMSIsICJudW1fcHJv
-        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1
-        Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI4ZDBlMzU4
-        LTU2NjAtNDE1Yy05N2UwLTg0OTJjMDUzZmIxMCIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiV3Jp
-        dGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXpl
-        X3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDBjNjA1NzAt
-        ZjgyOC00MGI1LWIyMTQtYTBkNDI4YWE1ZWI3IiwgIm51bV9wcm9jZXNzZWQi
-        OiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        ZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29y
-        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2LmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
-        aWQiOiB7IiRvaWQiOiAiNTkwYjQyM2MzZjdhZDU5MzI4NTEzNzdmIn0sICJp
-        ZCI6ICI1OTBiNDIzYzNmN2FkNTkzMjg1MTM3N2YifQ==
-    http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:16 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/4ac5eb51-1732-4a36-8444-2ca5aee335d5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 May 2017 15:01:17 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3760'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80YWM1ZWI1MS0xNzMyLTRhMzYtODQ0NC0yY2E1
-        YWVlMzM1ZDUvIiwgInRhc2tfaWQiOiAiNGFjNWViNTEtMTczMi00YTM2LTg0
-        NDQtMmNhNWFlZTMzNWQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTctMDUtMDRUMTU6MDE6MTZaIiwgInRyYWNlYmFjayI6IG51
+        aW1lIjogIjIwMTctMDgtMDlUMjE6NTM6MTRaIiwgInRyYWNlYmFjayI6IG51
         bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
         InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
         dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
         cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
         IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImE4NWVjZmExLWJhODktNDc5Zi04ZTNiLWNmNmJmZGUzOGU4OSIsICJu
+        IjogImU5YzA5NWFjLTFjY2EtNDkzNi05OTljLTU3NTRjZTg2MTY1YyIsICJu
         dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
         cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
         cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNTIy
-        NzEwNi0wN2ZmLTQ3YWMtOTI5Mi0wN2RiYTVhNTQ4MTciLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5YmVk
+        YmVkYy0wNWZmLTRlNGUtYTQ1NC02ZDg5NDcwM2U2ZTIiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJkYTgyZjFmYy05MDMxLTRkYzAtYmQ0ZC0yMDMyOGZh
-        OWFlZGIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJz
-        dGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTNiMGVi
-        ZjctYTQ1Zi00NjI3LWI5NjAtYjU3ZjA3NzFlZWMzIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICJlYzgyOGU4Ni01MDE3LTQ3MmUtYWRjZC0yZGZiNDNjNTJh
+        NjIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyMmMwZDdjZi0zZTNj
+        LTRkNjItODg2Yy04OTQyY2UzOTdlYWQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiNTdiOWQyYzItZjJiNS00OWU1LWE0ZGEtMThiN2ViMzIwZjNm
+        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90
+        eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5P
+        VF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI2NDg3MzVkLTZj
+        ZjctNDNjYy05ZDU4LTk3N2VlMjllZGJiYiIsICJudW1fcHJvY2Vzc2VkIjog
+        MH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
         ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjJhZjZhYTI3LTdiMDItNGM2Ni1iYzFiLWM4YWU3
-        YzYyODY3MyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0OGRi
-        M2Q4Mi01MDAzLTQ2ZWYtYmU1OC1lMjgwNDk0NjU3NzAiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0
+        IDAsICJzdGVwX2lkIjogImNjNTlhNjY0LWFhODItNDA4MC1hODAzLTg2YjZh
+        OTQ1ZmY2NCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwg
+        InN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3Rv
+        dGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImI1YWM0MjhkLTNkNTEtNGNlZS1iOGY2LTAyNGU1MTVlNjEx
+        YyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAi
+        ZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICJmZDA5NDg2OC1kMzc3LTQ4NzEtYjA4ZS00ODBlOGU5MzUzNjAiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
+        cmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
+        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTcwMmUyMTYtYjdmZC00
+        MmVhLWJmYTMtM2M2YTdmY2M2Y2JiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
+        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
+        IGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rv
+        cnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOWQ3MWI0ZmQtMjczMC00YmRmLWI1
+        MWYtZDQyNTNjYWM5ZDM4IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3Rpbmdz
+        IEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0
         YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIs
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4OWMyMDA2Ni1mMGZjLTRjOTEtOTNl
-        ZC00NTU4YzMyZmI4ZjkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRh
-        ZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJmMzZkNDg0Zi1mY2E5LTRjODQtODMyYy0yZmIz
-        MWIyYzQyYmIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVz
-        IiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
-        ZXBfaWQiOiAiZDU0MmEyYjgtZTFiMS00OTIxLWJmYjItYTllNmM4NThkZTFi
-        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
-        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90
-        eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM5MzZhMzkw
-        LTIzOWItNGIwZi05NmE3LWZiMzNkNzVhMjJlMSIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
-        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI4ZDBlMzU4LTU2NjAt
-        NDE1Yy05N2UwLTg0OTJjMDUzZmIxMCIsICJudW1fcHJvY2Vzc2VkIjogMH0s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBM
-        aXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9f
-        bWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
-        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDBjNjA1NzAtZjgyOC00
-        MGI1LWIyMTQtYTBkNDI4YWE1ZWI3IiwgIm51bV9wcm9jZXNzZWQiOiAwfV19
-        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2LmV4
-        YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25h
-        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2LmV4YW1wbGUu
-        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNTkwYjQyM2MzZjdhZDU5MzI4NTEzNzdmIn0sICJpZCI6ICI1
-        OTBiNDIzYzNmN2FkNTkzMjg1MTM3N2YifQ==
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0MjM1MDhiOS1hOTAwLTRjYmQtYTdm
+        ZS04NzI5Y2I3OWMwNWQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWRldmwy
+        LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2Vy
+        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAY2VudG9zNy1k
+        ZXZsMi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjU5OGI4NDRhYmJjNmY0YjkzNjVmOTBl
+        MiJ9LCAiaWQiOiAiNTk4Yjg0NGFiYmM2ZjRiOTM2NWY5MGUyIn0=
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:17 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:14 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/4ac5eb51-1732-4a36-8444-2ca5aee335d5/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/tasks/24f74d12-6ece-4605-b036-84e3c0db1602/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1052,13 +626,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:17 GMT
+      - Wed, 09 Aug 2017 21:53:14 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '3733'
+      - '3750'
       Connection:
       - close
       Content-Type:
@@ -1068,212 +642,93 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80YWM1ZWI1MS0xNzMyLTRhMzYtODQ0NC0yY2E1
-        YWVlMzM1ZDUvIiwgInRhc2tfaWQiOiAiNGFjNWViNTEtMTczMi00YTM2LTg0
-        NDQtMmNhNWFlZTMzNWQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy8yNGY3NGQxMi02ZWNlLTQ2MDUtYjAzNi04NGUz
+        YzBkYjE2MDIvIiwgInRhc2tfaWQiOiAiMjRmNzRkMTItNmVjZS00NjA1LWIw
+        MzYtODRlM2MwZGIxNjAyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
         aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTctMDUtMDRUMTU6MDE6MTZaIiwgInRyYWNlYmFjayI6IG51
+        aW1lIjogIjIwMTctMDgtMDlUMjE6NTM6MTRaIiwgInRyYWNlYmFjayI6IG51
         bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
         InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
         dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
         cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
         IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImE4NWVjZmExLWJhODktNDc5Zi04ZTNiLWNmNmJmZGUzOGU4OSIsICJu
+        IjogImU5YzA5NWFjLTFjY2EtNDkzNi05OTljLTU3NTRjZTg2MTY1YyIsICJu
         dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
         cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
         cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNTIy
-        NzEwNi0wN2ZmLTQ3YWMtOTI5Mi0wN2RiYTVhNTQ4MTciLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5YmVk
+        YmVkYy0wNWZmLTRlNGUtYTQ1NC02ZDg5NDcwM2U2ZTIiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
         c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICJkYTgyZjFmYy05MDMxLTRkYzAtYmQ0ZC0yMDMyOGZhOWFl
-        ZGIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICJlYzgyOGU4Ni01MDE3LTQ3MmUtYWRjZC0yZGZiNDNjNTJh
+        NjIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
         X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
         U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5M2IwZWJmNy1hNDVm
-        LTQ2MjctYjk2MC1iNTdmMDc3MWVlYzMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyMmMwZDdjZi0zZTNj
+        LTRkNjItODg2Yy04OTQyY2UzOTdlYWQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
         LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
         bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
         YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMmFmNmFhMjctN2IwMi00YzY2LWJjMWItYzhhZTdjNjI4NjczIiwg
+        aWQiOiAiNTdiOWQyYzItZjJiNS00OWU1LWE0ZGEtMThiN2ViMzIwZjNmIiwg
         Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
         IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQ4ZGIzZDgyLTUwMDMtNDZl
-        Zi1iZTU4LWUyODA0OTQ2NTc3MCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI2NDg3MzVkLTZjZjctNDNj
+        Yy05ZDU4LTk3N2VlMjllZGJiYiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
         bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
         ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
         dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
         OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjg5YzIwMDY2LWYwZmMtNGM5MS05M2VkLTQ1NThjMzJmYjhmOSIs
+        X2lkIjogImNjNTlhNjY0LWFhODItNDA4MC1hODAzLTg2YjZhOTQ1ZmY2NCIs
         ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
         Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
         ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImYz
-        NmQ0ODRmLWZjYTktNGM4NC04MzJjLTJmYjMxYjJjNDJiYiIsICJudW1fcHJv
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI1
+        YWM0MjhkLTNkNTEtNGNlZS1iOGY2LTAyNGU1MTVlNjExYyIsICJudW1fcHJv
         Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
         OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
         bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
         S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ1NDJhMmI4LWUxYjEt
-        NDkyMS1iZmIyLWE5ZTZjODU4ZGUxYiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZkMDk0ODY4LWQzNzct
+        NDg3MS1iMDhlLTQ4MGU4ZTkzNTM2MCIsICJudW1fcHJvY2Vzc2VkIjogMH0s
         IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
         ZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVt
         c190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFp
         bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjM5MzZhMzkwLTIzOWItNGIwZi05NmE3LWZiMzNkNzVhMjJl
-        MSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3Rl
-        cF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjog
-        MSwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjI4ZDBlMzU4LTU2NjAtNDE1Yy05N2UwLTg0OTJjMDUzZmIxMCIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6
-        ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAx
-        LCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiNDBjNjA1NzAtZjgyOC00MGI1LWIyMTQtYTBkNDI4YWE1ZWI3IiwgIm51
-        bV9wcm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
-        Y2Vfd29ya2VyLTFAZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1
-        bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJv
-        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTkwYjQyM2MzZjdhZDU5MzI4
-        NTEzNzdmIn0sICJpZCI6ICI1OTBiNDIzYzNmN2FkNTkzMjg1MTM3N2YifQ==
-    http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:17 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/4ac5eb51-1732-4a36-8444-2ca5aee335d5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 May 2017 15:01:17 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3727'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80YWM1ZWI1MS0xNzMyLTRhMzYtODQ0NC0yY2E1
-        YWVlMzM1ZDUvIiwgInRhc2tfaWQiOiAiNGFjNWViNTEtMTczMi00YTM2LTg0
-        NDQtMmNhNWFlZTMzNWQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTctMDUtMDRUMTU6MDE6MTZaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImE4NWVjZmExLWJhODktNDc5Zi04ZTNiLWNmNmJmZGUzOGU4OSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
-        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNTIy
-        NzEwNi0wN2ZmLTQ3YWMtOTI5Mi0wN2RiYTVhNTQ4MTciLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICJkYTgyZjFmYy05MDMxLTRkYzAtYmQ0ZC0yMDMyOGZhOWFl
-        ZGIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
-        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5M2IwZWJmNy1hNDVm
-        LTQ2MjctYjk2MC1iNTdmMDc3MWVlYzMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
-        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMmFmNmFhMjctN2IwMi00YzY2LWJjMWItYzhhZTdjNjI4NjczIiwg
-        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
-        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQ4ZGIzZDgyLTUwMDMtNDZl
-        Zi1iZTU4LWUyODA0OTQ2NTc3MCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
-        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
-        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjg5YzIwMDY2LWYwZmMtNGM5MS05M2VkLTQ1NThjMzJmYjhmOSIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
-        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
-        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImYz
-        NmQ0ODRmLWZjYTktNGM4NC04MzJjLTJmYjMxYjJjNDJiYiIsICJudW1fcHJv
-        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
-        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
-        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ1NDJhMmI4LWUxYjEt
-        NDkyMS1iZmIyLWE5ZTZjODU4ZGUxYiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
-        ZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVt
-        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjM5MzZhMzkwLTIzOWItNGIwZi05NmE3LWZiMzNkNzVhMjJl
-        MSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
+        dGVwX2lkIjogImU3MDJlMjE2LWI3ZmQtNDJlYS1iZmEzLTNjNmE3ZmNjNmNi
+        YiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
         ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3Rl
         cF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjog
         MSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
         ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjI4ZDBlMzU4LTU2NjAtNDE1Yy05N2UwLTg0OTJjMDUzZmIxMCIsICJudW1f
+        IjlkNzFiNGZkLTI3MzAtNGJkZi1iNTFmLWQ0MjUzY2FjOWQzOCIsICJudW1f
         cHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRp
         b24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJp
         bml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDBj
-        NjA1NzAtZjgyOC00MGI1LWIyMTQtYTBkNDI4YWE1ZWI3IiwgIm51bV9wcm9j
-        ZXNzZWQiOiAxfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmci
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        ZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51
-        bGwsICJfaWQiOiB7IiRvaWQiOiAiNTkwYjQyM2MzZjdhZDU5MzI4NTEzNzdm
-        In0sICJpZCI6ICI1OTBiNDIzYzNmN2FkNTkzMjg1MTM3N2YifQ==
+        c3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        NDIzNTA4YjktYTkwMC00Y2JkLWE3ZmUtODcyOWNiNzljMDVkIiwgIm51bV9w
+        cm9jZXNzZWQiOiAxfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAY2VudG9zNy1kZXZsMi5leGFtcGxlLmNvbS5kcSIsICJzdGF0
+        ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
+        cmNlX3dvcmtlci0xQGNlbnRvczctZGV2bDIuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        OThiODQ0YWJiYzZmNGI5MzY1ZjkwZTIifSwgImlkIjogIjU5OGI4NDRhYmJj
+        NmY0YjkzNjVmOTBlMiJ9
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:17 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:14 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/4ac5eb51-1732-4a36-8444-2ca5aee335d5/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/tasks/24f74d12-6ece-4605-b036-84e3c0db1602/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1292,13 +747,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:17 GMT
+      - Wed, 09 Aug 2017 21:53:14 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '7442'
+      - '7462'
       Connection:
       - close
       Content-Type:
@@ -1308,170 +763,170 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80YWM1ZWI1MS0xNzMyLTRhMzYtODQ0NC0yY2E1
-        YWVlMzM1ZDUvIiwgInRhc2tfaWQiOiAiNGFjNWViNTEtMTczMi00YTM2LTg0
-        NDQtMmNhNWFlZTMzNWQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy8yNGY3NGQxMi02ZWNlLTQ2MDUtYjAzNi04NGUz
+        YzBkYjE2MDIvIiwgInRhc2tfaWQiOiAiMjRmNzRkMTItNmVjZS00NjA1LWIw
+        MzYtODRlM2MwZGIxNjAyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogIjIwMTctMDUtMDRUMTU6MDE6MTdaIiwgIl9ucyI6ICJ0YXNr
-        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTctMDUtMDRUMTU6MDE6MTZa
+        aF90aW1lIjogIjIwMTctMDgtMDlUMjE6NTM6MTRaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTctMDgtMDlUMjE6NTM6MTRa
         IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
         cm9ncmVzc19yZXBvcnQiOiB7InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3Vj
         Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
         ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
         YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImE4NWVjZmExLWJhODktNDc5Zi04ZTNi
-        LWNmNmJmZGUzOGU4OSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImU5YzA5NWFjLTFjY2EtNDkzNi05OTlj
+        LTU3NTRjZTg2MTY1YyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
         Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
         dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
         dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIxNTIyNzEwNi0wN2ZmLTQ3YWMtOTI5Mi0wN2RiYTVh
-        NTQ4MTciLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICI5YmVkYmVkYy0wNWZmLTRlNGUtYTQ1NC02ZDg5NDcw
+        M2U2ZTIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
         MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
         cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
         U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkYTgyZjFmYy05MDMxLTRk
-        YzAtYmQ0ZC0yMDMyOGZhOWFlZGIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlYzgyOGU4Ni01MDE3LTQ3
+        MmUtYWRjZC0yZGZiNDNjNTJhNjIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
         Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
         RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
         W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI5M2IwZWJmNy1hNDVmLTQ2MjctYjk2MC1iNTdmMDc3MWVlYzMiLCAi
+        ZCI6ICIyMmMwZDdjZi0zZTNjLTRkNjItODg2Yy04OTQyY2UzOTdlYWQiLCAi
         bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
         aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
         cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
         LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmFmNmFhMjctN2IwMi00YzY2LWJj
-        MWItYzhhZTdjNjI4NjczIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTdiOWQyYzItZjJiNS00OWU1LWE0
+        ZGEtMThiN2ViMzIwZjNmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
         c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBz
         IGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjog
         MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
         ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjQ4ZGIzZDgyLTUwMDMtNDZlZi1iZTU4LWUyODA0OTQ2NTc3MCIsICJudW1f
+        IjI2NDg3MzVkLTZjZjctNDNjYy05ZDU4LTk3N2VlMjllZGJiYiIsICJudW1f
         cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
         b24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1l
         dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
         IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjg5YzIwMDY2LWYwZmMtNGM5MS05
-        M2VkLTQ1NThjMzJmYjhmOSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNjNTlhNjY0LWFhODItNDA4MC1h
+        ODAzLTg2YjZhOTQ1ZmY2NCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
         X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1l
         dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImYzNmQ0ODRmLWZjYTktNGM4NC04MzJjLTJmYjMx
-        YjJjNDJiYiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
+        IDAsICJzdGVwX2lkIjogImI1YWM0MjhkLTNkNTEtNGNlZS1iOGY2LTAyNGU1
+        MTVlNjExYyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
         OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMi
         LCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3Rh
         bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImQ1NDJhMmI4LWUxYjEtNDkyMS1iZmIyLWE5ZTZjODU4ZGUxYiIsICJu
+        IjogImZkMDk0ODY4LWQzNzctNDg3MS1iMDhlLTQ4MGU4ZTkzNTM2MCIsICJu
         dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
         cHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6
         ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQ
         UEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM5MzZhMzkwLTIzOWItNGIw
-        Zi05NmE3LWZiMzNkNzVhMjJlMSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImU3MDJlMjE2LWI3ZmQtNDJl
+        YS1iZmEzLTNjNmE3ZmNjNmNiYiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
         bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBm
         aWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5
         IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
         cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjI4ZDBlMzU4LTU2NjAtNDE1Yy05N2UwLTg0
-        OTJjMDUzZmIxMCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        cyI6IDAsICJzdGVwX2lkIjogIjlkNzFiNGZkLTI3MzAtNGJkZi1iNTFmLWQ0
+        MjUzY2FjOWQzOCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
         c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxl
         IiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAi
         aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
         ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiNDBjNjA1NzAtZjgyOC00MGI1LWIyMTQtYTBkNDI4
-        YWE1ZWI3IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAicXVldWUiOiAicmVz
-        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2LmV4YW1wbGUuY29tLmRxIiwg
-        InN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVk
-        X3Jlc291cmNlX3dvcmtlci0xQGRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQi
-        OiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGwsICJy
-        ZXBvX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAic3RhcnRlZCI6ICIyMDE3LTA1
-        LTA0VDE1OjAxOjE2WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMi
-        LCAiY29tcGxldGVkIjogIjIwMTctMDUtMDRUMTU6MDE6MTdaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0
-        cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJ
-        UFBFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQi
-        LCAicnBtcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjog
-        IkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklO
-        SVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInJlcG92aWV3
-        IjogIlNLSVBQRUQiLCAicHVibGlzaF9kaXJlY3RvcnkiOiAiRklOSVNIRUQi
-        LCAiZXJyYXRhIjogIkZJTklTSEVEIiwgIm1ldGFkYXRhIjogIkZJTklTSEVE
-        In0sICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjog
-        InNjZW5hcmlvX3Rlc3QiLCAiaWQiOiAiNTkwYjQyM2Q0MThhOGEwN2JhZmI1
-        NjY3IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImE4NWVjZmExLWJhODktNDc5Zi04ZTNiLWNmNmJmZGUzOGU4OSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
-        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNTIy
-        NzEwNi0wN2ZmLTQ3YWMtOTI5Mi0wN2RiYTVhNTQ4MTciLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICJkYTgyZjFmYy05MDMxLTRkYzAtYmQ0ZC0yMDMyOGZhOWFl
-        ZGIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
-        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5M2IwZWJmNy1hNDVm
-        LTQ2MjctYjk2MC1iNTdmMDc3MWVlYzMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
-        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMmFmNmFhMjctN2IwMi00YzY2LWJjMWItYzhhZTdjNjI4NjczIiwg
-        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
-        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQ4ZGIzZDgyLTUwMDMtNDZl
-        Zi1iZTU4LWUyODA0OTQ2NTc3MCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
-        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
-        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        MCwgInN0ZXBfaWQiOiAiNDIzNTA4YjktYTkwMC00Y2JkLWE3ZmUtODcyOWNi
+        NzljMDVkIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAicXVldWUiOiAicmVz
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAY2VudG9zNy1kZXZsMi5leGFtcGxl
+        LmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWRldmwyLmV4
+        YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAi
+        ZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIs
+        ICJzdGFydGVkIjogIjIwMTctMDgtMDlUMjE6NTM6MTRaIiwgIl9ucyI6ICJy
+        ZXBvX3B1Ymxpc2hfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNy0wOC0w
+        OVQyMTo1MzoxNFoiLCAidHJhY2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9y
+        X3R5cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7Imdl
+        bmVyYXRlIHNxbGl0ZSI6ICJTS0lQUEVEIiwgImluaXRpYWxpemVfcmVwb19t
+        ZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJycG1zIjogIkZJTklTSEVEIiwgImNs
+        b3NlX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAiZHJwbXMiOiAiU0tJ
+        UFBFRCIsICJjb21wcyI6ICJGSU5JU0hFRCIsICJkaXN0cmlidXRpb24iOiAi
+        RklOSVNIRUQiLCAicmVwb3ZpZXciOiAiU0tJUFBFRCIsICJwdWJsaXNoX2Rp
+        cmVjdG9yeSI6ICJGSU5JU0hFRCIsICJlcnJhdGEiOiAiRklOSVNIRUQiLCAi
+        bWV0YWRhdGEiOiAiRklOSVNIRUQifSwgImVycm9yX21lc3NhZ2UiOiBudWxs
+        LCAiZGlzdHJpYnV0b3JfaWQiOiAic2NlbmFyaW9fdGVzdCIsICJpZCI6ICI1
+        OThiODQ0YWQwMzVjYTA1NWEwZWU0NzUiLCAiZGV0YWlscyI6IFt7Im51bV9z
+        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBv
+        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTljMDk1YWMtMWNjYS00OTM2LTk5
+        OWMtNTc1NGNlODYxNjVjIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3Ry
+        aWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwg
+        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjliZWRiZWRjLTA1ZmYtNGU0ZS1hNDU0LTZkODk0
+        NzAzZTZlMiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBf
+        dHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVjODI4ZTg2LTUwMTct
+        NDcyZS1hZGNkLTJkZmI0M2M1MmE2MiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMi
         OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjg5YzIwMDY2LWYwZmMtNGM5MS05M2VkLTQ1NThjMzJmYjhmOSIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
-        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
-        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImYz
-        NmQ0ODRmLWZjYTktNGM4NC04MzJjLTJmYjMxYjJjNDJiYiIsICJudW1fcHJv
-        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
-        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
-        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ1NDJhMmI4LWUxYjEt
-        NDkyMS1iZmIyLWE5ZTZjODU4ZGUxYiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
-        ZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVt
-        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjM5MzZhMzkwLTIzOWItNGIwZi05NmE3LWZiMzNkNzVhMjJl
-        MSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3Rl
-        cF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjog
-        MSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjI4ZDBlMzU4LTU2NjAtNDE1Yy05N2UwLTg0OTJjMDUzZmIxMCIsICJudW1f
-        cHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRp
-        b24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJp
-        bml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDBj
-        NjA1NzAtZjgyOC00MGI1LWIyMTQtYTBkNDI4YWE1ZWI3IiwgIm51bV9wcm9j
-        ZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjog
-        IjU5MGI0MjNjM2Y3YWQ1OTMyODUxMzc3ZiJ9LCAiaWQiOiAiNTkwYjQyM2Mz
-        ZjdhZDU5MzI4NTEzNzdmIn0=
+        X2lkIjogIjIyYzBkN2NmLTNlM2MtNGQ2Mi04ODZjLTg5NDJjZTM5N2VhZCIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
+        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjog
+        ImVycmF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1N2I5ZDJjMi1mMmI1LTQ5ZTUt
+        YTRkYS0xOGI3ZWIzMjBmM2YiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29t
+        cHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiMjY0ODczNWQtNmNmNy00M2NjLTlkNTgtOTc3ZWUyOWVkYmJiIiwgIm51
+        bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
+        dGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAi
+        bWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiY2M1OWE2NjQtYWE4Mi00MDgw
+        LWE4MDMtODZiNmE5NDVmZjY0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8g
+        bWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiYjVhYzQyOGQtM2Q1MS00Y2VlLWI4ZjYtMDI0
+        ZTUxNWU2MTFjIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2Vz
+        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxl
+        cyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3Rv
+        dGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiZmQwOTQ4NjgtZDM3Ny00ODcxLWIwOGUtNDgwZThlOTM1MzYwIiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBl
+        IjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNL
+        SVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTcwMmUyMTYtYjdmZC00
+        MmVhLWJmYTMtM2M2YTdmY2M2Y2JiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
+        eyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
+        IGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rv
+        cnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiOWQ3MWI0ZmQtMjczMC00YmRmLWI1MWYt
+        ZDQyNTNjYWM5ZDM4IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZp
+        bGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI0MjM1MDhiOS1hOTAwLTRjYmQtYTdmZS04NzI5
+        Y2I3OWMwNWQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9XX0sICJlcnJvciI6IG51
+        bGwsICJfaWQiOiB7IiRvaWQiOiAiNTk4Yjg0NGFiYmM2ZjRiOTM2NWY5MGUy
+        In0sICJpZCI6ICI1OThiODQ0YWJiYzZmNGI5MzY1ZjkwZTIifQ==
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:17 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:14 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/repo_sync.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/repo_sync.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/actions/sync/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/repositories/scenario_test/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -25,7 +25,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:37 GMT
+      - Wed, 09 Aug 2017 21:53:34 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -38,14 +38,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzgxZTdiNTZlLTNjNGMtNDMzMS1hZmUwLWUwZmZjNGZhMWMyYi8iLCAi
-        dGFza19pZCI6ICI4MWU3YjU2ZS0zYzRjLTQzMzEtYWZlMC1lMGZmYzRmYTFj
-        MmIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzljMDlkNjZkLTNhMGQtNGU3Ny1iNzZiLWIwMDk0YmNjZmY2My8iLCAi
+        dGFza19pZCI6ICI5YzA5ZDY2ZC0zYTBkLTRlNzctYjc2Yi1iMDA5NGJjY2Zm
+        NjMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:37 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:34 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/81e7b56e-3c4c-4331-afe0-e0ffc4fa1c2b/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/tasks/9c09d66d-3a0d-4e77-b76b-b0094bccff63/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -64,13 +64,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:37 GMT
+      - Wed, 09 Aug 2017 21:53:34 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '629'
+      - '569'
       Connection:
       - close
       Content-Type:
@@ -80,63 +80,62 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84MWU3YjU2ZS0zYzRjLTQzMzEtYWZlMC1lMGZmYzRmYTFj
-        MmIvIiwgInRhc2tfaWQiOiAiODFlN2I1NmUtM2M0Yy00MzMxLWFmZTAtZTBm
-        ZmM0ZmExYzJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogbnVs
-        bCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
-        cm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJ3
-        YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
-        cmtlci0xQGRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU5MGI0MjUxM2Y3YWQ1OTMy
-        ODUxMzc4MCJ9LCAiaWQiOiAiNTkwYjQyNTEzZjdhZDU5MzI4NTEzNzgwIn0=
-    http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:37 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/81e7b56e-3c4c-4331-afe0-e0ffc4fa1c2b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 May 2017 15:01:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1119'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84MWU3YjU2ZS0zYzRjLTQzMzEtYWZlMC1lMGZmYzRmYTFj
-        MmIvIiwgInRhc2tfaWQiOiAiODFlN2I1NmUtM2M0Yy00MzMxLWFmZTAtZTBm
-        ZmM0ZmExYzJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy85YzA5ZDY2ZC0zYTBkLTRlNzctYjc2Yi1iMDA5NGJjY2Zm
+        NjMvIiwgInRhc2tfaWQiOiAiOWMwOWQ2NmQtM2EwZC00ZTc3LWI3NmItYjAw
+        OTRiY2NmZjYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTctMDUtMDRUMTU6MDE6MzdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTctMDgtMDlUMjE6NTM6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVl
+        IjogIk5vbmUuZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6IG51bGwsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjU5OGI4NDVlYmJjNmY0YjkzNjVmOTBlMyJ9LCAiaWQi
+        OiAiNTk4Yjg0NWViYmM2ZjRiOTM2NWY5MGUzIn0=
+    http_version: 
+  recorded_at: Wed, 09 Aug 2017 21:53:34 GMT
+- request:
+    method: get
+    uri: https://centos7-devl2.example.com/pulp/api/v2/tasks/9c09d66d-3a0d-4e77-b76b-b0094bccff63/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 09 Aug 2017 21:53:34 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1139'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85YzA5ZDY2ZC0zYTBkLTRlNzctYjc2Yi1iMDA5NGJjY2Zm
+        NjMvIiwgInRhc2tfaWQiOiAiOWMwOWQ2NmQtM2EwZC00ZTc3LWI3NmItYjAw
+        OTRiY2NmZjYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTctMDgtMDlUMjE6NTM6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
@@ -147,18 +146,19 @@ http_interactions:
         YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
         X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
         dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3Rh
-        dGUiOiAiTk9UX1NUQVJURUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJO
-        T1RfU1RBUlRFRCJ9fX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
-        b3JrZXItMUBkZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmlu
-        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MUBkZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjog
-        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1OTBiNDI1MTNmN2FkNTkzMjg1MTM3
-        ODAifSwgImlkIjogIjU5MGI0MjUxM2Y3YWQ1OTMyODUxMzc4MCJ9
+        dGUiOiAiTk9UX1NUQVJURUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJJ
+        Tl9QUk9HUkVTUyJ9fX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMUBjZW50b3M3LWRldmwyLmV4YW1wbGUuY29tLmRxIiwgInN0YXRl
+        IjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTFAY2VudG9zNy1kZXZsMi5leGFtcGxlLmNvbSIsICJyZXN1
+        bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU5
+        OGI4NDVlYmJjNmY0YjkzNjVmOTBlMyJ9LCAiaWQiOiAiNTk4Yjg0NWViYmM2
+        ZjRiOTM2NWY5MGUzIn0=
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:37 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:34 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/81e7b56e-3c4c-4331-afe0-e0ffc4fa1c2b/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/tasks/9c09d66d-3a0d-4e77-b76b-b0094bccff63/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -177,13 +177,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:37 GMT
+      - Wed, 09 Aug 2017 21:53:34 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1116'
+      - '1136'
       Connection:
       - close
       Content-Type:
@@ -193,15 +193,15 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84MWU3YjU2ZS0zYzRjLTQzMzEtYWZlMC1lMGZmYzRmYTFj
-        MmIvIiwgInRhc2tfaWQiOiAiODFlN2I1NmUtM2M0Yy00MzMxLWFmZTAtZTBm
-        ZmM0ZmExYzJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy85YzA5ZDY2ZC0zYTBkLTRlNzctYjc2Yi1iMDA5NGJjY2Zm
+        NjMvIiwgInRhc2tfaWQiOiAiOWMwOWQ2NmQtM2EwZC00ZTc3LWI3NmItYjAw
+        OTRiY2NmZjYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTctMDUtMDRUMTU6MDE6MzdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTctMDgtMDlUMjE6NTM6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
         cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
         YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
         emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
@@ -211,16 +211,17 @@ http_interactions:
         dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3Rh
         dGUiOiAiTk9UX1NUQVJURUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
         SU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMUBkZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBk
-        ZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVs
-        bCwgIl9pZCI6IHsiJG9pZCI6ICI1OTBiNDI1MTNmN2FkNTkzMjg1MTM3ODAi
-        fSwgImlkIjogIjU5MGI0MjUxM2Y3YWQ1OTMyODUxMzc4MCJ9
+        ZXItMUBjZW50b3M3LWRldmwyLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAY2VudG9zNy1kZXZsMi5leGFtcGxlLmNvbSIsICJyZXN1bHQi
+        OiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU5OGI4
+        NDVlYmJjNmY0YjkzNjVmOTBlMyJ9LCAiaWQiOiAiNTk4Yjg0NWViYmM2ZjRi
+        OTM2NWY5MGUzIn0=
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:37 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:34 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/81e7b56e-3c4c-4331-afe0-e0ffc4fa1c2b/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/tasks/9c09d66d-3a0d-4e77-b76b-b0094bccff63/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -239,13 +240,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:37 GMT
+      - Wed, 09 Aug 2017 21:53:34 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1124'
+      - '1136'
       Connection:
       - close
       Content-Type:
@@ -255,34 +256,35 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84MWU3YjU2ZS0zYzRjLTQzMzEtYWZlMC1lMGZmYzRmYTFj
-        MmIvIiwgInRhc2tfaWQiOiAiODFlN2I1NmUtM2M0Yy00MzMxLWFmZTAtZTBm
-        ZmM0ZmExYzJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy85YzA5ZDY2ZC0zYTBkLTRlNzctYjc2Yi1iMDA5NGJjY2Zm
+        NjMvIiwgInRhc2tfaWQiOiAiOWMwOWQ2NmQtM2EwZC00ZTc3LWI3NmItYjAw
+        OTRiY2NmZjYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTctMDUtMDRUMTU6MDE6MzdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTctMDgtMDlUMjE6NTM6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
-        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUi
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIs
-        ICJzaXplX2xlZnQiOiAxNzg3MiwgIml0ZW1zX2xlZnQiOiA4fSwgImNvbXBz
-        IjogeyJzdGF0ZSI6ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRl
-        cyI6IHsic3RhdGUiOiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6
-        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
-        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
-        cmtlci0xQGRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU5MGI0MjUxM2Y3YWQ1OTMy
-        ODUxMzc4MCJ9LCAiaWQiOiAiNTkwYjQyNTEzZjdhZDU5MzI4NTEzNzgwIn0=
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMUBjZW50b3M3LWRldmwyLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAY2VudG9zNy1kZXZsMi5leGFtcGxlLmNvbSIsICJyZXN1bHQi
+        OiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU5OGI4
+        NDVlYmJjNmY0YjkzNjVmOTBlMyJ9LCAiaWQiOiAiNTk4Yjg0NWViYmM2ZjRi
+        OTM2NWY5MGUzIn0=
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:37 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:34 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/81e7b56e-3c4c-4331-afe0-e0ffc4fa1c2b/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/tasks/9c09d66d-3a0d-4e77-b76b-b0094bccff63/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -301,13 +303,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:37 GMT
+      - Wed, 09 Aug 2017 21:53:34 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1124'
+      - '1136'
       Connection:
       - close
       Content-Type:
@@ -317,34 +319,35 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84MWU3YjU2ZS0zYzRjLTQzMzEtYWZlMC1lMGZmYzRmYTFj
-        MmIvIiwgInRhc2tfaWQiOiAiODFlN2I1NmUtM2M0Yy00MzMxLWFmZTAtZTBm
-        ZmM0ZmExYzJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy85YzA5ZDY2ZC0zYTBkLTRlNzctYjc2Yi1iMDA5NGJjY2Zm
+        NjMvIiwgInRhc2tfaWQiOiAiOWMwOWQ2NmQtM2EwZC00ZTc3LWI3NmItYjAw
+        OTRiY2NmZjYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTctMDUtMDRUMTU6MDE6MzdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTctMDgtMDlUMjE6NTM6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
-        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUi
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIs
-        ICJzaXplX2xlZnQiOiAxNzg3MiwgIml0ZW1zX2xlZnQiOiA4fSwgImNvbXBz
-        IjogeyJzdGF0ZSI6ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRl
-        cyI6IHsic3RhdGUiOiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6
-        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
-        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
-        cmtlci0xQGRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU5MGI0MjUxM2Y3YWQ1OTMy
-        ODUxMzc4MCJ9LCAiaWQiOiAiNTkwYjQyNTEzZjdhZDU5MzI4NTEzNzgwIn0=
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMUBjZW50b3M3LWRldmwyLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTFAY2VudG9zNy1kZXZsMi5leGFtcGxlLmNvbSIsICJyZXN1bHQi
+        OiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU5OGI4
+        NDVlYmJjNmY0YjkzNjVmOTBlMyJ9LCAiaWQiOiAiNTk4Yjg0NWViYmM2ZjRi
+        OTM2NWY5MGUzIn0=
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:38 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:34 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/81e7b56e-3c4c-4331-afe0-e0ffc4fa1c2b/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/tasks/9c09d66d-3a0d-4e77-b76b-b0094bccff63/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -363,13 +366,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:38 GMT
+      - Wed, 09 Aug 2017 21:53:34 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1124'
+      - '1130'
       Connection:
       - close
       Content-Type:
@@ -379,158 +382,35 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84MWU3YjU2ZS0zYzRjLTQzMzEtYWZlMC1lMGZmYzRmYTFj
-        MmIvIiwgInRhc2tfaWQiOiAiODFlN2I1NmUtM2M0Yy00MzMxLWFmZTAtZTBm
-        ZmM0ZmExYzJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy85YzA5ZDY2ZC0zYTBkLTRlNzctYjc2Yi1iMDA5NGJjY2Zm
+        NjMvIiwgInRhc2tfaWQiOiAiOWMwOWQ2NmQtM2EwZC00ZTc3LWI3NmItYjAw
+        OTRiY2NmZjYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTctMDUtMDRUMTU6MDE6MzdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTctMDgtMDlUMjE6NTM6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
-        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUi
-        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogMSwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIs
-        ICJzaXplX2xlZnQiOiAxNTY0MCwgIml0ZW1zX2xlZnQiOiA3fSwgImNvbXBz
-        IjogeyJzdGF0ZSI6ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRl
-        cyI6IHsic3RhdGUiOiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6
-        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
-        IjogeyJzdGF0ZSI6ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJy
-        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
-        cmtlci0xQGRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU5MGI0MjUxM2Y3YWQ1OTMy
-        ODUxMzc4MCJ9LCAiaWQiOiAiNTkwYjQyNTEzZjdhZDU5MzI4NTEzNzgwIn0=
-    http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:38 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/81e7b56e-3c4c-4331-afe0-e0ffc4fa1c2b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 May 2017 15:01:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1123'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84MWU3YjU2ZS0zYzRjLTQzMzEtYWZlMC1lMGZmYzRmYTFj
-        MmIvIiwgInRhc2tfaWQiOiAiODFlN2I1NmUtM2M0Yy00MzMxLWFmZTAtZTBm
-        ZmM0ZmExYzJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTctMDUtMDRUMTU6MDE6MzdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
-        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
-        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUi
-        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogNCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIs
-        ICJzaXplX2xlZnQiOiA4OTI0LCAiaXRlbXNfbGVmdCI6IDR9LCAiY29tcHMi
-        OiB7InN0YXRlIjogIk5PVF9TVEFSVEVEIn0sICJwdXJnZV9kdXBsaWNhdGVz
-        IjogeyJzdGF0ZSI6ICJOT1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjog
-        eyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIk5PVF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
-        Y2Vfd29ya2VyLTFAZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1
-        bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJv
-        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTkwYjQyNTEzZjdhZDU5MzI4
-        NTEzNzgwIn0sICJpZCI6ICI1OTBiNDI1MTNmN2FkNTkzMjg1MTM3ODAifQ==
-    http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:38 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/81e7b56e-3c4c-4331-afe0-e0ffc4fa1c2b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 May 2017 15:01:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1120'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84MWU3YjU2ZS0zYzRjLTQzMzEtYWZlMC1lMGZmYzRmYTFj
-        MmIvIiwgInRhc2tfaWQiOiAiODFlN2I1NmUtM2M0Yy00MzMxLWFmZTAtZTBm
-        ZmM0ZmExYzJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTctMDUtMDRUMTU6MDE6MzdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
-        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
-        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUi
-        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIs
-        ICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7
-        InN0YXRlIjogIk5PVF9TVEFSVEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
-        eyJzdGF0ZSI6ICJOT1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJp
-        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7
-        InN0YXRlIjogIk5PVF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5p
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        SU5fUFJPR1JFU1MifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9fX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBj
+        ZW50b3M3LWRldmwyLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5p
         bmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTFAZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
-        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNTkwYjQyNTEzZjdhZDU5MzI4NTEz
-        NzgwIn0sICJpZCI6ICI1OTBiNDI1MTNmN2FkNTkzMjg1MTM3ODAifQ==
+        LTFAY2VudG9zNy1kZXZsMi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU5OGI4NDVlYmJj
+        NmY0YjkzNjVmOTBlMyJ9LCAiaWQiOiAiNTk4Yjg0NWViYmM2ZjRiOTM2NWY5
+        MGUzIn0=
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:38 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:34 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/81e7b56e-3c4c-4331-afe0-e0ffc4fa1c2b/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/tasks/9c09d66d-3a0d-4e77-b76b-b0094bccff63/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -549,13 +429,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:38 GMT
+      - Wed, 09 Aug 2017 21:53:34 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1117'
+      - '1130'
       Connection:
       - close
       Content-Type:
@@ -565,34 +445,35 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84MWU3YjU2ZS0zYzRjLTQzMzEtYWZlMC1lMGZmYzRmYTFj
-        MmIvIiwgInRhc2tfaWQiOiAiODFlN2I1NmUtM2M0Yy00MzMxLWFmZTAtZTBm
-        ZmM0ZmExYzJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy85YzA5ZDY2ZC0zYTBkLTRlNzctYjc2Yi1iMDA5NGJjY2Zm
+        NjMvIiwgInRhc2tfaWQiOiAiOWMwOWQ2NmQtM2EwZC00ZTc3LWI3NmItYjAw
+        OTRiY2NmZjYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTctMDUtMDRUMTU6MDE6MzdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTctMDgtMDlUMjE6NTM6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
-        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUi
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1fdG90YWwi
-        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIsICJz
-        aXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
-        dGF0ZSI6ICJOT1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0
-        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTFAZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmci
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        ZGV2LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51
-        bGwsICJfaWQiOiB7IiRvaWQiOiAiNTkwYjQyNTEzZjdhZDU5MzI4NTEzNzgw
-        In0sICJpZCI6ICI1OTBiNDI1MTNmN2FkNTkzMjg1MTM3ODAifQ==
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        SU5fUFJPR1JFU1MifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9fX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBj
+        ZW50b3M3LWRldmwyLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5p
+        bmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTFAY2VudG9zNy1kZXZsMi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU5OGI4NDVlYmJj
+        NmY0YjkzNjVmOTBlMyJ9LCAiaWQiOiAiNTk4Yjg0NWViYmM2ZjRiOTM2NWY5
+        MGUzIn0=
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:38 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:34 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/81e7b56e-3c4c-4331-afe0-e0ffc4fa1c2b/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/tasks/9c09d66d-3a0d-4e77-b76b-b0094bccff63/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -611,13 +492,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:38 GMT
+      - Wed, 09 Aug 2017 21:53:34 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1114'
+      - '1121'
       Connection:
       - close
       Content-Type:
@@ -627,34 +508,123 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84MWU3YjU2ZS0zYzRjLTQzMzEtYWZlMC1lMGZmYzRmYTFj
-        MmIvIiwgInRhc2tfaWQiOiAiODFlN2I1NmUtM2M0Yy00MzMxLWFmZTAtZTBm
-        ZmM0ZmExYzJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy85YzA5ZDY2ZC0zYTBkLTRlNzctYjc2Yi1iMDA5NGJjY2Zm
+        NjMvIiwgInRhc2tfaWQiOiAiOWMwOWQ2NmQtM2EwZC00ZTc3LWI3NmItYjAw
+        OTRiY2NmZjYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTctMDUtMDRUMTU6MDE6MzdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTctMDgtMDlUMjE6NTM6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
-        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUi
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1fdG90YWwi
-        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIsICJz
-        aXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
-        dGF0ZSI6ICJOT1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVt
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJx
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWRl
+        dmwyLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29y
+        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAY2VudG9z
+        Ny1kZXZsMi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3Ii
+        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU5OGI4NDVlYmJjNmY0YjkzNjVm
+        OTBlMyJ9LCAiaWQiOiAiNTk4Yjg0NWViYmM2ZjRiOTM2NWY5MGUzIn0=
+    http_version: 
+  recorded_at: Wed, 09 Aug 2017 21:53:34 GMT
+- request:
+    method: get
+    uri: https://centos7-devl2.example.com/pulp/api/v2/tasks/9c09d66d-3a0d-4e77-b76b-b0094bccff63/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 09 Aug 2017 21:53:34 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2306'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85YzA5ZDY2ZC0zYTBkLTRlNzctYjc2Yi1iMDA5NGJjY2Zm
+        NjMvIiwgInRhc2tfaWQiOiAiOWMwOWQ2NmQtM2EwZC00ZTc3LWI3NmItYjAw
+        OTRiY2NmZjYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTctMDgtMDlUMjE6NTM6MzRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTctMDgtMDlUMjE6NTM6MzRaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzLzc2OTZkOGExLWViNDMtNDhlNS05NDcwLWJhYzMz
+        ZjQ5YzNlNC8iLCAidGFza19pZCI6ICI3Njk2ZDhhMS1lYjQzLTQ4ZTUtOTQ3
+        MC1iYWMzM2Y0OWMzZTQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3
+        LWRldmwyLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNl
+        bnRvczctZGV2bDIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
+        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
+        ZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIs
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE3LTA4LTA5VDIx
+        OjUzOjM0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxl
+        dGVkIjogIjIwMTctMDgtMDlUMjE6NTM6MzRaIiwgImltcG9ydGVyX3R5cGVf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAi
+        c3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVw
+        ZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTk4Yjg0NWVkMDM1Y2EwNTVhMGVl
+        NDg3IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAw
+        LCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBt
+        X3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAi
+        ZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVt
         c190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRl
-        IjogIklOX1BST0dSRVNTIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTFAZGV2LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAi
-        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2
-        LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNTkwYjQyNTEzZjdhZDU5MzI4NTEzNzgwIn0s
-        ICJpZCI6ICI1OTBiNDI1MTNmN2FkNTkzMjg1MTM3ODAifQ==
+        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU5OGI4
+        NDVlYmJjNmY0YjkzNjVmOTBlMyJ9LCAiaWQiOiAiNTk4Yjg0NWViYmM2ZjRi
+        OTM2NWY5MGUzIn0=
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:38 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:34 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/81e7b56e-3c4c-4331-afe0-e0ffc4fa1c2b/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/tasks/7696d8a1-eb43-48e5-9470-bac33f49c3e4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -673,225 +643,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:38 GMT
+      - Wed, 09 Aug 2017 21:53:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1108'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84MWU3YjU2ZS0zYzRjLTQzMzEtYWZlMC1lMGZmYzRmYTFj
-        MmIvIiwgInRhc2tfaWQiOiAiODFlN2I1NmUtM2M0Yy00MzMxLWFmZTAtZTBm
-        ZmM0ZmExYzJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTctMDUtMDRUMTU6MDE6MzdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
-        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
-        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1fdG90YWwi
-        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIsICJz
-        aXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJJTl9QUk9HUkVTUyJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
-        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2
-        LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2Vy
-        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2LmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQi
-        OiB7IiRvaWQiOiAiNTkwYjQyNTEzZjdhZDU5MzI4NTEzNzgwIn0sICJpZCI6
-        ICI1OTBiNDI1MTNmN2FkNTkzMjg1MTM3ODAifQ==
-    http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:38 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/81e7b56e-3c4c-4331-afe0-e0ffc4fa1c2b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 May 2017 15:01:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1105'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84MWU3YjU2ZS0zYzRjLTQzMzEtYWZlMC1lMGZmYzRmYTFj
-        MmIvIiwgInRhc2tfaWQiOiAiODFlN2I1NmUtM2M0Yy00MzMxLWFmZTAtZTBm
-        ZmM0ZmExYzJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTctMDUtMDRUMTU6MDE6MzdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
-        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
-        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1fdG90YWwi
-        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIsICJz
-        aXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
-        bCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
-        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2LmV4
-        YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25h
-        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2LmV4YW1wbGUu
-        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNTkwYjQyNTEzZjdhZDU5MzI4NTEzNzgwIn0sICJpZCI6ICI1
-        OTBiNDI1MTNmN2FkNTkzMjg1MTM3ODAifQ==
-    http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:38 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/81e7b56e-3c4c-4331-afe0-e0ffc4fa1c2b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 May 2017 15:01:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2294'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84MWU3YjU2ZS0zYzRjLTQzMzEtYWZlMC1lMGZmYzRmYTFj
-        MmIvIiwgInRhc2tfaWQiOiAiODFlN2I1NmUtM2M0Yy00MzMxLWFmZTAtZTBm
-        ZmM0ZmExYzJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTctMDUtMDRUMTU6MDE6MzhaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTctMDUtMDRUMTU6MDE6MzdaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzLzc3MDYyMDQyLTZhMGQtNDJmMS05ZjRlLTMwYTM1
-        NjdlZjNlNi8iLCAidGFza19pZCI6ICI3NzA2MjA0Mi02YTBkLTQyZjEtOWY0
-        ZS0zMGEzNTY3ZWYzZTYifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
-        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIs
-        ICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
-        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2
-        LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGRldi5leGFt
-        cGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImlt
-        cG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzdGFydGVkIjogIjIwMTctMDUtMDRUMTU6MDE6MzdaIiwgIl9ucyI6
-        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNy0wNS0w
-        NFQxNTowMTozOFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
-        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250
-        ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0
-        YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQi
-        OiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAs
-        ICJpZCI6ICI1OTBiNDI1MjQxOGE4YTA3YmFmYjU2NzEiLCAiZGV0YWlscyI6
-        IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDE3ODcyLCAiaXRlbXNfbGVm
-        dCI6IDAsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogOCwg
-        InJwbV9kb25lIjogOCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
-        MH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
-        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU5MGI0MjUxM2Y3YWQ1OTMy
-        ODUxMzc4MCJ9LCAiaWQiOiAiNTkwYjQyNTEzZjdhZDU5MzI4NTEzNzgwIn0=
-    http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:38 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/77062042-6a0d-42f1-9f4e-30a3567ef3e6/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 May 2017 15:01:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '638'
+      - '658'
       Connection:
       - close
       Content-Type:
@@ -901,24 +659,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy83NzA2MjA0Mi02YTBkLTQyZjEtOWY0ZS0zMGEz
-        NTY3ZWYzZTYvIiwgInRhc2tfaWQiOiAiNzcwNjIwNDItNmEwZC00MmYxLTlm
-        NGUtMzBhMzU2N2VmM2U2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy83Njk2ZDhhMS1lYjQzLTQ4ZTUtOTQ3MC1iYWMz
+        M2Y0OWMzZTQvIiwgInRhc2tfaWQiOiAiNzY5NmQ4YTEtZWI0My00OGU1LTk0
+        NzAtYmFjMzNmNDljM2U0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
         aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
         aW1lIjogbnVsbCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
         IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0xQGRldi5leGFtcGxlLmNvbS5kcSIsICJz
-        dGF0ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
-        c291cmNlX3dvcmtlci0xQGRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
-        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU5MGI0MjUy
-        M2Y3YWQ1OTMyODUxMzc5MCJ9LCAiaWQiOiAiNTkwYjQyNTIzZjdhZDU5MzI4
-        NTEzNzkwIn0=
+        dmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczctZGV2bDIuZXhhbXBsZS5j
+        b20uZHEiLCAic3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWRldmwyLmV4YW1w
+        bGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQi
+        OiB7IiRvaWQiOiAiNTk4Yjg0NWViYmM2ZjRiOTM2NWY5MGYzIn0sICJpZCI6
+        ICI1OThiODQ1ZWJiYzZmNGI5MzY1ZjkwZjMifQ==
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:38 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:35 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/81e7b56e-3c4c-4331-afe0-e0ffc4fa1c2b/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/tasks/9c09d66d-3a0d-4e77-b76b-b0094bccff63/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -937,13 +695,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:38 GMT
+      - Wed, 09 Aug 2017 21:53:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2294'
+      - '2306'
       Connection:
       - close
       Content-Type:
@@ -953,60 +711,61 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84MWU3YjU2ZS0zYzRjLTQzMzEtYWZlMC1lMGZmYzRmYTFj
-        MmIvIiwgInRhc2tfaWQiOiAiODFlN2I1NmUtM2M0Yy00MzMxLWFmZTAtZTBm
-        ZmM0ZmExYzJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy85YzA5ZDY2ZC0zYTBkLTRlNzctYjc2Yi1iMDA5NGJjY2Zm
+        NjMvIiwgInRhc2tfaWQiOiAiOWMwOWQ2NmQtM2EwZC00ZTc3LWI3NmItYjAw
+        OTRiY2NmZjYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTctMDUtMDRUMTU6MDE6MzhaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTctMDUtMDRUMTU6MDE6MzdaIiwgInRyYWNl
+        IjIwMTctMDgtMDlUMjE6NTM6MzRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTctMDgtMDlUMjE6NTM6MzRaIiwgInRyYWNl
         YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzLzc3MDYyMDQyLTZhMGQtNDJmMS05ZjRlLTMwYTM1
-        NjdlZjNlNi8iLCAidGFza19pZCI6ICI3NzA2MjA0Mi02YTBkLTQyZjEtOWY0
-        ZS0zMGEzNTY3ZWYzZTYifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
-        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3Rh
+        bHAvYXBpL3YyL3Rhc2tzLzc2OTZkOGExLWViNDMtNDhlNS05NDcwLWJhYzMz
+        ZjQ5YzNlNC8iLCAidGFza19pZCI6ICI3Njk2ZDhhMS1lYjQzLTQ4ZTUtOTQ3
+        MC1iYWMzM2Y0OWMzZTQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
         dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIs
-        ICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
-        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2
-        LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGRldi5leGFt
-        cGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImlt
-        cG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzdGFydGVkIjogIjIwMTctMDUtMDRUMTU6MDE6MzdaIiwgIl9ucyI6
-        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNy0wNS0w
-        NFQxNTowMTozOFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
-        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250
-        ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0
-        YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQi
-        OiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAs
-        ICJpZCI6ICI1OTBiNDI1MjQxOGE4YTA3YmFmYjU2NzEiLCAiZGV0YWlscyI6
-        IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDE3ODcyLCAiaXRlbXNfbGVm
-        dCI6IDAsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogOCwg
-        InJwbV9kb25lIjogOCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
-        MH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
-        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU5MGI0MjUxM2Y3YWQ1OTMy
-        ODUxMzc4MCJ9LCAiaWQiOiAiNTkwYjQyNTEzZjdhZDU5MzI4NTEzNzgwIn0=
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3
+        LWRldmwyLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNl
+        bnRvczctZGV2bDIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
+        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
+        ZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIs
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE3LTA4LTA5VDIx
+        OjUzOjM0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxl
+        dGVkIjogIjIwMTctMDgtMDlUMjE6NTM6MzRaIiwgImltcG9ydGVyX3R5cGVf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAi
+        c3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVw
+        ZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTk4Yjg0NWVkMDM1Y2EwNTVhMGVl
+        NDg3IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAw
+        LCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBt
+        X3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAi
+        ZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVt
+        c190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU5OGI4
+        NDVlYmJjNmY0YjkzNjVmOTBlMyJ9LCAiaWQiOiAiNTk4Yjg0NWViYmM2ZjRi
+        OTM2NWY5MGUzIn0=
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:38 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:35 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/77062042-6a0d-42f1-9f4e-30a3567ef3e6/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/tasks/7696d8a1-eb43-48e5-9470-bac33f49c3e4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1025,436 +784,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4008'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy83NzA2MjA0Mi02YTBkLTQyZjEtOWY0ZS0zMGEz
-        NTY3ZWYzZTYvIiwgInRhc2tfaWQiOiAiNzcwNjIwNDItNmEwZC00MmYxLTlm
-        NGUtMzBhMzU2N2VmM2U2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTctMDUtMDRUMTU6MDE6MzhaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
-        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI3M2MzMTUzMy1mMGE1LTQyNTQtOTI1NS0y
-        M2QxMTdlNzI5NzAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiSU5fUFJPR1JFU1Mi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjc1NDI5NTAtOTVmZC00YWFlLWEw
-        NjYtMzMxOGEzMjFkNzliIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3Ry
-        aWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogImU4OTIwOTc3LWVjN2QtNDUwOS1iYWQ5LTE3
-        NTdlNzhmNTkwZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
-        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0
-        ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImEyMjE5ZWIw
-        LWRiYWUtNDA2ZC1hMTMyLWU0NzJlYzI1NTJkNSIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJkYTcyZGY0Yi0zODE1LTRhNWUtOTllMS0xMmZi
-        ZGI5N2QzNjciLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMWM4OGFl
-        MDMtMWYzNi00YzU4LWJhY2ItZmRiYTkzNDk3ZjRiIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjIyNDNiZjFhLTc0ZDctNGI2MC1iZTNmLWZh
-        MGZkZGVmZDcxMCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
-        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4i
-        LCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImM0YzAxNjIyLTQ1NmYtNDA3YS05NTE5LTI4YTY3NDQ3OTMyNCIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJj
-        bG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUwYWQx
-        ZGQxLWZiYWUtNDNlNi1iN2E0LTFmNzcyOGYyYzRiMCIsICJudW1fcHJvY2Vz
-        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
-        R2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVy
-        YXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
-        U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMTc2YzU1Yy0yODRh
-        LTRiMWQtOTkxOS05Y2QxNmY3NDA3NzIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRp
-        bmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiMGM1ZDY2NDQtZWFhOS00MTFlLWI2OWMtZmIxNzRk
-        MDIzMmRhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
-        IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIs
-        ICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
-        ZXBfaWQiOiAiYjExYmQwNTAtOGE3NC00ZDRmLWI3MTAtODliNWYyNmJhN2Iw
-        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
-        ZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90
-        eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIyNGY5MTExYy01YmI1LTQ2NGYtOWQ5MC1jODQyZmU4ZTU0ODYi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9y
-        ZXNvdXJjZV93b3JrZXItMUBkZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUi
-        OiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMUBkZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwg
-        ImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1OTBiNDI1MjNmN2Fk
-        NTkzMjg1MTM3OTAifSwgImlkIjogIjU5MGI0MjUyM2Y3YWQ1OTMyODUxMzc5
-        MCJ9
-    http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:38 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/81e7b56e-3c4c-4331-afe0-e0ffc4fa1c2b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 May 2017 15:01:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2294'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84MWU3YjU2ZS0zYzRjLTQzMzEtYWZlMC1lMGZmYzRmYTFj
-        MmIvIiwgInRhc2tfaWQiOiAiODFlN2I1NmUtM2M0Yy00MzMxLWFmZTAtZTBm
-        ZmM0ZmExYzJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTctMDUtMDRUMTU6MDE6MzhaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTctMDUtMDRUMTU6MDE6MzdaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzLzc3MDYyMDQyLTZhMGQtNDJmMS05ZjRlLTMwYTM1
-        NjdlZjNlNi8iLCAidGFza19pZCI6ICI3NzA2MjA0Mi02YTBkLTQyZjEtOWY0
-        ZS0zMGEzNTY3ZWYzZTYifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
-        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIs
-        ICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
-        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2
-        LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGRldi5leGFt
-        cGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImlt
-        cG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzdGFydGVkIjogIjIwMTctMDUtMDRUMTU6MDE6MzdaIiwgIl9ucyI6
-        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNy0wNS0w
-        NFQxNTowMTozOFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
-        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250
-        ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0
-        YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQi
-        OiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAs
-        ICJpZCI6ICI1OTBiNDI1MjQxOGE4YTA3YmFmYjU2NzEiLCAiZGV0YWlscyI6
-        IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDE3ODcyLCAiaXRlbXNfbGVm
-        dCI6IDAsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogOCwg
-        InJwbV9kb25lIjogOCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
-        MH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
-        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU5MGI0MjUxM2Y3YWQ1OTMy
-        ODUxMzc4MCJ9LCAiaWQiOiAiNTkwYjQyNTEzZjdhZDU5MzI4NTEzNzgwIn0=
-    http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:38 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/77062042-6a0d-42f1-9f4e-30a3567ef3e6/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 May 2017 15:01:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4002'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy83NzA2MjA0Mi02YTBkLTQyZjEtOWY0ZS0zMGEz
-        NTY3ZWYzZTYvIiwgInRhc2tfaWQiOiAiNzcwNjIwNDItNmEwZC00MmYxLTlm
-        NGUtMzBhMzU2N2VmM2U2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTctMDUtMDRUMTU6MDE6MzhaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
-        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI3M2MzMTUzMy1mMGE1LTQyNTQtOTI1NS0y
-        M2QxMTdlNzI5NzAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
-        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZjc1NDI5NTAtOTVmZC00YWFlLWEwNjYt
-        MzMxOGEzMjFkNzliIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
-        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImU4OTIwOTc3LWVjN2QtNDUwOS1iYWQ5LTE3NTdlNzhm
-        NTkwZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAw
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
-        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIklOX1BS
-        T0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImEyMjE5ZWIwLWRiYWUt
-        NDA2ZC1hMTMyLWU0NzJlYzI1NTJkNSIsICJudW1fcHJvY2Vzc2VkIjogMH0s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
-        ZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICJkYTcyZGY0Yi0zODE1LTRhNWUtOTllMS0xMmZiZGI5N2Qz
-        NjciLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlw
-        ZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
-        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMWM4OGFlMDMtMWYz
-        Ni00YzU4LWJhY2ItZmRiYTkzNDk3ZjRiIiwgIm51bV9wcm9jZXNzZWQiOiAw
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjIyNDNiZjFhLTc0ZDctNGI2MC1iZTNmLWZhMGZkZGVm
-        ZDcxMCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3Rl
-        cF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM0YzAx
-        NjIyLTQ1NmYtNDA3YS05NTE5LTI4YTY3NDQ3OTMyNCIsICJudW1fcHJvY2Vz
-        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
-        Q2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9y
-        ZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5P
-        VF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUwYWQxZGQxLWZi
-        YWUtNDNlNi1iN2E0LTFmNzcyOGYyYzRiMCIsICJudW1fcHJvY2Vzc2VkIjog
-        MH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJh
-        dGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNx
-        bGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMTc2YzU1Yy0yODRhLTRiMWQt
-        OTkxOS05Y2QxNmY3NDA3NzIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
-        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRN
-        TCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
-        ZXBfaWQiOiAiMGM1ZDY2NDQtZWFhOS00MTFlLWI2OWMtZmIxNzRkMDIzMmRh
-        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
-        ZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVw
-        X3R5cGUiOiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAx
-        LCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiYjExYmQwNTAtOGE3NC00ZDRmLWI3MTAtODliNWYyNmJhN2IwIiwgIm51
-        bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjog
-        ImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICIyNGY5MTExYy01YmI1LTQ2NGYtOWQ5MC1jODQyZmU4ZTU0ODYiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMUBkZXYuZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVu
-        bmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMUBkZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9y
-        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1OTBiNDI1MjNmN2FkNTkzMjg1
-        MTM3OTAifSwgImlkIjogIjU5MGI0MjUyM2Y3YWQ1OTMyODUxMzc5MCJ9
-    http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:38 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/81e7b56e-3c4c-4331-afe0-e0ffc4fa1c2b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 May 2017 15:01:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2294'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84MWU3YjU2ZS0zYzRjLTQzMzEtYWZlMC1lMGZmYzRmYTFj
-        MmIvIiwgInRhc2tfaWQiOiAiODFlN2I1NmUtM2M0Yy00MzMxLWFmZTAtZTBm
-        ZmM0ZmExYzJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTctMDUtMDRUMTU6MDE6MzhaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTctMDUtMDRUMTU6MDE6MzdaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzLzc3MDYyMDQyLTZhMGQtNDJmMS05ZjRlLTMwYTM1
-        NjdlZjNlNi8iLCAidGFza19pZCI6ICI3NzA2MjA0Mi02YTBkLTQyZjEtOWY0
-        ZS0zMGEzNTY3ZWYzZTYifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
-        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIs
-        ICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
-        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2
-        LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGRldi5leGFt
-        cGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImlt
-        cG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzdGFydGVkIjogIjIwMTctMDUtMDRUMTU6MDE6MzdaIiwgIl9ucyI6
-        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNy0wNS0w
-        NFQxNTowMTozOFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
-        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250
-        ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0
-        YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQi
-        OiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAs
-        ICJpZCI6ICI1OTBiNDI1MjQxOGE4YTA3YmFmYjU2NzEiLCAiZGV0YWlscyI6
-        IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDE3ODcyLCAiaXRlbXNfbGVm
-        dCI6IDAsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogOCwg
-        InJwbV9kb25lIjogOCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
-        MH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
-        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU5MGI0MjUxM2Y3YWQ1OTMy
-        ODUxMzc4MCJ9LCAiaWQiOiAiNTkwYjQyNTEzZjdhZDU5MzI4NTEzNzgwIn0=
-    http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:38 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/77062042-6a0d-42f1-9f4e-30a3567ef3e6/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 May 2017 15:01:38 GMT
+      - Wed, 09 Aug 2017 21:53:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -1470,312 +800,98 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy83NzA2MjA0Mi02YTBkLTQyZjEtOWY0ZS0zMGEz
-        NTY3ZWYzZTYvIiwgInRhc2tfaWQiOiAiNzcwNjIwNDItNmEwZC00MmYxLTlm
-        NGUtMzBhMzU2N2VmM2U2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy83Njk2ZDhhMS1lYjQzLTQ4ZTUtOTQ3MC1iYWMz
+        M2Y0OWMzZTQvIiwgInRhc2tfaWQiOiAiNzY5NmQ4YTEtZWI0My00OGU1LTk0
+        NzAtYmFjMzNmNDljM2U0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
         aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTctMDUtMDRUMTU6MDE6MzhaIiwgInRyYWNlYmFjayI6IG51
+        aW1lIjogIjIwMTctMDgtMDlUMjE6NTM6MzVaIiwgInRyYWNlYmFjayI6IG51
         bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
         InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
         dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
         ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI3M2MzMTUzMy1mMGE1LTQyNTQtOTI1NS0y
-        M2QxMTdlNzI5NzAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJlMzJiNTQ1ZS01ZWVmLTRkNzAtYTljNC1m
+        Nzk3MmM5MzM2YWMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
         ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
         dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
         dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZjc1NDI5NTAtOTVmZC00YWFlLWEwNjYt
-        MzMxOGEzMjFkNzliIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNGNhZmYyMTgtNmRmZS00ZTMyLTk5MTIt
+        M2YzN2EzMmJjN2NjIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
         Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
         dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
         ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
         dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImU4OTIwOTc3LWVjN2QtNDUwOS1iYWQ5LTE3NTdlNzhm
-        NTkwZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        ICJzdGVwX2lkIjogIjk4ZjlhN2ZkLWY4MzctNGEyNi04OGU2LWNkY2FmZjAx
+        OTRiMCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
         LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
         ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImEyMjE5ZWIwLWRiYWUtNDA2
-        ZC1hMTMyLWU0NzJlYzI1NTJkNSIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjViOGFkODlhLTkxZGQtNGZi
+        Ny1hYjVkLTMxYmQ2MzgxMmZkMiIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
         bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
         ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
         bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImRhNzJkZjRiLTM4MTUtNGE1ZS05OWUxLTEyZmJkYjk3ZDM2NyIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
-        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJJTl9QUk9HUkVT
-        UyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxYzg4YWUwMy0xZjM2LTRjNTgt
-        YmFjYi1mZGJhOTM0OTdmNGIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
-        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29t
-        cHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwi
-        OiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMjI0M2JmMWEtNzRkNy00YjYwLWJlM2YtZmEwZmRkZWZkNzEwIiwg
-        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUi
-        OiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
-        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzRjMDE2MjItNDU2
-        Zi00MDdhLTk1MTktMjhhNjc0NDc5MzI0IiwgIm51bV9wcm9jZXNzZWQiOiAw
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5n
-        IHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTBhZDFkZDEtZmJhZS00M2U2
-        LWI3YTQtMWY3NzI4ZjJjNGIwIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
-        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNx
-        bGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogImIxNzZjNTVjLTI4NGEtNGIxZC05OTE5LTlj
-        ZDE2Zjc0MDc3MiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
-        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVz
-        IiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICIwYzVkNjY0NC1lYWE5LTQxMWUtYjY5Yy1mYjE3NGQwMjMyZGEiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6
-        ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMTFi
-        ZDA1MC04YTc0LTRkNGYtYjcxMC04OWI1ZjI2YmE3YjAiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
-        IldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
-        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI0Zjkx
-        MTFjLTViYjUtNDY0Zi05ZDkwLWM4NDJmZThlNTQ4NiIsICJudW1fcHJvY2Vz
-        c2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGRldi5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGRl
-        di5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
-        LCAiX2lkIjogeyIkb2lkIjogIjU5MGI0MjUyM2Y3YWQ1OTMyODUxMzc5MCJ9
-        LCAiaWQiOiAiNTkwYjQyNTIzZjdhZDU5MzI4NTEzNzkwIn0=
-    http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:38 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/81e7b56e-3c4c-4331-afe0-e0ffc4fa1c2b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 May 2017 15:01:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2294'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84MWU3YjU2ZS0zYzRjLTQzMzEtYWZlMC1lMGZmYzRmYTFj
-        MmIvIiwgInRhc2tfaWQiOiAiODFlN2I1NmUtM2M0Yy00MzMxLWFmZTAtZTBm
-        ZmM0ZmExYzJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTctMDUtMDRUMTU6MDE6MzhaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTctMDUtMDRUMTU6MDE6MzdaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzLzc3MDYyMDQyLTZhMGQtNDJmMS05ZjRlLTMwYTM1
-        NjdlZjNlNi8iLCAidGFza19pZCI6ICI3NzA2MjA0Mi02YTBkLTQyZjEtOWY0
-        ZS0zMGEzNTY3ZWYzZTYifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
-        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIs
-        ICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
-        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2
-        LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGRldi5leGFt
-        cGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImlt
-        cG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzdGFydGVkIjogIjIwMTctMDUtMDRUMTU6MDE6MzdaIiwgIl9ucyI6
-        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNy0wNS0w
-        NFQxNTowMTozOFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
-        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250
-        ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0
-        YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQi
-        OiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAs
-        ICJpZCI6ICI1OTBiNDI1MjQxOGE4YTA3YmFmYjU2NzEiLCAiZGV0YWlscyI6
-        IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDE3ODcyLCAiaXRlbXNfbGVm
-        dCI6IDAsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogOCwg
-        InJwbV9kb25lIjogOCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
-        MH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
-        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU5MGI0MjUxM2Y3YWQ1OTMy
-        ODUxMzc4MCJ9LCAiaWQiOiAiNTkwYjQyNTEzZjdhZDU5MzI4NTEzNzgwIn0=
-    http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:38 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/77062042-6a0d-42f1-9f4e-30a3567ef3e6/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 04 May 2017 15:01:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3975'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy83NzA2MjA0Mi02YTBkLTQyZjEtOWY0ZS0zMGEz
-        NTY3ZWYzZTYvIiwgInRhc2tfaWQiOiAiNzcwNjIwNDItNmEwZC00MmYxLTlm
-        NGUtMzBhMzU2N2VmM2U2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTctMDUtMDRUMTU6MDE6MzhaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
-        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI3M2MzMTUzMy1mMGE1LTQyNTQtOTI1NS0y
-        M2QxMTdlNzI5NzAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
-        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZjc1NDI5NTAtOTVmZC00YWFlLWEwNjYt
-        MzMxOGEzMjFkNzliIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
-        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImU4OTIwOTc3LWVjN2QtNDUwOS1iYWQ5LTE3NTdlNzhm
-        NTkwZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
-        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImEyMjE5ZWIwLWRiYWUtNDA2
-        ZC1hMTMyLWU0NzJlYzI1NTJkNSIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
-        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImRhNzJkZjRiLTM4MTUtNGE1ZS05OWUxLTEyZmJkYjk3ZDM2NyIsICJu
+        IjogIjlhZjZlZDg2LWY0NWQtNDhjOC1iYTcwLWFmYmYwMjljNjc4MiIsICJu
         dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
         cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
         cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxYzg4YWUwMy0xZjM2LTRjNTgtYmFj
-        Yi1mZGJhOTM0OTdmNGIiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxOGFmYzE3Ny05OTIyLTRkNGEtODE3
+        YS1jMTc1NjU4MTAzZDYiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
         dWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMg
         ZmlsZSIsICJzdGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAz
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        MjI0M2JmMWEtNzRkNy00YjYwLWJlM2YtZmEwZmRkZWZkNzEwIiwgIm51bV9w
+        ODE1OTUzZGItNmNkYy00ODRhLWFkOTctZWY2ZjZmMGEyY2UwIiwgIm51bV9w
         cm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
         biI6ICJQdWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0
         YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
         LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzRjMDE2MjItNDU2Zi00MDdhLTk1
-        MTktMjhhNjc0NDc5MzI0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjgzNDA5YmItZTkxNS00YTg4LTgy
+        NmYtYzhiMzUzZjU0OTYzIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
         c3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0
         YWRhdGEiLCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAi
         aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
         ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiZTBhZDFkZDEtZmJhZS00M2U2LWI3YTQtMWY3NzI4
-        ZjJjNGIwIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6
+        MCwgInN0ZXBfaWQiOiAiODFmOTY1ZjgtYzJkYy00ODQ3LTg0ZWYtODYyZGIw
+        MDM2MWUwIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6
         IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIs
         ICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFs
         IjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
         LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiYjE3NmM1NWMtMjg0YS00YjFkLTk5MTktOWNkMTZmNzQwNzcyIiwgIm51
+        OiAiNjdlMmI0OWYtZTBmZS00MWViLThjOGUtM2ExMGVlNzI3NjM2IiwgIm51
         bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
         dGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjog
         InJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQ
         RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGM1ZDY2NDQtZWFhOS00MTFl
-        LWI2OWMtZmIxNzRkMDIzMmRhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiY2Q4NWEyZTgtN2NmNy00MzI2
+        LWIzMWItYjViYzdjNWEzNzI0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
         dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZp
         bGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rvcnki
         LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiYjExYmQwNTAtOGE3NC00ZDRmLWI3MTAt
-        ODliNWYyNmJhN2IwIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiYzc5ZjFlZTQtMWU4OS00NzkwLThiNzAt
+        YzYyOTY3ODBmYjJkIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZp
         bGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIyNGY5MTExYy01YmI1LTQ2NGYtOWQ5MC1j
-        ODQyZmU4ZTU0ODYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBkZXYuZXhhbXBsZS5jb20u
-        ZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBkZXYuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        OTBiNDI1MjNmN2FkNTkzMjg1MTM3OTAifSwgImlkIjogIjU5MGI0MjUyM2Y3
-        YWQ1OTMyODUxMzc5MCJ9
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI4M2I0M2IwNS1mZGY2LTQzYWMtYTY0NC0y
+        OWMxMjg0NzA1YWUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWRldmwyLmV4
+        YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25h
+        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAY2VudG9zNy1kZXZs
+        Mi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjU5OGI4NDVlYmJjNmY0YjkzNjVmOTBmMyJ9
+        LCAiaWQiOiAiNTk4Yjg0NWViYmM2ZjRiOTM2NWY5MGYzIn0=
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:38 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:35 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/81e7b56e-3c4c-4331-afe0-e0ffc4fa1c2b/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/tasks/9c09d66d-3a0d-4e77-b76b-b0094bccff63/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1794,13 +910,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:38 GMT
+      - Wed, 09 Aug 2017 21:53:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2294'
+      - '2306'
       Connection:
       - close
       Content-Type:
@@ -1810,60 +926,61 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy84MWU3YjU2ZS0zYzRjLTQzMzEtYWZlMC1lMGZmYzRmYTFj
-        MmIvIiwgInRhc2tfaWQiOiAiODFlN2I1NmUtM2M0Yy00MzMxLWFmZTAtZTBm
-        ZmM0ZmExYzJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy85YzA5ZDY2ZC0zYTBkLTRlNzctYjc2Yi1iMDA5NGJjY2Zm
+        NjMvIiwgInRhc2tfaWQiOiAiOWMwOWQ2NmQtM2EwZC00ZTc3LWI3NmItYjAw
+        OTRiY2NmZjYzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTctMDUtMDRUMTU6MDE6MzhaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTctMDUtMDRUMTU6MDE6MzdaIiwgInRyYWNl
+        IjIwMTctMDgtMDlUMjE6NTM6MzRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTctMDgtMDlUMjE6NTM6MzRaIiwgInRyYWNl
         YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzLzc3MDYyMDQyLTZhMGQtNDJmMS05ZjRlLTMwYTM1
-        NjdlZjNlNi8iLCAidGFza19pZCI6ICI3NzA2MjA0Mi02YTBkLTQyZjEtOWY0
-        ZS0zMGEzNTY3ZWYzZTYifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
-        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3Rh
+        bHAvYXBpL3YyL3Rhc2tzLzc2OTZkOGExLWViNDMtNDhlNS05NDcwLWJhYzMz
+        ZjQ5YzNlNC8iLCAidGFza19pZCI6ICI3Njk2ZDhhMS1lYjQzLTQ4ZTUtOTQ3
+        MC1iYWMzM2Y0OWMzZTQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
         dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIs
-        ICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
-        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2
-        LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGRldi5leGFt
-        cGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImlt
-        cG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxs
-        LCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzdGFydGVkIjogIjIwMTctMDUtMDRUMTU6MDE6MzdaIiwgIl9ucyI6
-        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNy0wNS0w
-        NFQxNTowMTozOFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
-        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJjb250
-        ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5J
-        U0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0
-        YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQi
-        OiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAs
-        ICJpZCI6ICI1OTBiNDI1MjQxOGE4YTA3YmFmYjU2NzEiLCAiZGV0YWlscyI6
-        IHsiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDE3ODcyLCAiaXRlbXNfbGVm
-        dCI6IDAsICJpdGVtc190b3RhbCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogOCwg
-        InJwbV9kb25lIjogOCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjog
-        MH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJp
-        dGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU5MGI0MjUxM2Y3YWQ1OTMy
-        ODUxMzc4MCJ9LCAiaWQiOiAiNTkwYjQyNTEzZjdhZDU5MzI4NTEzNzgwIn0=
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3
+        LWRldmwyLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNl
+        bnRvczctZGV2bDIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
+        OiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
+        ZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIs
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE3LTA4LTA5VDIx
+        OjUzOjM0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29tcGxl
+        dGVkIjogIjIwMTctMDgtMDlUMjE6NTM6MzRaIiwgImltcG9ydGVyX3R5cGVf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAi
+        c3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50IjogMCwgInVw
+        ZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNTk4Yjg0NWVkMDM1Y2EwNTVhMGVl
+        NDg3IiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAw
+        LCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBt
+        X3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAi
+        ZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVt
+        c190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU5OGI4
+        NDVlYmJjNmY0YjkzNjVmOTBlMyJ9LCAiaWQiOiAiNTk4Yjg0NWViYmM2ZjRi
+        OTM2NWY5MGUzIn0=
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:38 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:35 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/77062042-6a0d-42f1-9f4e-30a3567ef3e6/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/tasks/7696d8a1-eb43-48e5-9470-bac33f49c3e4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1882,13 +999,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:38 GMT
+      - Wed, 09 Aug 2017 21:53:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '7950'
+      - '7970'
       Connection:
       - close
       Content-Type:
@@ -1898,186 +1015,187 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy83NzA2MjA0Mi02YTBkLTQyZjEtOWY0ZS0zMGEz
-        NTY3ZWYzZTYvIiwgInRhc2tfaWQiOiAiNzcwNjIwNDItNmEwZC00MmYxLTlm
-        NGUtMzBhMzU2N2VmM2U2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy83Njk2ZDhhMS1lYjQzLTQ4ZTUtOTQ3MC1iYWMz
+        M2Y0OWMzZTQvIiwgInRhc2tfaWQiOiAiNzY5NmQ4YTEtZWI0My00OGU1LTk0
+        NzAtYmFjMzNmNDljM2U0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogIjIwMTctMDUtMDRUMTU6MDE6MzhaIiwgIl9ucyI6ICJ0YXNr
-        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTctMDUtMDRUMTU6MDE6Mzha
+        aF90aW1lIjogIjIwMTctMDgtMDlUMjE6NTM6MzVaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTctMDgtMDlUMjE6NTM6MzVa
         IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
         cm9ncmVzc19yZXBvcnQiOiB7InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3Vj
         Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0
         ZXBfdHlwZSI6ICJzYXZlX3RhciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3M2MzMTUz
-        My1mMGE1LTQyNTQtOTI1NS0yM2QxMTdlNzI5NzAiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlMzJiNTQ1
+        ZS01ZWVmLTRkNzAtYTljNC1mNzk3MmM5MzM2YWMiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIklu
         aXRpYWxpemluZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0
         aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
         dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjc1NDI5
-        NTAtOTVmZC00YWFlLWEwNjYtMzMxOGEzMjFkNzliIiwgIm51bV9wcm9jZXNz
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGNhZmYy
+        MTgtNmRmZS00ZTMyLTk5MTItM2YzN2EzMmJjN2NjIiwgIm51bV9wcm9jZXNz
         ZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
         dWJsaXNoaW5nIERpc3RyaWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
         ZGlzdHJpYnV0aW9uIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
         TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImU4OTIwOTc3LWVjN2Qt
-        NDUwOS1iYWQ5LTE3NTdlNzhmNTkwZiIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjk4ZjlhN2ZkLWY4Mzct
+        NGEyNi04OGU2LWNkY2FmZjAxOTRiMCIsICJudW1fcHJvY2Vzc2VkIjogMX0s
         IHsibnVtX3N1Y2Nlc3MiOiA4LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
         ZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjog
         OCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
         ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImEyMjE5ZWIwLWRiYWUtNDA2ZC1hMTMyLWU0NzJlYzI1NTJkNSIsICJudW1f
+        IjViOGFkODlhLTkxZGQtNGZiNy1hYjVkLTMxYmQ2MzgxMmZkMiIsICJudW1f
         cHJvY2Vzc2VkIjogOH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
         b24iOiAiUHVibGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJk
         cnBtcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImRhNzJkZjRiLTM4MTUtNGE1ZS05OWUx
-        LTEyZmJkYjk3ZDM2NyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjlhZjZlZDg2LWY0NWQtNDhjOC1iYTcw
+        LWFmYmYwMjljNjc4MiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
         Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEi
         LCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxYzg4
-        YWUwMy0xZjM2LTRjNTgtYmFjYi1mZGJhOTM0OTdmNGIiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxOGFm
+        YzE3Ny05OTIyLTRkNGEtODE3YS1jMTc1NjU4MTAzZDYiLCAibnVtX3Byb2Nl
         c3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29tcHMi
         LCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
         b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiMjI0M2JmMWEtNzRkNy00YjYwLWJlM2YtZmEw
-        ZmRkZWZkNzEwIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2Vz
+        IjogMCwgInN0ZXBfaWQiOiAiODE1OTUzZGItNmNkYy00ODRhLWFkOTctZWY2
+        ZjZmMGEyY2UwIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2Vz
         cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRhLiIs
         ICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAi
         c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzRj
-        MDE2MjItNDU2Zi00MDdhLTk1MTktMjhhNjc0NDc5MzI0IiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjgz
+        NDA5YmItZTkxNS00YTg4LTgyNmYtYzhiMzUzZjU0OTYzIiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
         ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNsb3Nl
         X3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
         RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTBhZDFkZDEtZmJh
-        ZS00M2U2LWI3YTQtMWY3NzI4ZjJjNGIwIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODFmOTY1ZjgtYzJk
+        Yy00ODQ3LTg0ZWYtODYyZGIwMDM2MWUwIiwgIm51bV9wcm9jZXNzZWQiOiAx
         fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
         aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3Fs
         aXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiYjE3NmM1NWMtMjg0YS00YjFkLTk5MTkt
-        OWNkMTZmNzQwNzcyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNjdlMmI0OWYtZTBmZS00MWViLThjOGUt
+        M2ExMGVlNzI3NjM2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmls
         ZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjog
         MSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        MGM1ZDY2NDQtZWFhOS00MTFlLWI2OWMtZmIxNzRkMDIzMmRhIiwgIm51bV9w
+        Y2Q4NWEyZTgtN2NmNy00MzI2LWIzMWItYjViYzdjNWEzNzI0IiwgIm51bV9w
         cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
         biI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAi
         cHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
         OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjExYmQwNTAt
-        OGE3NC00ZDRmLWI3MTAtODliNWYyNmJhN2IwIiwgIm51bV9wcm9jZXNzZWQi
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzc5ZjFlZTQt
+        MWU4OS00NzkwLThiNzAtYzYyOTY3ODBmYjJkIiwgIm51bV9wcm9jZXNzZWQi
         OiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJXcml0
         aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVf
         cmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyNGY5MTExYy01YmI1
-        LTQ2NGYtOWQ5MC1jODQyZmU4ZTU0ODYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBkZXYu
-        ZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2Vy
-        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2LmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhj
-        ZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIsICJz
-        dGFydGVkIjogIjIwMTctMDUtMDRUMTU6MDE6MzhaIiwgIl9ucyI6ICJyZXBv
-        X3B1Ymxpc2hfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxNy0wNS0wNFQx
-        NTowMTozOFoiLCAidHJhY2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5
-        cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7ImdlbmVy
-        YXRlIHNxbGl0ZSI6ICJTS0lQUEVEIiwgImluaXRpYWxpemVfcmVwb19tZXRh
-        ZGF0YSI6ICJGSU5JU0hFRCIsICJycG1zIjogIkZJTklTSEVEIiwgInJlcG92
-        aWV3IjogIlNLSVBQRUQiLCAiY2xvc2VfcmVwb19tZXRhZGF0YSI6ICJGSU5J
-        U0hFRCIsICJkcnBtcyI6ICJTS0lQUEVEIiwgImNvbXBzIjogIkZJTklTSEVE
-        IiwgImRpc3RyaWJ1dGlvbiI6ICJGSU5JU0hFRCIsICJzYXZlX3RhciI6ICJG
-        SU5JU0hFRCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6ICJGSU5JU0hFRCIsICJl
-        cnJhdGEiOiAiRklOSVNIRUQiLCAibWV0YWRhdGEiOiAiRklOSVNIRUQifSwg
-        ImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3JfaWQiOiAic2Nl
-        bmFyaW9fdGVzdCIsICJpZCI6ICI1OTBiNDI1MjQxOGE4YTA3YmFmYjU2NzIi
-        LCAiZGV0YWlscyI6IFt7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9u
-        IjogIkNvcHlpbmcgZmlsZXMiLCAic3RlcF90eXBlIjogInNhdmVfdGFyIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjczYzMxNTMzLWYwYTUtNDI1NC05MjU1LTIzZDEx
-        N2U3Mjk3MCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAxLCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRh
-        dGEiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJmNzU0Mjk1MC05NWZkLTRhYWUtYTA2Ni0zMzE4
-        YTMyMWQ3OWIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9u
-        IGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNf
-        dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
-        ZXBfaWQiOiAiZTg5MjA5NzctZWM3ZC00NTA5LWJhZDktMTc1N2U3OGY1OTBm
-        IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJk
-        ZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjog
-        InJwbXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTIyMTllYjAtZGJhZS00MDZkLWEx
-        MzItZTQ3MmVjMjU1MmQ1IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1f
-        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRh
-        IFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjog
-        MSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        ZGE3MmRmNGItMzgxNS00YTVlLTk5ZTEtMTJmYmRiOTdkMzY3IiwgIm51bV9w
-        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlv
-        biI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRh
-        IiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjFjODhhZTAzLTFmMzYtNGM1OC1iYWNiLWZk
-        YmE5MzQ5N2Y0YiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nl
-        c3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxl
-        IiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyMjQz
-        YmYxYS03NGQ3LTRiNjAtYmUzZi1mYTBmZGRlZmQ3MTAiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0
-        YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4M2I0M2IwNS1mZGY2
+        LTQzYWMtYTY0NC0yOWMxMjg0NzA1YWUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50
+        b3M3LWRldmwyLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogImZpbmlzaGVk
+        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
+        QGNlbnRvczctZGV2bDIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1
+        bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6
+        ICJzY2VuYXJpb190ZXN0IiwgInN0YXJ0ZWQiOiAiMjAxNy0wOC0wOVQyMTo1
+        MzozNVoiLCAiX25zIjogInJlcG9fcHVibGlzaF9yZXN1bHRzIiwgImNvbXBs
+        ZXRlZCI6ICIyMDE3LTA4LTA5VDIxOjUzOjM1WiIsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0b3Ii
+        LCAic3VtbWFyeSI6IHsiZ2VuZXJhdGUgc3FsaXRlIjogIlNLSVBQRUQiLCAi
+        aW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgInJwbXMi
+        OiAiRklOSVNIRUQiLCAicmVwb3ZpZXciOiAiU0tJUFBFRCIsICJjbG9zZV9y
+        ZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQi
+        LCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklT
+        SEVEIiwgInNhdmVfdGFyIjogIkZJTklTSEVEIiwgInB1Ymxpc2hfZGlyZWN0
+        b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRh
+        ZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJk
+        aXN0cmlidXRvcl9pZCI6ICJzY2VuYXJpb190ZXN0IiwgImlkIjogIjU5OGI4
+        NDVmZDAzNWNhMDU1YTBlZTQ4OCIsICJkZXRhaWxzIjogW3sibnVtX3N1Y2Nl
+        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ29weWluZyBmaWxlcyIsICJzdGVw
+        X3R5cGUiOiAic2F2ZV90YXIiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTMyYjU0NWUt
+        NWVlZi00ZDcwLWE5YzQtZjc5NzJjOTMzNmFjIiwgIm51bV9wcm9jZXNzZWQi
+        OiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0
+        aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
+        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRjYWZmMjE4
+        LTZkZmUtNGUzMi05OTEyLTNmMzdhMzJiYzdjYyIsICJudW1fcHJvY2Vzc2Vk
+        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRp
+        c3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5OGY5YTdmZC1mODM3LTRh
+        MjYtODhlNi1jZGNhZmYwMTk0YjAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
+        Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
+        UlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1
+        YjhhZDg5YS05MWRkLTRmYjctYWI1ZC0zMWJkNjM4MTJmZDIiLCAibnVtX3By
+        b2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJw
+        bXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJjNGMwMTYyMi00NTZmLTQwN2EtOTUxOS0y
-        OGE2NzQ0NzkzMjQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
-        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0
-        YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVt
-        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICJlMGFkMWRkMS1mYmFlLTQzZTYtYjdhNC0xZjc3MjhmMmM0
-        YjAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0
-        ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAx
-        LCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJi
-        MTc2YzU1Yy0yODRhLTRiMWQtOTkxOS05Y2QxNmY3NDA3NzIiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVw
-        b3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYzVkNjY0NC1lYWE5LTQxMWUtYjY5
-        Yy1mYjE3NGQwMjMyZGEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMg
-        dG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJiMTFiZDA1MC04YTc0LTRkNGYtYjcxMC04OWI1ZjI2
-        YmE3YjAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjI0ZjkxMTFjLTViYjUtNDY0Zi05ZDkwLWM4NDJmZThlNTQ4
-        NiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1OTBiNDI1MjNmN2FkNTkzMjg1MTM3OTAifSwgImlk
-        IjogIjU5MGI0MjUyM2Y3YWQ1OTMyODUxMzc5MCJ9
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI5YWY2ZWQ4Ni1mNDVkLTQ4YzgtYmE3MC1h
+        ZmJmMDI5YzY3ODIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwg
+        InN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMThhZmMx
+        NzctOTkyMi00ZDRhLTgxN2EtYzE3NTY1ODEwM2Q2IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwg
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjgxNTk1M2RiLTZjZGMtNDg0YS1hZDk3LWVmNmY2
+        ZjBhMmNlMCIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAi
+        c3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0
+        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI4MzQw
+        OWJiLWU5MTUtNGE4OC04MjZmLWM4YjM1M2Y1NDk2MyIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        Q2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9y
+        ZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjgxZjk2NWY4LWMyZGMt
+        NDg0Ny04NGVmLTg2MmRiMDAzNjFlMCIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
+        ZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0
+        ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjY3ZTJiNDlmLWUwZmUtNDFlYi04YzhlLTNh
+        MTBlZTcyNzYzNiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVz
+        IiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNk
+        ODVhMmU4LTdjZjctNDMyNi1iMzFiLWI1YmM3YzVhMzcyNCIsICJudW1fcHJv
+        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
+        OiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1
+        Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM3OWYxZWU0LTFl
+        ODktNDc5MC04YjcwLWM2Mjk2NzgwZmIyZCIsICJudW1fcHJvY2Vzc2VkIjog
+        MX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGlu
+        ZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3Jl
+        cG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklO
+        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODNiNDNiMDUtZmRmNi00
+        M2FjLWE2NDQtMjljMTI4NDcwNWFlIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjU5OGI4NDVlYmJj
+        NmY0YjkzNjVmOTBmMyJ9LCAiaWQiOiAiNTk4Yjg0NWViYmM2ZjRiOTM2NWY5
+        MGYzIn0=
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:38 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:35 GMT
 - request:
     method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2100,7 +1218,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:38 GMT
+      - Wed, 09 Aug 2017 21:53:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -2114,63 +1232,63 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIzYTlhMTRkNC01MjU5LTRkNWYtODY4
-        Yi1iZWUyMWQwNTYyNzMiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
-        Il9pZCI6IHsiJG9pZCI6ICI1OTBiNDI1MjNmN2FkNTkzMjg1MTM3ODMifSwg
-        InVuaXRfaWQiOiAiM2E5YTE0ZDQtNTI1OS00ZDVmLTg2OGItYmVlMjFkMDU2
-        MjczIiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogIjYyMjBiZTU5LWE4ZDEtNGU1OC1hY2E3LTg5YWExN2IyNzI1NyIs
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIwNTFkNjY3Ni1hMzA4LTQyMGQtOTBm
+        My01M2ViMTM4YjdhNzIiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1OThiODQ1ZWJiYzZmNGI5MzY1ZjkwZTcifSwg
+        InVuaXRfaWQiOiAiMDUxZDY2NzYtYTMwOC00MjBkLTkwZjMtNTNlYjEzOGI3
+        YTcyIiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
+        X2lkIjogIjkyY2NiNGQyLWQ1OWUtNGU3MS1hY2I2LWI2OGViY2ZkYjM0NyIs
         ICJfY29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjog
-        IjU5MGI0MjUyM2Y3YWQ1OTMyODUxMzc4NSJ9LCAidW5pdF9pZCI6ICI2MjIw
-        YmU1OS1hOGQxLTRlNTgtYWNhNy04OWFhMTdiMjcyNTciLCAidW5pdF90eXBl
-        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiODEzNTFjNWEt
-        Y2Y3Mi00OGMyLWFhNzctMWI1MDZlMDFlOGU0IiwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTkwYjQyNTIzZjdhZDU5
-        MzI4NTEzNzg3In0sICJ1bml0X2lkIjogIjgxMzUxYzVhLWNmNzItNDhjMi1h
-        YTc3LTFiNTA2ZTAxZThlNCIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
-        bWV0YWRhdGEiOiB7Il9pZCI6ICI4ZTY3ZGZhZi1iNWIyLTQxNmEtYmJiOS1h
-        NmZiMTczODUxYjEiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1OTBiNDI1MjNmN2FkNTkzMjg1MTM3ODIifSwgInVu
-        aXRfaWQiOiAiOGU2N2RmYWYtYjViMi00MTZhLWJiYjktYTZmYjE3Mzg1MWIx
+        IjU5OGI4NDVlYmJjNmY0YjkzNjVmOTBlOCJ9LCAidW5pdF9pZCI6ICI5MmNj
+        YjRkMi1kNTllLTRlNzEtYWNiNi1iNjhlYmNmZGIzNDciLCAidW5pdF90eXBl
+        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiOWVjMjg1MGUt
+        YWIwMi00N2Y0LTk2YzYtYmYxNDI4MWZhMTliIiwgIl9jb250ZW50X3R5cGVf
+        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTk4Yjg0NWViYmM2ZjRi
+        OTM2NWY5MGU0In0sICJ1bml0X2lkIjogIjllYzI4NTBlLWFiMDItNDdmNC05
+        NmM2LWJmMTQyODFmYTE5YiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
+        bWV0YWRhdGEiOiB7Il9pZCI6ICJiZjlhZjQ0Mi05ZTRhLTQ1MGYtYWEwNy1k
+        ZTI4NmE2NGZmNjUiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1OThiODQ1ZWJiYzZmNGI5MzY1ZjkwZWEifSwgInVu
+        aXRfaWQiOiAiYmY5YWY0NDItOWU0YS00NTBmLWFhMDctZGUyODZhNjRmZjY1
         IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lk
-        IjogIjkxZjNhMDExLWViZmQtNGM5Ny1iNWFkLWJkYTNmYzY4YWNmNCIsICJf
+        IjogImNkZjA0M2I0LWE1ZTQtNDVlMi1hMzkwLWI1MGNkMjZiNmVmOCIsICJf
         Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU5
-        MGI0MjUyM2Y3YWQ1OTMyODUxMzc4OCJ9LCAidW5pdF9pZCI6ICI5MWYzYTAx
-        MS1lYmZkLTRjOTctYjVhZC1iZGEzZmM2OGFjZjQiLCAidW5pdF90eXBlX2lk
-        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiZTY1OGJlYjItMWI1
-        Ny00NTQ5LTlhMWMtMDczMzI1ZGM3YWQwIiwgIl9jb250ZW50X3R5cGVfaWQi
-        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTkwYjQyNTIzZjdhZDU5MzI4
-        NTEzNzg2In0sICJ1bml0X2lkIjogImU2NThiZWIyLTFiNTctNDU0OS05YTFj
-        LTA3MzMyNWRjN2FkMCIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
-        YWRhdGEiOiB7Il9pZCI6ICJlZjNmMjk0MS1iOTQ0LTQ5MzYtYTliNi02MjQy
-        M2I3NzVjOGYiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
-        IHsiJG9pZCI6ICI1OTBiNDI1MjNmN2FkNTkzMjg1MTM3ODEifSwgInVuaXRf
-        aWQiOiAiZWYzZjI5NDEtYjk0NC00OTM2LWE5YjYtNjI0MjNiNzc1YzhmIiwg
+        OGI4NDVlYmJjNmY0YjkzNjVmOTBlYiJ9LCAidW5pdF9pZCI6ICJjZGYwNDNi
+        NC1hNWU0LTQ1ZTItYTM5MC1iNTBjZDI2YjZlZjgiLCAidW5pdF90eXBlX2lk
+        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiY2YxYzBhNTYtZDNh
+        OC00YjQxLWIxODgtNjc0ODI1ZWEyODc1IiwgIl9jb250ZW50X3R5cGVfaWQi
+        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNTk4Yjg0NWViYmM2ZjRiOTM2
+        NWY5MGU2In0sICJ1bml0X2lkIjogImNmMWMwYTU2LWQzYTgtNGI0MS1iMTg4
+        LTY3NDgyNWVhMjg3NSIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
+        YWRhdGEiOiB7Il9pZCI6ICJkZTFjOWQyMS0wNWEwLTRhNTgtOGFmNi05Mjg0
+        MTliNzIxMDQiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
+        IHsiJG9pZCI6ICI1OThiODQ1ZWJiYzZmNGI5MzY1ZjkwZTUifSwgInVuaXRf
+        aWQiOiAiZGUxYzlkMjEtMDVhMC00YTU4LThhZjYtOTI4NDE5YjcyMTA0Iiwg
         InVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjog
-        ImZhMmU3ZTg2LTE2YjQtNDg4My05NDlmLWY4YWJlN2MyNzBlYiIsICJfY29u
-        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU5MGI0
-        MjUyM2Y3YWQ1OTMyODUxMzc4NCJ9LCAidW5pdF9pZCI6ICJmYTJlN2U4Ni0x
-        NmI0LTQ4ODMtOTQ5Zi1mOGFiZTdjMjcwZWIiLCAidW5pdF90eXBlX2lkIjog
+        ImVjMjYwNWJhLTYxNzItNDk4Mi04NjkzLWU2NTJiMTQ2MGFlOSIsICJfY29u
+        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjU5OGI4
+        NDVlYmJjNmY0YjkzNjVmOTBlOSJ9LCAidW5pdF9pZCI6ICJlYzI2MDViYS02
+        MTcyLTQ5ODItODY5My1lNjUyYjE0NjBhZTkiLCAidW5pdF90eXBlX2lkIjog
         InJwbSJ9XQ==
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:38 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:35 GMT
 - request:
     method: post
-    uri: https://dev.example.com/pulp/api/v2/content/units/rpm/search/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/content/units/rpm/search/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjcml0ZXJpYSI6eyJsaW1pdCI6OCwic2tpcCI6MCwiZmllbGRzIjpbIm5h
         bWUiLCJ2ZXJzaW9uIiwicmVsZWFzZSIsImFyY2giLCJlcG9jaCIsInN1bW1h
         cnkiLCJzb3VyY2VycG0iLCJjaGVja3N1bSIsImZpbGVuYW1lIiwiX2lkIl0s
-        ImZpbHRlcnMiOnsiX2lkIjp7IiRpbiI6WyIzYTlhMTRkNC01MjU5LTRkNWYt
-        ODY4Yi1iZWUyMWQwNTYyNzMiLCI2MjIwYmU1OS1hOGQxLTRlNTgtYWNhNy04
-        OWFhMTdiMjcyNTciLCI4MTM1MWM1YS1jZjcyLTQ4YzItYWE3Ny0xYjUwNmUw
-        MWU4ZTQiLCI4ZTY3ZGZhZi1iNWIyLTQxNmEtYmJiOS1hNmZiMTczODUxYjEi
-        LCI5MWYzYTAxMS1lYmZkLTRjOTctYjVhZC1iZGEzZmM2OGFjZjQiLCJlNjU4
-        YmViMi0xYjU3LTQ1NDktOWExYy0wNzMzMjVkYzdhZDAiLCJlZjNmMjk0MS1i
-        OTQ0LTQ5MzYtYTliNi02MjQyM2I3NzVjOGYiLCJmYTJlN2U4Ni0xNmI0LTQ4
-        ODMtOTQ5Zi1mOGFiZTdjMjcwZWIiXX19fSwiaW5jbHVkZV9yZXBvcyI6dHJ1
+        ImZpbHRlcnMiOnsiX2lkIjp7IiRpbiI6WyIwNTFkNjY3Ni1hMzA4LTQyMGQt
+        OTBmMy01M2ViMTM4YjdhNzIiLCI5MmNjYjRkMi1kNTllLTRlNzEtYWNiNi1i
+        NjhlYmNmZGIzNDciLCI5ZWMyODUwZS1hYjAyLTQ3ZjQtOTZjNi1iZjE0Mjgx
+        ZmExOWIiLCJiZjlhZjQ0Mi05ZTRhLTQ1MGYtYWEwNy1kZTI4NmE2NGZmNjUi
+        LCJjZGYwNDNiNC1hNWU0LTQ1ZTItYTM5MC1iNTBjZDI2YjZlZjgiLCJjZjFj
+        MGE1Ni1kM2E4LTRiNDEtYjE4OC02NzQ4MjVlYTI4NzUiLCJkZTFjOWQyMS0w
+        NWEwLTRhNTgtOGFmNi05Mjg0MTliNzIxMDQiLCJlYzI2MDViYS02MTcyLTQ5
+        ODItODY5My1lNjUyYjE0NjBhZTkiXX19fSwiaW5jbHVkZV9yZXBvcyI6dHJ1
         ZX0=
     headers:
       Accept:
@@ -2189,7 +1307,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:38 GMT
+      - Wed, 09 Aug 2017 21:53:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -2204,96 +1322,96 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVzdCJd
-        LCAic291cmNlcnBtIjogInBlbmd1aW4tMC4zLTAuOC5zcmMucnBtIiwgIm5h
-        bWUiOiAicGVuZ3VpbiIsICJjaGVja3N1bSI6ICIzZmNiMmM5MjdkZTllMTNi
-        ZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIxMGZkNmU0ODYzNWJl
-        Njk0IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIHBlbmd1aW4i
-        LCAiZmlsZW5hbWUiOiAicGVuZ3Vpbi0wLjMtMC44Lm5vYXJjaC5ycG0iLCAi
-        ZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAu
-        OCIsICJfaWQiOiAiM2E5YTE0ZDQtNTI1OS00ZDVmLTg2OGItYmVlMjFkMDU2
-        MjczIiwgImFyY2giOiAibm9hcmNoIiwgImNoaWxkcmVuIjoge30sICJfaHJl
-        ZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9ycG0vM2E5YTE0ZDQt
-        NTI1OS00ZDVmLTg2OGItYmVlMjFkMDU2MjczLyJ9LCB7InJlcG9zaXRvcnlf
-        bWVtYmVyc2hpcHMiOiBbInNjZW5hcmlvX3Rlc3QiXSwgInNvdXJjZXJwbSI6
-        ICJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogImNoZWV0YWgi
-        LCAiY2hlY2tzdW0iOiAiNDIyZDBiYWEwY2Q5ZDc3MTNhZTc5NmU4ODZhMjNl
-        MTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2OGRhZSIsICJzdW1tYXJ5
-        IjogIkEgZHVtbXkgcGFja2FnZSBvZiBjaGVldGFoIiwgImZpbGVuYW1lIjog
-        ImNoZWV0YWgtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAi
-        dmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjYy
-        MjBiZTU5LWE4ZDEtNGU1OC1hY2E3LTg5YWExN2IyNzI1NyIsICJhcmNoIjog
-        Im5vYXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBp
-        L3YyL2NvbnRlbnQvdW5pdHMvcnBtLzYyMjBiZTU5LWE4ZDEtNGU1OC1hY2E3
-        LTg5YWExN2IyNzI1Ny8ifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjog
-        WyJzY2VuYXJpb190ZXN0Il0sICJzb3VyY2VycG0iOiAibGlvbi0wLjMtMC44
-        LnNyYy5ycG0iLCAibmFtZSI6ICJsaW9uIiwgImNoZWNrc3VtIjogIjEyNDAw
-        ZGM5NWMyM2E0YzE2MDcyNWE5MDg3MTZjZDNmY2RkN2E4OTgxNTg1NDM3YWI2
-        NGNkNjJlZmEzZTRhZTQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ug
-        b2YgbGlvbiIsICJmaWxlbmFtZSI6ICJsaW9uLTAuMy0wLjgubm9hcmNoLnJw
-        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2Ui
-        OiAiMC44IiwgIl9pZCI6ICI4MTM1MWM1YS1jZjcyLTQ4YzItYWE3Ny0xYjUw
-        NmUwMWU4ZTQiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwg
-        Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS84MTM1
-        MWM1YS1jZjcyLTQ4YzItYWE3Ny0xYjUwNmUwMWU4ZTQvIn0sIHsicmVwb3Np
-        dG9yeV9tZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVzdCJdLCAic291cmNl
-        cnBtIjogIndhbHJ1cy0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJ3YWxy
-        dXMiLCAiY2hlY2tzdW0iOiAiNmU4ZDZkYzA1N2UzZTJjOTgxOWYwZGM3ZTZj
-        N2I3Zjg2YmYyZTg1NzFiYmE0MTRhZGVjN2ZiNjIxYTQ2MWRmZCIsICJzdW1t
-        YXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCAiZmlsZW5hbWUi
-        OiAid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwg
-        InZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICI4
-        ZTY3ZGZhZi1iNWIyLTQxNmEtYmJiOS1hNmZiMTczODUxYjEiLCAiYXJjaCI6
-        ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi9jb250ZW50L3VuaXRzL3JwbS84ZTY3ZGZhZi1iNWIyLTQxNmEtYmJi
-        OS1hNmZiMTczODUxYjEvIn0sIHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6
-        IFsic2NlbmFyaW9fdGVzdCJdLCAic291cmNlcnBtIjogImdpcmFmZmUtMC4z
-        LTAuOC5zcmMucnBtIiwgIm5hbWUiOiAiZ2lyYWZmZSIsICJjaGVja3N1bSI6
-        ICJmMjVkNjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2Uz
-        NTViODJkZTZkMTkyMjAwOWY5ZjE0IiwgInN1bW1hcnkiOiAiQSBkdW1teSBw
-        YWNrYWdlIG9mIGdpcmFmZmUiLCAiZmlsZW5hbWUiOiAiZ2lyYWZmZS0wLjMt
-        MC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAu
-        MyIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiOTFmM2EwMTEtZWJmZC00
-        Yzk3LWI1YWQtYmRhM2ZjNjhhY2Y0IiwgImFyY2giOiAibm9hcmNoIiwgImNo
-        aWxkcmVuIjoge30sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91
-        bml0cy9ycG0vOTFmM2EwMTEtZWJmZC00Yzk3LWI1YWQtYmRhM2ZjNjhhY2Y0
-        LyJ9LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBbInNjZW5hcmlvX3Rl
-        c3QiXSwgInNvdXJjZXJwbSI6ICJlbGVwaGFudC0wLjMtMC44LnNyYy5ycG0i
-        LCAibmFtZSI6ICJlbGVwaGFudCIsICJjaGVja3N1bSI6ICIzZTFjNzBjZDFi
-        NDIxMzI4YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3
-        MmEwYTcwMWYzIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGVs
-        ZXBoYW50IiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNo
-        LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVh
-        c2UiOiAiMC44IiwgIl9pZCI6ICJlNjU4YmViMi0xYjU3LTQ1NDktOWExYy0w
-        NzMzMjVkYzdhZDAiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7
-        fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS9l
-        NjU4YmViMi0xYjU3LTQ1NDktOWExYy0wNzMzMjVkYzdhZDAvIn0sIHsicmVw
-        b3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVzdCJdLCAic291
-        cmNlcnBtIjogIm1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJt
-        b25rZXkiLCAiY2hlY2tzdW0iOiAiMGU4ZmE1MGQwMTI4ZmJhYmM3Y2NjNTYz
-        MmUzZmEyNWQzOWIwMjgwMTY5ZjYxNjZjYjhlMmM4NGRlODUwMWRiMSIsICJz
-        dW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCAiZmlsZW5h
-        bWUiOiAibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIw
-        IiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6
-        ICJlZjNmMjk0MS1iOTQ0LTQ5MzYtYTliNi02MjQyM2I3NzVjOGYiLCAiYXJj
-        aCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxw
-        L2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS9lZjNmMjk0MS1iOTQ0LTQ5MzYt
-        YTliNi02MjQyM2I3NzVjOGYvIn0sIHsicmVwb3NpdG9yeV9tZW1iZXJzaGlw
-        cyI6IFsic2NlbmFyaW9fdGVzdCJdLCAic291cmNlcnBtIjogInNxdWlycmVs
-        LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogInNxdWlycmVsIiwgImNoZWNr
-        c3VtIjogIjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUx
-        ZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCAic3VtbWFyeSI6ICJBIGR1
-        bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCAiZmlsZW5hbWUiOiAic3F1aXJy
-        ZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lv
-        biI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogImZhMmU3ZTg2
-        LTE2YjQtNDg4My05NDlmLWY4YWJlN2MyNzBlYiIsICJhcmNoIjogIm5vYXJj
+        LCAic291cmNlcnBtIjogIm1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCAibmFt
+        ZSI6ICJtb25rZXkiLCAiY2hlY2tzdW0iOiAiMGU4ZmE1MGQwMTI4ZmJhYmM3
+        Y2NjNTYzMmUzZmEyNWQzOWIwMjgwMTY5ZjYxNjZjYjhlMmM4NGRlODUwMWRi
+        MSIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCAi
+        ZmlsZW5hbWUiOiAibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9j
+        aCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44Iiwg
+        Il9pZCI6ICIwNTFkNjY3Ni1hMzA4LTQyMGQtOTBmMy01M2ViMTM4YjdhNzIi
+        LCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjog
+        Ii9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS8wNTFkNjY3Ni1hMzA4
+        LTQyMGQtOTBmMy01M2ViMTM4YjdhNzIvIn0sIHsicmVwb3NpdG9yeV9tZW1i
+        ZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVzdCJdLCAic291cmNlcnBtIjogInBl
+        bmd1aW4tMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAicGVuZ3VpbiIsICJj
+        aGVja3N1bSI6ICIzZmNiMmM5MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQz
+        ZTVhZDJlNTg1NjRmYzIxMGZkNmU0ODYzNWJlNjk0IiwgInN1bW1hcnkiOiAi
+        QSBkdW1teSBwYWNrYWdlIG9mIHBlbmd1aW4iLCAiZmlsZW5hbWUiOiAicGVu
+        Z3Vpbi0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJz
+        aW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiOTJjY2I0
+        ZDItZDU5ZS00ZTcxLWFjYjYtYjY4ZWJjZmRiMzQ3IiwgImFyY2giOiAibm9h
+        cmNoIiwgImNoaWxkcmVuIjoge30sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIv
+        Y29udGVudC91bml0cy9ycG0vOTJjY2I0ZDItZDU5ZS00ZTcxLWFjYjYtYjY4
+        ZWJjZmRiMzQ3LyJ9LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBbInNj
+        ZW5hcmlvX3Rlc3QiXSwgInNvdXJjZXJwbSI6ICJnaXJhZmZlLTAuMy0wLjgu
+        c3JjLnJwbSIsICJuYW1lIjogImdpcmFmZmUiLCAiY2hlY2tzdW0iOiAiZjI1
+        ZDY3ZDFkOWRhMDRmMTJlNTdjYTMyMzI0N2I0Mzg5MWFjNDY1MzNlMzU1Yjgy
+        ZGU2ZDE5MjIwMDlmOWYxNCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2Fn
+        ZSBvZiBnaXJhZmZlIiwgImZpbGVuYW1lIjogImdpcmFmZmUtMC4zLTAuOC5u
+        b2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAi
+        cmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjllYzI4NTBlLWFiMDItNDdmNC05
+        NmM2LWJmMTQyODFmYTE5YiIsICJhcmNoIjogIm5vYXJjaCIsICJjaGlsZHJl
+        biI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMv
+        cnBtLzllYzI4NTBlLWFiMDItNDdmNC05NmM2LWJmMTQyODFmYTE5Yi8ifSwg
+        eyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJzY2VuYXJpb190ZXN0Il0s
+        ICJzb3VyY2VycG0iOiAid2FscnVzLTAuMy0wLjguc3JjLnJwbSIsICJuYW1l
+        IjogIndhbHJ1cyIsICJjaGVja3N1bSI6ICI2ZThkNmRjMDU3ZTNlMmM5ODE5
+        ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFhNDYxZGZk
+        IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIHdhbHJ1cyIsICJm
+        aWxlbmFtZSI6ICJ3YWxydXMtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2No
+        IjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAi
+        X2lkIjogImJmOWFmNDQyLTllNGEtNDUwZi1hYTA3LWRlMjg2YTY0ZmY2NSIs
+        ICJhcmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAi
+        L3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBtL2JmOWFmNDQyLTllNGEt
+        NDUwZi1hYTA3LWRlMjg2YTY0ZmY2NS8ifSwgeyJyZXBvc2l0b3J5X21lbWJl
+        cnNoaXBzIjogWyJzY2VuYXJpb190ZXN0Il0sICJzb3VyY2VycG0iOiAic3F1
+        aXJyZWwtMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAic3F1aXJyZWwiLCAi
+        Y2hlY2tzdW0iOiAiMjUxNzY4YmRkMTVmMTNkNzg0ODdjMjc2MzhhYTZhZWNk
+        MDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdkMiIsICJzdW1tYXJ5Ijog
+        IkEgZHVtbXkgcGFja2FnZSBvZiBzcXVpcnJlbCIsICJmaWxlbmFtZSI6ICJz
+        cXVpcnJlbC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2
+        ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiY2Rm
+        MDQzYjQtYTVlNC00NWUyLWEzOTAtYjUwY2QyNmI2ZWY4IiwgImFyY2giOiAi
+        bm9hcmNoIiwgImNoaWxkcmVuIjoge30sICJfaHJlZiI6ICIvcHVscC9hcGkv
+        djIvY29udGVudC91bml0cy9ycG0vY2RmMDQzYjQtYTVlNC00NWUyLWEzOTAt
+        YjUwY2QyNmI2ZWY4LyJ9LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBb
+        InNjZW5hcmlvX3Rlc3QiXSwgInNvdXJjZXJwbSI6ICJsaW9uLTAuMy0wLjgu
+        c3JjLnJwbSIsICJuYW1lIjogImxpb24iLCAiY2hlY2tzdW0iOiAiMTI0MDBk
+        Yzk1YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0MzdhYjY0
+        Y2Q2MmVmYTNlNGFlNCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBv
+        ZiBsaW9uIiwgImZpbGVuYW1lIjogImxpb24tMC4zLTAuOC5ub2FyY2gucnBt
+        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6
+        ICIwLjgiLCAiX2lkIjogImNmMWMwYTU2LWQzYTgtNGI0MS1iMTg4LTY3NDgy
+        NWVhMjg3NSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6IHt9LCAi
+        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBtL2NmMWMw
+        YTU2LWQzYTgtNGI0MS1iMTg4LTY3NDgyNWVhMjg3NS8ifSwgeyJyZXBvc2l0
+        b3J5X21lbWJlcnNoaXBzIjogWyJzY2VuYXJpb190ZXN0Il0sICJzb3VyY2Vy
+        cG0iOiAiZWxlcGhhbnQtMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAiZWxl
+        cGhhbnQiLCAiY2hlY2tzdW0iOiAiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3
+        Y2IzZDE2MTQ1MzA2YmI5NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsICJz
+        dW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBlbGVwaGFudCIsICJmaWxl
+        bmFtZSI6ICJlbGVwaGFudC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2gi
+        OiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJf
+        aWQiOiAiZGUxYzlkMjEtMDVhMC00YTU4LThhZjYtOTI4NDE5YjcyMTA0Iiwg
+        ImFyY2giOiAibm9hcmNoIiwgImNoaWxkcmVuIjoge30sICJfaHJlZiI6ICIv
+        cHVscC9hcGkvdjIvY29udGVudC91bml0cy9ycG0vZGUxYzlkMjEtMDVhMC00
+        YTU4LThhZjYtOTI4NDE5YjcyMTA0LyJ9LCB7InJlcG9zaXRvcnlfbWVtYmVy
+        c2hpcHMiOiBbInNjZW5hcmlvX3Rlc3QiXSwgInNvdXJjZXJwbSI6ICJjaGVl
+        dGFoLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogImNoZWV0YWgiLCAiY2hl
+        Y2tzdW0iOiAiNDIyZDBiYWEwY2Q5ZDc3MTNhZTc5NmU4ODZhMjNlMTdmNTc4
+        ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2OGRhZSIsICJzdW1tYXJ5IjogIkEg
+        ZHVtbXkgcGFja2FnZSBvZiBjaGVldGFoIiwgImZpbGVuYW1lIjogImNoZWV0
+        YWgtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lv
+        biI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogImVjMjYwNWJh
+        LTYxNzItNDk4Mi04NjkzLWU2NTJiMTQ2MGFlOSIsICJhcmNoIjogIm5vYXJj
         aCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2Nv
-        bnRlbnQvdW5pdHMvcnBtL2ZhMmU3ZTg2LTE2YjQtNDg4My05NDlmLWY4YWJl
-        N2MyNzBlYi8ifV0=
+        bnRlbnQvdW5pdHMvcnBtL2VjMjYwNWJhLTYxNzItNDk4Mi04NjkzLWU2NTJi
+        MTQ2MGFlOS8ifV0=
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:38 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:35 GMT
 - request:
     method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2316,7 +1434,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:38 GMT
+      - Wed, 09 Aug 2017 21:53:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -2330,33 +1448,33 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIyODZmNzFlYi03ZDc1LTQxYWMtOTc1
-        NC03MjY5ODg1YzEwOTQiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
-        In0sICJfaWQiOiB7IiRvaWQiOiAiNTkwYjQyNTIzZjdhZDU5MzI4NTEzNzhj
-        In0sICJ1bml0X2lkIjogIjI4NmY3MWViLTdkNzUtNDFhYy05NzU0LTcyNjk4
-        ODVjMTA5NCIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
-        YXRhIjogeyJfaWQiOiAiOGE3NWJjOTEtNzg0MC00MjBiLWE3N2UtMmMwMjRh
-        YWQ4MzQwIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
-        IjogeyIkb2lkIjogIjU5MGI0MjUyM2Y3YWQ1OTMyODUxMzc4YSJ9LCAidW5p
-        dF9pZCI6ICI4YTc1YmM5MS03ODQwLTQyMGItYTc3ZS0yYzAyNGFhZDgzNDAi
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICI5YmZlOTQyNy0xMzYwLTQ3N2QtOWYw
+        ZS04MzIwN2I3MGQyMDEiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
+        In0sICJfaWQiOiB7IiRvaWQiOiAiNTk4Yjg0NWViYmM2ZjRiOTM2NWY5MGVk
+        In0sICJ1bml0X2lkIjogIjliZmU5NDI3LTEzNjAtNDc3ZC05ZjBlLTgzMjA3
+        YjcwZDIwMSIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
+        YXRhIjogeyJfaWQiOiAiYjU0NTI4ZmEtMzc3ZS00MTFkLTk0Y2MtNzBkOTU0
+        OGIwOTkyIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
+        IjogeyIkb2lkIjogIjU5OGI4NDVlYmJjNmY0YjkzNjVmOTBlZSJ9LCAidW5p
+        dF9pZCI6ICJiNTQ1MjhmYS0zNzdlLTQxMWQtOTRjYy03MGQ5NTQ4YjA5OTIi
         LCAidW5pdF90eXBlX2lkIjogImVycmF0dW0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogImI1NTAzOGI0LTc5ZWItNGRkYi04ZjBhLWRiY2I3NjA3YWJkNSIs
+        X2lkIjogImJhZDVmZTg2LWU5ZjYtNDQ0MS04MjU5LWExNzUyZWE5MDA4MiIs
         ICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0ifSwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1OTBiNDI1MjNmN2FkNTkzMjg1MTM3OGIifSwgInVuaXRfaWQiOiAi
-        YjU1MDM4YjQtNzllYi00ZGRiLThmMGEtZGJjYjc2MDdhYmQ1IiwgInVuaXRf
+        ZCI6ICI1OThiODQ1ZWJiYzZmNGI5MzY1ZjkwZWYifSwgInVuaXRfaWQiOiAi
+        YmFkNWZlODYtZTlmNi00NDQxLTgyNTktYTE3NTJlYTkwMDgyIiwgInVuaXRf
         dHlwZV9pZCI6ICJlcnJhdHVtIn1d
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:38 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:35 GMT
 - request:
     method: post
-    uri: https://dev.example.com/pulp/api/v2/content/units/erratum/search/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/content/units/erratum/search/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjcml0ZXJpYSI6eyJsaW1pdCI6Mywic2tpcCI6MCwiZmlsdGVycyI6eyJf
-        aWQiOnsiJGluIjpbIjI4NmY3MWViLTdkNzUtNDFhYy05NzU0LTcyNjk4ODVj
-        MTA5NCIsIjhhNzViYzkxLTc4NDAtNDIwYi1hNzdlLTJjMDI0YWFkODM0MCIs
-        ImI1NTAzOGI0LTc5ZWItNGRkYi04ZjBhLWRiY2I3NjA3YWJkNSJdfX19LCJp
+        aWQiOnsiJGluIjpbIjliZmU5NDI3LTEzNjAtNDc3ZC05ZjBlLTgzMjA3Yjcw
+        ZDIwMSIsImI1NDUyOGZhLTM3N2UtNDExZC05NGNjLTcwZDk1NDhiMDk5MiIs
+        ImJhZDVmZTg2LWU5ZjYtNDQ0MS04MjU5LWExNzUyZWE5MDA4MiJdfX19LCJp
         bmNsdWRlX3JlcG9zIjp0cnVlfQ==
     headers:
       Accept:
@@ -2375,7 +1493,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:39 GMT
+      - Wed, 09 Aug 2017 21:53:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -2391,118 +1509,118 @@ http_interactions:
       base64_string: |
         W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVzdCJd
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvZXJyYXR1
-        bS8yODZmNzFlYi03ZDc1LTQxYWMtOTc1NC03MjY5ODg1YzEwOTQvIiwgImlz
+        bS85YmZlOTQyNy0xMzYwLTQ3N2QtOWYwZS04MzIwN2I3MGQyMDEvIiwgImlz
         c3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAxIiwgInJlZmVyZW5jZXMiOiBb
         XSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9p
-        ZCI6ICJlcnJhdHVtIiwgImlkIjogIlJIRUEtMjAxMDowMDAyIiwgImZyb20i
+        ZCI6ICJlcnJhdHVtIiwgImlkIjogIlJIRUEtMjAxMDowMDAxIiwgImZyb20i
         OiAibHphcCtwdWJAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6ICIiLCAidGl0
-        bGUiOiAiT25lIHBhY2thZ2UgZXJyYXRhIiwgImNoaWxkcmVuIjoge30sICJ2
-        ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlw
-        ZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3siX3B1bHBfcmVwb19pZCI6
-        ICJzY2VuYXJpb190ZXN0IiwgInBhY2thZ2VzIjogW3sic3JjIjogImh0dHA6
-        Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJlbGVwaGFudCIs
-        ICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5u
-        b2FyY2gucnBtIiwgImVwb2NoIjogbnVsbCwgInZlcnNpb24iOiAiMC4zIiwg
-        InJlbGVhc2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6
-        ICIxIiwgInNob3J0IjogIiJ9XSwgInN0YXR1cyI6ICJzdGFibGUiLCAidXBk
-        YXRlZCI6ICIiLCAiZGVzY3JpcHRpb24iOiAiT25lIHBhY2thZ2UgZXJyYXRh
-        IiwgIl9sYXN0X3VwZGF0ZWQiOiAiMjAxNy0wNS0wNFQxNTowMTozOFoiLCAi
-        cHVzaGNvdW50IjogIiIsICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIs
-        ICJzdW1tYXJ5IjogIiIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjI4NmY3
-        MWViLTdkNzUtNDFhYy05NzU0LTcyNjk4ODVjMTA5NCJ9LCB7InJlcG9zaXRv
-        cnlfbWVtYmVyc2hpcHMiOiBbInNjZW5hcmlvX3Rlc3QiXSwgIl9ocmVmIjog
-        Ii9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL2VycmF0dW0vOGE3NWJjOTEt
-        Nzg0MC00MjBiLWE3N2UtMmMwMjRhYWQ4MzQwLyIsICJpc3N1ZWQiOiAiMjAx
-        MC0wMS0wMSAwMTowMTowMSIsICJyZWZlcmVuY2VzIjogW10sICJwdWxwX3Vz
-        ZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1
-        bSIsICJpZCI6ICJSSEVBLTIwMTA6MDAwMSIsICJmcm9tIjogImx6YXArcHVi
-        QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjogIkVtcHR5
-        IGVycmF0YSIsICJjaGlsZHJlbiI6IHt9LCAidmVyc2lvbiI6ICIxIiwgInJl
-        Ym9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAi
-        cGtnbGlzdCI6IFtdLCAic3RhdHVzIjogInN0YWJsZSIsICJ1cGRhdGVkIjog
-        IiIsICJkZXNjcmlwdGlvbiI6ICJFbXB0eSBlcnJhdGEiLCAiX2xhc3RfdXBk
-        YXRlZCI6ICIyMDE3LTA1LTA0VDE1OjAxOjM4WiIsICJwdXNoY291bnQiOiAi
-        IiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAi
-        IiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiOGE3NWJjOTEtNzg0MC00MjBi
-        LWE3N2UtMmMwMjRhYWQ4MzQwIn0sIHsicmVwb3NpdG9yeV9tZW1iZXJzaGlw
-        cyI6IFsic2NlbmFyaW9fdGVzdCJdLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
-        L2NvbnRlbnQvdW5pdHMvZXJyYXR1bS9iNTUwMzhiNC03OWViLTRkZGItOGYw
-        YS1kYmNiNzYwN2FiZDUvIiwgImlzc3VlZCI6ICIyMDEwLTExLTEwIDAwOjAw
-        OjAwIiwgInJlZmVyZW5jZXMiOiBbeyJocmVmIjogImh0dHBzOi8vcmhuLnJl
-        ZGhhdC5jb20vZXJyYXRhL1JIU0EtMjAxMC0wODU4Lmh0bWwiLCAidHlwZSI6
-        ICJzZWxmIiwgImlkIjogbnVsbCwgInRpdGxlIjogIlJIU0EtMjAxMDowODU4
-        In0sIHsiaHJlZiI6ICJodHRwczovL2J1Z3ppbGxhLnJlZGhhdC5jb20vYnVn
-        emlsbGEvc2hvd19idWcuY2dpP2lkPTYyNzg4MiIsICJ0eXBlIjogImJ1Z3pp
-        bGxhIiwgImlkIjogIjYyNzg4MiIsICJ0aXRsZSI6ICJDVkUtMjAxMC0wNDA1
-        IGJ6aXAyOiBpbnRlZ2VyIG92ZXJmbG93IGZsYXcgaW4gQloyX2RlY29tcHJl
-        c3MifSwgeyJocmVmIjogImh0dHBzOi8vd3d3LnJlZGhhdC5jb20vc2VjdXJp
-        dHkvZGF0YS9jdmUvQ1ZFLTIwMTAtMDQwNS5odG1sIiwgInR5cGUiOiAiY3Zl
-        IiwgImlkIjogIkNWRS0yMDEwLTA0MDUiLCAidGl0bGUiOiAiQ1ZFLTIwMTAt
-        MDQwNSJ9LCB7ImhyZWYiOiAiaHR0cDovL3d3dy5yZWRoYXQuY29tL3NlY3Vy
-        aXR5L3VwZGF0ZXMvY2xhc3NpZmljYXRpb24vI2ltcG9ydGFudCIsICJ0eXBl
-        IjogIm90aGVyIiwgImlkIjogbnVsbCwgInRpdGxlIjogbnVsbH1dLCAicHVs
-        cF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lkIjogImVy
-        cmF0dW0iLCAiaWQiOiAiUkhTQS0yMDEwOjA4NTgiLCAiZnJvbSI6ICJzZWN1
-        cml0eUByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIkltcG9ydGFudCIsICJ0
-        aXRsZSI6ICJJbXBvcnRhbnQ6IGJ6aXAyIHNlY3VyaXR5IHVwZGF0ZSIsICJj
-        aGlsZHJlbiI6IHt9LCAidmVyc2lvbiI6ICIzIiwgInJlYm9vdF9zdWdnZXN0
-        ZWQiOiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFt7
-        Il9wdWxwX3JlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIsICJwYWNrYWdlcyI6
-        IFt7InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFt
-        ZSI6ICJiemlwMi1kZXZlbCIsICJzdW0iOiBbInNoYTI1NiIsICJlYTY3YzY2
-        NGRhMWZmOTZhNmRjOTRkMzMwMDliNzNkOGZhYjMxYjU5ODI0MTgzZmI0NWU5
-        YmEyZWJmODJkNTgzIl0sICJmaWxlbmFtZSI6ICJiemlwMi1kZXZlbC0xLjAu
-        NS03LmVsNl8wLmk2ODYucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
-        ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJjaCI6ICJpNjg2
-        In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3JjLnJwbSIsICJu
-        YW1lIjogImJ6aXAyLWxpYnMiLCAic3VtIjogWyJzaGEyNTYiLCAiYzlmMDY0
-        YTY4NjI1NzNmYjlmMmE2YWZmN2MzNjIxZjE5NDBiNDkyZGYyZWRmYzJlYmJk
-        YzBiODMwNWY1MTE0NyJdLCAiZmlsZW5hbWUiOiAiYnppcDItbGlicy0xLjAu
-        NS03LmVsNl8wLmk2ODYucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
-        ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJjaCI6ICJpNjg2
-        In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3JjLnJwbSIsICJu
-        YW1lIjogImJ6aXAyIiwgInN1bSI6IFsic2hhMjU2IiwgImI4YTNmNzJiYzJi
-        MGQ4OWJhNzM3MDk5YWM5OGJmOGQyYWY0YmVhMDJkMzE4ODRjMDJkYjk3Zjdm
-        NjZjM2Q1YzIiXSwgImZpbGVuYW1lIjogImJ6aXAyLTEuMC41LTcuZWw2XzAu
-        eDg2XzY0LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUi
-        LCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAieDg2XzY0In0sIHsi
-        c3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3JjLnJwbSIsICJuYW1lIjog
-        ImJ6aXAyLWRldmVsIiwgInN1bSI6IFsic2hhMjU2IiwgIjdmNjMxMjRlNDY1
-        NWI3YzkyZDIzZWM0YzM4MjI2ZjVkMzc0NjU2ODg1M2RmZjc1MGZjODVlMDU4
-        ZTc0YjVjZjYiXSwgImZpbGVuYW1lIjogImJ6aXAyLWRldmVsLTEuMC41LTcu
-        ZWw2XzAueDg2XzY0LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAi
-        MS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAieDg2XzY0
-        In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3JjLnJwbSIsICJu
-        YW1lIjogImJ6aXAyLWxpYnMiLCAic3VtIjogWyJzaGEyNTYiLCAiODAyZjQz
-        OTlkYmRkMDE0NzZlMjU0YzNiMzJjNDBhZmY1OWNmNWQyM2E0NWZhNDg4YzY5
-        MTdjZTg5MDRkNmI0ZCJdLCAiZmlsZW5hbWUiOiAiYnppcDItbGlicy0xLjAu
-        NS03LmVsNl8wLng4Nl82NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9u
-        IjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogIng4
-        Nl82NCJ9XSwgIm5hbWUiOiAiUmVkIEhhdCBFbnRlcnByaXNlIExpbnV4IFNl
-        cnZlciAodi4gNiBmb3IgNjQtYml0IHg4Nl82NCkiLCAic2hvcnQiOiAicmhl
-        bC14ODZfNjQtc2VydmVyLTYifV0sICJzdGF0dXMiOiAiZmluYWwiLCAidXBk
-        YXRlZCI6ICIyMDEwLTExLTEwIDAwOjAwOjAwIiwgImRlc2NyaXB0aW9uIjog
-        ImJ6aXAyIGlzIGEgZnJlZWx5IGF2YWlsYWJsZSwgaGlnaC1xdWFsaXR5IGRh
-        dGEgY29tcHJlc3Nvci4gSXQgcHJvdmlkZXMgYm90aFxubGliYnoyIGxpYnJh
-        cnkgbXVzdCBiZSByZXN0YXJ0ZWQgZm9yIHRoZSB1cGRhdGUgdG8gdGFrZSBl
-        ZmZlY3QuIiwgIl9sYXN0X3VwZGF0ZWQiOiAiMjAxNy0wNS0wNFQxNTowMToz
-        OFoiLCAicHVzaGNvdW50IjogIiIsICJyaWdodHMiOiAiQ29weXJpZ2h0IDIw
-        MTAgUmVkIEhhdCBJbmMiLCAic29sdXRpb24iOiAiQmVmb3JlIGFwcGx5aW5n
-        IHRoaXMgdXBkYXRlLCBtYWtlIHN1cmUgYWxsIHByZXZpb3VzbHktcmVsZWFz
-        ZWQgZXJyYXRhXG5yZWxldmFudCB0byB5b3VyIHN5c3RlbSBoYXZlIGJlZW4g
-        YXBwbGllZC5cblxuVGhpcyB1cGRhdGUgaXMgYXZhaWxhYmxlIHZpYSB0aGUg
-        UmVkIEhhdCBOZXR3b3JrLiBEZXRhaWxzIG9uIGhvdyB0b1xudXNlIHRoZSBS
-        ZWQgSGF0IE5ldHdvcmsgdG8gYXBwbHkgdGhpcyB1cGRhdGUgYXJlIGF2YWls
-        YWJsZSBhdFxuaHR0cDovL2tiYXNlLnJlZGhhdC5jb20vZmFxL2RvY3MvRE9D
-        LTExMjU5IiwgInN1bW1hcnkiOiAiVXBkYXRlZCBiemlwMiBwYWNrYWdlcyB0
-        aGF0IGZpeCBvbmUgc2VjdXJpdHkgaXNzdWUiLCAicmVsZWFzZSI6ICIiLCAi
-        X2lkIjogImI1NTAzOGI0LTc5ZWItNGRkYi04ZjBhLWRiY2I3NjA3YWJkNSJ9
+        bGUiOiAiRW1wdHkgZXJyYXRhIiwgImNoaWxkcmVuIjoge30sICJ2ZXJzaW9u
+        IjogIjEiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJz
+        ZWN1cml0eSIsICJwa2dsaXN0IjogW10sICJzdGF0dXMiOiAic3RhYmxlIiwg
+        InVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjogIkVtcHR5IGVycmF0YSIs
+        ICJfbGFzdF91cGRhdGVkIjogIjIwMTctMDgtMDlUMjE6NTM6MzRaIiwgInB1
+        c2hjb3VudCI6ICIiLCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAi
+        c3VtbWFyeSI6ICIiLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI5YmZlOTQy
+        Ny0xMzYwLTQ3N2QtOWYwZS04MzIwN2I3MGQyMDEifSwgeyJyZXBvc2l0b3J5
+        X21lbWJlcnNoaXBzIjogWyJzY2VuYXJpb190ZXN0Il0sICJfaHJlZiI6ICIv
+        cHVscC9hcGkvdjIvY29udGVudC91bml0cy9lcnJhdHVtL2I1NDUyOGZhLTM3
+        N2UtNDExZC05NGNjLTcwZDk1NDhiMDk5Mi8iLCAiaXNzdWVkIjogIjIwMTAt
+        MTEtMTAgMDA6MDA6MDAiLCAicmVmZXJlbmNlcyI6IFt7ImhyZWYiOiAiaHR0
+        cHM6Ly9yaG4ucmVkaGF0LmNvbS9lcnJhdGEvUkhTQS0yMDEwLTA4NTguaHRt
+        bCIsICJ0eXBlIjogInNlbGYiLCAiaWQiOiBudWxsLCAidGl0bGUiOiAiUkhT
+        QS0yMDEwOjA4NTgifSwgeyJocmVmIjogImh0dHBzOi8vYnVnemlsbGEucmVk
+        aGF0LmNvbS9idWd6aWxsYS9zaG93X2J1Zy5jZ2k/aWQ9NjI3ODgyIiwgInR5
+        cGUiOiAiYnVnemlsbGEiLCAiaWQiOiAiNjI3ODgyIiwgInRpdGxlIjogIkNW
+        RS0yMDEwLTA0MDUgYnppcDI6IGludGVnZXIgb3ZlcmZsb3cgZmxhdyBpbiBC
+        WjJfZGVjb21wcmVzcyJ9LCB7ImhyZWYiOiAiaHR0cHM6Ly93d3cucmVkaGF0
+        LmNvbS9zZWN1cml0eS9kYXRhL2N2ZS9DVkUtMjAxMC0wNDA1Lmh0bWwiLCAi
+        dHlwZSI6ICJjdmUiLCAiaWQiOiAiQ1ZFLTIwMTAtMDQwNSIsICJ0aXRsZSI6
+        ICJDVkUtMjAxMC0wNDA1In0sIHsiaHJlZiI6ICJodHRwOi8vd3d3LnJlZGhh
+        dC5jb20vc2VjdXJpdHkvdXBkYXRlcy9jbGFzc2lmaWNhdGlvbi8jaW1wb3J0
+        YW50IiwgInR5cGUiOiAib3RoZXIiLCAiaWQiOiBudWxsLCAidGl0bGUiOiBu
+        dWxsfV0sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5
+        cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6ICJSSFNBLTIwMTA6MDg1OCIsICJm
+        cm9tIjogInNlY3VyaXR5QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiSW1w
+        b3J0YW50IiwgInRpdGxlIjogIkltcG9ydGFudDogYnppcDIgc2VjdXJpdHkg
+        dXBkYXRlIiwgImNoaWxkcmVuIjoge30sICJ2ZXJzaW9uIjogIjMiLCAicmVi
+        b290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJw
+        a2dsaXN0IjogW3siX3B1bHBfcmVwb19pZCI6ICJzY2VuYXJpb190ZXN0Iiwg
+        InBhY2thZ2VzIjogW3sic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3Jj
+        LnJwbSIsICJuYW1lIjogImJ6aXAyLWRldmVsIiwgInN1bSI6IFsic2hhMjU2
+        IiwgImVhNjdjNjY0ZGExZmY5NmE2ZGM5NGQzMzAwOWI3M2Q4ZmFiMzFiNTk4
+        MjQxODNmYjQ1ZTliYTJlYmY4MmQ1ODMiXSwgImZpbGVuYW1lIjogImJ6aXAy
+        LWRldmVsLTEuMC41LTcuZWw2XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIs
+        ICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJh
+        cmNoIjogImk2ODYifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5z
+        cmMucnBtIiwgIm5hbWUiOiAiYnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1
+        NiIsICJjOWYwNjRhNjg2MjU3M2ZiOWYyYTZhZmY3YzM2MjFmMTk0MGI0OTJk
+        ZjJlZGZjMmViYmRjMGI4MzA1ZjUxMTQ3Il0sICJmaWxlbmFtZSI6ICJiemlw
+        Mi1saWJzLTEuMC41LTcuZWw2XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIs
+        ICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJh
+        cmNoIjogImk2ODYifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5z
+        cmMucnBtIiwgIm5hbWUiOiAiYnppcDIiLCAic3VtIjogWyJzaGEyNTYiLCAi
+        YjhhM2Y3MmJjMmIwZDg5YmE3MzcwOTlhYzk4YmY4ZDJhZjRiZWEwMmQzMTg4
+        NGMwMmRiOTdmN2Y2NmMzZDVjMiJdLCAiZmlsZW5hbWUiOiAiYnppcDItMS4w
+        LjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lv
+        biI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJjaCI6ICJ4
+        ODZfNjQifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBt
+        IiwgIm5hbWUiOiAiYnppcDItZGV2ZWwiLCAic3VtIjogWyJzaGEyNTYiLCAi
+        N2Y2MzEyNGU0NjU1YjdjOTJkMjNlYzRjMzgyMjZmNWQzNzQ2NTY4ODUzZGZm
+        NzUwZmM4NWUwNThlNzRiNWNmNiJdLCAiZmlsZW5hbWUiOiAiYnppcDItZGV2
+        ZWwtMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjogIjAiLCAi
+        dmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJj
+        aCI6ICJ4ODZfNjQifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5z
+        cmMucnBtIiwgIm5hbWUiOiAiYnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1
+        NiIsICI4MDJmNDM5OWRiZGQwMTQ3NmUyNTRjM2IzMmM0MGFmZjU5Y2Y1ZDIz
+        YTQ1ZmE0ODhjNjkxN2NlODkwNGQ2YjRkIl0sICJmaWxlbmFtZSI6ICJiemlw
+        Mi1saWJzLTEuMC41LTcuZWw2XzAueDg2XzY0LnJwbSIsICJlcG9jaCI6ICIw
+        IiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwg
+        ImFyY2giOiAieDg2XzY0In1dLCAibmFtZSI6ICJSZWQgSGF0IEVudGVycHJp
+        c2UgTGludXggU2VydmVyICh2LiA2IGZvciA2NC1iaXQgeDg2XzY0KSIsICJz
+        aG9ydCI6ICJyaGVsLXg4Nl82NC1zZXJ2ZXItNiJ9XSwgInN0YXR1cyI6ICJm
+        aW5hbCIsICJ1cGRhdGVkIjogIjIwMTAtMTEtMTAgMDA6MDA6MDAiLCAiZGVz
+        Y3JpcHRpb24iOiAiYnppcDIgaXMgYSBmcmVlbHkgYXZhaWxhYmxlLCBoaWdo
+        LXF1YWxpdHkgZGF0YSBjb21wcmVzc29yLiBJdCBwcm92aWRlcyBib3RoXG5s
+        aWJiejIgbGlicmFyeSBtdXN0IGJlIHJlc3RhcnRlZCBmb3IgdGhlIHVwZGF0
+        ZSB0byB0YWtlIGVmZmVjdC4iLCAiX2xhc3RfdXBkYXRlZCI6ICIyMDE3LTA4
+        LTA5VDIxOjUzOjM0WiIsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0cyI6ICJD
+        b3B5cmlnaHQgMjAxMCBSZWQgSGF0IEluYyIsICJzb2x1dGlvbiI6ICJCZWZv
+        cmUgYXBwbHlpbmcgdGhpcyB1cGRhdGUsIG1ha2Ugc3VyZSBhbGwgcHJldmlv
+        dXNseS1yZWxlYXNlZCBlcnJhdGFcbnJlbGV2YW50IHRvIHlvdXIgc3lzdGVt
+        IGhhdmUgYmVlbiBhcHBsaWVkLlxuXG5UaGlzIHVwZGF0ZSBpcyBhdmFpbGFi
+        bGUgdmlhIHRoZSBSZWQgSGF0IE5ldHdvcmsuIERldGFpbHMgb24gaG93IHRv
+        XG51c2UgdGhlIFJlZCBIYXQgTmV0d29yayB0byBhcHBseSB0aGlzIHVwZGF0
+        ZSBhcmUgYXZhaWxhYmxlIGF0XG5odHRwOi8va2Jhc2UucmVkaGF0LmNvbS9m
+        YXEvZG9jcy9ET0MtMTEyNTkiLCAic3VtbWFyeSI6ICJVcGRhdGVkIGJ6aXAy
+        IHBhY2thZ2VzIHRoYXQgZml4IG9uZSBzZWN1cml0eSBpc3N1ZSIsICJyZWxl
+        YXNlIjogIiIsICJfaWQiOiAiYjU0NTI4ZmEtMzc3ZS00MTFkLTk0Y2MtNzBk
+        OTU0OGIwOTkyIn0sIHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsic2Nl
+        bmFyaW9fdGVzdCJdLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQv
+        dW5pdHMvZXJyYXR1bS9iYWQ1ZmU4Ni1lOWY2LTQ0NDEtODI1OS1hMTc1MmVh
+        OTAwODIvIiwgImlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAxIiwgInJl
+        ZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2Nv
+        bnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIlJIRUEtMjAxMDow
+        MDAyIiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0LmNvbSIsICJzZXZlcml0
+        eSI6ICIiLCAidGl0bGUiOiAiT25lIHBhY2thZ2UgZXJyYXRhIiwgImNoaWxk
+        cmVuIjoge30sICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dlc3RlZCI6
+        IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3siX3B1
+        bHBfcmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgInBhY2thZ2VzIjogW3si
+        c3JjIjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6
+        ICJlbGVwaGFudCIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogbnVsbCwgInZlcnNp
+        b24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNo
+        In1dLCAibmFtZSI6ICIxIiwgInNob3J0IjogIiJ9XSwgInN0YXR1cyI6ICJz
+        dGFibGUiLCAidXBkYXRlZCI6ICIiLCAiZGVzY3JpcHRpb24iOiAiT25lIHBh
+        Y2thZ2UgZXJyYXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAiMjAxNy0wOC0wOVQy
+        MTo1MzozNFoiLCAicHVzaGNvdW50IjogIiIsICJyaWdodHMiOiAiIiwgInNv
+        bHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxlYXNlIjogIjEiLCAi
+        X2lkIjogImJhZDVmZTg2LWU5ZjYtNDQ0MS04MjU5LWExNzUyZWE5MDA4MiJ9
         XQ==
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:39 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:35 GMT
 - request:
     method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2525,7 +1643,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:39 GMT
+      - Wed, 09 Aug 2017 21:53:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -2539,28 +1657,28 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICI4N2E0ODI1YS04NmYyLTRjOWItOGRk
-        Ny1iODhkM2Q1NGFjNGUiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwYWNrYWdl
-        X2dyb3VwIn0sICJfaWQiOiB7IiRvaWQiOiAiNTkwYjQyNTIzZjdhZDU5MzI4
-        NTEzNzhlIn0sICJ1bml0X2lkIjogIjg3YTQ4MjVhLTg2ZjItNGM5Yi04ZGQ3
-        LWI4OGQzZDU0YWM0ZSIsICJ1bml0X3R5cGVfaWQiOiAicGFja2FnZV9ncm91
-        cCJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiYmYwNDVmZmMtMjU5MS00OTMw
-        LTliZDQtYzAyOTVlMjJiNDRhIiwgIl9jb250ZW50X3R5cGVfaWQiOiAicGFj
-        a2FnZV9ncm91cCJ9LCAiX2lkIjogeyIkb2lkIjogIjU5MGI0MjUyM2Y3YWQ1
-        OTMyODUxMzc4ZCJ9LCAidW5pdF9pZCI6ICJiZjA0NWZmYy0yNTkxLTQ5MzAt
-        OWJkNC1jMDI5NWUyMmI0NGEiLCAidW5pdF90eXBlX2lkIjogInBhY2thZ2Vf
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICI3ODA1MGZhYS1lM2RjLTQxN2ItOTQ3
+        MC00NDY5MmUyZDEyM2YiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwYWNrYWdl
+        X2dyb3VwIn0sICJfaWQiOiB7IiRvaWQiOiAiNTk4Yjg0NWViYmM2ZjRiOTM2
+        NWY5MGYxIn0sICJ1bml0X2lkIjogIjc4MDUwZmFhLWUzZGMtNDE3Yi05NDcw
+        LTQ0NjkyZTJkMTIzZiIsICJ1bml0X3R5cGVfaWQiOiAicGFja2FnZV9ncm91
+        cCJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiYTg1OWQyMTQtMTNhZC00MWRi
+        LTg2ODMtYzdjOTk1NzNkZjMzIiwgIl9jb250ZW50X3R5cGVfaWQiOiAicGFj
+        a2FnZV9ncm91cCJ9LCAiX2lkIjogeyIkb2lkIjogIjU5OGI4NDVlYmJjNmY0
+        YjkzNjVmOTBmMCJ9LCAidW5pdF9pZCI6ICJhODU5ZDIxNC0xM2FkLTQxZGIt
+        ODY4My1jN2M5OTU3M2RmMzMiLCAidW5pdF90eXBlX2lkIjogInBhY2thZ2Vf
         Z3JvdXAifV0=
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:39 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:35 GMT
 - request:
     method: post
-    uri: https://dev.example.com/pulp/api/v2/content/units/package_group/search/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/content/units/package_group/search/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjcml0ZXJpYSI6eyJsaW1pdCI6Miwic2tpcCI6MCwiZmlsdGVycyI6eyJf
-        aWQiOnsiJGluIjpbIjg3YTQ4MjVhLTg2ZjItNGM5Yi04ZGQ3LWI4OGQzZDU0
-        YWM0ZSIsImJmMDQ1ZmZjLTI1OTEtNDkzMC05YmQ0LWMwMjk1ZTIyYjQ0YSJd
+        aWQiOnsiJGluIjpbIjc4MDUwZmFhLWUzZGMtNDE3Yi05NDcwLTQ0NjkyZTJk
+        MTIzZiIsImE4NTlkMjE0LTEzYWQtNDFkYi04NjgzLWM3Yzk5NTczZGYzMyJd
         fX19LCJpbmNsdWRlX3JlcG9zIjp0cnVlfQ==
     headers:
       Accept:
@@ -2579,7 +1697,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:39 GMT
+      - Wed, 09 Aug 2017 21:53:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -2598,35 +1716,35 @@ http_interactions:
         ZmUsY2hlZXRhaCxsaW9uLG1vbmtleSxwZW5ndWluLHNxdWlycmVsLHdhbHJ1
         cyIsICJwZW5ndWluIl0sICJyZXBvX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAi
         bmFtZSI6ICJtYW1tYWwiLCAidXNlcl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1
-        bHQiOiB0cnVlLCAiX2xhc3RfdXBkYXRlZCI6ICIyMDE3LTA1LTA0VDE1OjAx
-        OjM4WiIsICJjaGlsZHJlbiI6IHt9LCAib3B0aW9uYWxfcGFja2FnZV9uYW1l
+        bHQiOiB0cnVlLCAiX2xhc3RfdXBkYXRlZCI6ICIyMDE3LTA4LTA5VDIxOjQ3
+        OjM3WiIsICJjaGlsZHJlbiI6IHt9LCAib3B0aW9uYWxfcGFja2FnZV9uYW1l
         cyI6IFtdLCAidHJhbnNsYXRlZF9uYW1lIjoge30sICJfaHJlZiI6ICIvcHVs
-        cC9hcGkvdjIvY29udGVudC91bml0cy9wYWNrYWdlX2dyb3VwLzg3YTQ4MjVh
-        LTg2ZjItNGM5Yi04ZGQ3LWI4OGQzZDU0YWM0ZS8iLCAidHJhbnNsYXRlZF9k
+        cC9hcGkvdjIvY29udGVudC91bml0cy9wYWNrYWdlX2dyb3VwLzc4MDUwZmFh
+        LWUzZGMtNDE3Yi05NDcwLTQ0NjkyZTJkMTIzZi8iLCAidHJhbnNsYXRlZF9k
         ZXNjcmlwdGlvbiI6IHt9LCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJk
         ZWZhdWx0X3BhY2thZ2VfbmFtZXMiOiBbXSwgIl9jb250ZW50X3R5cGVfaWQi
-        OiAicGFja2FnZV9ncm91cCIsICJpZCI6ICJtYW1tYWwiLCAiX2lkIjogIjg3
-        YTQ4MjVhLTg2ZjItNGM5Yi04ZGQ3LWI4OGQzZDU0YWM0ZSIsICJkaXNwbGF5
+        OiAicGFja2FnZV9ncm91cCIsICJpZCI6ICJtYW1tYWwiLCAiX2lkIjogIjc4
+        MDUwZmFhLWUzZGMtNDE3Yi05NDcwLTQ0NjkyZTJkMTIzZiIsICJkaXNwbGF5
         X29yZGVyIjogMTAyNCwgImNvbmRpdGlvbmFsX3BhY2thZ2VfbmFtZXMiOiBb
         XX0sIHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVz
         dCJdLCAibWFuZGF0b3J5X3BhY2thZ2VfbmFtZXMiOiBbInBlbmd1aW4iXSwg
         InJlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIsICJuYW1lIjogImJpcmQiLCAi
         dXNlcl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVlLCAiX2xhc3Rf
-        dXBkYXRlZCI6ICIyMDE3LTA1LTA0VDE1OjAxOjM4WiIsICJjaGlsZHJlbiI6
+        dXBkYXRlZCI6ICIyMDE3LTA4LTA5VDIxOjQ3OjM3WiIsICJjaGlsZHJlbiI6
         IHt9LCAib3B0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdLCAidHJhbnNsYXRl
         ZF9uYW1lIjoge30sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91
-        bml0cy9wYWNrYWdlX2dyb3VwL2JmMDQ1ZmZjLTI1OTEtNDkzMC05YmQ0LWMw
-        Mjk1ZTIyYjQ0YS8iLCAidHJhbnNsYXRlZF9kZXNjcmlwdGlvbiI6IHt9LCAi
+        bml0cy9wYWNrYWdlX2dyb3VwL2E4NTlkMjE0LTEzYWQtNDFkYi04NjgzLWM3
+        Yzk5NTczZGYzMy8iLCAidHJhbnNsYXRlZF9kZXNjcmlwdGlvbiI6IHt9LCAi
         cHVscF91c2VyX21ldGFkYXRhIjoge30sICJkZWZhdWx0X3BhY2thZ2VfbmFt
         ZXMiOiBbXSwgIl9jb250ZW50X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIs
-        ICJpZCI6ICJiaXJkIiwgIl9pZCI6ICJiZjA0NWZmYy0yNTkxLTQ5MzAtOWJk
-        NC1jMDI5NWUyMmI0NGEiLCAiZGlzcGxheV9vcmRlciI6IDEwMjQsICJjb25k
+        ICJpZCI6ICJiaXJkIiwgIl9pZCI6ICJhODU5ZDIxNC0xM2FkLTQxZGItODY4
+        My1jN2M5OTU3M2RmMzMiLCAiZGlzcGxheV9vcmRlciI6IDEwMjQsICJjb25k
         aXRpb25hbF9wYWNrYWdlX25hbWVzIjogW119XQ==
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:39 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:35 GMT
 - request:
     method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2648,7 +1766,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:39 GMT
+      - Wed, 09 Aug 2017 21:53:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -2676,24 +1794,24 @@ http_interactions:
         cy9kaXN0cmlidXRpb24vOWIvODMxMjU2YTEyNDcxOGJmMzkxNjZiNTY0ZDhl
         Njg5OTU0ZmYwYThmMGY0NzliYTI0Y2ZhMjYzNTAxMDliYzUiLCAiZmFtaWx5
         IjogIlRlc3QgRmFtaWx5IiwgImRvd25sb2FkZWQiOiB0cnVlLCAidGltZXN0
-        YW1wIjogMTMyMzExMjE1My4wOSwgIl9sYXN0X3VwZGF0ZWQiOiAxNDkzOTEw
-        MDk4LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJkaXN0cmlidXRpb24iLCAidmFy
+        YW1wIjogMTMyMzExMjE1My4wOSwgIl9sYXN0X3VwZGF0ZWQiOiAxNTAyMzE1
+        NjE0LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJkaXN0cmlidXRpb24iLCAidmFy
         aWFudCI6ICJUZXN0VmFyaWFudCIsICJpZCI6ICJrcy1UZXN0IEZhbWlseS1U
         ZXN0VmFyaWFudC0xNi14ODZfNjQiLCAidmVyc2lvbiI6ICIxNiIsICJ2ZXJz
         aW9uX3NvcnRfaW5kZXgiOiAiMDItMTYiLCAicHVscF91c2VyX21ldGFkYXRh
-        Ijoge30sICJwYWNrYWdlZGlyIjogIiIsICJfaWQiOiAiYTI0MjVlZDUtNzU0
-        Yy00MzgxLWE0NzEtYjE0NjUxZDVlZDg2IiwgImFyY2giOiAieDg2XzY0Iiwg
+        Ijoge30sICJwYWNrYWdlZGlyIjogIiIsICJfaWQiOiAiNmJjZDgxMGItNWQ4
+        Yi00MWQ1LThjZmMtNGQ4MDk4YzI5YjM2IiwgImFyY2giOiAieDg2XzY0Iiwg
         Il9ucyI6ICJ1bml0c19kaXN0cmlidXRpb24ifSwgInVwZGF0ZWQiOiAiMjAx
-        Ny0wNS0wNFQxNTowMTozOFoiLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0
-        IiwgImNyZWF0ZWQiOiAiMjAxNy0wNS0wNFQxNTowMTozOFoiLCAidW5pdF90
-        eXBlX2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogImEyNDI1ZWQ1
-        LTc1NGMtNDM4MS1hNDcxLWIxNDY1MWQ1ZWQ4NiIsICJfaWQiOiB7IiRvaWQi
-        OiAiNTkwYjQyNTIzZjdhZDU5MzI4NTEzNzg5In19XQ==
+        Ny0wOC0wOVQyMTo1MzozNFoiLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0
+        IiwgImNyZWF0ZWQiOiAiMjAxNy0wOC0wOVQyMTo1MzozNFoiLCAidW5pdF90
+        eXBlX2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogIjZiY2Q4MTBi
+        LTVkOGItNDFkNS04Y2ZjLTRkODA5OGMyOWIzNiIsICJfaWQiOiB7IiRvaWQi
+        OiAiNTk4Yjg0NWViYmM2ZjRiOTM2NWY5MGVjIn19XQ==
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:39 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:35 GMT
 - request:
     method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/actions/content/regenerate_applicability//
+    uri: https://centos7-devl2.example.com/pulp/api/v2/repositories/actions/content/regenerate_applicability//
     body:
       encoding: UTF-8
       base64_string: |
@@ -2716,7 +1834,7 @@ http_interactions:
       message: ACCEPTED
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:39 GMT
+      - Wed, 09 Aug 2017 21:53:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -2728,14 +1846,14 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJncm91cF9pZCI6ICI2NGRhYmE0NS1mMzY1LTRiODktOTZhYS1hZjhjNjYy
-        Y2JkYmYiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tfZ3JvdXBzLzY0
-        ZGFiYTQ1LWYzNjUtNGI4OS05NmFhLWFmOGM2NjJjYmRiZi8ifQ==
+        eyJncm91cF9pZCI6ICJmODcwMGZlMC0xOGU2LTQ5ZjItYjVlZC03MzVhNWJj
+        MGRlNmIiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tfZ3JvdXBzL2Y4
+        NzAwZmUwLTE4ZTYtNDlmMi1iNWVkLTczNWE1YmMwZGU2Yi8ifQ==
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:39 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:35 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/task_groups/64daba45-f365-4b89-96aa-af8c662cbdbf/state_summary/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/task_groups/f8700fe0-18e6-49f2-b5ed-735a5bc0de6b/state_summary/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2754,7 +1872,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:39 GMT
+      - Wed, 09 Aug 2017 21:53:35 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -2772,10 +1890,10 @@ http_interactions:
         ImNhbmNlbGVkIjogMCwgIndhaXRpbmciOiAwLCAic2tpcHBlZCI6IDAsICJz
         dXNwZW5kZWQiOiAwLCAiZXJyb3IiOiAwLCAidG90YWwiOiAwfQ==
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:39 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:35 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/?details=true
+    uri: https://centos7-devl2.example.com/pulp/api/v2/repositories/scenario_test/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2794,7 +1912,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:39 GMT
+      - Wed, 09 Aug 2017 21:53:36 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
@@ -2811,60 +1929,60 @@ http_interactions:
         eyJzY3JhdGNocGFkIjogeyJjaGVja3N1bV90eXBlIjogInNoYTI1NiJ9LCAi
         ZGlzcGxheV9uYW1lIjogIlNjZW5hcmlvIHl1bSBwcm9kdWN0IiwgImRlc2Ny
         aXB0aW9uIjogbnVsbCwgImRpc3RyaWJ1dG9ycyI6IFt7InJlcG9faWQiOiAi
-        c2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxNy0wNS0wNFQx
-        NTowMToxNVoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
+        c2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxNy0wOC0wOVQy
+        MTo1MzoxM1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
         cy9zY2VuYXJpb190ZXN0L2Rpc3RyaWJ1dG9ycy9zY2VuYXJpb190ZXN0X2Ns
         b25lLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJs
         aXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Nsb25l
         X2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRj
         aHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6
-        IHsiJG9pZCI6ICI1OTBiNDIzYjQxOGE4YTA3YjZhOGM5ZGMifSwgImNvbmZp
+        IHsiJG9pZCI6ICI1OThiODQ0OWQwMzVjYTAzZDM2NjhhNWYifSwgImNvbmZp
         ZyI6IHsiZGVzdGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiAic2NlbmFyaW9f
         dGVzdCJ9LCAiaWQiOiAic2NlbmFyaW9fdGVzdF9jbG9uZSJ9LCB7InJlcG9f
         aWQiOiAic2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxNy0w
-        NS0wNFQxNTowMTozOFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9z
+        OC0wOVQyMTo1MzozNVoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9z
         aXRvcmllcy9zY2VuYXJpb190ZXN0L2Rpc3RyaWJ1dG9ycy9zY2VuYXJpb190
         ZXN0LyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJs
-        aXNoIjogIjIwMTctMDUtMDRUMTU6MDE6MzhaIiwgImRpc3RyaWJ1dG9yX3R5
+        aXNoIjogIjIwMTctMDgtMDlUMjE6NTM6MzVaIiwgImRpc3RyaWJ1dG9yX3R5
         cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IHRy
         dWUsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRv
-        cnMiLCAiX2lkIjogeyIkb2lkIjogIjU5MGI0MjNiNDE4YThhMDdiNmE4Yzlk
-        YSJ9LCAiY29uZmlnIjogeyJjaGVja3N1bV90eXBlIjogInNoYTI1NiIsICJw
+        cnMiLCAiX2lkIjogeyIkb2lkIjogIjU5OGI4NDQ5ZDAzNWNhMDNkMzY2OGE1
+        ZCJ9LCAiY29uZmlnIjogeyJjaGVja3N1bV90eXBlIjogInNoYTI1NiIsICJw
         cm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6IGZhbHNlLCAiaHR0cHMiOiB0cnVl
         LCAicmVsYXRpdmVfdXJsIjogInNjZW5hcmlvX3Rlc3QifSwgImlkIjogInNj
         ZW5hcmlvX3Rlc3QifSwgeyJyZXBvX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAi
-        bGFzdF91cGRhdGVkIjogIjIwMTctMDUtMDRUMTU6MDE6MTVaIiwgIl9ocmVm
+        bGFzdF91cGRhdGVkIjogIjIwMTctMDgtMDlUMjE6NTM6MTNaIiwgIl9ocmVm
         IjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvc2NlbmFyaW9fdGVzdC9k
         aXN0cmlidXRvcnMvZXhwb3J0X2Rpc3RyaWJ1dG9yLyIsICJsYXN0X292ZXJy
         aWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3Ry
         aWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIiwgImF1dG9f
         cHVibGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJl
-        cG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1OTBiNDIzYjQx
-        OGE4YTA3YjZhOGM5ZGIifSwgImNvbmZpZyI6IHsiaHR0cCI6IGZhbHNlLCAi
+        cG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1OThiODQ0OWQw
+        MzVjYTAzZDM2NjhhNWUifSwgImNvbmZpZyI6IHsiaHR0cCI6IGZhbHNlLCAi
         cmVsYXRpdmVfdXJsIjogInNjZW5hcmlvX3Rlc3QiLCAiaHR0cHMiOiBmYWxz
         ZX0sICJpZCI6ICJleHBvcnRfZGlzdHJpYnV0b3IifV0sICJsYXN0X3VuaXRf
-        YWRkZWQiOiAiMjAxNy0wNS0wNFQxNTowMTozOFoiLCAibm90ZXMiOiB7Il9y
+        YWRkZWQiOiAiMjAxNy0wOC0wOVQyMTo1MzozNFoiLCAibm90ZXMiOiB7Il9y
         ZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwgImxhc3RfdW5pdF9yZW1vdmVkIjog
         bnVsbCwgImNvbnRlbnRfdW5pdF9jb3VudHMiOiB7InBhY2thZ2VfZ3JvdXAi
         OiAyLCAiZGlzdHJpYnV0aW9uIjogMSwgInBhY2thZ2VfY2F0ZWdvcnkiOiAx
         LCAicnBtIjogOCwgImVycmF0dW0iOiAzfSwgIl9ucyI6ICJyZXBvcyIsICJp
         bXBvcnRlcnMiOiBbeyJyZXBvX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAibGFz
-        dF91cGRhdGVkIjogIjIwMTctMDUtMDRUMTU6MDE6MTVaIiwgIl9ocmVmIjog
+        dF91cGRhdGVkIjogIjIwMTctMDgtMDlUMjE6NTM6MTNaIiwgIl9ocmVmIjog
         Ii9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvc2NlbmFyaW9fdGVzdC9pbXBv
         cnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBvcnRlcnMi
         LCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAibGFzdF9v
         dmVycmlkZV9jb25maWciOiB7Im51bV90aHJlYWRzIjogNCwgInZhbGlkYXRl
-        IjogdHJ1ZX0sICJsYXN0X3N5bmMiOiAiMjAxNy0wNS0wNFQxNTowMTozOFoi
+        IjogdHJ1ZX0sICJsYXN0X3N5bmMiOiAiMjAxNy0wOC0wOVQyMTo1MzozNFoi
         LCAic2NyYXRjaHBhZCI6IHsicmVwb21kX3JldmlzaW9uIjogMTMyMTg5Mzgw
-        MH0sICJfaWQiOiB7IiRvaWQiOiAiNTkwYjQyM2I0MThhOGEwN2I2YThjOWQ5
+        MH0sICJfaWQiOiB7IiRvaWQiOiAiNTk4Yjg0NDlkMDM1Y2EwM2QzNjY4YTVj
         In0sICJjb25maWciOiB7ImZlZWQiOiAiZmlsZTovLy92YXIvd3d3L3Rlc3Rf
         cmVwb3Mvem9vIiwgInNzbF92YWxpZGF0aW9uIjogdHJ1ZSwgInJlbW92ZV9t
         aXNzaW5nIjogdHJ1ZSwgImRvd25sb2FkX3BvbGljeSI6ICJpbW1lZGlhdGUi
         fSwgImlkIjogInl1bV9pbXBvcnRlciJ9XSwgImxvY2FsbHlfc3RvcmVkX3Vu
-        aXRzIjogMTUsICJfaWQiOiB7IiRvaWQiOiAiNTkwYjQyM2I0MThhOGEwN2I2
-        YThjOWQ4In0sICJ0b3RhbF9yZXBvc2l0b3J5X3VuaXRzIjogMTUsICJpZCI6
+        aXRzIjogMTUsICJfaWQiOiB7IiRvaWQiOiAiNTk4Yjg0NDlkMDM1Y2EwM2Qz
+        NjY4YTViIn0sICJ0b3RhbF9yZXBvc2l0b3J5X3VuaXRzIjogMTUsICJpZCI6
         ICJzY2VuYXJpb190ZXN0IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBv
         c2l0b3JpZXMvc2NlbmFyaW9fdGVzdC8ifQ==
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:39 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:36 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/support/destroy_org_if_exists.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/support/destroy_org_if_exists.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test
+    uri: https://centos7-devl2.example.com:8443/candlepin/owners/scenario_test
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -14,9 +14,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.2.4p230
       Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="cbJlIGHa6pGKxEy26WN6lyJAu1ZurxFbKbOatDr0bY4",
-        oauth_signature="%2F6%2FTq3%2BxU4xttUauISfP2HzPoyc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1493910072", oauth_version="1.0"
+      - OAuth oauth_consumer_key="BuwYxVLAM5Q5nfZ5j6auFWWZnaZdQsif", oauth_nonce="KZiKzEnQjhCVJ3vh1s1ZNreKAeL12PHtHFKymA",
+        oauth_signature="be9vV6x1%2Br7XUImhaXh8aMSVv2Q%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1502315591", oauth_version="1.0"
       Cp-User:
       - foreman_admin
   response:
@@ -27,22 +27,22 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 7c735f65-7b81-4bea-ab95-7db319a029ce
+      - b6f4ab4e-7e03-4743-a470-719b6944e5e4
       X-Version:
-      - 2.0.26-1
-      - 2.0.26-1
+      - 2.0.35-1
+      - 2.0.35-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 04 May 2017 15:01:13 GMT
+      - Wed, 09 Aug 2017 21:53:11 GMT
     body:
       encoding: UTF-8
       base64_string: |
         eyJkaXNwbGF5TWVzc2FnZSI6Ik9yZ2FuaXphdGlvbiB3aXRoIGlkIHNjZW5h
         cmlvX3Rlc3QgY291bGQgbm90IGJlIGZvdW5kLiIsInJlcXVlc3RVdWlkIjoi
-        N2M3MzVmNjUtN2I4MS00YmVhLWFiOTUtN2RiMzE5YTAyOWNlIn0=
+        YjZmNGFiNGUtN2UwMy00NzQzLWE0NzAtNzE5YjY5NDRlNWU0In0=
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:13 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:11 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/support/destroy_repo_if_exists.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/support/destroy_repo_if_exists.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/
+    uri: https://centos7-devl2.example.com/pulp/api/v2/repositories/scenario_test/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -21,7 +21,7 @@ http_interactions:
       message: NOT FOUND
     headers:
       Date:
-      - Thu, 04 May 2017 15:01:15 GMT
+      - Wed, 09 Aug 2017 21:53:13 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
@@ -44,5 +44,5 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         InNjZW5hcmlvX3Rlc3QifX0=
     http_version: 
-  recorded_at: Thu, 04 May 2017 15:01:15 GMT
+  recorded_at: Wed, 09 Aug 2017 21:53:13 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
This is a rebase of Samir's PR: https://github.com/Katello/katello/pull/6894

Probably good to there to see where the review discussion left off.

I've done my own review of the code and I have one question: with this change one is able to modify the architecture of Red Hat repositories. Is that the expected behavior? Why would someone want to change an x86 repo to i386?