### PR TITLE
Fixes #21243 - replace alias_method_chain

### DIFF
--- a/app/controllers/katello/concerns/containers/steps_controller_extensions.rb
+++ b/app/controllers/katello/concerns/containers/steps_controller_extensions.rb
@@ -3,49 +3,51 @@ module Katello
     module Containers
       module StepsControllerExtensions
         extend ActiveSupport::Concern
+
+        module Overrides
+          def set_form
+            if step == :image && @state.image.nil?
+              @docker_container_wizard_states_image = @state.build_image(:katello => true)
+            else
+              super
+            end
+          end
+
+          def build_state
+            if step == :image && params.key?(:katello)
+              repo = nil
+              tag = nil
+              capsule_id = nil
+              if params[:repository] && params[:repository][:id]
+                repo = Repository.where(:id => params[:repository][:id]).first
+              end
+
+              if params[:tag] && params[:tag][:id]
+                tag = DockerMetaTag.where(:id => params[:tag][:id]).first
+              end
+              if params[:capsule] && params[:capsule][:id]
+                capsule_id = params[:capsule][:id]
+              end
+
+              katello_content = {
+                organization_id: params[:organization_id],
+                environment_id: params.fetch(:kt_environment, {})[:id],
+                content_view_id: params.fetch(:content_view, {})[:id],
+                repository_id: repo.try(:id),
+                tag_id: tag.try(:id)
+              }
+              @docker_container_wizard_states_image = @state.build_image(:repository_name => repo.try(:container_repository_name),
+                                  :tag => tag.try(:name),
+                                  :capsule_id => capsule_id,
+                                  :katello => true, :katello_content => katello_content)
+            else
+              super
+            end
+          end
+        end
+
         included do
-          alias_method_chain :set_form, :katello
-          alias_method_chain :build_state, :katello
-        end
-
-        def set_form_with_katello
-          if step == :image && @state.image.nil?
-            @docker_container_wizard_states_image = @state.build_image(:katello => true)
-          else
-            set_form_without_katello
-          end
-        end
-
-        def build_state_with_katello
-          if step == :image && params.key?(:katello)
-            repo = nil
-            tag = nil
-            capsule_id = nil
-            if params[:repository] && params[:repository][:id]
-              repo = Repository.where(:id => params[:repository][:id]).first
-            end
-
-            if params[:tag] && params[:tag][:id]
-              tag = DockerMetaTag.where(:id => params[:tag][:id]).first
-            end
-            if params[:capsule] && params[:capsule][:id]
-              capsule_id = params[:capsule][:id]
-            end
-
-            katello_content = {
-              organization_id: params[:organization_id],
-              environment_id: params.fetch(:kt_environment, {})[:id],
-              content_view_id: params.fetch(:content_view, {})[:id],
-              repository_id: repo.try(:id),
-              tag_id: tag.try(:id)
-            }
-            @docker_container_wizard_states_image = @state.build_image(:repository_name => repo.try(:container_repository_name),
-                                :tag => tag.try(:name),
-                                :capsule_id => capsule_id,
-                                :katello => true, :katello_content => katello_content)
-          else
-            build_state_without_katello
-          end
+          prepend Overrides
         end
       end
     end

--- a/app/controllers/katello/concerns/hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/hosts_controller_extensions.rb
@@ -4,8 +4,19 @@ module Katello
       extend ActiveSupport::Concern
       include ForemanTasks::Triggers
 
+      module Overrides
+        def action_permission
+          case params[:action]
+          when 'content_hosts'
+            'view'
+          else
+            super
+          end
+        end
+      end
+
       included do
-        alias_method_chain :action_permission, :katello
+        prepend Overrides
 
         def destroy
           sync_task(::Actions::Katello::Host::Destroy, @host)
@@ -44,17 +55,6 @@ module Katello
                  'Registered', 'Last Checkin'])
             end
           end
-        end
-      end
-
-      private
-
-      def action_permission_with_katello
-        case params[:action]
-        when 'content_hosts'
-          'view'
-        else
-          action_permission_without_katello
         end
       end
     end

--- a/app/controllers/katello/concerns/organizations_controller_extensions.rb
+++ b/app/controllers/katello/concerns/organizations_controller_extensions.rb
@@ -4,45 +4,46 @@ module Katello
       extend ActiveSupport::Concern
       include ForemanTasks::Triggers
 
