### PR TITLE
Fixes #20480 - New API call applicable errata in host bulk action

### DIFF
--- a/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
@@ -6,9 +6,9 @@ module Katello
     before_action :find_host_collections, :only => [:bulk_add_host_collections, :bulk_remove_host_collections]
     before_action :find_environment, :only => [:environment_content_view]
     before_action :find_content_view, :only => [:environment_content_view]
-    before_action :find_editable_hosts, :except => [:destroy_hosts, :installable_errata]
+    before_action :find_editable_hosts, :except => [:destroy_hosts, :applicable_errata, :installable_errata]
     before_action :find_deletable_hosts, :only => [:destroy_hosts]
-    before_action :find_readable_hosts, :only => [:installable_errata, :available_incremental_updates]
+    before_action :find_readable_hosts, :only => [:applicable_errata, :installable_errata, :available_incremental_updates]
     before_action :find_errata, :only => [:available_incremental_updates]
 
     before_action :validate_content_action, :only => [:install_content, :update_content, :remove_content]
@@ -89,6 +89,14 @@ module Katello
 
       respond_for_show :template => 'bulk_action', :resource_name => 'common',
                        :resource => { 'displayMessages' => display_messages }
+    end
+
+    api :POST, "/hosts/bulk/applicable_errata",
+        N_("Fetch applicable errata for a host.")
+    param_group :bulk_params
+    def applicable_errata
+      respond_for_index(:collection => scoped_search(Katello::Erratum.applicable_to_hosts(@hosts), 'updated', 'desc',
+                                                     :resource_class => Erratum))
     end
 
     api :POST, "/hosts/bulk/installable_errata",

--- a/app/views/katello/api/v2/hosts_bulk_actions/applicable_errata.json.rabl
+++ b/app/views/katello/api/v2/hosts_bulk_actions/applicable_errata.json.rabl
@@ -1,0 +1,7 @@
+object false
+
+extends "katello/api/v2/common/metadata"
+
+node :results do
+  partial("katello/api/v2/hosts_bulk_actions/erratum", :object => @collection[:results])
+end

--- a/config/routes/overrides.rb
+++ b/config/routes/overrides.rb
@@ -69,6 +69,7 @@ Foreman::Application.routes.draw do
             match '/bulk/content_overrides' => 'hosts_bulk_actions#content_overrides', :via => :put
 
             match '/bulk/install_content' => 'hosts_bulk_actions#install_content', :via => :put
+            match '/bulk/applicable_errata' => 'hosts_bulk_actions#applicable_errata', :via => :post
             match '/bulk/installable_errata' => 'hosts_bulk_actions#installable_errata', :via => :post
             match '/bulk/update_content' => 'hosts_bulk_actions#update_content', :via => :put
             match '/bulk/remove_content' => 'hosts_bulk_actions#remove_content', :via => :put

--- a/lib/katello/permissions/host_permissions.rb
+++ b/lib/katello/permissions/host_permissions.rb
@@ -43,6 +43,7 @@ Foreman::AccessControl.permission(:view_hosts).actions.concat [
   'katello/api/v2/host_subscriptions/index',
   'katello/api/v2/host_subscriptions/events',
   'katello/api/v2/host_subscriptions/product_content',
+  'katello/api/v2/hosts_bulk_actions/applicable_errata',
   'katello/api/v2/hosts_bulk_actions/installable_errata',
   'katello/api/v2/hosts_bulk_actions/available_incremental_updates',
   'katello/api/v2/host_packages/index',


### PR DESCRIPTION
New API call for `applicable_errata` in host bulk action created with in this PR.
`POST /api/hosts/bulk/applicable_errata`