### PR TITLE
Fixes #21009: React scaffolding for Katello

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["env", "react"],
+  "plugins": ["transform-object-rest-spread"]
+}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,11 @@
+module.exports = {
+  env: {
+    browser: true,
+    'jest/globals': true,
+  },
+  extends: ['airbnb', 'plugin:jest/recommended'],
+  plugins: ['jest', 'react'],
+  rules: {
+    'react/jsx-filename-extension': 'off',
+  },
+};

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ doc/graphs/*.svg
 *.swn
 *.gem
 .zanata-cache
+node_modules
+.vscode

--- a/engines/bastion_katello/package.json
+++ b/engines/bastion_katello/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "bastion_katello",
+  "version": "1.0.0"
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "katello",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest webpack",
+    "test:watch": "jest webpack --watchAll",
+    "test:current": "jest webpack --watch",
+    "format":
+      "prettier --single-quote --trailing-comma es5 --write 'webpack/**/*.js' '*.{js,json}'",
+    "build": "npm run format && npm run lint",
+    "lint": "eslint --fix webpack/index.js || exit 0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/katello/katello.git"
+  },
+  "bugs": {
+    "url": "http://projects.theforeman.org/projects/katello/issues"
+  },
+  "devDependencies": {
+    "babel-jest": "^21.2.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-preset-env": "^1.6.0",
+    "babel-preset-react": "^6.24.1",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.1",
+    "enzyme-to-json": "^3.1.2",
+    "eslint": "^4.8.0",
+    "eslint-config-airbnb": "^16.0.0",
+    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-jest": "^21.2.0",
+    "eslint-plugin-jsx-a11y": "^6.0.2",
+    "eslint-plugin-react": "^7.4.0",
+    "jest": "^21.2.1",
+    "prettier": "^1.7.4",
+    "react-test-renderer": "^16.0.0"
+  },
+  "dependencies": {
+    "prop-types": "^15.6.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
+    "react-router-dom": "^4.2.2"
+  },
+  "jest": {
+    "setupFiles": ["raf/polyfill"]
+  }
+}

--- a/webpack/containers/Application/Menu.js
+++ b/webpack/containers/Application/Menu.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Route } from 'react-router-dom';
+import { DropdownKebab, MenuItem } from 'patternfly-react';
+import { links } from './config';
+
+const dropDownItems = links.map(({ text, path }) => (
+  <Route
+    key={path}
+    render={({ history }) => (
+      <MenuItem
+        onClick={() => {
+          history.push(`/${path}`);
+        }}
+      >
+        {text}
+      </MenuItem>
+    )}
+  />
+));
+
+export default () => (
+  <div style={{ float: 'right' }}>
+    <DropdownKebab id="xui_menu" pullRight>
+      {dropDownItems}
+    </DropdownKebab>
+  </div>
+);

--- a/webpack/containers/Application/Routes.js
+++ b/webpack/containers/Application/Routes.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Route } from 'react-router-dom';
+import Menu from './Menu';
+import { links } from './config';
+
+export default () => (
+  <div>
+    <Menu />
+    {links.map(({ path, component }) => (
+      <Route exact key={path} path={`/${path}`} component={component} />
+    ))}
+  </div>
+);

--- a/webpack/containers/Application/config.js
+++ b/webpack/containers/Application/config.js
@@ -1,0 +1,21 @@
+import Welcome from '../../scenes/Welcome';
+import Dashboard from '../../scenes/Dashboard';
+import Repos from '../../scenes/Repos';
+
+export const links = [
+  {
+    text: 'Welcome',
+    path: 'xui',
+    component: Welcome,
+  },
+  {
+    text: 'Dashboard',
+    path: 'xui/dashboard',
+    component: Dashboard,
+  },
+  {
+    text: 'RH Repos',
+    path: 'xui/repos',
+    component: Repos,
+  },
+];

--- a/webpack/containers/Application/index.js
+++ b/webpack/containers/Application/index.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
+import Routes from './Routes';
+
+export default () => (
+  <Router>
+    <Routes />
+  </Router>
+);

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -1,0 +1,10 @@
+import componentRegistry from 'foremanReact/components/componentRegistry';
+import { mount } from 'foremanReact/common/MountingService';
+import ExperimentalUi from './containers/Application/index';
+
+componentRegistry.register({
+  name: 'xui_katello',
+  type: ExperimentalUi,
+});
+
+mount('xui_katello', '#reactRoot');

--- a/webpack/scenes/Dashboard/__snapshots__/dashboard.test.js.snap
+++ b/webpack/scenes/Dashboard/__snapshots__/dashboard.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Nav component renders the navigation 1`] = `
+<Component>
+  <h1>
+    Dashboard Page
+  </h1>
+</Component>
+`;

--- a/webpack/scenes/Dashboard/dashboard.test.js
+++ b/webpack/scenes/Dashboard/dashboard.test.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { configure, mount } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import Adapter from 'enzyme-adapter-react-16';
+import Dashboard from './index';
+
+configure({ adapter: new Adapter() });
+
+describe('Nav component', () => {
+  it('renders the navigation', () => {
+    const wrapper = mount(<Dashboard />);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+});

--- a/webpack/scenes/Dashboard/index.js
+++ b/webpack/scenes/Dashboard/index.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export default () => <h1>Dashboard Page</h1>;

--- a/webpack/scenes/Repos/__snapshots__/repos.test.js.snap
+++ b/webpack/scenes/Repos/__snapshots__/repos.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Nav component renders the navigation 1`] = `
+<Component>
+  <h1>
+    Repos Page
+  </h1>
+</Component>
+`;

--- a/webpack/scenes/Repos/index.js
+++ b/webpack/scenes/Repos/index.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export default () => <h1>Repos Page</h1>;

--- a/webpack/scenes/Repos/repos.test.js
+++ b/webpack/scenes/Repos/repos.test.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { configure, mount } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import Adapter from 'enzyme-adapter-react-16';
+import Repos from './index';
+
+configure({ adapter: new Adapter() });
+
+describe('Nav component', () => {
+  it('renders the navigation', () => {
+    const wrapper = mount(<Repos />);
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+});

--- a/webpack/scenes/Welcome/index.js
+++ b/webpack/scenes/Welcome/index.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default () => (
+  <div>
+    <h1>Experimental UI</h1>
+    <sub>Thanks for testing out the new React interface!</sub>
+    <hr />
+    <p>
+      Click on the kebab to the right to navigate through the available pages.
+    </p>
+  </div>
+);


### PR DESCRIPTION
The idea here is to leverage the placeholder div from [4894](https://github.com/theforeman/foreman/pull/4894) and mount the React navigation. This mounted component would be in charge of routing and also rendering the matching component to the DOM.

http://projects.theforeman.org/issues/21009