### PR TITLE
Fixes #21187 - show registered capsule in WebUI for content-hosts

### DIFF
--- a/app/models/katello/concerns/subscription_facet_host_extensions.rb
+++ b/app/models/katello/concerns/subscription_facet_host_extensions.rb
@@ -28,7 +28,7 @@ module Katello
         scoped_search :on => :autoheal, :relation => :subscription_facet, :complete_value => true
         scoped_search :on => :service_level, :relation => :subscription_facet, :complete_value => true
         scoped_search :on => :last_checkin, :relation => :subscription_facet, :complete_value => true, :only_explicit => true
-        scoped_search :on => :registered_through, :relation => :subscription_facet, :complete_value => true
+        scoped_search :on => :registered_through, :relation => :subscription_facet, :complete_value => true, :aliases => [:registered_to]
         scoped_search :on => :registered_at, :relation => :subscription_facet, :rename => :registered_at, :only_explicit => true
         scoped_search :on => :uuid, :relation => :subscription_facet, :rename => :subscription_uuid
         scoped_search :relation => :activation_keys, :on => :name, :rename => :activation_key, :complete_value => true, :ext_method => :find_by_activation_key

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -234,7 +234,7 @@
 
       <dl class="dl-horizontal dl-horizontal-left">
         <dt translate>Registered</dt>
-        <dd>{{ host.created | date:'short' }}</dd>
+        <dd>{{ host.created_at | date:'short' }}</dd>
 
         <dt translate> Registered By</dt>
         <dd>
@@ -247,6 +247,9 @@
                   translate-plural="Activation Keys">
               Activation Key
             </span>
+
+        <dt translate>Registered To</dt>
+        <dd>{{ host.subscription_facet_attributes.registered_through }}</dd>
 
           <ul ng-show="host.subscription_facet_attributes.activation_keys.length > 0">
             <li ng-repeat="activation_key in host.subscription_facet_attributes.activation_keys">


### PR DESCRIPTION
This is to go in consistency with the CLI (hammer host info --name client.example.com) to show which capsule a content-host is registered to. Additionally added an alias `registered_to` in the scoped search for Content Hosts page.