### PR TITLE
Fixes #20579 - Made hammer ordering work for list

### DIFF
--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -50,6 +50,7 @@ module Katello
 
     # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/PerceivedComplexity
     def scoped_search(query, default_sort_by, default_sort_order, options = {})
       resource = options[:resource_class] || resource_class
@@ -66,12 +67,18 @@ module Katello
       query = query.select(group).group(group) if group
       sub_total = total.zero? ? 0 : scoped_search_total(query, group)
 
+      if params[:order]
+        (params[:sort_by], params[:sort_order]) = params[:order].split(' ')
+      end
+
       sort_attr = params[:sort_by] || default_sort_by
 
       if sort_attr
         sort_order = (params[:sort_order] || default_sort_order).to_s.downcase
         sort_order = default_sort_order unless ['desc', 'asc'].include?(sort_order)
         query = query.order(sort_attr => sort_order.to_sym)
+        params[:sort_by] = sort_attr
+        params[:sort_order] = sort_order
       elsif options[:custom_sort]
         query = options[:custom_sort].call(query)
       end

--- a/test/controllers/api/v2/api_controller_test.rb
+++ b/test/controllers/api/v2/api_controller_test.rb
@@ -102,6 +102,17 @@ module Katello
       assert_equal ["RHBA-2014-013", "RHEA-2014-111", "RHEA-2017-007", "RHSA-1999-1231"], results.map(&:errata_id)
     end
 
+    def test_scoped_search_order_via_hammer_order
+      params = {:order => "errata_id DESC"}
+      @controller.stubs(:params).returns(params)
+
+      query = Erratum.all
+      options = {resource_class: Katello::Erratum}
+
+      results = @controller.scoped_search(query, "errata_id", "desc", options)[:results]
+      assert_equal ["RHBA-2014-013", "RHEA-2014-111", "RHEA-2017-007", "RHSA-1999-1231"].sort.reverse, results.map(&:errata_id)
+    end
+
     def test_scoped_search_group
       types = Katello::Erratum.pluck(:errata_type).uniq
       4.times do


### PR DESCRIPTION
When we fullly moved to scoped search and
removed traces of elastic search as part of Issue 5334
PR# 5578
We removed logic that processed the "order" parameter

This caused hammer .. --order=".." to break in future versions.

This commit remedies that issue.