### PR TITLE
Fixes #21147 - Shows ks repo name in hosts json

### DIFF
--- a/app/views/katello/api/v2/content_facet/base.json.rabl
+++ b/app/views/katello/api/v2/content_facet/base.json.rabl
@@ -2,7 +2,8 @@ attributes :id, :uuid
 attributes :content_view_id, :content_view_name
 attributes :lifecycle_environment_id, :lifecycle_environment_name
 attributes :content_source_id, :content_source_name
-attributes :kickstart_repository_id, :errata_counts
+attributes :kickstart_repository_id, :kickstart_repository_name
+attributes :errata_counts
 attributes :applicable_rpm_count => :applicable_package_count
 attributes :upgradable_rpm_count => :upgradable_package_count
 
@@ -16,4 +17,8 @@ end
 
 child :content_source => :content_source do
   attributes :id, :name, :url
+end
+
+child :kickstart_repository => :kickstart_repository do
+  attributes :id, :name
 end

--- a/app/views/katello/api/v2/hostgroups_extensions/show.json.rabl
+++ b/app/views/katello/api/v2/hostgroups_extensions/show.json.rabl
@@ -1,3 +1,4 @@
 object @hostgroup
 extends 'api/v2/hostgroups/show'
-attributes :content_source_id, :content_source_name, :content_view_id, :content_view_name, :lifecycle_environment_id, :lifecycle_environment_name, :kickstart_repository_id
+attributes :content_source_id, :content_source_name, :content_view_id, :content_view_name, :lifecycle_environment_id, :lifecycle_environment_name
+attributes :kickstart_repository_id, :kickstart_repository_name


### PR DESCRIPTION
We need the kickstart repository name if available in the content facets
json so that we can show that info in hammer along with other content
facet attributes