### PR TITLE
Fixes #20785 - Validate host and hostgroup kickstart repos

### DIFF
--- a/app/lib/katello/validators/kickstart_repository_validator.rb
+++ b/app/lib/katello/validators/kickstart_repository_validator.rb
@@ -1,0 +1,42 @@
+module Katello
+  module Validators
+    class KickstartRepositoryValidator < ActiveModel::Validator
+      def validate(record)
+        ks_repo_id = kickstart_repository_id(record)
+        return unless ks_repo_id && kickstart_repository_changed(record)
+
+        msg = if record.operatingsystem.blank?
+                _("Please select an operating system before assigning a kickstart repository")
+              elsif record.architecture.blank?
+                _("Please select an architecture before assigning a kickstart repository")
+              elsif !record.operatingsystem.is_a?(Redhat)
+                _("Kickstart repositories can only be assigned to hosts in the Red Hat family")
+              elsif record.content_source.blank?
+                _("Please select a content source before assigning a kickstart repository")
+              elsif record.operatingsystem.kickstart_repos(record).none? { |repo| repo[:id] == ks_repo_id }
+                _("The selected kickstart repository is not part of the assigned content view, lifecycle environment,
+                  content source, operating system, and architecture")
+              end
+        record.errors.add(:base, msg) if msg
+      end
+
+      private
+
+      def kickstart_repository_changed(record)
+        if record.is_a?(::Hostgroup)
+          record.kickstart_repository_id_changed?
+        else
+          record.content_facet.kickstart_repository_id_changed?
+        end
+      end
+
+      def kickstart_repository_id(record)
+        if record.is_a?(::Hostgroup)
+          record.kickstart_repository_id
+        elsif record.content_facet.present?
+          record.content_facet.kickstart_repository_id
+        end
+      end
+    end
+  end
+end

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -25,6 +25,8 @@ module Katello
         scoped_search :relation => :host_traces, :on => :application, :complete_value => true, :rename => :trace_app, :only_explicit => true
         scoped_search :relation => :host_traces, :on => :app_type, :complete_value => true, :rename => :trace_app_type, :only_explicit => true
         scoped_search :relation => :host_traces, :on => :helper, :complete_value => true, :rename => :trace_helper, :only_explicit => true
+
+        validates_with Validators::KickstartRepositoryValidator
       end
 
       def validate_media_with_capsule?

--- a/app/models/katello/concerns/hostgroup_extensions.rb
+++ b/app/models/katello/concerns/hostgroup_extensions.rb
@@ -12,6 +12,7 @@ module Katello
         belongs_to :lifecycle_environment, :inverse_of => :hostgroups, :class_name => "::Katello::KTEnvironment"
 
         validates_with Katello::Validators::ContentViewEnvironmentValidator
+        validates_with Katello::Validators::KickstartRepositoryValidator
 
         scoped_search :relation => :content_source, :on => :name, :complete_value => true, :rename => :content_source
         scoped_search :relation => :content_view, :on => :name, :complete_value => true, :rename => :content_view

--- a/test/lib/validators/kickstart_repository_validator_test.rb
+++ b/test/lib/validators/kickstart_repository_validator_test.rb
@@ -1,0 +1,137 @@
+# encoding: utf-8
+
+require 'katello_test_helper'
+
+module Katello
+  class KickstartRepositoryValidatorTest < ActiveSupport::TestCase
+    def setup
+      @validator = Validators::KickstartRepositoryValidator.new({})
+      @os = ::Redhat.create_operating_system('RedHat', '9', '0')
+      @content_source = FactoryGirl.create(:smart_proxy, :name => "foobar", :url => "http://capsule.com/")
+      @repos = [{:name => "foo", :id => 4}]
+      @error_messages = {
+        :missing_os => 'Please select an operating system before assigning a kickstart repository',
+        :missing_arch => 'Please select an architecture before assigning a kickstart repository',
+        :invalid_os => 'Kickstart repositories can only be assigned to hosts in the Red Hat family',
+        :missing_content_source => 'Please select a content source before assigning a kickstart repository',
+        :mismatched_ks_repo => 'The selected kickstart repository is not part of the assigned content view, lifecycle environment,
+                  content source, operating system, and architecture'
+      }
+      @hostgroup = ::Hostgroup.new(:operatingsystem => @os, :kickstart_repository_id => 4,
+                                   :architecture => ::Architecture.new, :content_source_id => @content_source.id)
+      @host = ::Host.new(:operatingsystem => @os, :architecture => ::Architecture.new,
+                        :content_facet_attributes => {
+                          :content_source_id => @content_source.id,
+                          :kickstart_repository_id => 4
+                        })
+    end
+
+    test 'it validates a host' do
+      @os.expects(:kickstart_repos).returns(@repos)
+
+      @validator.validate(@host)
+
+      assert_empty @host.errors[:base]
+    end
+
+    test 'it validates a hostgroup' do
+      @os.expects(:kickstart_repos).returns(@repos)
+
+      @validator.validate(@hostgroup)
+
+      assert_empty @hostgroup.errors[:base]
+    end
+
+    test 'it invalidates on missing OS' do
+      @host.operatingsystem = nil
+
+      @validator.validate(@host)
+
+      assert_equal @error_messages[:missing_os], @host.errors[:base].first
+    end
+
+    test 'it invalidates on missing arch' do
+      @host.architecture = nil
+
+      @validator.validate(@host)
+
+      assert_equal @error_messages[:missing_arch], @host.errors[:base].first
+    end
+
+    test 'it short-circuits on nil kickstart repo id' do
+      @host.content_facet.kickstart_repository_id = nil
+      @host.expects(:operatingsystem).never
+
+      @validator.validate(@host)
+
+      assert_empty @host.errors.values
+    end
+
+    test 'it short-circuits unless ks repo has changed on a host' do
+      @host.expects(:operatingsystem).never
+      @host.content_facet.expects(:kickstart_repository_id_changed?).returns(false)
+
+      @validator.validate(@host)
+
+      assert_empty @host.errors.values
+    end
+
+    test 'it short-circuits unless ks repo has changed on a hostgroup' do
+      @hostgroup.expects(:operatingsystem).never
+      @hostgroup.expects(:kickstart_repository_id_changed?).returns(false)
+
+      @validator.validate(@hostgroup)
+
+      assert_empty @hostgroup.errors.values
+    end
+
+    test 'it invalidates missing content source on a host' do
+      @host.content_facet.content_source_id = nil
+
+      @validator.validate(@host)
+
+      assert_equal @error_messages[:missing_content_source], @host.errors[:base].first
+    end
+
+    test 'it invalidates missing content source on a hostgroup' do
+      @hostgroup.content_source_id = nil
+      @validator.validate(@hostgroup)
+
+      assert_equal @error_messages[:missing_content_source], @hostgroup.errors[:base].first
+    end
+
+    test 'it invalidates non-RedHat OS on a hostgroup' do
+      @hostgroup.operatingsystem = ::Operatingsystem.new
+
+      @validator.validate(@hostgroup)
+
+      assert_equal @error_messages[:invalid_os], @hostgroup.errors[:base].first
+    end
+
+    test 'it invalidates non-RedHat OS on a host' do
+      @host.operatingsystem = ::Operatingsystem.new
+
+      @validator.validate(@host)
+
+      assert_equal @error_messages[:invalid_os], @host.errors[:base].first
+    end
+
+    test 'it invalidates mismatched selected ks repo on a host' do
+      @host.content_facet.kickstart_repository_id = 5
+      @os.expects(:kickstart_repos).returns(@repos)
+
+      @validator.validate(@host)
+
+      assert_equal @error_messages[:mismatched_ks_repo], @host.errors[:base].first
+    end
+
+    test 'it invalidates mismatched selected ks repo on a hostgroup' do
+      @hostgroup.kickstart_repository_id = 5
+      @os.expects(:kickstart_repos).returns(@repos)
+
+      @validator.validate(@hostgroup)
+
+      assert_equal @error_messages[:mismatched_ks_repo], @hostgroup.errors[:base].first
+    end
+  end
+end


### PR DESCRIPTION
It was entirely possible to add bogus or otherwise improper kickstart repos to hostgroups. No longer!

Examples:

>hammer hostgroup update --id=2 --kickstart-repository-id=211
Could not update the hostgroup:
No such repository in the assigned content view, environment, content source, OS, and architecture`


>hammer hostgroup update --id=2 --kickstart-repository-id=17
Hostgroup updated


Originally opened as #6987