-      included do
-        alias_method_chain :destroy, :dynflow
-        alias_method_chain :create, :dynflow
-      end
-
-      def destroy_with_dynflow
-        if @taxonomy.is_a?(Organization)
-          begin
-            async_task(::Actions::Katello::Organization::Destroy, @taxonomy,
-                       ::Organization.current)
-            process_success :success_msg => _("Organization %s is being deleted.") % @taxonomy.name
-          rescue ::Katello::Errors::OrganizationDestroyException => ex
-            process_error(:error_msg => ex.message)
-          end
-        else
-          destroy_without_dynflow
-        end
-      end
-
-      def create_with_dynflow
-        if taxonomy_class == Organization
-          begin
-            @taxonomy = Organization.new(resource_params)
-            sync_task(::Actions::Katello::Organization::Create, @taxonomy)
-            @taxonomy.reload
-            switch_taxonomy
-            if @count_nil_hosts > 0
-              redirect_to send("step2_#{taxonomy_single}_path", @taxonomy)
-            else
-              process_success(:object => @taxonomy, :success_redirect => send("edit_#{taxonomy_single}_path", @taxonomy))
+      module Overrides
+        def destroy
+          if @taxonomy.is_a?(Organization)
+            begin
+              async_task(::Actions::Katello::Organization::Destroy, @taxonomy,
+                         ::Organization.current)
+              process_success :success_msg => _("Organization %s is being deleted.") % @taxonomy.name
+            rescue ::Katello::Errors::OrganizationDestroyException => ex
+              process_error(:error_msg => ex.message)
             end
-          rescue ActiveRecord::RecordInvalid
-            process_error(:render => "taxonomies/new", :object => @taxonomy)
-          rescue StandardError => ex
-            process_error(:render => "taxonomies/new", :object => @taxonomy, :error_msg => ex.message)
+          else
+            super
           end
-        else
-          create_without_dynflow
         end
+
+        def create
+          if taxonomy_class == Organization
+            begin
+              @taxonomy = Organization.new(resource_params)
+              sync_task(::Actions::Katello::Organization::Create, @taxonomy)
+              @taxonomy.reload
+              switch_taxonomy
+              if @count_nil_hosts > 0
+                redirect_to send("step2_#{taxonomy_single}_path", @taxonomy)
+              else
+                process_success(:object => @taxonomy, :success_redirect => send("edit_#{taxonomy_single}_path", @taxonomy))
+              end
+            rescue ActiveRecord::RecordInvalid
+              process_error(:render => "taxonomies/new", :object => @taxonomy)
+            rescue StandardError => ex
+              process_error(:render => "taxonomies/new", :object => @taxonomy, :error_msg => ex.message)
+            end
+          else
+            super
+          end
+        end
+      end
+
+      included do
+        prepend Overrides
       end
     end
   end

--- a/app/helpers/katello/concerns/hosts_and_hostgroups_helper_extensions.rb
+++ b/app/helpers/katello/concerns/hosts_and_hostgroups_helper_extensions.rb
@@ -3,16 +3,17 @@ module Katello
     module HostsAndHostgroupsHelperExtensions
       extend ActiveSupport::Concern
 
-      included do
-        alias_method_chain :puppet_environment_field, :katello
+      module Overrides
+        def puppet_environment_field(form, environments_choice, select_options = {}, html_options = {})
+          html_options.merge!(
+            :label => _("Puppet Environment"),
+            'data-content_puppet_match' => (@host || @hostgroup).new_record? || (@host || @hostgroup).content_and_puppet_match?,
+            :help_inline => link_to(_("Reset Puppet Environment"), '#', :id => 'reset_puppet_environment'))
+          super(form, environments_choice, select_options, html_options)
+        end
       end
-
-      def puppet_environment_field_with_katello(form, environments_choice, select_options = {}, html_options = {})
-        html_options.merge!(
-          :label => _("Puppet Environment"),
-          'data-content_puppet_match' => (@host || @hostgroup).new_record? || (@host || @hostgroup).content_and_puppet_match?,
-          :help_inline => link_to(_("Reset Puppet Environment"), '#', :id => 'reset_puppet_environment'))
-        puppet_environment_field_without_katello(form, environments_choice, select_options, html_options)
+      included do
+        prepend Overrides
       end
     end
   end

--- a/app/helpers/katello/concerns/settings_helper_extensions.rb
+++ b/app/helpers/katello/concerns/settings_helper_extensions.rb
@@ -3,41 +3,43 @@ module Katello
     module SettingsHelperExtensions
       extend ActiveSupport::Concern
 
