### PR TITLE
Fixes #21185 - Enables synced content on new HG

### DIFF
--- a/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
+++ b/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
@@ -119,7 +119,7 @@ KT.hosts.getSelectedEnvironment = function () {
 
 KT.hosts.onKatelloHostEditLoad = function(){
     var prefxies = ['host', 'hostgroup'],
-        attributes = ['lifecycle_environment_id', 'content_view_id', 'environment_id', 'content_source_id', 'architecture_id'];
+        attributes = ['lifecycle_environment_id', 'content_view_id', 'environment_id', 'architecture_id'];
 
     $.each(prefxies, function(index, prefix) {
         $.each(attributes, function(attrIndex, attribute) {
@@ -127,6 +127,10 @@ KT.hosts.onKatelloHostEditLoad = function(){
                 KT.hosts.toggle_installation_medium();
             });
         });
+    });
+
+    $('body').on('change', '#content_source_id', function () {
+        KT.hosts.toggle_installation_medium();
     });
 };
 
@@ -136,13 +140,13 @@ KT.hosts.toggle_installation_medium = function() {
     if ($('#hostgroup_parent_id').length > 0) {
       lifecycle_environment_id = KT.hosts.getSelectedEnvironment();
       content_view_id = KT.hosts.getSelectedContentView();
-      content_source_id = $('#hostgroup_content_source_id').val();
+      content_source_id = $('#content_source_id').val();
       architecture_id = $('#hostgroup_architecture_id').val();
       operatingsystem_id = $('#hostgroup_operatingsystem_id').val();
     } else {
       lifecycle_environment_id = KT.hosts.getSelectedEnvironment();
       content_view_id = KT.hosts.getSelectedContentView();
-      content_source_id = $('#host_content_source_id').val();
+      content_source_id = $('#content_source_id').val();
       architecture_id = $('#host_architecture_id').val();
       operatingsystem_id = $('#host_operatingsystem_id').val();
     }


### PR DESCRIPTION
This commit fixes a bug introduced by
https://github.com/Katello/katello/commit/b5202aefc6fc40124aa781dfc50fbcc1b42f2503#diff-b00c6110bdd0244ed7e91bdb05cf3ba2R33

The content source id got changed in the erb but was not reflected in
the javascript causing the page to forget to make the os_selected call
if the the Arch/OS/LCE/CV/and Content Source were selected in the wrong
order.