### PR TITLE
Fixes #21323,#21290,#21291 - Adds Docker Manifest List

### DIFF
--- a/app/controllers/katello/api/v2/docker_manifest_lists_controller.rb
+++ b/app/controllers/katello/api/v2/docker_manifest_lists_controller.rb
@@ -1,0 +1,20 @@
+module Katello
+  class Api::V2::DockerManifestListsController < Api::V2::ApiController
+    apipie_concern_subst(:a_resource => N_("a docker manifest list"), :resource => "docker_manifest_lists")
+    include Katello::Concerns::Api::V2::RepositoryContentController
+
+    private
+
+    def resource_class
+      DockerManifestList
+    end
+
+    def custom_index_relation(collection)
+      collection.includes(:docker_tags)
+    end
+
+    def default_sort
+      lambda { |query| query.default_sort }
+    end
+  end
+end

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -237,11 +237,16 @@ module Katello
       ostree_branches.count
     end
 
-    def docker_manifest_count
-      manifest_counts = repositories.archived.docker_type.map do |repo|
-        repo.docker_manifests.count
+    def docker_manifest_list_count
+      repositories.archived.docker_type.inject(0) do |sum, repo|
+        sum + repo.docker_manifest_lists.count
       end
-      manifest_counts.sum
+    end
+
+    def docker_manifest_count
+      repositories.archived.docker_type.inject(0) do |sum, repo|
+        sum + repo.docker_manifests.count
+      end
     end
 
     def docker_tags
@@ -271,6 +276,10 @@ module Katello
 
     def docker_manifests
       DockerManifest.in_repositories(archived_repos).uniq
+    end
+
+    def docker_manifest_lists
+      DockerManifestList.in_repositories(archived_repos).uniq
     end
 
     def package_groups

--- a/app/models/katello/docker_manifest_list_manifest.rb
+++ b/app/models/katello/docker_manifest_list_manifest.rb
@@ -1,0 +1,6 @@
+module Katello
+  class DockerManifestListManifest < Katello::Model
+    belongs_to :docker_manifest, :inverse_of => :docker_manifest_list_manifests, :class_name => 'Katello::DockerManifest'
+    belongs_to :docker_manifest_list, :inverse_of => :docker_manifest_list_manifests, :class_name => 'Katello::DockerManifestList'
+  end
+end

--- a/app/models/katello/docker_meta_tag.rb
+++ b/app/models/katello/docker_meta_tag.rb
@@ -46,7 +46,7 @@ module Katello
       end
     end
 
-    delegate_to_tags :full_name, :docker_manifest
+    delegate_to_tags :docker_manifest
     delegate_to_tags :product, :environment, :content_view_version
 
     def repositories
@@ -71,11 +71,11 @@ module Katello
     end
 
     def schema1_manifest
-      schema1.try(:docker_manifest)
+      schema1.try(:docker_taggable)
     end
 
     def schema2_manifest
-      schema2.try(:docker_manifest)
+      schema2.try(:docker_taggable)
     end
 
     def self.with_uuid(ids)

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -737,6 +737,7 @@ module Katello
         self.import_distribution_data
       elsif self.docker?
         Katello::DockerManifest.import_for_repository(self)
+        Katello::DockerManifestList.import_for_repository(self)
         Katello::DockerTag.import_for_repository(self, true)
       elsif self.puppet?
         Katello::PuppetModule.import_for_repository(self)

--- a/app/models/katello/repository_docker_manifest_list.rb
+++ b/app/models/katello/repository_docker_manifest_list.rb
@@ -1,0 +1,7 @@
+module Katello
+  class RepositoryDockerManifestList < Katello::Model
+    # Do not use active record callbacks in this join model.  Direct INSERTs and DELETEs are done
+    belongs_to :repository, :inverse_of => :repository_docker_manifest_lists, :class_name => 'Katello::Repository'
+    belongs_to :docker_manifest_list, :inverse_of => :repository_docker_manifest_lists
+  end
+end

--- a/app/services/katello/pulp/docker_manifest_list.rb
+++ b/app/services/katello/pulp/docker_manifest_list.rb
@@ -1,0 +1,7 @@
+module Katello
+  module Pulp
+    class DockerManifestList < PulpContentUnit
+      CONTENT_TYPE = "docker_manifest_list".freeze
+    end
+  end
+end

--- a/app/views/katello/api/v2/content_view_versions/base.json.rabl
+++ b/app/views/katello/api/v2/content_view_versions/base.json.rabl
@@ -13,6 +13,7 @@ attributes :file_count
 attributes :package_group_count
 attributes :puppet_module_count
 attributes :docker_manifest_count
+attributes :docker_manifest_list_count
 attributes :docker_tag_count
 attributes :ostree_branch_count
 

--- a/app/views/katello/api/v2/docker_manifest_lists/index.json.rabl
+++ b/app/views/katello/api/v2/docker_manifest_lists/index.json.rabl
@@ -1,0 +1,7 @@
+object false
+
+extends "katello/api/v2/common/metadata"
+
+child @collection[:results] => :results do
+  extends 'katello/api/v2/docker_manifest_lists/show'
+end

--- a/app/views/katello/api/v2/docker_manifest_lists/show.json.rabl
+++ b/app/views/katello/api/v2/docker_manifest_lists/show.json.rabl
@@ -7,6 +7,6 @@ child :docker_tags => :tags do
   attributes :repository_id, :name
 end
 
-child :docker_manifest_lists => :manifest_lists do
+child :docker_manifests => :manifests do
   attributes :id, :digest, :schema_version, :manifest_type
 end

--- a/app/views/katello/api/v2/docker_tags/_base.json.rabl
+++ b/app/views/katello/api/v2/docker_tags/_base.json.rabl
@@ -1,21 +1,21 @@
 object @resource
 
