### PR TITLE
Fixes #20393: Hide pagination and show the latest 10 tasks

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/views/tasks-table.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/views/tasks-table.html
@@ -3,9 +3,12 @@
     No tasks exist for this resource.
   </span>
 
+  <div data-block="search">
+    <input type="text" class="form-control" placeholder="{{ 'Filter' | translate }}" ng-model="taskFilter" />
+  </div>
+
   <div data-block="table">
-    <table bst-table="table"
-           ng-class="{'table-mask': table.working}" class="table table-striped table-bordered">
+    <table bst-table="table" ng-class="{'table-mask': table.working}" class="table table-striped table-bordered">
       <thead>
         <tr bst-table-head>
           <th bst-table-column="Status"><span translate>Status</span></th>
@@ -16,7 +19,7 @@
       </thead>
 
       <tbody>
-        <tr bst-table-row ng-repeat="task in table.rows">
+        <tr bst-table-row ng-repeat="task in table.rows | filter:taskFilter">
           <td bst-table-cell>
             <div ng-class="{ active: (task.state === 'pending' || task.state === 'running') }" class="progress progress-striped">
               <span uib-progressbar animate="false" value="task.progressbar.value" type="{{task.progressbar.type}}"></span>


### PR DESCRIPTION
This removes the legacy bulk_search for the new api call using queryPaged.

http://projects.theforeman.org/issues/20393