### PR TITLE
Fixes #20761 - Allow filter rule name search

### DIFF
--- a/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
@@ -7,14 +7,12 @@ module Katello
     param :content_view_filter_id, :identifier, :desc => N_("filter identifier"), :required => true
     param_group :search, Api::V2::ApiController
     def index
-      ids = ContentViewFilter.rule_ids_for(@filter)
-      results = ids.map { |id| ContentViewFilter.rule_class_for(@filter).find(id) }
-      collection = {
-        :results  => results.uniq,
-        :subtotal => results.count,
-        :total    => results.count
-      }
-      respond :collection => collection
+      respond(collection: scoped_search(index_relation, :name, :asc, resource_class: ContentViewFilter.rule_class_for(@filter)))
+    end
+
+    def index_relation
+      query = ContentViewFilter.rule_class_for(@filter).where(content_view_filter_id: @filter.id)
+      query
     end
 
     api :POST, "/content_view_filters/:content_view_filter_id/rules",

--- a/app/models/katello/concerns/content_view_filter_rule_common.rb
+++ b/app/models/katello/concerns/content_view_filter_rule_common.rb
@@ -1,0 +1,13 @@
+module Katello
+  module Concerns
+    module ContentViewFilterRuleCommon
+      extend ActiveSupport::Concern
+
+      included do
+        scoped_search on: :name
+
+        validates_lengths_from_database
+      end
+    end
+  end
+end

--- a/app/models/katello/content_view_docker_filter_rule.rb
+++ b/app/models/katello/content_view_docker_filter_rule.rb
@@ -1,11 +1,12 @@
 module Katello
   class ContentViewDockerFilterRule < Katello::Model
+    include ::Katello::Concerns::ContentViewFilterRuleCommon
+
     belongs_to :filter,
                :class_name => "Katello::ContentViewDockerFilter",
                :inverse_of => :docker_rules,
                :foreign_key => :content_view_filter_id
 
-    validates_lengths_from_database
     validates :name, :presence => true
     validate :ensure_unique_attributes
 

--- a/app/models/katello/content_view_erratum_filter_rule.rb
+++ b/app/models/katello/content_view_erratum_filter_rule.rb
@@ -1,5 +1,7 @@
 module Katello
   class ContentViewErratumFilterRule < Katello::Model
+    include ::Katello::Concerns::ContentViewFilterRuleCommon
+
     before_create :default_types
 
     ISSUED = "issued".freeze
@@ -13,7 +15,6 @@ module Katello
 
     serialize :types, Array
 
-    validates_lengths_from_database
     validates :errata_id, :uniqueness => { :scope => :content_view_filter_id }, :allow_blank => true
     validates_with Validators::ContentViewErratumFilterRuleValidator
 

--- a/app/models/katello/content_view_package_filter_rule.rb
+++ b/app/models/katello/content_view_package_filter_rule.rb
@@ -1,11 +1,12 @@
 module Katello
   class ContentViewPackageFilterRule < Katello::Model
+    include ::Katello::Concerns::ContentViewFilterRuleCommon
+
     belongs_to :filter,
                :class_name => "Katello::ContentViewPackageFilter",
                :inverse_of => :package_rules,
                :foreign_key => :content_view_filter_id
 
-    validates_lengths_from_database
     validates :name, :presence => true
     validate :ensure_unique_attributes
     validates_with Validators::ContentViewFilterVersionValidator

--- a/app/models/katello/content_view_package_group_filter_rule.rb
+++ b/app/models/katello/content_view_package_group_filter_rule.rb
@@ -1,11 +1,12 @@
 module Katello
   class ContentViewPackageGroupFilterRule < Katello::Model
+    include ::Katello::Concerns::ContentViewFilterRuleCommon
+
     belongs_to :filter,
                :class_name => "Katello::ContentViewPackageGroupFilter",
                :inverse_of => :package_group_rules,
                :foreign_key => :content_view_filter_id
 
-    validates_lengths_from_database
     validates :uuid, :presence => true, :uniqueness => { :scope => :content_view_filter_id }
   end
 end


### PR DESCRIPTION
Support scoped search for `ContentViewFilterRule#index`

To test:

```sh
curl -X GET 'https://katello.example.com/katello/api/v2/content_view_filters/1/rules?search=name%3D%22vim%22'
```