-      included do
-        alias_method_chain :value, :katello
+      module Overrides
+        def value(setting)
+          return super(setting) unless [
+            'default_download_policy',
+            'katello_default_finish',
+            'katello_default_iPXE',
+            'katello_default_provision',
+            'katello_default_ptable',
+            'katello_default_PXELinux',
+            'katello_default_user_data',
+            'katello_default_kexec',
+            'katello_default_atomic_provision'
+          ].include?(setting.name)
+
+          case setting.name
+          when "default_download_policy"
+            edit_select(setting, :value, :select_values => Hash[::Runcible::Models::YumImporter::DOWNLOAD_POLICIES.collect { |p| [p, p] }].to_json)
+          when "katello_default_finish"
+            edit_select(setting, :value, :select_values => katello_template_setting_values("finish"))
+          when "katello_default_iPXE"
+            edit_select(setting, :value, :select_values => katello_template_setting_values("iPXE"))
+          when "katello_default_provision", "katello_default_atomic_provision"
+            edit_select(setting, :value, :select_values => katello_template_setting_values("provision"))
+          when "katello_default_ptable"
+            edit_select(setting, :value, :select_values => Hash[Template.all.where(:type => "Ptable").map { |tmp| [tmp[:name], tmp[:name]] }].to_json)
+          when "katello_default_PXELinux"
+            edit_select(setting, :value, :select_values => katello_template_setting_values("PXELinux"))
+          when "katello_default_user_data"
+            edit_select(setting, :value, :select_values => katello_template_setting_values("user_data"))
+          when "katello_default_kexec"
+            edit_select(setting, :value, :select_values => katello_template_setting_values("kexec"))
+          end
+        end
       end
 
-      def value_with_katello(setting)
-        return value_without_katello(setting) unless [
-          'default_download_policy',
-          'katello_default_finish',
-          'katello_default_iPXE',
-          'katello_default_provision',
-          'katello_default_ptable',
-          'katello_default_PXELinux',
-          'katello_default_user_data',
-          'katello_default_kexec',
-          'katello_default_atomic_provision'
-        ].include?(setting.name)
-
-        case setting.name
-        when "default_download_policy"
-          edit_select(setting, :value, :select_values => Hash[::Runcible::Models::YumImporter::DOWNLOAD_POLICIES.collect { |p| [p, p] }].to_json)
-        when "katello_default_finish"
-          edit_select(setting, :value, :select_values => katello_template_setting_values("finish"))
-        when "katello_default_iPXE"
-          edit_select(setting, :value, :select_values => katello_template_setting_values("iPXE"))
-        when "katello_default_provision", "katello_default_atomic_provision"
-          edit_select(setting, :value, :select_values => katello_template_setting_values("provision"))
-        when "katello_default_ptable"
-          edit_select(setting, :value, :select_values => Hash[Template.all.where(:type => "Ptable").map { |tmp| [tmp[:name], tmp[:name]] }].to_json)
-        when "katello_default_PXELinux"
-          edit_select(setting, :value, :select_values => katello_template_setting_values("PXELinux"))
-        when "katello_default_user_data"
-          edit_select(setting, :value, :select_values => katello_template_setting_values("user_data"))
-        when "katello_default_kexec"
-          edit_select(setting, :value, :select_values => katello_template_setting_values("kexec"))
-        end
+      included do
+        prepend Overrides
       end
 
       private

--- a/app/models/katello/concerns/container_extensions.rb
+++ b/app/models/katello/concerns/container_extensions.rb
@@ -3,21 +3,23 @@ module Katello
     module ContainerExtensions
       extend ActiveSupport::Concern
 
-      included do
-        belongs_to :capsule, :inverse_of => :containers, :foreign_key => :capsule_id,
-          :class_name => "SmartProxy"
-
-        alias_method_chain :repository_pull_url, :katello
+      module Overrides
+        def repository_pull_url
+          repo_url = super
+          if Repository.where(:container_repository_name => repository_name).count > 0
+            manifest_capsule = self.capsule || CapsuleContent.default_capsule.capsule
+            "#{URI(manifest_capsule.url).hostname}:#{Setting['pulp_docker_registry_port']}/#{repo_url}"
+          else
+            repo_url
+          end
+        end
       end
 
