### PR TITLE
Fixes #20988 - fixes HTML title on Content Hosts page

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
@@ -1,3 +1,5 @@
+<span page-title>{{ 'Content Hosts' | translate }}</span>
+
 <div data-extend-template="layouts/table-with-header.html">
 
   <div data-block="header">


### PR DESCRIPTION
HTML title on the Content Hosts page now properly shows the title. See below image 
![content-host-page](https://user-images.githubusercontent.com/14857032/30579526-997a57f6-9d08-11e7-9c7f-fd190fa9060b.png)
