### PR TITLE
fixes #21274 - determine cvv errata based on errata_counts total

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-version.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-version.controller.js
@@ -26,10 +26,11 @@
         $scope.hasErrata = function (version) {
             var found = false;
 
-            found = _.find(version['errata_counts'], function (counts) {
-                return counts !== 0;
-            });
-
+            if (version['errata_counts'] &&
+                version['errata_counts'].total &&
+                version['errata_counts'].total !== 0) {
+                return true;
+            }
             return found;
         };
 


### PR DESCRIPTION
This is a small change to address an edge case where when a user
would view the details of a content view version in the UI, they
may not see the Errata tab.

This was occuring in cases where the errata_counts had null
as the first entry in the result set (e.g. errata_counts['security']==null).
Since the version['errata_counts'] (if included) will include a
'total', this logic will use that total to decide if the
Errata tab will be shown.

To test this specific edge case:
1. enable the RH Tools repo (e.g. Red Hat Satellite Tools 6.2 for RHEL 7 Server RPMs x86_64)
2. sync the repo
3. create a content view, add the repo to it and publish a content view version
4. click on the version 
5. confirm that the Errata tab is shown

Note: performing a similar scenario with a docker repository only, should illustrate that the Errata tab is not included when not needed.