### PR TITLE
Fixes #21050 - Docker Container Create fixes

### DIFF
--- a/app/controllers/katello/concerns/containers/steps_controller_extensions.rb
+++ b/app/controllers/katello/concerns/containers/steps_controller_extensions.rb
@@ -26,7 +26,7 @@ module Katello
             end
 
             if params[:tag] && params[:tag][:id]
-              tag = DockerTag.where(:id => params[:tag][:id]).first
+              tag = DockerMetaTag.where(:id => params[:tag][:id]).first
             end
             if params[:capsule] && params[:capsule][:id]
               capsule_id = params[:capsule][:id]
@@ -39,7 +39,7 @@ module Katello
               repository_id: repo.try(:id),
               tag_id: tag.try(:id)
             }
-            @docker_container_wizard_states_image = @state.build_image(:repository_name => repo.try(:pulp_id),
+            @docker_container_wizard_states_image = @state.build_image(:repository_name => repo.try(:container_repository_name),
                                 :tag => tag.try(:name),
                                 :capsule_id => capsule_id,
                                 :katello => true, :katello_content => katello_content)

--- a/app/models/katello/concerns/container_extensions.rb
+++ b/app/models/katello/concerns/container_extensions.rb
@@ -12,7 +12,7 @@ module Katello
 
       def repository_pull_url_with_katello
         repo_url = repository_pull_url_without_katello
-        if Repository.where(:pulp_id => repository_name).count > 0
+        if Repository.where(:container_repository_name => repository_name).count > 0
           manifest_capsule = self.capsule || CapsuleContent.default_capsule.capsule
           "#{URI(manifest_capsule.url).hostname}:#{Setting['pulp_docker_registry_port']}/#{repo_url}"
         else

--- a/app/models/katello/concerns/docker_container_wizard_state_image_extensions.rb
+++ b/app/models/katello/concerns/docker_container_wizard_state_image_extensions.rb
@@ -4,22 +4,35 @@ module Katello
       extend ActiveSupport::Concern
 
       included do
-        alias_method :orig_image_exists, :image_exists
-        def image_exists
-          orig_image_exists unless katello
-        end
+        alias_method_chain :image_exists, :katello
 
         serialize :katello_content, Hash
-        validate :katello_content_completed
+        validate :katello_content_completed, :if => :katello?
+      end
+
+      def image_exists_with_katello
+        return true if katello?
+        image_exists_without_katello
       end
 
       def katello_content_completed
         empty_values = katello_content.map do |key, value|
           key if value.blank?
         end
-        return true if empty_values.compact.empty?
-        error_msg = _("Content View not completelly set")
-        errors.add(:katello_content, error_msg)
+        empty_values.compact!
+
+        return true if empty_values.empty?
+
+        message_mapping = {
+          organization_id: _("Organization not set"),
+          environment_id: _("Lifecycle Environment not set"),
+          content_view_id: _("Content View not set"),
+          repository_id: _("Repository not set"),
+          tag_id: _("Tag not set")
+        }
+        empty_values.each do |key|
+          errors.add(:katello_content, message_mapping[key])
+        end
       end
     end
   end

--- a/test/controllers/foreman/containers/steps_controller_test.rb
+++ b/test/controllers/foreman/containers/steps_controller_test.rb
@@ -33,16 +33,16 @@ module Containers
     end
 
     def test_create_image_with_katello
-      repo = OpenStruct.new(:id => 100, :pulp_id => "repo_pulp_id")
+      repo = OpenStruct.new(:id => 100, :container_repository_name => "repo_pulp_id")
       ::Katello::Repository.expects(:where).with(:id => repo.id.to_s).returns([repo])
 
       tag = OpenStruct.new(:id => 200, :name => "tag_name")
-      ::Katello::DockerTag.expects(:where).with(:id => tag.id.to_s).returns([tag])
+      ::Katello::DockerMetaTag.expects(:where).with(:id => tag.id.to_s).returns([tag])
 
       capsule_id = 300
       image = OpenStruct.new(:id => 1000)
 
-      @state.expects(:build_image).with(:repository_name => repo.pulp_id,
+      @state.expects(:build_image).with(:repository_name => repo.container_repository_name,
                                         :tag => tag.name,
                                         :capsule_id => capsule_id.to_s,
                                         :katello => true,

--- a/test/models/concerns/container_extensions_test.rb
+++ b/test/models/concerns/container_extensions_test.rb
@@ -15,7 +15,7 @@ module Katello
       capsule = mock
       capsule.expects(:url => "http://" + hostname + ":8000")
       @container.stubs(:capsule).returns(capsule)
-      Repository.expects(:where).with(:pulp_id => @container.repository_name).returns(counter)
+      Repository.expects(:where).with(:container_repository_name => @container.repository_name).returns(counter)
       url = @container.repository_pull_url
       assert_equal "#{hostname}:6000/#{@container.repository_name}:#{@container.tag}", url
     end
@@ -29,7 +29,7 @@ module Katello
       capsule.expects(:url => "http://" + hostname + ":8000")
       default_capsule.expects(:capsule).returns(capsule)
       @container.stubs(:capsule).returns
-      Repository.expects(:where).with(:pulp_id => @container.repository_name).returns(counter)
+      Repository.expects(:where).with(:container_repository_name => @container.repository_name).returns(counter)
       url = @container.repository_pull_url
       assert_equal "#{hostname}:6000/#{@container.repository_name}:#{@container.tag}", url
     end


### PR DESCRIPTION
This commit includes fixes related to container creation and tag
selection. The container repository name was not being used to provision
the container image and instead the repo name was being used which
implies that containers were never able to provision in the first place.

More over this fix make the container create use DockerMetaTag instead
of DockerTag. This fixes the issue where the wrong tag would get applied
to the repository.