-attributes :id, :name, :full_name
+attributes :id, :name
 attributes :repository_id
 
 child :schema1_manifest => :manifest_schema1 do
   attributes :uuid => :id
-  attributes :name, :schema_version, :digest
+  attributes :schema_version, :digest, :manifest_type
 end
 
 child :schema2_manifest => :manifest_schema2 do
   attributes :uuid => :id
-  attributes :name, :schema_version, :digest
+  attributes :schema_version, :digest, :manifest_type
 end
 
 child :docker_manifest => :manifest do
   attributes :uuid => :id
-  attributes :name, :schema_version, :digest
+  attributes :schema_version, :digest, :manifest_type
 end
 
 child :repository => :repository do

--- a/app/views/katello/api/v2/docker_tags/show.json.rabl
+++ b/app/views/katello/api/v2/docker_tags/show.json.rabl
@@ -4,7 +4,7 @@ extends 'katello/api/v2/docker_tags/base'
 
 child :docker_manifest => :manifest do
   attributes :uuid => :id
-  attributes :name, :schema_version, :digest
+  attributes :schema_version, :digest, :manifest_type
 end
 
 child :related_tags => :related_tags do

--- a/app/views/katello/api/v2/repositories/base.json.rabl
+++ b/app/views/katello/api/v2/repositories/base.json.rabl
@@ -16,6 +16,7 @@ node :content_counts do |repo|
   {
     :ostree_branch => repo.ostree_branches.count,
     :docker_manifest => repo.docker_manifests.count,
+    :docker_manifest_list => repo.docker_manifest_lists.count,
     :docker_tag => repo.docker_meta_tag_count,
     :rpm => repo.rpms.count,
     :package => repo.rpms.count,

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -125,6 +125,12 @@ Katello::Engine.routes.draw do
           end
         end
 
+        api_resources :docker_manifest_lists, :only => [:index, :show] do
+          collection do
+            get :auto_complete_search
+          end
+        end
+
         api_resources :docker_tags, :only => [:index, :show] do
           collection do
             get :auto_complete_search
@@ -300,6 +306,7 @@ Katello::Engine.routes.draw do
           api_resources :errata, :only => [:index, :show], :constraints => {:id => /[0-9a-zA-Z\-\+%_.:]+/}
           api_resources :puppet_modules, :only => [:index, :show]
           api_resources :docker_manifests, :only => [:index, :show]
+          api_resources :docker_manifest_lists, :only => [:index, :show]
           api_resources :docker_tags, :only => [:index, :show]
 
           api_resources :ostree_branches, :only => [:index, :show]

--- a/db/migrate/20171010172724_add_docker_manifest_list.rb
+++ b/db/migrate/20171010172724_add_docker_manifest_list.rb
@@ -1,0 +1,67 @@
+class AddDockerManifestList < ActiveRecord::Migration
+  def up
+    create_table :katello_docker_manifest_lists do |t|
+      t.integer :schema_version
+      t.string :uuid, :limit => 255
+      t.string :digest, :limit => 255
+      t.boolean :downloaded
+      t.timestamps
+    end
+
+    create_table :katello_repository_docker_manifest_lists do |t|
+      t.references :docker_manifest_list, :null => false
+      t.references :repository, :null => true
+      t.timestamps
+    end
+
+    create_table :katello_docker_manifest_list_manifests do |t|
+      t.references :docker_manifest_list, :null => false
+      t.references :docker_manifest, :null => false
+      t.timestamps
+    end
+
+    remove_foreign_key :katello_docker_tags, :docker_manifest
+    rename_column :katello_docker_tags, :docker_manifest_id, :docker_taggable_id
+    add_column :katello_docker_tags, :docker_taggable_type, :string, :limit => 255, :default => "Katello::DockerManifest"
+
+    add_index :katello_docker_tags, [:docker_taggable_id, :docker_taggable_type], :name => "docker_taggable_type_index"
+
+    add_index :katello_repository_docker_manifest_lists, [:docker_manifest_list_id, :repository_id],
+              :name => :katello_repo_docker_manifest_list_repo_id, :unique => true
+
+    add_index :katello_docker_manifest_list_manifests, [:docker_manifest_list_id, :docker_manifest_id],
+              :name => :katello_docker_manifest_lisst_manifest, :unique => true
+
+    add_foreign_key :katello_repository_docker_manifest_lists, :katello_repositories,
+                    :column => :repository_id
+
+    add_foreign_key :katello_docker_manifest_list_manifests, :katello_docker_manifests,
+                    :column => :docker_manifest_id
+  end
+
+  class FakeDockerMetaTag < ApplicationRecord
+    self.table_name = 'katello_docker_meta_tags'
+    def self.cleanup
+      self.where(:schema2_id => nil, :schema1_id => nil).delete_all
+    end
+  end
+
+  class FakeDockerTag < ApplicationRecord
+    self.table_name = 'katello_docker_tags'
+  end
+
+  def down
+    drop_table :katello_docker_manifest_list_manifests
+    drop_table :katello_repository_docker_manifest_lists
+    drop_table :katello_docker_manifest_lists
+
+    FakeDockerTag.where("docker_taggable_id not in (select id from katello_docker_manifests)").destroy_all
+    FakeDockerMetaTag.cleanup
+
+    remove_column :katello_docker_tags, :docker_taggable_type
+    rename_column :katello_docker_tags, :docker_taggable_id, :docker_manifest_id
+
+    add_foreign_key :katello_docker_tags, :katello_docker_manifests,
+                    :column => 'docker_manifest_id'
+  end
+end

--- a/db/migrate/20171014051810_remove_docker_manifest_name.rb
+++ b/db/migrate/20171014051810_remove_docker_manifest_name.rb
@@ -1,0 +1,9 @@
+class RemoveDockerManifestName < ActiveRecord::Migration
+  def up
+    remove_column :katello_docker_manifests, :name
+  end
+
+  def down
+    add_column :katello_docker_manifests, :name, :string, :limit => 255
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/bastion_katello.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/bastion_katello.js
@@ -22,6 +22,9 @@
 //= require "bastion_katello/docker-manifests/docker-manifests.module.js"
 //= require_tree "./docker-manifests"
 
+//= require "bastion_katello/docker-manifest-lists/docker-manifest-lists.module.js"
+//= require_tree "./docker-manifest-lists"
+
 //= require "bastion_katello/docker-tags/docker-tags.module.js"
 //= require_tree "./docker-tags"
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-docker-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-docker-repositories.html
@@ -97,6 +97,12 @@
             </div>
             <div>
               <span translate>
+                {{ repository.content_counts.docker_manifest_list }} Docker Manifest Lists
+              </span>
+            </div>
+
+            <div>
+              <span translate>
                 {{ repository.content_counts.docker_tag }} Docker Tags
               </span>
             </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
@@ -8,7 +8,7 @@
   <span data-block="no-search-results-message" translate>
     Your search returned zero Content View.
   </span>
-  
+
   <div data-block="table">
     <table class="table table-striped table-bordered" bst-table="table">
       <thead>
@@ -64,6 +64,9 @@
             </div>
             <div translate ng-if="version.docker_manifest_count && version.docker_manifest_count > 0">
               {{ version.docker_manifest_count }} Docker Manifests
+            </div>
+            <div translate ng-if="version.docker_manifest_list_count && version.docker_manifest_list_count > 0">
+              {{ version.docker_manifest_list_count }} Docker Manifest Lists
             </div>
             <div translate ng-if="version.docker_tag_count && version.docker_tag_count > 0">
               {{ version.docker_tag_count }} Docker Tags

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-manifest-lists/docker-manifest-list.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-manifest-lists/docker-manifest-list.factory.js
@@ -1,0 +1,26 @@
+(function () {
+    'use strict';
+
+    /**
+     * @ngdoc factory
+     * @name  Bastion.docker-manifest-lists.factory:DockerManifestList
+     *
+     * @description
+     *   Provides a BastionResource for interacting with Docker Manifest Lists
+     */
+    function DockerManifestList(BastionResource) {
+        return BastionResource('katello/api/v2/docker_manifest_lists/:id',
+            {'id': '@id'},
+            {
+                'autocomplete': {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}}
+            }
+        );
+    }
+
+    angular
+        .module('Bastion.docker-manifest-lists')
+        .factory('DockerManifestList', DockerManifestList);
+
+    DockerManifestList.$inject = ['BastionResource'];
+
+})();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-manifest-lists/docker-manifest-lists.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-manifest-lists/docker-manifest-lists.module.js
@@ -1,0 +1,19 @@
+(function () {
+    'use strict';
+
+    /**
+     * @ngdoc module
+     * @name  Bastion.docker-manifest-lists
+     *
+     * @description
+     *   Module for Docker Manifest List related functionality.
+     */
+    angular
+        .module('Bastion.docker-manifest-lists', [
+            'ui.router',
+            'Bastion',
+            'Bastion.i18n',
+            'Bastion.components'
+        ]);
+
+})();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/docker-tag-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/docker-tag-details.controller.js
@@ -3,6 +3,7 @@
  * @name  Bastion.docker-tags.controller:DockerTagDetailsController
  *
  * @requires $scope
