### PR TITLE
Fixes #21235 - empty Registered date fix for Content Hosts webUI

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -234,7 +234,7 @@
 
       <dl class="dl-horizontal dl-horizontal-left">
         <dt translate>Registered</dt>
-        <dd>{{ host.created | date:'short' }}</dd>
+        <dd>{{ host.created_at | date:'short' }}</dd>
 
         <dt translate> Registered By</dt>
         <dd>


### PR DESCRIPTION
Fixes empty Registered date for the Content Hosts webpage (Hosts >> Content Hosts >> click on a Content Host >> check Registered value under Content Host Status). 