### PR TITLE
Fixes #21484 - Auto complete for Docker Meta Tag

### DIFF
--- a/app/models/katello/docker_manifest.rb
+++ b/app/models/katello/docker_manifest.rb
@@ -9,6 +9,8 @@ module Katello
     CONTENT_TYPE = Pulp::DockerManifest::CONTENT_TYPE
     scoped_search :on => :name, :complete_value => true
     scoped_search :relation => :docker_tags, :on => :name, :rename => :tag, :complete_value => true, :only_explicit => true
+    scoped_search :on => :digest, :rename => :digest, :complete_value => true, :only_explicit => true
+    scoped_search :on => :schema_version, :rename => :schema_version, :complete_value => true, :only_explicit => true
 
     def self.repository_association_class
       RepositoryDockerManifest

--- a/app/models/katello/docker_tag.rb
+++ b/app/models/katello/docker_tag.rb
@@ -12,15 +12,6 @@ module Katello
                                :inverse_of => :schema2, :dependent => :nullify
 
     before_destroy :cleanup_meta_tags
-    scoped_search :on => :name, :complete_value => true, :rename => :tag
-    scoped_search :relation => :docker_manifest, :on => :name, :rename => :manifest,
-      :complete_value => true, :only_explicit => false
-    scoped_search :relation => :docker_manifest, :on => :digest, :rename => :digest,
-      :complete_value => false, :only_explicit => true
-    scoped_search :relation => :docker_manifest, :on => :schema_version, :rename => :schema_version,
-      :complete_value => false, :only_explicit => true
-    scoped_search :relation => :repository, :on => :name, :rename => :repository,
-      :complete_value => true, :only_explicit => true
 
     scope :in_repositories, ->(repos) { where(:repository_id => repos) }
 

--- a/test/models/docker_manifest_test.rb
+++ b/test/models/docker_manifest_test.rb
@@ -2,6 +2,7 @@ require 'katello_test_helper'
 
 module Katello
   class DockerManifestTest < ActiveSupport::TestCase
+    extend ActiveRecord::TestFixtures
     REPO_ID = "Default_Organization-Test-redis".freeze
     MANIFESTS = File.join(Katello::Engine.root, "test", "fixtures", "pulp", "docker_manifests.yml")
     TAGS = File.join(Katello::Engine.root, "test", "fixtures", "pulp", "docker_tags.yml")
@@ -23,6 +24,12 @@ module Katello
       assert_equal 1, @repo.docker_manifests.count
       assert_equal ["manifest1", "one", "three", "two"], DockerManifest.all.map(&:name).sort
       assert_equal "sha256:f52325afc9c353f58d65b24d8f9a5e61be83f0518aa222639cb77bc7b77d49a9", DockerManifest.find_by_name("manifest1").digest
+    end
+
+    def test_search_manifest
+      manifest = create(:docker_manifest)
+      assert_includes DockerManifest.search_for("schema_version = #{manifest.schema_version}"), manifest
+      assert_includes DockerManifest.search_for("digest = #{manifest.digest}"), manifest
     end
   end
 end

--- a/test/models/docker_meta_tag_test.rb
+++ b/test/models/docker_meta_tag_test.rb
@@ -112,5 +112,18 @@ module Katello
       assert_equal dmt.schema2.schema2_meta_tag, dmt.schema2.associated_meta_tag
       assert_equal dmt.id, dmt.schema2.associated_meta_tag_identifier
     end
+
+    def test_search_meta_tag
+      DockerMetaTag.import_meta_tags([@repo])
+      dmt = DockerMetaTag.first
+      assert_includes DockerMetaTag.search_for("schema_version = 2"), dmt
+      assert_includes DockerMetaTag.search_for("schema_version = 1"), dmt
+      refute_includes DockerMetaTag.search_for("schema_version = 3"), dmt
+
+      assert_includes DockerMetaTag.search_for("tag = #{dmt.name}"), dmt
+      refute_includes DockerMetaTag.search_for("tag = #{dmt.name}00009s"), dmt
+
+      assert_includes DockerMetaTag.search_for("repository = #{dmt.repository.name}"), dmt
+    end
   end
 end

--- a/test/models/docker_tag_test.rb
+++ b/test/models/docker_tag_test.rb
@@ -16,11 +16,6 @@ module Katello
       end
     end
 
-    def test_search_version
-      tags = DockerTag.search_for("schema_version = 2")
-      assert_includes tags, @tag
-    end
-
     def test_import_from_json
       @tag.repository_id = nil
       @tag.docker_manifest_id = nil


### PR DESCRIPTION
This commit adds autocomplete constructs to docker meta tag and removes
the unused ones in docker tag. Idea here is DockerTagsController has now
completely shifted to using the DockerMetaTag model for all data
purposes and hence there is no value in holding auto complete
constructs there.

This commit also includes sensible auto complete values for docker
manifests so that one can search by things like the manifest's digest
name and schema version in the Repository -> Manage Docker Manifests
page.