+ * @requires translate
  * @requires $location
  * @requires DockerTag
  * @requires CurrentOrganization
@@ -12,8 +13,8 @@
  *   Provides the functionality for the docker tags details action pane.
  */
 angular.module('Bastion.docker-tags').controller('DockerTagDetailsController',
-    ['$scope', '$location', 'Nutupane', 'DockerTag', 'CurrentOrganization', 'ApiErrorHandler',
-    function ($scope, $location, Nutupane, DockerTag, CurrentOrganization, ApiErrorHandler) {
+    ['$scope', 'translate', '$location', 'Nutupane', 'DockerTag', 'CurrentOrganization', 'ApiErrorHandler',
+    function ($scope, translate, $location, Nutupane, DockerTag, CurrentOrganization, ApiErrorHandler) {
         $scope.panel = {
             error: false,
             loading: true
@@ -52,5 +53,14 @@ angular.module('Bastion.docker-tags').controller('DockerTagDetailsController',
                 nutupane.refresh();
             }
         });
+
+        $scope.getManifestType = function (schema) {
+            if (schema['manifest_type'] === 'image') {
+                return translate("Image");
+            }
+            return translate("List");
+
+        };
+
     }
 ]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/views/docker-tag-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/views/docker-tag-details.html
@@ -1,8 +1,8 @@
-<span page-title ng-model="tag">{{ 'Details for Docker Tag:' | translate }} {{ tag.full_name }}</span>
+<span page-title ng-model="tag">{{ 'Details for Docker Tag:' | translate }} {{ tag.name }}</span>
 
 <div data-extend-template="layouts/details-page-with-breadcrumbs.html">
   <header data-block="header">
-    <h2>{{ tag.full_name }}</h2>
+    <h2>{{ tag.name }}</h2>
   </header>
 
   <nav data-block="navigation">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/views/docker-tag-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/views/docker-tag-info.html
@@ -24,11 +24,11 @@
     <div ng-if="!_.isEmpty(tag.manifest_schema1)">
       <h5 translate>Schema Version 1</h5>
       <dl class="dl-horizontal dl-horizontal-left">
-        <dt translate>Name</dt>
-        <dd>
-          {{ tag.manifest_schema1.name }}
-        </dd>
 
+        <dt translate>Manifest Type</dt>
+        <dd>
+          {{ getManifestType(tag.manifest_schema1) }}
+        </dd>
         <dt translate>Digest</dt>
         <dd>
           {{ tag.manifest_schema1.digest }}
@@ -38,11 +38,10 @@
     <div ng-if="!_.isEmpty(tag.manifest_schema2)">
       <h5 translate>Schema Version 2</h5>
       <dl class="dl-horizontal dl-horizontal-left">
-        <dt translate>Name</dt>
+        <dt translate>Manifest Type</dt>
         <dd>
-          {{ tag.manifest_schema2.name }}
+          {{ getManifestType(tag.manifest_schema2) }}
         </dd>
-
         <dt translate>Digest</dt>
         <dd>
           {{ tag.manifest_schema2.digest }}

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/docker-tags.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/docker-tags.routes.js
@@ -38,7 +38,7 @@ angular.module('Bastion.docker-tags').config(['$stateProvider', function ($state
         permission: 'view_products',
         templateUrl: 'docker-tags/details/views/docker-tag-info.html',
         ncyBreadcrumb: {
-            label: "{{ tag.full_name }}",
+            label: "{{ tag.name }}",
             parent: 'docker-tag'
         }
     })

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/views/docker-tags.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/views/docker-tags.html
@@ -29,7 +29,7 @@
         <tr bst-table-row ng-repeat="tag in table.rows">
           <td bst-table-cell>
             <a ui-sref="docker-tag.info({tagId: tag.id})">
-              {{ tag.full_name }}
+              {{ tag.name }}
             </a>
           </td>
           <td bst-table-cell>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-manage-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-manage-content.controller.js
@@ -12,15 +12,16 @@
  * @requires PackageGroup
  * @requires PuppetModule
  * @requires DockerManifest
+ * @requires DockerManifestList
  * @requires OstreeBranch
  *
  * @description
  *   Provides the functionality for the repository details pane.
  */
 angular.module('Bastion.repositories').controller('RepositoryManageContentController',
-    ['$scope', '$state', 'translate', 'Notification', 'Nutupane', 'Repository', 'Package', 'PackageGroup', 'PuppetModule', 'DockerManifest', 'OstreeBranch', 'File',
-    function ($scope, $state, translate, Notification, Nutupane, Repository, Package, PackageGroup, PuppetModule, DockerManifest, OstreeBranch, File) {
-        var currentState, contentTypes;
+    ['$scope', '$state', 'translate', 'Notification', 'Nutupane', 'Repository', 'Package', 'PackageGroup', 'PuppetModule', 'DockerManifest', 'DockerManifestList', 'OstreeBranch', 'File',
+    function ($scope, $state, translate, Notification, Nutupane, Repository, Package, PackageGroup, PuppetModule, DockerManifest, DockerManifestList, OstreeBranch, File) {
+        var contentTypes;
 
         function success(response, selected) {
             var message;
@@ -46,18 +47,19 @@ angular.module('Bastion.repositories').controller('RepositoryManageContentContro
             $scope.product = repository.product;
         });
 
-        currentState = $state.current.name.split('.').pop();
+        $scope.currentState = $state.current.name.split('.').pop();
 
         contentTypes = {
             'packages': { type: Package },
             'package-groups': { type: PackageGroup },
             'puppet-modules': { type: PuppetModule },
             'docker-manifests': { type: DockerManifest },
+            'docker-manifest-lists': { type: DockerManifestList },
             'ostree-branches': { type: OstreeBranch },
             'files': {type: File}
         };
 
-        $scope.contentNutupane = new Nutupane(contentTypes[currentState].type, {
+        $scope.contentNutupane = new Nutupane(contentTypes[$scope.currentState].type, {
             'repository_id': $scope.$stateParams.repositoryId
         });
         $scope.table = $scope.contentNutupane.table;
@@ -87,5 +89,11 @@ angular.module('Bastion.repositories').controller('RepositoryManageContentContro
             });
         };
 
+        $scope.updateSelectable = function(item) {
+            if ($scope.currentState === "docker-manifests" && !_.isEmpty(item.manifest_lists)) {
+                item.unselectable = true;
+            }
+            return item;
+        };
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -242,6 +242,15 @@
           </td>
         </tr>
         <tr ng-show="repository.content_type === 'docker'">
+          <td translate>Docker Manifest Lists</td>
+          <td class="align-center">
+            <a ui-sref="product.repository.manage-content.docker-manifest-lists({productId: product.id, repositoryId: repository.id})">
+              {{ repository.content_counts.docker_manifest_list || 0 }}
+            </a>
+          </td>
+        </tr>
+
+        <tr ng-show="repository.content_type === 'docker'">
           <td translate>Docker Tags</td>
           <td class="align-center">
             <a ui-sref="product.repository.manage-content.docker-manifests({productId: product.id, repositoryId: repository.id})">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-manage-docker-manifest-lists.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-manage-docker-manifest-lists.html
@@ -1,0 +1,44 @@
+<span page-title ng-model="repository">{{ 'View Docker Manifest Lists for Repository:' | translate }} {{ repository.name }}</span>
+
+<div data-block="messages">
+  <div bst-alert="success" ng-hide="generationTaskId === undefined">
+    <button type="button" class="close" ng-click="clearTaskId()">&times;</button>
+    <p translate>
+      Docker metadata generation has been initiated in the background.  Click
+      <a ng-href="{{ taskUrl() }}">Here</a> to monitor the progress.
+    </p>
+  </div>
+</div>
+
+<div data-extend-template="layouts/partials/table.html">
+  <div data-block="table">
+    <table class="table table-striped table-bordered" >
+
+      <thead>
+        <tr bst-table-head>
+          <th bst-table-column><span translate>Digest</span></th>
+          <th bst-table-column><span translate>Tags</span></th>
+          <th bst-table-column><span translate>Schema Version</span></th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr bst-table-row ng-repeat="item in table.rows" >
+          <td bst-table-cell>
+            {{ item.digest }}
+          </td>
+          <td>
+            <span ng-repeat="tag in tagsForManifest(item) ">
+              <a ui-sref="docker-tag.info({tagId: tag.id})">
+                <span class="registry-image-tag">{{ tag.name }}</span>
+              </a>
+            </span>
+          </td>
+          <td bst-table-cell>
+            {{ item.schema_version }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-manage-docker-manifests.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-manage-docker-manifests.html
@@ -41,22 +41,23 @@
 
       <thead>
         <tr bst-table-head row-select>
-          <th bst-table-column><span translate>Manifest Name</span></th>
           <th bst-table-column><span translate>Tags</span></th>
           <th bst-table-column><span translate>Schema Version</span></th>
           <th bst-table-column><span translate>Digest</span></th>
+          <th bst-table-column><span translate>Manifest Lists</span></th>
         </tr>
       </thead>
 
       <tbody>
-        <tr bst-table-row ng-repeat="item in table.rows" row-select="item">
+        <tr bst-table-row ng-repeat="item in table.rows"
+            row-select="item" ng-init="updateSelectable(item)">
           <td bst-table-cell>
-            {{ item.name }}
-          </td>
-          <td bst-table-cell>
-            <span ng-repeat="tag in tagsForManifest(item) ">
+            <div ng-if="item.manifest_lists.length > 0" translate>
+              Part of a manifest list
+            </div>
+            <span ng-if="item.manifest_lists.length === 0" ng-repeat="tag in tagsForManifest(item) ">
               <a ui-sref="docker-tag.info({tagId: tag.id})">
-                {{ tag.name }}
+                <span class="registry-image-tag">{{ tag.name }}</span>
               </a>
             </span>
           </td>
@@ -65,6 +66,11 @@
           </td>
           <td bst-table-cell>
             {{ item.digest }}
+          </td>
+          <td bst-table-cell>
+            <span ng-if="item.manifest_lists.length > 0" ng-repeat="ml in item.manifest_lists ">
+              {{ml.digest}}
+            </span>
           </td>
         </tr>
       </tbody>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/repositories.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/repositories.module.js
@@ -18,6 +18,7 @@ angular.module('Bastion.repositories', [
     'Bastion.packages',
     'Bastion.products',
     'Bastion.docker-manifests',
+    'Bastion.docker-manifest-lists',
     'Bastion.files'
 ]);
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/repositories.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/repositories.routes.js
@@ -108,6 +108,15 @@
                 parent: 'product.repository.info'
             }
         })
+        .state('product.repository.manage-content.docker-manifest-lists', {
+            url: '/content/docker_manifest_lists',
+            permission: 'view_products',
+            templateUrl: 'products/details/repositories/details/views/repository-manage-docker-manifest-lists.html',
+            ncyBreadcrumb: {
+                label: "{{'Docker Manifest Lists' | translate }}",
+                parent: 'product.repository.info'
+            }
+        })
         .state('product.repository.manage-content.files', {
             url: '/content/files',
             permission: 'view_products',

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/views/product-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/views/product-repositories.html
@@ -135,6 +135,11 @@
                 </a>
               </div>
               <div>
+                <a ui-sref="product.repository.manage-content.docker-manifest-lists({productId: product.id, repositoryId: repository.id})" translate>
+                  {{ repository.content_counts.docker_manifest_list || 0 }} Docker Manifest Lists
+                </a>
+              </div>
+              <div>
                 <a ui-sref="product.repository.manage-content.docker-manifests({productId: product.id, repositoryId: repository.id})" translate>
                   {{ repository.content_counts.docker_tag || 0 }} Docker Tags
                 </a>

--- a/engines/bastion_katello/app/assets/stylesheets/bastion_katello/bastion_katello.scss
+++ b/engines/bastion_katello/app/assets/stylesheets/bastion_katello/bastion_katello.scss
@@ -6,6 +6,7 @@
   @import "errata";
   @import "subscriptions";
   @import "host_subscriptions";
+  @import "docker";
 
   a {
     &.confined-text {

--- a/engines/bastion_katello/app/assets/stylesheets/bastion_katello/docker.scss
+++ b/engines/bastion_katello/app/assets/stylesheets/bastion_katello/docker.scss
@@ -1,0 +1,16 @@
+@import "bastion/variables";
+
+.registry-image-tag {
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    white-space: nowrap;
+    overflow: hidden;
+    background-color: #fff;
+    margin-left: 2px;
+    text-align: center;
+    font-weight: normal;
+    display: inline;
+    padding: 0 5px;
+    -webkit-border-radius: 3;
+    -moz-border-radius: 3;
+}

--- a/engines/bastion_katello/test/docker-manifest-lists/docker-manifest-list.factory.test.js
+++ b/engines/bastion_katello/test/docker-manifest-lists/docker-manifest-list.factory.test.js
@@ -1,0 +1,36 @@
+describe('Factory: DockerManifestList', function () {
+    var $httpBackend,
+        dockerManifestLists;
+
+    beforeEach(module('Bastion.docker-manifest-lists', 'Bastion.test-mocks'));
+
+    beforeEach(module(function ($provide) {
+        dockerManifestLists = {
+            records: [
+                { digest: 'abc123', id: 1 }
+            ],
+            total: 2,
+            subtotal: 1
+        };
+    }));
+
+    beforeEach(inject(function ($injector) {
+        $httpBackend = $injector.get('$httpBackend');
+        DockerManifestList = $injector.get('DockerManifestList');
+    }));
+
+    afterEach(function () {
+        $httpBackend.flush();
+        $httpBackend.verifyNoOutstandingExpectation();
+        $httpBackend.verifyNoOutstandingRequest();
+    });
+
+    it('provides a way to get a list of repositories', function () {
+        $httpBackend.expectGET('katello/api/v2/docker_manifest_lists').respond(dockerManifestLists);
+
+        DockerManifestList.queryPaged(function (dockerManifestLists) {
+            expect(dockerManifestLists.records.length).toBe(1);
+        });
+    });
+
+});

--- a/engines/bastion_katello/test/docker-tags/details/docker-tag-details.controller.test.js
+++ b/engines/bastion_katello/test/docker-tags/details/docker-tag-details.controller.test.js
@@ -2,7 +2,8 @@ describe('Controller: DockerTagDetailsController', function() {
     var $scope,
         DockerTag,
         Nutupane,
-        dockerTag;
+        dockerTag,
+        translate;
 
     beforeEach(module('Bastion.docker-tags', 'Bastion.test-mocks', 'Bastion.common'));
 
@@ -19,6 +20,9 @@ describe('Controller: DockerTagDetailsController', function() {
         DockerTag = $injector.get('MockResource').$new();
         spyOn(DockerTag, 'get').and.callThrough();
         dockerTag = DockerTag.get({id: 1});
+        translate = function(message) {
+            return message;
+        };
     }));
 
     beforeEach(inject(function($controller, $rootScope, $location, MockResource, translateMock, $injector) {
@@ -32,6 +36,7 @@ describe('Controller: DockerTagDetailsController', function() {
 
         $controller('DockerTagDetailsController', {
             $scope: $scope,
+            translate: translate,
             $location: $location,
             Nutupane: Nutupane,
             DockerTag: DockerTag,

--- a/engines/bastion_katello/test/products/details/repositories/details/repository-manage-content.controller.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/details/repository-manage-content.controller.test.js
@@ -1,5 +1,5 @@
 describe('Controller: RepositoryManageContentController', function() {
-    var $scope, translate, Repository, Nutupane, PuppetModule, Package, PackageGroup, DockerManifest, OstreeBranch;
+    var $scope, translate, Repository, Nutupane, PuppetModule, Package, PackageGroup, DockerManifestList,  DockerManifest, OstreeBranch;
 
     beforeEach(module(
         'Bastion.repositories',
@@ -42,6 +42,7 @@ describe('Controller: RepositoryManageContentController', function() {
             Package: Package,
             PackageGroup: PackageGroup,
             DockerManifest: DockerManifest,
+            DockerManifestList: DockerManifestList,
             OstreeBranch: OstreeBranch,
         });
     }));
@@ -72,4 +73,20 @@ describe('Controller: RepositoryManageContentController', function() {
         expect(tags[0].id).toBe(1);
     });
 
+    it('updates selectability appropriately', function() {
+        var manifest;
+        manifest = {manifest_lists: [1]};
+        $scope.currentState = "docker-manifests";
+        $scope.updateSelectable(manifest);
+        expect(manifest.unselectable).toBe(true);
+
+        manifest = {manifest_lists: []};
+        $scope.updateSelectable(manifest);
+        expect(manifest.unselectable).not.toBe(true);
+
+        $scope.currentState = "packages";
+        manifest = {manifest_lists: [1]};
+        $scope.updateSelectable(manifest);
+        expect(manifest.unselectable).not.toBe(true);
+    });
 });

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -225,6 +225,7 @@ module Katello
                            'katello/api/v2/packages' => [:index, :show, :auto_complete_search, :auto_complete_name, :auto_complete_arch],
                            'katello/api/v2/package_groups' => [:index, :show, :auto_complete_search],
                            'katello/api/v2/docker_manifests' => [:index, :show, :auto_complete_search],
+                           'katello/api/v2/docker_manifest_lists' => [:index, :show, :auto_complete_search],
                            'katello/api/v2/docker_tags' => [:index, :show, :auto_complete_search, :auto_complete_name],
                            'katello/api/v2/file_units' => [:index, :show, :auto_complete_search],
                            'katello/api/v2/ostree_branches' => [:index, :show, :auto_complete_search],

--- a/lib/katello/tasks/reimport.rake
+++ b/lib/katello/tasks/reimport.rake
@@ -25,6 +25,7 @@ namespace :katello do
               Katello::Subscription,
               Katello::Pool,
               Katello::DockerManifest,
+              Katello::DockerManifestList,
               Katello::DockerTag,
               Katello::ContentViewPuppetEnvironment]
 

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -172,7 +172,7 @@ module ::Actions::Katello::Repository
 
     it 'plans' do
       uuids.each do |str|
-        docker_repo.docker_manifests.create!(:name => str) do |manifest|
+        docker_repo.docker_manifests.create!(:digest => str) do |manifest|
           manifest.uuid = str
         end
       end

--- a/test/controllers/api/v2/docker_manifest_list_controller_test.rb
+++ b/test/controllers/api/v2/docker_manifest_list_controller_test.rb
@@ -1,10 +1,10 @@
 require "katello_test_helper"
 
 module Katello
-  class Api::V2::DockerManifestsControllerTest < ActionController::TestCase
+  class Api::V2::DockerManifestListsControllerTest < ActionController::TestCase
     def models
       @repo = Repository.find(katello_repositories(:redis).id)
-      @manifest = @repo.docker_manifests.create!(:digest => "abc123", :uuid => "123xyz")
+      @manifest_list = @repo.docker_manifest_lists.create!(:digest => "aeeeeeebc123", :uuid => "123xyz")
     end
 
     def setup
@@ -15,32 +15,32 @@ module Katello
     def test_index
       get :index
       assert_response :success
-      assert_template "katello/api/v2/docker_manifests/index"
+      assert_template "katello/api/v2/docker_manifest_lists/index"
     end
 
     def test_index_with_repository
       get :index, :repository_id => @repo.id
       assert_response :success
-      assert_template "katello/api/v2/docker_manifests/index"
+      assert_template "katello/api/v2/docker_manifest_lists/index"
     end
 
     def test_index_with_organization
       get :index, :organization_id => @repo.organization.id
       assert_response :success
-      assert_template "katello/api/v2/docker_manifests/index"
+      assert_template "katello/api/v2/docker_manifest_lists/index"
     end
 
     def test_index_with_content_view_version
       get :index, :content_view_version_id => ContentViewVersion.last
       assert_response :success
-      assert_template "katello/api/v2/docker_manifests/index"
+      assert_template "katello/api/v2/docker_manifest_lists/index"
     end
 
     def test_show
-      get :show, :repository_id => @repo.id, :id => @manifest.uuid
+      get :show, :repository_id => @repo.id, :id => @manifest_list.uuid
 
       assert_response :success
-      assert_template "katello/api/v2/docker_manifests/show"
+      assert_template "katello/api/v2/docker_manifest_lists/show"
     end
   end
 end

--- a/test/controllers/api/v2/docker_tags_controller_test.rb
+++ b/test/controllers/api/v2/docker_tags_controller_test.rb
@@ -4,8 +4,8 @@ module Katello
   class Api::V2::DockerTagsControllerTest < ActionController::TestCase
     def models
       @repo = Repository.find(katello_repositories(:redis).id)
-      @manifest = @repo.docker_manifests.create!(:name => "abc123", :uuid => "123xyz")
-      @tag = @repo.docker_tags.create!(:name => "wat", :docker_manifest => @manifest)
+      @manifest = @repo.docker_manifests.create!(:digest => "abc123", :uuid => "123xyz")
+      @tag = @repo.docker_tags.create!(:name => "wat", :docker_taggable => @manifest)
       @meta_tag = DockerMetaTag.create!(:name => @tag.name, :schema1 => @tag, :repository => @repo)
     end
 

--- a/test/factories/docker_manifest_factory.rb
+++ b/test/factories/docker_manifest_factory.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :docker_manifest, :class => Katello::DockerManifest do
-    sequence(:name) { |n| "2.#{n}" }
     digest { SecureRandom.hex }
     uuid { SecureRandom.hex }
     schema_version 2

--- a/test/factories/docker_manifest_list_factory.rb
+++ b/test/factories/docker_manifest_list_factory.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :docker_manifest_list, :class => Katello::DockerManifestList do
+    digest { SecureRandom.hex }
+    uuid { SecureRandom.hex }
+    schema_version 2
+
+    after(:build) do |manifest_list|
+      manifest_list.docker_manifests << create(:docker_manifest)
+    end
+
+    trait :schema1 do
+      schema_version 1
+    end
+  end
+end

--- a/test/factories/docker_tag_factory.rb
+++ b/test/factories/docker_tag_factory.rb
@@ -2,14 +2,18 @@ FactoryBot.define do
   factory :docker_tag, :class => Katello::DockerTag do
     sequence(:name) { |n| "2.#{n}" }
     repository :docker_repository
-    docker_manifest
+    association :docker_taggable, :factory => :docker_manifest
   end
   trait :schema1 do
     after(:build) do |tag|
-      tag.docker_manifest.schema_version = 1
+      tag.docker_taggable.schema_version = 1
     end
   end
   trait :latest do
     name "latest"
+  end
+
+  trait :with_manifest_list do
+    association :docker_taggable, :factory => :docker_manifest_list
   end
 end

--- a/test/fixtures/models/katello_docker_manifests.yml
+++ b/test/fixtures/models/katello_docker_manifests.yml
@@ -1,8 +1,8 @@
 one:
-  name: one
+  digest: one
 
 two:
-  name: two
+  digest: two
 
 three:
-  name: three
+  digest: three

--- a/test/fixtures/pulp/docker_manifest_lists.yml
+++ b/test/fixtures/pulp/docker_manifest_lists.yml
@@ -1,0 +1,15 @@
+manifest_list1:
+  _id: "1674d07f-61c0-48ed-8efc-9469c4d5e8d2"
+  pulp_user_metadata": {}
+  _last_updated: 1506004243
+  _storage_path: "/var/lib/pulp/content/units/docker_manifest_list/3b/b9d5223c33963cc018de94b00d5c948258907d7d6f5818ebcaea9ae5299f08/sha256:99ccecf3da28a93c063d5dddcdf69aeed44826d0db219aabc3d5178d47649dfa"
+  downloaded: true
+  digest: "sha256:99ccecf3da28a93c063d5dddcdf69aeed44826d0db219aabc3d5178d47649dfa"
+  schema_version: 2
+  manifests : [
+    "sha256:f52325afc9c353f58d65b24d8f9a5e61be83f0518aa222639cb77bc7b77d49a9"
+  ]
+  amd64_digest: "sha256:030fcb92e1487b18c974784dcc110a93147c9fc402188370fbfd17efabffc6af"
+  amd64_schema_version: 2
+  _ns: "units_docker_manifest_list"
+  _content_type_id: "docker_manifest_list"

--- a/test/fixtures/pulp/docker_manifests.yml
+++ b/test/fixtures/pulp/docker_manifests.yml
@@ -1,7 +1,5 @@
-
 manifest1:
   _storage_path: "/var/lib/pulp/content/units/docker_manifest/10fe/10fea06e-d975-43a8-840c-cd7558bf8c17/sha256:f52325afc9c353f58d65b24d8f9a5e61be83f0518aa222639cb77bc7b77d49a9"
-  name: "manifest1"
   _ns: "units_docker_manifest"
   _last_updated: 1453993847
   fs_layers: [

--- a/test/models/content_view_version_test.rb
+++ b/test/models/content_view_version_test.rb
@@ -85,8 +85,8 @@ module Katello
       manifest_count = 0
       tag_count = 0
       cvv.repositories.archived.docker_type.each do |repo|
-        manifest = repo.docker_manifests.create!(:name => "abc123", :uuid => "123")
-        repo.docker_tags.create!(:name => "wat", :docker_manifest => manifest)
+        manifest = repo.docker_manifests.create!(:digest => "abc123", :uuid => "123")
+        repo.docker_tags.create!(:name => "wat", :docker_taggable => manifest)
         manifest_count += repo.docker_manifests.count
         tag_count += repo.docker_tags.count
       end

--- a/test/models/docker_manifest_list_test.rb
+++ b/test/models/docker_manifest_list_test.rb
@@ -1,0 +1,30 @@
+require 'katello_test_helper'
+
+module Katello
+  class DockerManifestListTest < ActiveSupport::TestCase
+    REPO_ID = "Default_Organization-Test-redis".freeze
+    MANIFESTS = File.join(Katello::Engine.root, "test", "fixtures", "pulp", "docker_manifest_lists.yml")
+    TAGS = File.join(Katello::Engine.root, "test", "fixtures", "pulp", "docker_tags.yml")
+
+    def setup
+      @manifest_lists = YAML.load_file(MANIFESTS).values.map(&:deep_symbolize_keys)
+      @repo = Repository.find(katello_repositories(:redis).id)
+
+      ids = @manifest_lists.map { |attrs| attrs[:_id] }
+      Katello::Pulp::DockerManifestList.stubs(:ids_for_repository).returns(ids)
+      Katello::Pulp::DockerManifestList.stubs(:fetch).returns(@manifest_lists)
+    end
+
+    def test_import_for_repository
+      Katello::DockerManifestList.import_for_repository(@repo)
+      assert_equal @manifest_lists.first[:_id], @repo.docker_manifest_lists.first.uuid
+      assert_equal @manifest_lists.first[:digest], @repo.docker_manifest_lists.first.digest
+    end
+
+    def test_search_manifest
+      manifest = create(:docker_manifest_list)
+      assert_includes DockerManifestList.search_for("schema_version = #{manifest.schema_version}"), manifest
+      assert_includes DockerManifestList.search_for("digest = #{manifest.digest}"), manifest
+    end
+  end
+end

--- a/test/models/docker_manifest_test.rb
+++ b/test/models/docker_manifest_test.rb
@@ -19,11 +19,8 @@ module Katello
 
     def test_import_for_repository
       Katello::DockerManifest.import_for_repository(@repo)
-
-      assert_equal 4, DockerManifest.count
       assert_equal 1, @repo.docker_manifests.count
-      assert_equal ["manifest1", "one", "three", "two"], DockerManifest.all.map(&:name).sort
-      assert_equal "sha256:f52325afc9c353f58d65b24d8f9a5e61be83f0518aa222639cb77bc7b77d49a9", DockerManifest.find_by_name("manifest1").digest
+      assert_equal @repo.docker_manifests.first, DockerManifest.find_by_digest(@manifests.first[:digest])
     end
 
     def test_search_manifest

--- a/test/models/docker_meta_tag_test.rb
+++ b/test/models/docker_meta_tag_test.rb
@@ -8,8 +8,7 @@ module Katello
 
     def setup
       @repo = Repository.find(katello_repositories(:busybox).id)
-      @manifest = create(:docker_manifest)
-      @tag_schema2 = create(:docker_tag, :repository => @repo, :name => "latest")
+      @tag_schema2 = create(:docker_tag, :with_manifest_list, :repository => @repo, :name => "latest")
       @tag_schema1 = create(:docker_tag, :schema1, :repository => @repo, :name => "latest")
 
       @repo.library_instances_inverse.each do |repo|

--- a/test/models/docker_tag_test.rb
+++ b/test/models/docker_tag_test.rb
@@ -18,7 +18,7 @@ module Katello
 
     def test_import_from_json
       @tag.repository_id = nil
-      @tag.docker_manifest_id = nil
+      @tag.docker_taggable = nil
       @tag.name = nil
       @tag.save!
 
@@ -48,10 +48,6 @@ module Katello
 
     def test_related_tags
       assert_equal 3, @tag.related_tags.count
-    end
-
-    def test_full_name
-      assert_equal "#{@tag.docker_manifest.name}:#{@tag.name}", @tag.full_name
     end
   end
 end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -561,7 +561,7 @@ module Katello
 
     def test_units_for_removal_docker
       ['one', 'two', 'three'].each do |str|
-        @redis.docker_manifests.create!(:name => str) do |manifest|
+        @redis.docker_manifests.create!(:digest => str) do |manifest|
           manifest.uuid = str
         end
       end


### PR DESCRIPTION
Pulp 2.14 added support for docker manifest lists
(https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list)
as part of https://pulp.plan.io/issues/2384

This commit is intended to address the functionality changes that go
with respect to that model change.

This commit contains Model Wise
1) Tables and migrations for Docker Manifest List object
2) Polymorphic associations for DockerTag so that it could point to a Manifest or Manifest List
3) A table that holds references between Docker Manifests belonging to a Manifest list
4) Repository associations to work appropriately for Docker Manifest and Manifest List
5) Unit Tests

UI Wise
1) The backend controller jsons to show the appropriate metadata for Docker Manifest and Docker Manifest list
2) The content counts for the repositories so that it highlights the metadata
3) A "Manage Docker Manifest List" button to the repo details page so that the User can list and delete appropriately
4) Content counts for the repo details, list, and  content view page.
5) Appropriate route changes
6) Unit tests