### PR TITLE
Fixes #21283 - correct errata query for content facet

### DIFF
--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -108,7 +108,8 @@ module Katello
           #{Katello::ContentFacetRepository.table_name}.repository_id = host_repo_errata.repository_id")
 
       if hosts
-        query = query.where("#{Katello::ContentFacetRepository.table_name}.content_facet_id" => hosts.joins(:content_facet))
+        query = query.where("#{Katello::ContentFacetRepository.table_name}.content_facet_id" => hosts.joins(:content_facet)
+                                .select("#{Katello::Host::ContentFacet.table_name}.id"))
       else
         query = query.joins(:content_facet_errata)
       end

--- a/test/controllers/api/v2/host_packages_controller_test.rb
+++ b/test/controllers/api/v2/host_packages_controller_test.rb
@@ -20,7 +20,7 @@ module Katello
       @request.env['HTTP_ACCEPT'] = 'application/json'
 
       @host = hosts(:one)
-      @content_facet = katello_content_facets(:one)
+      @content_facet = katello_content_facets(:content_facet_one)
       @host.content_facet = @content_facet
 
       setup_foreman_routes

--- a/test/fixtures/models/katello_content_facet_applicable_rpms.yml
+++ b/test/fixtures/models/katello_content_facet_applicable_rpms.yml
@@ -1,7 +1,7 @@
 rpm_server_one_rpm:
   rpm_id: <%= ActiveRecord::FixtureSet.identify(:one) %>
-  content_facet_id: <%= ActiveRecord::FixtureSet.identify(:one) %>
+  content_facet_id: <%= ActiveRecord::FixtureSet.identify(:content_facet_one) %>
 
 rpm_server_two_rpm:
   rpm_id: <%= ActiveRecord::FixtureSet.identify(:two) %>
-  content_facet_id: <%= ActiveRecord::FixtureSet.identify(:one) %>
+  content_facet_id: <%= ActiveRecord::FixtureSet.identify(:content_facet_one) %>

--- a/test/fixtures/models/katello_content_facet_errata.yml
+++ b/test/fixtures/models/katello_content_facet_errata.yml
@@ -1,15 +1,15 @@
 errata_server_security:
   erratum_id: <%= ActiveRecord::FixtureSet.identify(:security) %>
-  content_facet_id: <%= ActiveRecord::FixtureSet.identify(:one) %>
+  content_facet_id: <%= ActiveRecord::FixtureSet.identify(:content_facet_one) %>
 
 errata_server_bugfix:
   erratum_id: <%= ActiveRecord::FixtureSet.identify(:bugfix) %>
-  content_facet_id: <%= ActiveRecord::FixtureSet.identify(:one) %>
+  content_facet_id: <%= ActiveRecord::FixtureSet.identify(:content_facet_one) %>
 
 errata_server_dev_security:
   erratum_id: <%= ActiveRecord::FixtureSet.identify(:security) %>
-  content_facet_id: <%= ActiveRecord::FixtureSet.identify(:two) %>
+  content_facet_id: <%= ActiveRecord::FixtureSet.identify(:content_facet_two) %>
 
 errata_server_dev_bugfix:
   erratum_id: <%= ActiveRecord::FixtureSet.identify(:bugfix) %>
-  content_facet_id: <%= ActiveRecord::FixtureSet.identify(:two) %>
+  content_facet_id: <%= ActiveRecord::FixtureSet.identify(:content_facet_two) %>

--- a/test/fixtures/models/katello_content_facets.yml
+++ b/test/fixtures/models/katello_content_facets.yml
@@ -1,10 +1,10 @@
-one:
+content_facet_one:
   host_id:  <%= ActiveRecord::FixtureSet.identify(:one) %>
   content_view_id: <%= ActiveRecord::FixtureSet.identify(:library_view) %>
   lifecycle_environment_id: <%= ActiveRecord::FixtureSet.identify(:library) %>
   uuid: "abcdefghi"
 
-two:
+content_facet_two:
   host_id:  <%= ActiveRecord::FixtureSet.identify(:two) %>
   content_view_id: <%= ActiveRecord::FixtureSet.identify(:library_dev_view) %>
   lifecycle_environment_id: <%= ActiveRecord::FixtureSet.identify(:dev) %>

--- a/test/models/content_view_environment_test.rb
+++ b/test/models/content_view_environment_test.rb
@@ -4,7 +4,7 @@ module Katello
   class ContentViewEnvironmentTest < ActiveSupport::TestCase
     def setup
       User.current = User.find(users(:admin).id)
-      @content_facet = katello_content_facets(:one)
+      @content_facet = katello_content_facets(:content_facet_one)
     end
 
     def test_for_content_facets

--- a/test/models/erratum_test.rb
+++ b/test/models/erratum_test.rb
@@ -8,7 +8,7 @@ module Katello
       @bugfix = katello_errata(:bugfix)
       @enhancement = katello_errata(:enhancement)
       @host = hosts(:one)
-      @host_without_errata = @host.clone
+      @host_without_errata = hosts(:two)
       @host_without_errata.content_facet.applicable_errata = []
     end
   end
@@ -170,6 +170,7 @@ module Katello
 
     def test_installable_for_hosts
       errata = Erratum.installable_for_hosts([@host, @host_without_errata])
+
       assert_includes errata, @security
       assert_includes errata, @bugfix
       refute_includes errata, @enhancement

--- a/test/models/host/content_facet_test.rb
+++ b/test/models/host/content_facet_test.rb
@@ -123,7 +123,7 @@ module Katello
       content_facet.bound_repositories = [Katello::Repository.find(katello_repositories(:rhel_6_x86_64_library_view_1).id)]
       content_facet.save!
 
-      content_facet_dev = katello_content_facets(:two)
+      content_facet_dev = katello_content_facets(:content_facet_two)
       content_facet_dev.bound_repositories = [Katello::Repository.find(katello_repositories(:fedora_17_x86_64_dev).id)]
       content_facet_dev.save!
 

--- a/test/models/rpm_test.rb
+++ b/test/models/rpm_test.rb
@@ -69,8 +69,8 @@ module Katello
   class ApplicablityTest < RpmTestBase
     def setup
       super
-      @host_one = katello_content_facets(:one).host
-      @host_two = katello_content_facets(:two).host
+      @host_one = katello_content_facets(:content_facet_one).host
+      @host_two = katello_content_facets(:content_facet_two).host
     end
 
     def test_applicable_to_hosts


### PR DESCRIPTION
The installable errata query for a list of hosts
mistakenly did a subquery on content_facet_id =
host_id, which would work occasionally but not
in actual environments.

This was exacerbated by the fact that our fixtures
for hosts and content_facets used the same names
(:one, :two), which means they have the same ids.
Thus this commit also changes that for content_facets