### PR TITLE
Fixes #21326 - DockerTag deletion cleanup MetaTag

### DIFF
--- a/app/models/katello/docker_tag.rb
+++ b/app/models/katello/docker_tag.rb
@@ -11,6 +11,7 @@ module Katello
     has_one :schema2_meta_tag, :class_name => "Katello::DockerMetaTag", :foreign_key => "schema2_id",
                                :inverse_of => :schema2, :dependent => :nullify
 
+    before_destroy :cleanup_meta_tags
     scoped_search :on => :name, :complete_value => true, :rename => :tag
     scoped_search :relation => :docker_manifest, :on => :name, :rename => :manifest,
       :complete_value => true, :only_explicit => false
@@ -72,6 +73,16 @@ module Katello
 
     def self.completer_scope_options
       {"#{Katello::Repository.table_name}" => lambda { |repo_class| repo_class.docker_type } }
+    end
+
+    def cleanup_meta_tags
+      if schema1_meta_tag && schema1_meta_tag.schema2.blank?
+        schema1_meta_tag.destroy
+      end
+
+      if schema2_meta_tag && schema2_meta_tag.schema1.blank?
+        schema2_meta_tag.destroy
+      end
     end
   end
 end

--- a/test/models/docker_meta_tag_test.rb
+++ b/test/models/docker_meta_tag_test.rb
@@ -72,5 +72,18 @@ module Katello
       dmt.schema2 = nil
       assert_equal @tag_schema1.docker_manifest, dmt.docker_manifest
     end
+
+    def test_delete_docker_meta_tag
+      DockerMetaTag.import_meta_tags([@repo])
+      assert_equal 1, DockerMetaTag.where(:schema1 => @tag_schema1.id).count
+      assert_equal 1, DockerMetaTag.where(:schema2 => @tag_schema2.id).count
+      dmt = DockerMetaTag.first
+      dmt.schema1.destroy
+      assert_equal 0, DockerMetaTag.where(:schema1 => @tag_schema1.id).count
+      dmt.schema2.destroy
+      assert_equal 0, DockerMetaTag.where(:schema2 => @tag_schema2.id).count
+
+      assert_equal 0, DockerMetaTag.where(:id => dmt.id).count
+    end
   end
 end


### PR DESCRIPTION
This commit addresses the issue of stale MetaTag if docker tag got
deleted. Prior to this commit if one deleted a docker tag, the code
would only nullify the appropriate schema column in the docker meta
tag table.
What we need to happen is that the DockerMetaTag entries need to get
wiped out if both schema1 and schema2 columns are nil. This commit
addresses that issue.