### PR TITLE
Fixes #21475 - Change the inline help

### DIFF
--- a/app/helpers/katello/concerns/hosts_and_hostgroups_helper_extensions.rb
+++ b/app/helpers/katello/concerns/hosts_and_hostgroups_helper_extensions.rb
@@ -11,7 +11,7 @@ module Katello
         html_options.merge!(
           :label => _("Puppet Environment"),
           'data-content_puppet_match' => (@host || @hostgroup).new_record? || (@host || @hostgroup).content_and_puppet_match?,
-          :help_inline => link_to(_("Reset Puppet Environment to match selected Content View"), '#', :id => 'reset_puppet_environment'))
+          :help_inline => link_to(_("Reset Puppet Environment"), '#', :id => 'reset_puppet_environment'))
         puppet_environment_field_without_katello(form, environments_choice, select_options, html_options)
       end
     end


### PR DESCRIPTION
Change link on “Reset Puppet Environment….” to be only on "Reset Puppet Environment"