### PR TITLE
Fixes #21145: erratum filter rules start_date fix

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/date-type-errata-filter.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/date-type-errata-filter.controller.js
@@ -63,7 +63,13 @@ angular.module('Bastion.content-views').controller('DateTypeErrataFilterControll
         };
 
         $scope.save = function (rule, filter) {
-            var params = {filterId: filter.id, ruleId: rule.id};
+            var params;
+
+            // Remove any hours from the dates
+            rule['start_date'].setHours(0, 0, 0, 0);
+            rule['end_date'].setHours(0, 0, 0, 0);
+
+            params = {filterId: filter.id, ruleId: rule.id};
             rule.$update(params, success, failure);
             $scope.filter.rules[0] = rule;
         };


### PR DESCRIPTION
The dates sent to the api from the ui should only include the
timezone offset and not any other time data. This change removes
the hours from the dates and leaves only the timezone offset.

The original issue reported was if you send 2013-03-24T00:00:00.000Z
to the api and then open the ui you might not see 2013-03-24. This is
because you need the timezone offset i.e. 2013-03-24T04:00:00.000Z.
This change will include the timezone offset.

http://projects.theforeman.org/issues/21145