### PR TITLE
Fixes #21284:  set table components for filter page.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/filter-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/filter-repositories.controller.js
@@ -46,6 +46,10 @@ angular.module('Bastion.content-views').controller('FilterRepositoriesController
             }
 
             $scope.table.rows = displayedRepositories;
+            $scope.table.numSelected = displayedRepositories.length;
+            $scope.table.resource = {
+                subtotal: displayedRepositories.length
+            };
             $scope.showRepos = filterRepositories.length !== 0;
         };
 


### PR DESCRIPTION
In order to display the correct number of rows and selections we
need to set the table components manually.

http://projects.theforeman.org/issues/21284