### PR TITLE
Fixes #21018 - Fix Rails 5 test failures

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -40,7 +40,7 @@ module Katello
                  :source     => :lifecycle_environment
 
         has_many :content_facets, :class_name => "::Katello::Host::ContentFacet", :foreign_key => :content_source_id,
-                                  :inverse_of => :content_source
+                                  :inverse_of => :content_source, :dependent => :nullify
 
         has_many :hostgroups, :class_name => "::Hostgroup", :foreign_key => :content_source_id,
                               :inverse_of => :content_source

--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -499,10 +499,10 @@ module Katello
                        alternate_env_read_permission, bad_cv_read_permission]
                      ]
 
-      env_ids = [ak.environment.id.to_s]
+      env_ids = [ak.environment.id.to_i]
 
       ::Katello::Host::ContentFacet.expects(:where).at_least_once.returns([]).with do |args|
-        args[:content_view_id].id == ak.content_view.id && args[:lifecycle_environment_id] == env_ids
+        args[:content_view_id].id == ak.content_view.id && args[:lifecycle_environment_id].map(&:to_i) == env_ids
       end
 
       assert_protected_action(:remove, allowed_perms, denied_perms) do

--- a/test/controllers/api/v2/host_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/host_subscriptions_controller_test.rb
@@ -85,7 +85,7 @@ module Katello
         assert_equal @host, host
         assert_equal 1, pools_with_quantities.count
         assert_equal @pool, pools_with_quantities[0].pool
-        assert_equal ["1"], pools_with_quantities[0].quantities
+        assert_equal [1], pools_with_quantities[0].quantities.map(&:to_i)
       end
 
       post :add_subscriptions, :host_id => @host.id, :subscriptions => [{:id => @pool.id, :quantity => "1"}]
@@ -108,7 +108,7 @@ module Katello
         assert_equal @host, host
         assert_equal "1", pools_with_quantities.count.to_s
         assert_equal @pool, pools_with_quantities[0].pool
-        assert_equal ["3"], pools_with_quantities[0].quantities
+        assert_equal [3], pools_with_quantities[0].quantities.map(&:to_i)
       end
       post :remove_subscriptions, :host_id => @host.id, :subscriptions => [{:id => @pool.id, :quantity => '3'}]
 

--- a/test/controllers/api/v2/hosts_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/hosts_bulk_actions_controller_test.rb
@@ -181,7 +181,7 @@ module Katello
       users(:restricted).update_attribute(:locations, [@host1.location, @host2.location].uniq)
     end
 
-    def test_permissions
+    def test_bulk_add_host_collections_permissions
       good_perms = [@update_permission]
       bad_perms = [@view_permission, @destroy_permission]
       allow_restricted_user_to_see_host
@@ -191,28 +191,50 @@ module Katello
                                          :organization_id => @org.id,
                                          :host_collection_ids => [@host_collection1.id, @host_collection2.id]
       end
+    end
 
+    def test_bulk_remove_host_collections_permissions
+      good_perms = [@update_permission]
+      bad_perms = [@view_permission, @destroy_permission]
+      allow_restricted_user_to_see_host
       assert_protected_action(:bulk_remove_host_collections, good_perms, bad_perms) do
         put :bulk_remove_host_collections,  :included => {:ids => @host_ids},
                                             :organization_id => @org.id,
                                             :host_collection_ids => [@host_collection1.id, @host_collection2.id]
       end
+    end
 
+    def test_install_content_permissions
+      good_perms = [@update_permission]
+      bad_perms = [@view_permission, @destroy_permission]
+      allow_restricted_user_to_see_host
       assert_protected_action(:install_content, good_perms, bad_perms) do
-        put :install_content, :included => {:ids => @host_ids}, :organization_id => @org.id,
-            :content_type => 'package', :content => ['foo']
+        put :install_content, :included => {:ids => @host_ids}, :organization_id => @org.id, :content_type => 'package', :content => ['foo']
       end
+    end
 
+    def test_update_content_permissions
+      good_perms = [@update_permission]
+      bad_perms = [@view_permission, @destroy_permission]
+      allow_restricted_user_to_see_host
       assert_protected_action(:update_content, good_perms, bad_perms) do
         put :update_content, :included => {:ids => @host_ids}, :organization_id => @org.id,
-            :content_type => 'package', :content => ['foo']
+            :content_type => "package", :content => ['foo']
       end
+    end
 
+    def test_remove_content_permissions
+      good_perms = [@update_permission]
+      bad_perms = [@view_permission, @destroy_permission]
+      allow_restricted_user_to_see_host
       assert_protected_action(:remove_content, good_perms, bad_perms) do
         put :remove_content, :included => {:ids => @host_ids}, :organization_id => @org.id,
             :content_type => 'package', :content => ['foo']
       end
+    end
 
+    def test_destroy_hosts_permissions
+      allow_restricted_user_to_see_host
       good_perms = [@destroy_permission]
       bad_perms = [@view_permission, @update_permission]
 
@@ -288,7 +310,7 @@ module Katello
         assert_includes hosts, @host1
         assert_includes hosts, @host2
         assert_equal pool, pools_with_quantities[0].pool
-        assert_equal ["1"], pools_with_quantities[0].quantities
+        assert_equal [1], pools_with_quantities[0].quantities.map(&:to_i)
       end
       put :add_subscriptions, :included => {:ids => @host_ids}, :subscriptions => [{:id => pool.id, :quantity => 1}]
       assert_response :success
@@ -302,7 +324,7 @@ module Katello
         assert_includes hosts, @host1
         assert_includes hosts, @host2
         assert_equal pool, pools_with_quantities[0].pool
-        assert_equal ["1"], pools_with_quantities[0].quantities
+        assert_equal [1], pools_with_quantities[0].quantities.map(&:to_i)
       end
       put :remove_subscriptions, :included => {:ids => @host_ids}, :subscriptions => [{:id => pool.id, :quantity => 1}]
       assert_response :success

--- a/test/controllers/api/v2/package_groups_controller_test.rb
+++ b/test/controllers/api/v2/package_groups_controller_test.rb
@@ -106,7 +106,7 @@ module Katello
       parameters = { :repository_id => @repo.id, :name => 'My_Group', :description => "My Group", :mandatory_package_names => ["katello-agent"]}
       assert_sync_task(::Actions::Katello::Repository::UploadPackageGroup) do |repository, params|
         repository.must_equal @repo
-        params[:repository_id].must_equal @repo.id.to_s
+        params[:repository_id].to_i.must_equal @repo.id.to_i
         params[:name].must_equal parameters[:name]
         params[:description].must_equal parameters[:description]
         params[:mandatory_package_names].must_equal parameters[:mandatory_package_names]

--- a/test/models/concerns/smart_proxy_extensions_test.rb
+++ b/test/models/concerns/smart_proxy_extensions_test.rb
@@ -26,6 +26,7 @@ module Katello
     end
 
     def test_destroy_with_content_facet
+      @proxy.save!
       host = FactoryGirl.create(:host, :with_content, :content_view => @view,
                                           :lifecycle_environment => @library)
 


### PR DESCRIPTION
On this PR all of the tests are passing on both rails 4 and 5, but only on top of two existing PRs which form the basis of my branch.

To test, simply add `:rails: '5.0'` in settings.yaml followed by a `bundle update` to check the tests against Rails 5.