-      def repository_pull_url_with_katello
-        repo_url = repository_pull_url_without_katello
-        if Repository.where(:container_repository_name => repository_name).count > 0
-          manifest_capsule = self.capsule || CapsuleContent.default_capsule.capsule
-          "#{URI(manifest_capsule.url).hostname}:#{Setting['pulp_docker_registry_port']}/#{repo_url}"
-        else
-          repo_url
-        end
+      included do
+        prepend Overrides
+
+        belongs_to :capsule, :inverse_of => :containers, :foreign_key => :capsule_id,
+          :class_name => "SmartProxy"
       end
     end
   end

--- a/app/models/katello/concerns/docker_container_wizard_state_extensions.rb
+++ b/app/models/katello/concerns/docker_container_wizard_state_extensions.rb
@@ -3,12 +3,14 @@ module Katello
     module DockerContainerWizardStateExtensions
       extend ActiveSupport::Concern
 
-      included do
-        alias_method_chain :container_attributes, :katello
+      module Overrides
+        def container_attributes
+          super.merge(:capsule_id => self.image.capsule_id)
+        end
       end
 
-      def container_attributes_with_katello
-        container_attributes_without_katello.merge(:capsule_id => self.image.capsule_id)
+      included do
+        prepend Overrides
       end
     end
   end

--- a/app/models/katello/concerns/docker_container_wizard_state_image_extensions.rb
+++ b/app/models/katello/concerns/docker_container_wizard_state_image_extensions.rb
@@ -3,16 +3,18 @@ module Katello
     module DockerContainerWizardStateImageExtensions
       extend ActiveSupport::Concern
 
+      module Overrides
+        def image_exists
+          return true if katello?
+          super
+        end
+      end
+
       included do
-        alias_method_chain :image_exists, :katello
+        prepend Overrides
 
         serialize :katello_content, Hash
         validate :katello_content_completed, :if => :katello?
-      end
-
-      def image_exists_with_katello
-        return true if katello?
-        image_exists_without_katello
       end
 
       def katello_content_completed

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -4,6 +4,14 @@ module Katello
     module SmartProxyExtensions
       extend ActiveSupport::Concern
 
+      module Overrides
+        def refresh
+          errors = super
+          update_puppet_path
+          errors
+        end
+      end
+
       PULP_FEATURE = "Pulp".freeze
       PULP_NODE_FEATURE = "Pulp Node".freeze
 
@@ -14,7 +22,7 @@ module Katello
         include ForemanTasks::Concerns::ActionSubject
         include LazyAccessor
 
-        alias_method_chain :refresh, :puppet_path
+        prepend Overrides
 
         before_create :associate_organizations
         before_create :associate_default_locations
@@ -75,12 +83,6 @@ module Katello
         end
         self.update_attribute(:puppet_path, path || '') if persisted?
         path
-      end
-
-      def refresh_with_puppet_path
-        errors = refresh_without_puppet_path
-        update_puppet_path
-        errors
       end
 
       def pulp_node

--- a/test/support/pulp/task_support.rb
+++ b/test/support/pulp/task_support.rb
@@ -23,21 +23,5 @@ module Katello
       puts e
       puts e.backtrace
     end
-
-    module TaskRunningWithVcr
-      extend ActiveSupport::Concern
-
-      included do
-        singleton_class.alias_method_chain :any_task_running, :vcr
-      end
-
-      module ClassMethods
-        def any_task_running_with_vcr(async_tasks)
-          VCR.live? ? any_task_running_without_vcr(async_tasks) : false
-        end
-      end
-    end
-
-    Katello::PulpTaskStatus.send(:include, TaskRunningWithVcr)
   end
 end

--- a/test/support/vcr.rb
+++ b/test/support/vcr.rb
@@ -17,6 +17,15 @@ module VCR
   module TestCase
     extend ActiveSupport::Concern
 
+    module Overrides
+      def run
+        VCR.insert_cassette(cassette_name, :match_requests_on => vcr_matches)
+        to_ret = super
+        VCR.eject_cassette
+        to_ret
+      end
+    end
+
     def vcr_matches
       [:method, :path, :params, :body_json]
     end
@@ -28,15 +37,8 @@ module VCR
       "#{class_path}/#{self_class}/#{test_name}"
     end
 
-    def run_with_vcr
-      VCR.insert_cassette(cassette_name, :match_requests_on => vcr_matches)
-      to_ret = run_without_vcr
-      VCR.eject_cassette
-      to_ret
-    end
-
     included do
-      alias_method_chain :run, :vcr
+      prepend Overrides
     end
   end
 end


### PR DESCRIPTION
This replaces alias_method_chain instances
with use of prepend, and sets a convention
for overriding  of foreman methods