### PR TITLE
Fixes #21273 - Make no-content subs available to keys

### DIFF
--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -88,7 +88,7 @@ module Katello
       added_pools = self.pools.pluck(:cp_id)
       available_pools = all_pools - added_pools
       Pool.where(:cp_id => available_pools,
-                 :subscription_id => Subscription.with_subscribable_content)
+                 :subscription_id => Subscription.subscribable)
     end
 
     def products

--- a/app/models/katello/product.rb
+++ b/app/models/katello/product.rb
@@ -55,10 +55,10 @@ module Katello
     scope :redhat, -> { joins(:provider).where("#{Provider.table_name}.provider_type" => Provider::REDHAT) }
     scope :custom, -> { joins(:provider).where("#{Provider.table_name}.provider_type" => [Provider::CUSTOM, Provider::ANONYMOUS]) }
 
-    def self.with_subscribable_content
-      joins(:repositories).uniq.
-        where("#{Katello::Repository.table_name}.content_type IN (?)",
-              Repository::SUBSCRIBABLE_TYPES)
+    def self.subscribable
+      joins("LEFT OUTER JOIN #{Katello::Repository.table_name} repo ON repo.product_id = #{self.table_name}.id")
+        .where("repo.content_type IN (?) OR repo IS NULL", Repository::SUBSCRIBABLE_TYPES)
+        .group("#{self.table_name}.id, repo.product_id")
     end
 
     def self.enabled

--- a/app/models/katello/subscription.rb
+++ b/app/models/katello/subscription.rb
@@ -12,9 +12,10 @@ module Katello
 
     scope :in_organization, ->(org) { where(:organization => org) }
 
-    def self.with_subscribable_content
-      joins(:products).
-        where("#{Katello::Product.table_name}.id" => Product.with_subscribable_content)
+    def self.subscribable
+      joins("LEFT OUTER JOIN #{Katello::SubscriptionProduct.table_name} subprod ON #{self.table_name}.id = subprod.subscription_id")
+        .where("subprod.product_id" => Product.subscribable << nil)
+        .group("#{self.table_name}.id")
     end
 
     def self.using_virt_who

--- a/test/models/activation_key_test.rb
+++ b/test/models/activation_key_test.rb
@@ -146,7 +146,7 @@ module Katello
       @dev_key.stubs(:get_pools).returns(cp_pools)
       @dev_key.pools = []
 
-      assert_equal [pool_one], @dev_key.available_subscriptions
+      assert_equal [pool_one, pool_two], @dev_key.available_subscriptions
     end
   end
 end

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -119,6 +119,30 @@ module Katello
       assert @redhat_product.used_by_another_org?
     end
 
+    def test_subscribable_with_puppet_repo
+      puppet_repo = katello_repositories(:p_forge)
+      product = katello_products(:fedora)
+      Repository.any_instance.stubs(:exist_for_environment?).returns(true)
+      product.repositories = [puppet_repo]
+
+      refute_includes Product.subscribable, product
+    end
+
+    def test_subscribable_without_repos
+      product = katello_products(:fedora)
+      product.repositories = []
+
+      assert_includes Product.subscribable, product
+    end
+
+    def test_subscribable_puppet_and_yum_repos
+      product = katello_products(:fedora)
+      Repository.any_instance.stubs(:exist_for_environment?).returns(true)
+      product.repositories << katello_repositories(:p_forge)
+
+      assert_includes Product.subscribable, product
+    end
+
     def test_available_content
       product = katello_products(:fedora)
       fedora = katello_repositories(:fedora_17_x86_64)

--- a/test/models/subscription_test.rb
+++ b/test/models/subscription_test.rb
@@ -19,12 +19,12 @@ module Katello
       refute @basic.recently_expired?
     end
 
-    def test_with_subscribable_content
+    def test_subscribable
       fedora = katello_products(:fedora)
-      assert_includes Subscription.with_subscribable_content, @other
+      assert_includes Subscription.subscribable, @other
 
       @other.products.delete(fedora)
-      refute_includes Subscription.with_subscribable_content, @other
+      assert_includes Subscription.subscribable, @other
     end
 
     def test_virt_who_scope


### PR DESCRIPTION
Easily validated with the manifest in the related BZ. I also went ahead and added a few more tests and adjusted method names for accuracy.