### PR TITLE
Fixes #21258: Remove pagination on discovery page

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
@@ -137,6 +137,8 @@ angular.module('Bastion.products').controller('DiscoveryController',
             };
 
             Organization.repoDiscover(params, function (task) {
+                // Hide pagination
+                $scope.table.resource['per_page'] = false;
                 $scope.taskSearchId = Task.registerSearch({ 'type': 'task', 'task_id': task.id }, $scope.updateTask);
             });
         };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.controller.js
@@ -95,6 +95,14 @@ angular.module('Bastion.products').controller('ProductsController',
             ProductBulkAction.syncProducts(getBulkParams(), success, bulkError);
         };
 
+        $scope.goToDiscoveries = function () {
+            nutupane.table.rows = [];
+            nutupane.table.resource.results = [];
+            nutupane.table.resource.total = 0;
+            nutupane.table.resource.subtotal = 0;
+            $state.go("product-discovery.scan");
+        };
+
         $scope.openSyncPlanModal = function () {
             nutupane.invalidate();
             $uibModal.open({

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/products.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/products.html
@@ -15,7 +15,7 @@
     </button>
 
     <button type="button" class="btn btn-default"
-            ui-sref="product-discovery.scan"
+            ng-click="goToDiscoveries()"
             bst-feature-flag="custom_products"
             ng-show="permitted('edit_products')">
       <span translate>Repo Discovery</span>


### PR DESCRIPTION
This removes extra blank rows when the discover page is first
loaded and also removes the pagination that isn't valid.

http://projects.theforeman.org/issues/21258