### PR TITLE
Fixes #21481: fix errata resource switcher.

### DIFF
--- a/app/views/katello/api/v2/errata/show.json.rabl
+++ b/app/views/katello/api/v2/errata/show.json.rabl
@@ -1,7 +1,6 @@
 object @resource
 
-attributes :uuid => :id
-attributes :title, :errata_id
+attributes :id, :uuid, :title, :errata_id
 attributes :issued, :updated, :version, :status, :release
 attributes :severity, :description, :solution, :summary, :reboot_suggested
 attributes :_href
@@ -10,6 +9,7 @@ child :cves => :cves do
   attributes :cve_id, :href
 end
 
+attributes :title => :name
 attributes :errata_type => :type
 
 node(:hosts_available_count) { |m| m.hosts_available(params[:organization_id]).count }


### PR DESCRIPTION
The resource switcher relies on the attribute name being present.
In the case of errata we use title instead of name. This commit
adds name to the json as well including uuid as well as id in
the json response.

http://projects.theforeman.org/issues/21481