### PR TITLE
Fixes #21491 - properly detect if inc update is needed

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
@@ -115,24 +115,20 @@ angular.module('Bastion.errata').controller('ApplyErrataController',
                 HostBulkAction.installContent(params, transitionToTask, error);
             };
 
-            if (IncrementalUpdate.canApply()) {
-                $scope.selectedContentHosts = IncrementalUpdate.getBulkContentHosts();
-                $scope.selectedContentHosts['errata_ids'] = IncrementalUpdate.getErrataIds();
-                $scope.selectedContentHosts['organization_id'] = CurrentOrganization;
-                HostBulkAction.availableIncrementalUpdates($scope.selectedContentHosts, function (updates) {
-                    $scope.updates = updates;
-                });
-            }
+            $scope.selectedContentHosts = IncrementalUpdate.getBulkContentHosts();
+            $scope.selectedContentHosts['errata_ids'] = IncrementalUpdate.getErrataIds();
+            $scope.selectedContentHosts['organization_id'] = CurrentOrganization;
+            HostBulkAction.availableIncrementalUpdates($scope.selectedContentHosts, function (updates) {
+                $scope.updates = updates;
+            });
 
             $scope.confirmApply = function() {
                 $scope.applyingErrata = true;
-                IncrementalUpdate.getIncrementalUpdates().then(function(updates) {
-                    if (updates.length === 0) {
-                        applyErrata();
-                    } else {
-                        incrementalUpdate();
-                    }
-                });
+                if ($scope.updates.length === 0) {
+                    applyErrata();
+                } else {
+                    incrementalUpdate();
+                }
             };
 
             $scope.incrementalUpdates = IncrementalUpdate.getIncrementalUpdates();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/erratum-content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/details/erratum-content-hosts.controller.js
@@ -80,6 +80,9 @@ angular.module('Bastion.errata').controller('ErratumContentHostsController',
 
         $scope.goToNextStep = function () {
             IncrementalUpdate.setBulkContentHosts(nutupane.getAllSelectedResults());
+            if ($scope.errata) {
+                IncrementalUpdate.setErrataIds([$scope.errata['errata_id']]);
+            }
 
             if ($scope.errata && $scope.errata.id) {
                 $scope.transitionTo('erratum.apply', {errataId: $scope.errata.id});

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/incremental-update.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/incremental-update.service.js
@@ -129,17 +129,6 @@
             searchId = Task.registerSearch(taskSearchParams, taskSearchComplete);
             return deferred.promise;
         };
-
-        /**
-         * Determines whether or not errata can be applied.
-         *
-         * For now, simply checks if the parameters exist.
-         *
-         * @returns boolean
-         */
-        this.canApply = function () {
-            return this.errataIds.length > 0 && this.contentHostIds.length > 0;
-        };
     }
 
     angular.module('Bastion.errata').service('IncrementalUpdate', IncrementalUpdate);

--- a/engines/bastion_katello/test/errata/apply-errata.controller.test.js
+++ b/engines/bastion_katello/test/errata/apply-errata.controller.test.js
@@ -36,17 +36,10 @@ describe('Controller: ApplyErrataController', function() {
         CurrentOrganization = 'foo';
 
         IncrementalUpdate = {
-            canApply: function () {},
             getContentHostIds: function () {},
             getErrataIds: function () {},
-            getBulkContentHosts: function () {},
-            getIncrementalUpdates: function () {
-                return {
-                    then: function(cb){
-                        cb($scope.updates)
-                    }
-                }
-            }
+            getBulkContentHosts: function () {return {}},
+            getIncrementalUpdates: function () {}
         };
 
         Notification = {
@@ -84,7 +77,6 @@ describe('Controller: ApplyErrataController', function() {
         };
 
         beforeEach(function () {
-            spyOn(IncrementalUpdate, 'canApply').and.returnValue(true);
             spyOn(IncrementalUpdate,'getBulkContentHosts').and.returnValue(bulkContentHosts);
             spyOn(IncrementalUpdate, 'getErrataIds').and.returnValue([10]);
 
@@ -92,7 +84,6 @@ describe('Controller: ApplyErrataController', function() {
         });
 
         afterEach(function () {
-            expect(IncrementalUpdate.canApply).toHaveBeenCalled();
             expect(IncrementalUpdate.getErrataIds).toHaveBeenCalled();
             expect(IncrementalUpdate.getBulkContentHosts).toHaveBeenCalled();
         });

--- a/engines/bastion_katello/test/errata/details/erratum-content-hosts.controller.test.js
+++ b/engines/bastion_katello/test/errata/details/erratum-content-hosts.controller.test.js
@@ -47,7 +47,8 @@ describe('Controller: ErratumContentHostsController', function() {
         IncrementalUpdate = {
             getIncrementalUpdates: function () {},
             getErrataIds: function () {},
-            setBulkContentHosts: function () {}
+            setBulkContentHosts: function () {},
+            setErrataIds: function () {}
         };
 
         Environment = MockResource.$new();

--- a/engines/bastion_katello/test/errata/incremental-update.service.test.js
+++ b/engines/bastion_katello/test/errata/incremental-update.service.test.js
@@ -78,12 +78,4 @@ describe('Service: IncrementalUpdate', function() {
         expect(Task.registerSearch).toHaveBeenCalled();
         expect(Task.unregisterSearch).toHaveBeenCalled();
     });
-
-    it("determines whether or not errata can be applied", function () {
-        expect(IncrementalUpdate.canApply()).toBe(false);
-        IncrementalUpdate.errataIds = [1];
-        expect(IncrementalUpdate.canApply()).toBe(false);
-        IncrementalUpdate.contentHostIds = [1];
-        expect(IncrementalUpdate.canApply()).toBe(true);
-    });
 });


### PR DESCRIPTION
A change was made in 0c6a18c that changed this logic
to make the decision of whether to apply this errata to the
host directly or perform an incremental update to base it on
whether an inc update is already in progress.  This does not
make any sense, as it should be based on whether the errata
is in the hosts' environments