### PR TITLE
Fixes #20788 - move sub indexing to run phase

### DIFF
--- a/app/lib/actions/katello/product/create.rb
+++ b/app/lib/actions/katello/product/create.rb
@@ -32,13 +32,10 @@ module Actions
         end
 
         def run
-          ::Katello::Repository.ensure_sync_notification
-        end
-
-        def finalize
           product = ::Katello::Product.find(input[:product][:id])
-          product.cp_id = input[:cp_id]
-          product.save!
+          product.update_attributes!(:cp_id => input[:cp_id])
+
+          ::Katello::Repository.ensure_sync_notification
         end
 
         def humanized_name

--- a/app/lib/actions/katello/product/reindex_subscriptions.rb
+++ b/app/lib/actions/katello/product/reindex_subscriptions.rb
@@ -15,7 +15,7 @@ module Actions
           plan_self(id: product.id, subscription_id: subscription_id)
         end
 
-        def finalize
+        def run
           product = ::Katello::Product.find_by!(:id => input[:id])
           product.import_subscription(input[:subscription_id])
         end


### PR DESCRIPTION
Subscription indexing uses our active record retry
to re-attempt indexing during errors (such as a race
condition where first_or_create fails, because it already
exists).  However when this is used in plan or finalize phases
it is executing in a db transaction.  When such a race condition
occurs, the transaction becomes aborted and the task fails. Requiring
the user to resume.

By moving it to the run phase, we are moving it out of a db transaction.
Because this changes the ordering of the steps, we will also move the
saving of cp_id into the run phase so it occurs prior to subscription
indexing, since we map products to subscriptions