### PR TITLE
Fixes #21051 - Add note while unregistering host

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-details.html
@@ -38,6 +38,10 @@
                    ng-value="true"
                    type="radio" />
             Completely deletes the host record and removes all reporting, provisioning, and configuration information.
+            <p translate>
+              While selecting the option <b>"Completely deletes the host record"</b>, virtual machine may get deleted from the hypervisor.
+              Confirm Settings -> Katello -> unregister_delete_host option is set to <b>False</b>.
+            </p>
           </label>
         </p>
       </div>


### PR DESCRIPTION
With this PR we are adding a note for admin, about caution needed while selecting one of the two options in process of unregisterring host. If the unregister_delete_host setting is set to True then the VM gets deleted from the hypervisor.
