### PR TITLE
Fixes #21016 - Can update content source in host

### DIFF
--- a/app/models/katello/concerns/content_facet_host_extensions.rb
+++ b/app/models/katello/concerns/content_facet_host_extensions.rb
@@ -45,8 +45,12 @@ module Katello
         accepts_nested_attributes_for(
           :content_facet,
           self.nested_attributes_options[:content_facet].merge(
-            :reject_if => proc { |attributes| attributes['content_view_id'].blank? && attributes['lifecycle_environment_id'].blank? })
+            :reject_if => :content_facet_ignore_update?)
         )
+
+        def content_facet_ignore_update?(attributes)
+          self.content_facet.blank? && attributes.blank?
+        end
       end
 
       module ClassMethods


### PR DESCRIPTION
Prior to this commit a simple call like
hammer host update --id=1 --content-source-id=2
would fail because the content facet nested attributes code would reject
updating any request that did not contain a content-view-id or a
lifecycle-environment-id. This code fixes that by updating the model to
say "if content facet is present update any changes that come in Else
check on cv-id and environment"