### PR TITLE
Fixes #21152 - correct detection of redhat subs

### DIFF
--- a/app/models/katello/subscription.rb
+++ b/app/models/katello/subscription.rb
@@ -22,7 +22,10 @@ module Katello
     end
 
     def redhat?
-      self.products.any? { |product| product.redhat? }
+      # for custom subscriptions, there is no separate marketing and engineering product
+      #   so query our Products table and check there
+      product = Katello::Product.where(:cp_id => self.product_id, :organization => self.organization).first
+      product.nil? || product.redhat?
     end
 
     def active?

--- a/test/fixtures/models/katello_subscriptions.yml
+++ b/test/fixtures/models/katello_subscriptions.yml
@@ -7,6 +7,7 @@ basic_subscription:
   cores: 2
   stacking_id: "stack123"
   instance_multiplier: 1
+  organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
 
 other_subscription:
   name: "other subscription"
@@ -16,3 +17,4 @@ other_subscription:
   sockets: 3
   cores: 4
   stacking_id: "stack8473"
+  organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>

--- a/test/models/subscription_test.rb
+++ b/test/models/subscription_test.rb
@@ -40,5 +40,13 @@ module Katello
       assert @basic.virt_who?
       refute @other.virt_who?
     end
+
+    def test_redhat?
+      assert @basic.redhat?
+
+      Katello::Product.create!(:name => "custom_#{rand(999)}", :cp_id => @basic.product_id,
+                               :organization => @basic.organization, :provider => @basic.organization.anonymous_provider)
+      refute @basic.redhat?
+    end
   end
 end


### PR DESCRIPTION
When attaching a subscription to an activation key, we have to assign the 
custom 'product' to the activation key in candlepin, in order for the system to 
actually get content from the subscription.   This generally works well, except 
we are assuming here that any redhat subscription has at least 1 engineering product.

There exists a redhat subscription (Smart Management) that contains no 
engineering products (and thus provides no content).  Thus we were
incorrectly thinking it was a custom subscription.  This really did not cause any
problems, until a user tries to add multiple pools of the same subscription to a key.
Then katello tries to add the same product to the key twice, which is not allowed by 
candlepin.  So to fix this, we change how we detect custom subscriptions to 
account for redhat subscriptions without any engineering products.