### PR TITLE
Fixes #21049: Pre-fill date on sync plan creation

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/new/new-sync-plan.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/new/new-sync-plan.controller.js
@@ -18,6 +18,7 @@ angular.module('Bastion.sync-plans').controller('NewSyncPlanController',
 
             $scope.syncPlan = new SyncPlan();
             $scope.syncPlan.interval = $scope.intervals[0].id;
+            $scope.syncPlan.startDate = new Date();
 
             function success(syncPlan) {
                 $scope.working = false;


### PR DESCRIPTION
This adds back in the default start date on the sync plan creation form.
The bz mentioned the time as well but the time wasn't ever pre-filled
and is not required to create the plan.

http://projects.theforeman.org/issues/21049