### PR TITLE
Fixes #21366 - use deliver method for email sending

### DIFF
--- a/app/lib/actions/katello/content_view/errata_mail.rb
+++ b/app/lib/actions/katello/content_view/errata_mail.rb
@@ -14,7 +14,7 @@ module Actions
           users = ::User.select { |user| user.receives?(:promote_errata) && user.organization_ids.include?(content_view.organization_id) && user.can?(:view_content_views, content_view) }
 
           begin
-            MailNotification[:promote_errata].deliver_now(:users => users, :content_view => content_view, :environment => environment) unless users.blank?
+            MailNotification[:promote_errata].deliver(:users => users, :content_view => content_view, :environment => environment) unless users.blank?
           rescue => e
             message = _('Unable to send errata e-mail notification: %{error}' % {:error => e})
             Rails.logger.error(message)

--- a/app/lib/actions/katello/repository/errata_mail.rb
+++ b/app/lib/actions/katello/repository/errata_mail.rb
@@ -17,7 +17,7 @@ module Actions
           errata = ::Katello::Erratum.where(:id => repo.repository_errata.where('katello_repository_errata.updated_at > ?', input[:last_updated].to_datetime).pluck(:erratum_id))
 
           begin
-            MailNotification[:sync_errata].deliver_now(:users => users, :repo => repo, :errata => errata) unless (users.blank? || errata.blank?)
+            MailNotification[:sync_errata].deliver(:users => users, :repo => repo, :errata => errata) unless (users.blank? || errata.blank?)
           rescue => e
             message = _('Unable to send errata e-mail notification: %{error}' % {:error => e})
             Rails.logger.error(message)


### PR DESCRIPTION
as part of the rails 4.2 migration, we mistakenly change
our usage of deliver to deliver_now.  This would have made sense
had we been calling it on the rails class that sends mail
but we are actually calling it on the foreman MailNotification class
which only has a deliver method