### PR TITLE
Fixes #20057 - fix duplicate akey repo sets

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -136,7 +136,14 @@ module Katello
     def product_content
       content_access_mode_all = ::Foreman::Cast.to_bool(params[:content_access_mode_all])
       content_access_mode_env = ::Foreman::Cast.to_bool(params[:content_access_mode_env])
-      content = @activation_key.available_content(content_access_mode_all, content_access_mode_env)
+
+      content_finder = ProductContentFinder.new(
+          :match_subscription => !content_access_mode_all,
+          :match_environment => content_access_mode_env,
+          :consumable => @activation_key
+      )
+
+      content = content_finder.presenter_with_overrides(@activation_key.content_overrides)
       response = {
         :results => content,
         :total => content.size,

--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -172,11 +172,16 @@ module Katello
     def product_content
       content_access_mode_all = ::Foreman::Cast.to_bool(params[:content_access_mode_all])
       content_access_mode_env = ::Foreman::Cast.to_bool(params[:content_access_mode_env])
-      content = @host.subscription_facet.candlepin_consumer.available_product_content(content_access_mode_all, content_access_mode_env)
-      overrides = @host.subscription_facet.candlepin_consumer.content_overrides
-      results = content.map { |product_content| Katello::ProductContentPresenter.new(product_content, overrides) }
 
-      respond_for_index(:collection => full_result_response(results))
+      content_finder = ProductContentFinder.new(
+          :consumable => @host.subscription_facet,
+          :match_subscription => !content_access_mode_all,
+          :match_environment => content_access_mode_env
+      )
+
+      content = content_finder.presenter_with_overrides(@host.subscription_facet.candlepin_consumer.content_overrides)
+
+      respond_for_index(:collection => full_result_response(content))
     end
 
     api :GET, "/hosts/:host_id/subscriptions/available_release_versions", N_("Show releases available for the content host")

--- a/app/controllers/katello/api/v2/repository_sets_controller.rb
+++ b/app/controllers/katello/api/v2/repository_sets_controller.rb
@@ -18,7 +18,7 @@ module Katello
     def index
       collection = {}
       if @product.nil?
-        collection[:results] = available_repository_sets
+        collection[:results] = @organization.enabled_product_content
       else
         collection[:results] = @product.displayable_product_contents
       end
@@ -107,15 +107,6 @@ module Katello
 
     def substitutions
       params.slice(:basearch, :releasever)
-    end
-
-    def available_repository_sets
-      repository_sets = @organization.products.enabled.uniq.flat_map do |product|
-        product.available_content
-      end
-      repository_sets.uniq.sort_by do |repository_set|
-        repository_set.content.name.downcase
-      end
     end
   end
 end

--- a/app/helpers/katello/providers_helper.rb
+++ b/app/helpers/katello/providers_helper.rb
@@ -20,8 +20,11 @@ module Katello
       tabs = {}.with_indifferent_access
       redhat_repo_tabs.each { |tab| tabs[tab[:id]] = tab }
 
+      product_content = provider.organization.filtered_product_content
+
       provider.products.each do |product|
-        product.displayable_product_contents.each do |prod_content|
+        selected_contents = product_content.select { |pc| pc.product_id == product.id }.select(&:displayable?)
+        selected_contents.each do |prod_content|
           name = prod_content.content.name
           if prod_content.content_type == ::Katello::Repository::CANDLEPIN_OSTREE_TYPE
             key = :ostree

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -399,6 +399,10 @@ module Katello
             self.post(path, {:import => File.new(path_to_file, 'rb')}, self.default_headers.except('content-type'))
           end
 
+          def product_content(organization_name)
+            Product.all(organization_name, [:id, :productContent])
+          end
+
           def destroy_imports(organization_name, wait_until_complete = false)
             response_json = self.delete(join_path(path(organization_name), 'imports'), self.default_headers)
             response = JSON.parse(response_json).with_indifferent_access
@@ -654,8 +658,8 @@ module Katello
 
       class Product < CandlepinResource
         class << self
-          def all(owner_label)
-            JSON.parse(Candlepin::CandlepinResource.get(path(owner_label), self.default_headers).body)
+          def all(owner_label, included = [])
+            JSON.parse(Candlepin::CandlepinResource.get(path(owner_label) + "?#{included_list(included)}", self.default_headers).body)
           end
 
           def find_for_stacking_id(owner_key, stacking_id)

--- a/app/models/katello/candlepin/product_content.rb
+++ b/app/models/katello/candlepin/product_content.rb
@@ -2,7 +2,7 @@ module Katello
   class Candlepin::ProductContent
     include ForemanTasks::Triggers
 
-    attr_accessor :content, :enabled, :product
+    attr_accessor :content, :enabled, :product, :product_id
 
     def initialize(params = {}, product_id = nil)
       params = params.with_indifferent_access
@@ -28,19 +28,6 @@ module Katello
 
     def repositories
       @repos ||= self.product.repos(self.product.organization.library).where(:content_id => self.content.id)
-    end
-
-    def legacy_content_override(activation_key)
-      override = activation_key.content_overrides.find { |pc| pc.content_label == content.label && pc.name == "enabled" }
-      override.nil? ? 'default' : override.value
-    end
-
-    def content_overrides(activation_key)
-      activation_key.content_overrides.select { |pc| pc.content_label == content.label }
-    end
-
-    def enabled_content_override(activation_key)
-      activation_key.content_overrides.find { |pc| pc.content_label == content.label && pc.name == "enabled" }
     end
 
     def content_type

--- a/app/models/katello/glue/candlepin/owner.rb
+++ b/app/models/katello/glue/candlepin/owner.rb
@@ -38,6 +38,38 @@ module Katello
         self.owner_details['contentAccessMode']
       end
 
+      def enabled_product_content_for(repositories)
+        return [] if repositories.blank?
+        content_ids = repositories.pluck(:content_id)
+
+        filtered_product_content do |pc|
+          content_ids.include?(pc.content.id) && pc.product.enabled?
+        end
+      end
+
+      def enabled_product_content
+        filtered_product_content do |pc|
+          pc.product.enabled? && pc.product.redhat?
+        end
+      end
+
+      def filtered_product_content
+        cp_products = Katello::Resources::Candlepin::Product.all(self.label, ['id', 'productContent.enabled', 'productContent.content.name', 'productContent.content.id',
+                                                                              'productContent.content.type', 'productContent.content.contentUrl', 'productContent.content.label'])
+        to_return = []
+
+        cp_products.each do |product_hash|
+          product = ::Katello::Product.find_by(:organization_id => self.id, :cp_id => product_hash['id'])
+          if product
+            product_hash['productContent'].each do |pc_hash|
+              pc = Katello::Candlepin::ProductContent.new(pc_hash, product.id)
+              to_return << pc if !block_given? || yield(pc)
+            end
+          end
+        end
+        to_return.sort_by { |pc| pc.content.name.downcase }
+      end
+
       def pools(consumer_uuid = nil)
         if consumer_uuid
           Resources::Candlepin::Owner.pools self.label, :consumer => consumer_uuid

--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -108,6 +108,18 @@ module Katello
         end
       end
 
+      def content_view
+        self.host.content_facet.try(:content_view) || self.organization.default_content_view
+      end
+
+      def lifecycle_environment
+        self.host.content_facet.try(:lifecycle_environment) || self.organization.library
+      end
+
+      def organization
+        self.host.organization
+      end
+
       def update_subscription_status(status_override = nil)
         status = host.get_status(::Katello::SubscriptionStatus)
         if status_override
@@ -170,6 +182,10 @@ module Katello
         end
 
         name.downcase
+      end
+
+      def products
+        Katello::Product.joins(:subscriptions => {:pools => :subscription_facets}).where("#{Katello::Host::SubscriptionFacet.table_name}.id" => self.id).enabled.uniq
       end
 
       def remove_subscriptions(pools_with_quantities)

--- a/app/presenters/katello/product_content_presenter.rb
+++ b/app/presenters/katello/product_content_presenter.rb
@@ -1,11 +1,11 @@
 module Katello
-  class ProductContentPresenter
+  class ProductContentPresenter < SimpleDelegator
     attr_accessor :product_content, :overrides
-    delegate :content, :enabled, :product, :to => :product_content
 
     def initialize(product_content, overrides)
       @product_content = product_content
       @overrides = overrides
+      super(@product_content)
     end
 
     def override
@@ -19,6 +19,11 @@ module Katello
 
     def content_overrides
       overrides.select { |pc| pc.content_label == content.label }
+    end
+
+    def legacy_content_override
+      override = @overrides.find { |pc| pc.content_label == content.label && pc.name == "enabled" }
+      override.nil? ? 'default' : override.value
     end
   end
 end

--- a/app/services/katello/candlepin/consumer.rb
+++ b/app/services/katello/candlepin/consumer.rb
@@ -116,34 +116,6 @@ module Katello
         end
       end
 
-      def products
-        pool_ids = self.entitlements.map { |entitlement| entitlement['pool']['id'] }
-        Katello::Product.joins(:subscriptions => :pools).where("#{Katello::Pool.table_name}.cp_id" => pool_ids).enabled.uniq
-      end
-
-      def all_products
-        ::Katello::Host::SubscriptionFacet.find_by_uuid(self.uuid).host.organization.products.enabled.uniq
-      end
-
-      def available_product_content(content_access_mode_all = false, content_access_mode_env = false)
-        if content_access_mode_env
-          host = ::Katello::Host::ContentFacet.find_by_uuid(self.uuid)
-          return [] unless host.lifecycle_environment_id && host.content_view_id
-          version = ContentViewVersion.in_environment(host.lifecycle_environment_id).where(:content_view_id => host.content_view_id).first
-          content_view_version_id = version.id
-        end
-        if content_access_mode_all
-          content = all_products.flat_map do |product|
-            product.available_content(content_view_version_id)
-          end
-        else
-          content = products.flat_map do |product|
-            product.available_content(content_view_version_id)
-          end
-        end
-        content.uniq
-      end
-
       def compliance_reasons
         Resources::Candlepin::Consumer.compliance(uuid)['reasons'].map do |reason|
           "#{reason['attributes']['name']}: #{reason['message']}"

--- a/app/services/katello/product_content_finder.rb
+++ b/app/services/katello/product_content_finder.rb
@@ -1,0 +1,37 @@
+module Katello
+  class ProductContentFinder
+    attr_accessor :match_environment, :match_subscription, :consumable
+
+    #consumable must implement:
+    #  content_view
+    #  lifecycle_environment
+    #  organization
+    #  products
+    def initialize(params = {})
+      self.match_subscription = false
+      self.match_environment = false
+
+      params.each_pair { |k, v| instance_variable_set("@#{k}", v) unless v.nil? }
+    end
+
+    def product_content
+      if match_environment
+        environment = consumable.lifecycle_environment
+        view = consumable.content_view
+        return [] unless environment && view
+        version = ContentViewVersion.in_environment(environment).where(:content_view_id => view).first
+      end
+
+      considered_products = match_subscription ? consumable.products : consumable.organization.products.enabled.uniq
+
+      repositories = Katello::Repository.where(:product_id => considered_products).subscribable
+      repositories = repositories.where(:content_view_version_id => version .id) if version
+
+      consumable.organization.enabled_product_content_for(repositories)
+    end
+
+    def presenter_with_overrides(overrides)
+      product_content.map { |pc| ProductContentPresenter.new(pc, overrides) }
+    end
+  end
+end

--- a/app/views/katello/api/v2/activation_keys/product_content.json.rabl
+++ b/app/views/katello/api/v2/activation_keys/product_content.json.rabl
@@ -13,17 +13,17 @@ child @collection[:results] => :results do
   end
 
   node :override do |pc|
-    pc.legacy_content_override(@activation_key)
+    pc.legacy_content_override
   end
 
   node :overrides do |pc|
-    pc.content_overrides(@activation_key).map do |override|
+    pc.content_overrides.map do |override|
       {:name => override.name, :value => override.computed_value}
     end
   end
 
   node :enabled_content_override do |pc|
-    override = pc.enabled_content_override(@activation_key)
+    override = pc.enabled_content_override
     override.computed_value if override
   end
 

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -205,7 +205,8 @@ module Katello
     end
 
     def test_product_content_access_modes
-      ActivationKey.any_instance.expects(:all_products).once.returns([])
+      ProductContentFinder.any_instance.expects(:product_content).once.returns([])
+
       mode_all = true
       mode_env = false
       get(:product_content, :id => @activation_key.id,

--- a/test/controllers/api/v2/host_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/host_subscriptions_controller_test.rb
@@ -154,9 +154,10 @@ module Katello
   class Api::V2::HostSubscriptionsProductContentTest < Api::V2::HostSubscriptionsControllerBase
     def setup
       super
-      ::Katello::Candlepin::Consumer.any_instance.stubs(:available_product_content).returns(
-          [Candlepin::ProductContent.new(:content => {:label => 'some-content'})])
+      pc = [Candlepin::ProductContent.new(:content => {:label => 'some-content'})]
+      ::Katello::Candlepin::Consumer.any_instance.stubs(:available_product_content).returns(pc)
       Katello::Candlepin::Consumer.any_instance.stubs(:content_overrides).returns([])
+      ProductContentFinder.any_instance.stubs(:product_content).returns(pc)
     end
 
     def test_product_content_protected

--- a/test/controllers/api/v2/repository_sets_controller_test.rb
+++ b/test/controllers/api/v2/repository_sets_controller_test.rb
@@ -134,8 +134,8 @@ module Katello
 
     def test_repositories_index_without_product
       Organization.stubs(:current).returns(@organization)
-      @organization.products.stubs(:enabled).returns([@product])
-      Product.any_instance.stubs(available_content: [OpenStruct.new(content: @content)])
+      @organization.stubs(:enabled_product_content).returns([OpenStruct.new(content: @content, product_id: @product.id)])
+      #Product.any_instance.stubs(available_content: [OpenStruct.new(content: @content)])
       get :index
       assert_response :success
     end

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -111,7 +111,7 @@ feedless_fedora_17_x86_64:
 rhel_7_x86_64:
   name:                 RHEL 7 x86_64
   pulp_id:              9
-  content_id:           1
+  content_id:           69
   major:                7
   minor:                7Server
   content_type:         yum
@@ -132,7 +132,7 @@ rhel_7_x86_64:
 rhel_6_x86_64:
   name:                 RHEL 6 x86_64
   pulp_id:              pulp-uuid-rhel_6_x86_64
-  content_id:           1
+  content_id:           69
   major:                6
   minor:                6Server
   content_type:         yum
@@ -153,7 +153,7 @@ rhel_6_x86_64:
 rhel_6_x86_64_dev:
   name:                 RHEL 6 x86_64
   pulp_id:              8
-  content_id:           1
+  content_id:           69
   major:                6
   minor:                6Server
   content_type:         yum
@@ -405,7 +405,7 @@ busybox_view2:
 rhel_6_x86_64_composite_view_version_1:
   name:                 RHEL 6 x86_64
   pulp_id:              8
-  content_id:           1
+  content_id:           69
   major:                6
   minor:                6Server
   content_type:         yum
@@ -435,7 +435,7 @@ ostree:
 ostree_view1:
   name:                 ostree
   pulp_id:              "Default_Organization-Test-ostree"
-  content_id:           1
+  content_id:           2
   content_type:         ostree
   library_instance:     ostree
   label:                ostree

--- a/test/models/activation_key_test.rb
+++ b/test/models/activation_key_test.rb
@@ -3,14 +3,14 @@ require 'katello_test_helper'
 module Katello
   class ActivationKeyTest < ActiveSupport::TestCase
     def setup
-      @dev_key = ActivationKey.find(katello_activation_keys(:dev_key).id)
-      @dev_staging_view_key = ActivationKey.find(katello_activation_keys(:library_dev_staging_view_key).id)
-      @dev_view = ContentView.find(katello_content_views(:library_dev_view).id)
-      @lib_view = ContentView.find(katello_content_views(:library_view).id)
+      @dev_key = katello_activation_keys(:dev_key)
+      @dev_staging_view_key = katello_activation_keys(:library_dev_staging_view_key)
+      @dev_view = katello_content_views(:library_dev_view)
+      @lib_view = katello_content_views(:library_view)
     end
 
     test "can have content view" do
-      @dev_key = ActivationKey.find(katello_activation_keys(:dev_key).id)
+      @dev_key = katello_activation_keys(:dev_key)
       @dev_key.content_view = @dev_view
       assert @dev_key.save!
       assert_not_nil @dev_key.content_view
@@ -33,13 +33,13 @@ module Katello
     end
 
     test "same name can be used across organizations" do
-      org = Organization.find(taxonomies(:organization2))
-      key = ActivationKey.find(katello_activation_keys(:simple_key).id)
+      org = taxonomies(:organization2)
+      key = katello_activation_keys(:simple_key)
       assert ActivationKey.new(:name => key.name, :organization => org).valid?
     end
 
     test "renamed key can be used again" do
-      key1 = ActivationKey.find(katello_activation_keys(:simple_key).id)
+      key1 = katello_activation_keys(:simple_key)
       org = key1.organization
       original_name = key1.name
       key1.name = "new name"
@@ -58,7 +58,7 @@ module Katello
     end
 
     test "unlimited hosts requires no max hosts" do
-      key1 = ActivationKey.find(katello_activation_keys(:simple_key).id)
+      key1 = katello_activation_keys(:simple_key)
       org = key1.organization
       new_key = ActivationKey.new(:name => "JarJar", :organization => org)
       new_key.unlimited_hosts = false
@@ -134,16 +134,6 @@ module Katello
 
       @dev_key.stubs(:get_key_pools).returns(cp_pools)
       assert_empty @dev_key.products
-    end
-
-    def test_not_all_available_content
-      @dev_key.expects(:products).returns([]).at_least_once
-      @dev_key.available_content(false, false)
-    end
-
-    def test_all_available_content
-      @dev_key.expects(:all_products).returns([]).at_least_once
-      @dev_key.available_content(true, false)
     end
 
     def test_available_subscriptions

--- a/test/models/host/subscription_facet_test.rb
+++ b/test/models/host/subscription_facet_test.rb
@@ -290,15 +290,5 @@ module Katello
       assert host.valid_content_override_label?('some-label')
       refute host.valid_content_override_label?('some-label1')
     end
-
-    def test_not_all_available_product_content
-      subscription_facet.candlepin_consumer.expects(:products).returns([]).at_least_once
-      subscription_facet.candlepin_consumer.available_product_content(false, false)
-    end
-
-    def test_all_available_product_content
-      subscription_facet.candlepin_consumer.expects(:all_products).returns([]).at_least_once
-      subscription_facet.candlepin_consumer.available_product_content(true, false)
-    end
   end
 end

--- a/test/services/product_content_finder_test.rb
+++ b/test/services/product_content_finder_test.rb
@@ -1,0 +1,68 @@
+require 'katello_test_helper'
+
+module Katello
+  class ProductContentFinderTestBase < ActiveSupport::TestCase
+    def product_hash(product, repo, name)
+      {
+        :id => product.cp_id,
+        :productContent => [
+          {
+            :content => {
+              :name => name,
+              :label => name,
+              :id => repo.content_id
+            }
+          }
+        ]
+      }.with_indifferent_access
+    end
+
+    def setup
+      @product1 = katello_products(:fedora)
+      @product2 = katello_products(:redhat)
+      @repo1 = katello_repositories(:fedora_17_x86_64)
+      @repo2 = katello_repositories(:rhel_7_x86_64)
+      @repo2_cv = katello_repositories(:rhel_6_x86_64_composite_view_version_1)
+
+      @content_json1 = product_hash(@product1, @repo1, 'foo')
+      @content_json2 = product_hash(@product2, @repo2, 'bar')
+    end
+  end
+
+  class ProductContentFinderActivationKeyTest < ProductContentFinderTestBase
+    def setup
+      super
+      @key = ActivationKey.new(:organization => @product1.organization)
+      Katello::Resources::Candlepin::Product.expects(:all).returns([@content_json1, @content_json2])
+    end
+
+    def test_all
+      pcf = Katello::ProductContentFinder.new(:consumable => @key)
+      product_content = pcf.product_content
+
+      assert product_content.any? { |pc| pc.content.id == @repo1.content_id }
+      assert product_content.any? { |pc| pc.content.id == @repo2.content_id }
+    end
+
+    def test_match_subs
+      @key.expects(:products).returns([@product1])
+
+      pcf = Katello::ProductContentFinder.new(:consumable => @key, :match_subscription => true)
+      product_content = pcf.product_content
+
+      assert product_content.any? { |pc| pc.content.id == @repo1.content_id }
+      refute product_content.any? { |pc| pc.content.id == @repo2.content_id }
+    end
+
+    def test_match_environments
+      @key.environment = @repo2_cv.environment
+      @key.content_view = @repo2_cv.content_view
+
+      pcf = Katello::ProductContentFinder.new(:consumable => @key, :match_environment => true)
+      product_content = pcf.product_content
+
+      refute product_content.any? { |pc| pc.content.id == @repo1.content_id }
+      assert product_content.any? { |pc| pc.content.id == @repo2.content_id }
+    end
+  end
+end


### PR DESCRIPTION
this fixes duplicate repository sets from being returned
when listing them for an activation key.  In addition this improves performance
by using a single api call for all product content in the org,
as well as using a presenter to only fetch the activation key overrides
once, instead of once per product content.

In addition this updates the redhat repos page to use this new
content fetching method to speed up that page as well.