### PR TITLE
Fixes #21470 - Corrects docker tag id on manifests

### DIFF
--- a/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
+++ b/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
@@ -202,7 +202,7 @@ module Katello
           _("Puppet Module")
         when "Katello::DockerManifest"
           _("Docker Manifest")
-        when "Katello::DockerTag"
+        when "Katello::DockerMetaTag"
           _("Docker Tag")
         when "Katello::OstreeBranch"
           _("OSTree Branch")

--- a/app/models/katello/docker_tag.rb
+++ b/app/models/katello/docker_tag.rb
@@ -26,6 +26,14 @@ module Katello
 
     delegate :relative_path, :environment, :content_view_version, :product, :to => :repository
 
+    def associated_meta_tag
+      schema1_meta_tag || schema2_meta_tag
+    end
+
+    def associated_meta_tag_identifier
+      associated_meta_tag.id
+    end
+
     def self.grouped
       grouped_fields = "#{table_name}.name, #{Repository.table_name}.name, #{Product.table_name}.name"
       ids = uniq.select("ON (#{grouped_fields}) #{table_name}.id").joins(:repository => :product)

--- a/app/views/katello/api/v2/docker_manifests/show.json.rabl
+++ b/app/views/katello/api/v2/docker_manifests/show.json.rabl
@@ -3,5 +3,6 @@ object @resource
 attributes :id, :name, :schema_version, :digest
 
 child :docker_tags => :tags do
-  attributes :id, :repository_id, :name
+  attributes :associated_meta_tag_identifier => :id
+  attributes :repository_id, :name
 end

--- a/test/models/docker_meta_tag_test.rb
+++ b/test/models/docker_meta_tag_test.rb
@@ -100,5 +100,17 @@ module Katello
 
       assert_equal 0, DockerMetaTag.where(:id => dmt.id).count
     end
+
+    def test_docker_tag_associated_meta_tag
+      DockerMetaTag.import_meta_tags([@repo])
+      dmt = DockerMetaTag.first
+      assert_equal dmt, dmt.schema1.associated_meta_tag
+      assert_equal dmt.schema1.schema1_meta_tag, dmt.schema1.associated_meta_tag
+      assert_equal dmt.id, dmt.schema1.associated_meta_tag_identifier
+
+      assert_equal dmt, dmt.schema2.associated_meta_tag
+      assert_equal dmt.schema2.schema2_meta_tag, dmt.schema2.associated_meta_tag
+      assert_equal dmt.id, dmt.schema2.associated_meta_tag_identifier
+    end
   end
 end


### PR DESCRIPTION
Prior to this commit if went the Docker Manifests list page and clicked
on the associated tag you 'd either get a  get a message along the lines
of "Can't find resource class: ::Katello::DockerMetaTag"
or it would point to a wrong tag. That is because the wrong tag id was
being returned in the json. This commit corrects that issue