### PR TITLE
Fixes #20785 - Validate hostgroup kickstart repos

### DIFF
--- a/app/lib/katello/validators/hostgroup_kickstart_repository_validator.rb
+++ b/app/lib/katello/validators/hostgroup_kickstart_repository_validator.rb
@@ -1,0 +1,30 @@
+module Katello
+  module Validators
+    class HostgroupKickstartRepositoryValidator < ActiveModel::Validator
+      def validate(hostgroup)
+        # check content source first, otherwise it's meaningless to proceed
+        if hostgroup.content_source && hostgroup.lifecycle_environment
+          valid = hostgroup.content_source.lifecycle_environments.include?(hostgroup.lifecycle_environment)
+          hostgroup.errors.add(:base, _("The selected content source and lifecycle environment do not match")) && return unless valid
+        end
+
+        return unless hostgroup.kickstart_repository_id
+
+        msg = if hostgroup.content_source.blank?
+                hostgroup.errors.add(:base, _("Please select a content source before assigning a kickstart repository"))
+              elsif hostgroup.operatingsystem.blank?
+                _("Please select an operating system before assigning a kickstart repository")
+              elsif !hostgroup.operatingsystem.is_a?(Redhat)
+                _("Kickstart repositories can only be assigned to hosts in the Red Hat family")
+              elsif hostgroup.architecture.blank?
+                _("Please select an architecture before assigning a kickstart repository")
+              elsif hostgroup.operatingsystem.kickstart_repos(hostgroup).none? { |repo| repo[:id] == hostgroup.kickstart_repository_id }
+                _("The selected kickstart repository is not part of the assigned content view, lifecycle environment,
+                  content source, operating system, and architecture")
+              end
+
+        hostgroup.errors.add(:base, msg) if msg
+      end
+    end
+  end
+end

--- a/app/models/katello/concerns/hostgroup_extensions.rb
+++ b/app/models/katello/concerns/hostgroup_extensions.rb
@@ -12,6 +12,7 @@ module Katello
         belongs_to :lifecycle_environment, :inverse_of => :hostgroups, :class_name => "::Katello::KTEnvironment"
 
         validates_with Katello::Validators::ContentViewEnvironmentValidator
+        validates_with Katello::Validators::HostgroupKickstartRepositoryValidator
 
         scoped_search :relation => :content_source, :on => :name, :complete_value => true, :rename => :content_source
         scoped_search :relation => :content_view, :on => :name, :complete_value => true, :rename => :content_view

--- a/test/lib/validators/hostgroup_kickstart_repository_validator_test.rb
+++ b/test/lib/validators/hostgroup_kickstart_repository_validator_test.rb
@@ -1,0 +1,94 @@
+# encoding: utf-8
+
+require 'katello_test_helper'
+
+module Katello
+  class HostgroupKickstartRepositoryValidatorTest < ActiveSupport::TestCase
+    def setup
+      @validator = Validators::HostgroupKickstartRepositoryValidator.new({})
+      @os = ::Redhat.create_operating_system('RedHat', '9', '0')
+      content_source = FactoryGirl.create(:smart_proxy)
+      library_environment = katello_environments(:library)
+      content_source.lifecycle_environments = [library_environment]
+
+      @repos = [{:name => "foo", :id => 4}]
+      @error_messages = {
+        :mismatched_cs_lce => 'The selected content source and lifecycle environment do not match',
+        :missing_os => 'Please select an operating system before assigning a kickstart repository',
+        :missing_arch => 'Please select an architecture before assigning a kickstart repository',
+        :invalid_os => 'Kickstart repositories can only be assigned to hosts in the Red Hat family',
+        :missing_content_source => 'Please select a content source before assigning a kickstart repository',
+        :mismatched_ks_repo => 'The selected kickstart repository is not part of the assigned content view, lifecycle environment,
+                  content source, operating system, and architecture'
+      }
+      @hostgroup = ::Hostgroup.new(:operatingsystem => @os, :kickstart_repository_id => 4, :lifecycle_environment_id => library_environment.id,
+                                   :architecture => ::Architecture.new, :content_source_id => content_source.id)
+    end
+
+    test 'it validates a hostgroup' do
+      @os.expects(:kickstart_repos).returns(@repos)
+
+      @validator.validate(@hostgroup)
+
+      assert_empty @hostgroup.errors[:base]
+    end
+
+    test 'it invalidates on content source and environment mismatch' do
+      @hostgroup.expects(:content_source).twice.returns(FactoryGirl.create(:smart_proxy))
+
+      @validator.validate(@hostgroup)
+
+      assert_equal @error_messages[:mismatched_cs_lce], @hostgroup.errors[:base].first
+    end
+
+    test 'it invalidates on missing OS' do
+      @hostgroup.operatingsystem = nil
+
+      @validator.validate(@hostgroup)
+
+      assert_equal @error_messages[:missing_os], @hostgroup.errors[:base].first
+    end
+
+    test 'it invalidates on missing arch' do
+      @hostgroup.architecture = nil
+
+      @validator.validate(@hostgroup)
+
+      assert_equal @error_messages[:missing_arch], @hostgroup.errors[:base].first
+    end
+
+    test 'it short-circuits on nil kickstart repo id' do
+      @hostgroup.kickstart_repository_id = nil
+      @hostgroup.expects(:operatingsystem).never
+
+      @validator.validate(@hostgroup)
+
+      assert_empty @hostgroup.errors.values
+    end
+
+    test 'it invalidates missing content source on a hostgroup' do
+      @hostgroup.content_source_id = nil
+
+      @validator.validate(@hostgroup)
+
+      assert_equal @error_messages[:missing_content_source], @hostgroup.errors[:base].first
+    end
+
+    test 'it invalidates non-RedHat OS on a hostgroup' do
+      @hostgroup.operatingsystem = ::Operatingsystem.new
+
+      @validator.validate(@hostgroup)
+
+      assert_equal @error_messages[:invalid_os], @hostgroup.errors[:base].first
+    end
+
+    test 'it invalidates mismatched selected ks repo on a hostgroup' do
+      @hostgroup.kickstart_repository_id = 5
+      @os.expects(:kickstart_repos).returns(@repos)
+
+      @validator.validate(@hostgroup)
+
+      assert_equal @error_messages[:mismatched_ks_repo], @hostgroup.errors[:base].first
+    end
+  end
+end


### PR DESCRIPTION
It was entirely possible to add bogus or otherwise improper kickstart repos to hostgroups. No longer!

Examples:

> hammer hostgroup update --id=2 --kickstart-repository-id=211                                               
Could not update the hostgroup:                                       
  No such repository in the assigned content view, environment, content source, OS, and architecture 
                                       
>hammer hostgroup update --id=2 --kickstart-repository-id=17
Hostgroup updated