### PR TITLE
 Refs #21397 - set repo_registry_id only on docker repos

### DIFF
--- a/app/lib/actions/katello/capsule_content/create_repos.rb
+++ b/app/lib/actions/katello/capsule_content/create_repos.rb
@@ -44,7 +44,7 @@ module Actions
                       path: relative_path,
                       with_importer: true,
                       docker_upstream_name: repository.docker? ? repository.container_repository_name : nil,
-                      repo_registry_id: repository.container_repository_name,
+                      repo_registry_id: repository.docker? ? repository.container_repository_name : nil,
                       download_policy: repository.capsule_download_policy(capsule_content.capsule),
                       capsule_id: capsule_content.capsule.id)
         end


### PR DESCRIPTION
Otherwise 'complete sync' is broken. 

Introduced by https://github.com/Katello/katello/pull/7017. Ping @jlsherrill 