### PR TITLE
fixes #20584 - Speed up activation key index

### DIFF
--- a/app/views/katello/api/v2/activation_keys/base.json.rabl
+++ b/app/views/katello/api/v2/activation_keys/base.json.rabl
@@ -1,0 +1,34 @@
+extends 'katello/api/v2/common/org_reference'
+extends 'katello/api/v2/common/timestamps'
+
+attributes :id, :name, :description, :unlimited_hosts, :auto_attach
+
+attributes :content_view_id
+
+child :content_view => :content_view do
+  attributes :id, :name
+end
+
+child :environment => :environment do
+  attributes :name, :id
+end
+attributes :environment_id
+
+attributes :usage_count, :user_id, :max_hosts, :system_template_id, :release_version
+
+node :permissions do |activation_key|
+  {
+    :view_activation_keys => activation_key.readable?,
+    :edit_activation_keys => activation_key.editable?,
+    :destroy_activation_keys => activation_key.deletable?
+  }
+end
+
+child :products => :products do |_product|
+  attributes :id, :name
+end
+
+child :host_collections => :host_collections do
+  attributes :id
+  attributes :name
+end

--- a/app/views/katello/api/v2/activation_keys/index.json.rabl
+++ b/app/views/katello/api/v2/activation_keys/index.json.rabl
@@ -1,3 +1,6 @@
 object false
+extends "katello/api/v2/common/metadata"
 
-extends "katello/api/v2/common/index"
+child @collection[:results] => :results do
+  extends "katello/api/v2/activation_keys/base"
+end

--- a/app/views/katello/api/v2/activation_keys/show.json.rabl
+++ b/app/views/katello/api/v2/activation_keys/show.json.rabl
@@ -1,40 +1,4 @@
 object @resource
-
-attributes :id, :name, :description, :unlimited_hosts, :auto_attach
-
-extends 'katello/api/v2/common/org_reference'
-
-attributes :content_view_id
-
-child :content_view => :content_view do
-  attributes :id, :name
-end
-
-child :environment => :environment do
-  attributes :name, :id
-end
-attributes :environment_id
-
-attributes :usage_count, :user_id, :max_hosts, :system_template_id, :release_version,
-           :service_level, :auto_attach
-
-child :products => :products do |_product|
-  attributes :id, :name
-end
-
-node :permissions do |activation_key|
-  {
-    :view_activation_keys => activation_key.readable?,
-    :edit_activation_keys => activation_key.editable?,
-    :destroy_activation_keys => activation_key.deletable?
-  }
-end
-
-child :host_collections => :host_collections do
-  attributes :id
-  attributes :name
-end
-
+extends "katello/api/v2/activation_keys/base"
+attributes :service_level
 attributes :content_overrides
-
-extends 'katello/api/v2/common/timestamps'


### PR DESCRIPTION
Basically moved the expensive service level
and content overrides call to show up only
for show.json.rabl

The index call now returns everything but
those 2 attributes.. while show will return
everything