### PR TITLE
Fixes #21017 - prevent ISE in repositories search

### DIFF
--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -95,8 +95,12 @@ module Katello
       query = (total.zero? || sub_total.zero?) ? [] : query
 
       scoped_search_results(query, sub_total, total, page, per_page)
-    rescue ScopedSearch::QueryNotSupported => error
-      return scoped_search_results([], sub_total, total, page, per_page, error.message)
+    rescue ScopedSearch::QueryNotSupported, ActiveRecord::StatementInvalid => error
+      message = error.message
+      if error.class == ActiveRecord::StatementInvalid
+        message = _('The query cannot be handled by the database. Please revise it and try again.')
+      end
+      scoped_search_results([], sub_total, total, page, per_page, message)
     end
 
     protected

--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -96,8 +96,11 @@ module Katello
 
       scoped_search_results(query, sub_total, total, page, per_page)
     rescue ScopedSearch::QueryNotSupported, ActiveRecord::StatementInvalid => error
-      Rails.logger.error("Invalid search: #{error.message}")
-      message = _('Your search query was invalid. Please revise it and try again. The full error has been sent to the application logs.')
+      message = error.message
+      if error.class == ActiveRecord::StatementInvalid
+        Rails.logger.error("Invalid search: #{error.message}")
+        message = _('Your search query was invalid. Please revise it and try again. The full error has been sent to the application logs.')
+      end
       scoped_search_results([], sub_total, total, page, per_page, message)
     end
 

--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -96,10 +96,8 @@ module Katello
 
       scoped_search_results(query, sub_total, total, page, per_page)
     rescue ScopedSearch::QueryNotSupported, ActiveRecord::StatementInvalid => error
-      message = error.message
-      if error.class == ActiveRecord::StatementInvalid
-        message = _('The query cannot be handled by the database. Please revise it and try again.')
-      end
+      Rails.logger.error("Invalid search: #{error.message}")
+      message = _('Your search query was invalid. Please revise it and try again. The full error has been sent to the application logs.')
       scoped_search_results([], sub_total, total, page, per_page, message)
     end
 

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -142,7 +142,7 @@ module Katello
     scoped_search :on => :content_type, :complete_value => -> do
       Katello::RepositoryTypeManager.repository_types.keys.each_with_object({}) { |value, hash| hash[value.to_sym] = value }
     end
-    scoped_search :on => :content_view_id, :relation => :content_view_repositories, :validator => ScopedSearch::Validators::INTEGER
+    scoped_search :on => :content_view_id, :relation => :content_view_repositories, :validator => ScopedSearch::Validators::INTEGER, :only_explicit => true
     scoped_search :on => :distribution_version, :complete_value => true
     scoped_search :on => :distribution_arch, :complete_value => true
     scoped_search :on => :distribution_family, :complete_value => true

--- a/test/controllers/api/v2/api_controller_test.rb
+++ b/test/controllers/api/v2/api_controller_test.rb
@@ -130,31 +130,20 @@ module Katello
 
     def test_scoped_search_error
       @controller.stubs(:params).returns({})
-      error_message = 'Unsupported query'
-      @controller.stubs(:scoped_search_total).raises(ScopedSearch::QueryNotSupported.new(error_message))
+      error_message = 'Your search query was invalid. Please revise it and try again. The full error has been sent to the application logs.'
 
-      results = @controller.scoped_search(@query, 'errata_type', @default_sort[1], @options)
+      [ScopedSearch::QueryNotSupported, ActiveRecord::StatementInvalid].each do |error_class|
+        @controller.stubs(:scoped_search_total).raises(error_class.new('invalid search'))
 
-      assert_equal [], results[:results]
-      assert_nil results[:subtotal]
-      assert_nil results[:total]
-      assert_nil results[:page]
-      assert_nil results[:per_page]
-      assert_equal error_message, results[:error]
-    end
+        results = @controller.scoped_search(@query, 'errata_type', @default_sort[1], @options)
 
-    def test_scoped_search_statement_invalid_error
-      @controller.stubs(:params).returns({})
-      @controller.stubs(:scoped_search_total).raises(ActiveRecord::StatementInvalid.new('invalid statement'))
-
-      results = @controller.scoped_search(@query, 'errata_type', @default_sort[1], @options)
-
-      assert_equal [], results[:results]
-      assert_nil results[:subtotal]
-      assert_nil results[:total]
-      assert_nil results[:page]
-      assert_nil results[:per_page]
-      assert_equal 'The query cannot be handled by the database. Please revise it and try again.', results[:error]
+        assert_equal [], results[:results]
+        assert_nil results[:subtotal]
+        assert_nil results[:total]
+        assert_nil results[:page]
+        assert_nil results[:per_page]
+        assert_equal error_message, results[:error]
+      end
     end
   end
 end


### PR DESCRIPTION
Searching on this view would break if giving a number larger than postgres' integer bounds. Now, we don't search on the content_view_id field so we can avoid that.