### PR TITLE
Fixes #21255 - Show correct envs for docker tags

### DIFF
--- a/app/models/katello/docker_meta_tag.rb
+++ b/app/models/katello/docker_meta_tag.rb
@@ -28,6 +28,10 @@ module Katello
       [self.repository]
     end
 
+    def related_tags
+      self.class.where(:repository_id => repository.group, :name => name)
+    end
+
     def self.in_repositories(repos, grouped = false)
       if grouped
         search_in_tags(DockerTag.in_repositories(repos).grouped)
@@ -47,6 +51,10 @@ module Katello
 
     def schema2_manifest
       schema2.try(:docker_manifest)
+    end
+
+    def self.with_uuid(ids)
+      self.with_identifiers(ids)
     end
 
     def self.with_identifiers(ids)

--- a/app/views/katello/api/v2/docker_tags/show.json.rabl
+++ b/app/views/katello/api/v2/docker_tags/show.json.rabl
@@ -8,5 +8,5 @@ child :docker_manifest => :manifest do
 end
 
 child :related_tags => :related_tags do
-  attributes :id, :name, :uuid
+  attributes :id, :name
 end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/docker-tag-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/docker-tag-details.controller.js
@@ -33,19 +33,24 @@ angular.module('Bastion.docker-tags').controller('DockerTagDetailsController',
         });
 
         $scope.tag.$promise.then(function () {
+            var ids = _.map($scope.tag.related_tags, 'id');
             var params = {
                 'organization_id': CurrentOrganization,
                 'search': $location.search().search || "",
                 'sort_by': 'name',
                 'sort_order': 'ASC',
                 'paged': false,
-                'ids[]': _.map($scope.tag['related_tags'], 'uuid')
+                'ids[]': ids
             };
-            var nutupane = new Nutupane(DockerTag, params);
+            var nutupane = new Nutupane(DockerTag, params, null, {disableAutoLoad: true});
+
             $scope.controllerName = 'katello_docker_tags';
             $scope.table = nutupane.table;
             $scope.panel.loading = false;
-            nutupane.refresh();
+
+            if (!_.isEmpty(ids)) {
+                nutupane.refresh();
+            }
         });
     }
 ]);

--- a/test/controllers/api/v2/docker_tags_controller_test.rb
+++ b/test/controllers/api/v2/docker_tags_controller_test.rb
@@ -49,5 +49,13 @@ module Katello
       assert_template "katello/api/v2/docker_tags/show"
       assert_template :layout => 'katello/api/v2/layouts/resource'
     end
+
+    def test_show_related_tags
+      get :show, :repository_id => @repo.id, :id => @meta_tag.id
+
+      related_tag = JSON.parse(response.body)['related_tags'].first
+      refute_nil related_tag['id']
+      assert_equal 'wat', related_tag['name']
+    end
   end
 end

--- a/test/models/docker_meta_tag_test.rb
+++ b/test/models/docker_meta_tag_test.rb
@@ -18,6 +18,21 @@ module Katello
       end
     end
 
+    def test_related_tags
+      assert_equal 6, @tag_schema1.related_tags.count
+      assert_equal 6, @tag_schema2.related_tags.count
+    end
+
+    def test_with_uuid
+      meta_one = DockerMetaTag.create!(:name => @tag_schema1.name, :schema1 => @tag_schema1, :repository => @repo)
+      DockerMetaTag.create!(:name => @tag_schema2.name, :schema2 => @tag_schema2, :repository => @repo)
+
+      result = DockerMetaTag.with_uuid(meta_one.id)
+
+      assert_includes result, meta_one
+      assert_equal 1, result.length
+    end
+
     def test_import_meta_tags
       assert_empty DockerMetaTag.where(:schema1 => [@tag_schema1.id, @tag_schema2.id])
       assert_empty DockerMetaTag.where(:schema2 => [@tag_schema1.id, @tag_schema2.id])


### PR DESCRIPTION
Only show the Lifecyle Environments for the docker tag we are looking at - not all of them!
