### PR TITLE
Fixes #21282 - Add index to content_facet_errata

### DIFF
--- a/db/migrate/20171010170443_add_index_to_katello_content_facet_errata.rb
+++ b/db/migrate/20171010170443_add_index_to_katello_content_facet_errata.rb
@@ -1,0 +1,5 @@
+class AddIndexToKatelloContentFacetErrata < ActiveRecord::Migration
+  def change
+    add_index :katello_content_facet_errata, :content_facet_id, using: 'btree'
+  end
+end


### PR DESCRIPTION
```sql
katello=# \d "katello_content_facet_errata"                         
                              Table "public.katello_content_facet_errata"
      Column      |  Type   |                                 Modifiers                                 
------------------+---------+---------------------------------------------------------------------------
 id               | integer | not null default nextval('katello_content_facet_errata_id_seq'::regclass)
 content_facet_id | integer | not null
 erratum_id       | integer | not null
Indexes:
    "katello_content_facet_errata_pkey" PRIMARY KEY, btree (id)
    "katello_content_facet_errata_eid_caid" UNIQUE, btree (erratum_id, content_facet_id)
    "index_katello_content_facet_errata_on_content_facet_id" btree (content_facet_id)
Foreign-key constraints:
    "katello_content_facet_errata_ca_id" FOREIGN KEY (content_facet_id) REFERENCES katello_content_facets(id)
    "katello_content_facet_errata_errata_id" FOREIGN KEY (erratum_id) REFERENCES katello_errata(id)
```