### PR TITLE
Refs #18987 - Do not stub over Settings[]

### DIFF
--- a/test/services/cert/certs_test.rb
+++ b/test/services/cert/certs_test.rb
@@ -7,23 +7,26 @@ module Katello
       VCR.insert_cassette('lib/tasks/verify_ueber_cert')
       @org = get_organization
       Resources::Candlepin::Owner.create(@org.label, @org.name)
+      @original_ssl_ca_file = Setting[:ssl_ca_file]
     end
 
     def teardown
       Resources::Candlepin::Owner.destroy(@org.label)
       VCR.eject_cassette
+      Setting[:ssl_ca_file] = @original_ssl_ca_file
     end
 
     def test_verify_ueber_cert_no_change
-      Setting.stubs(:[]).with(:ssl_ca_file).returns(File.join("#{Katello::Engine.root}", "/test/services/cert/helpers/ca.crt"))
+      Setting[:ssl_ca_file] = File.join("#{Katello::Engine.root}", "/test/services/cert/helpers/ca.crt")
       @org.expects(:regenerate_ueber_cert).never
       Cert::Certs.verify_ueber_cert(@org)
     end
 
     def test_verify_ueber_cert_changes
-      Setting.stubs(:[]).with(:ssl_ca_file).returns(File.join("#{Katello::Engine.root}", "/ca/redhat-uep.pem"))
+      Setting[:ssl_ca_file] = File.join("#{Katello::Engine.root}", "/ca/redhat-uep.pem")
       @org.expects(:regenerate_ueber_cert).once
       Cert::Certs.verify_ueber_cert(@org)
+      Setting[:ssl_ca_file] = @original_ssl_ca_file
     end
   end
 end


### PR DESCRIPTION
This test will fail when Settings[] is called with unexpected keys.

An example where this is happening is mentioned on [theforeman/foreman/4640](/theforeman/foreman/pull/4640#issuecomment-325335849)