### PR TITLE
Fixes #21512 - Make consumer_params optional on host update

### DIFF
--- a/app/lib/actions/katello/host/update.rb
+++ b/app/lib/actions/katello/host/update.rb
@@ -26,7 +26,7 @@ module Actions
         def run
           User.as_anonymous_admin do
             host = ::Host.find(input[:host_id])
-            unless input[:consumer_params][:facts].blank?
+            if input[:consumer_params].try(:[], :facts)
               ::Katello::Host::SubscriptionFacet.update_facts(host, input[:consumer_params][:facts])
             end
           end
@@ -38,7 +38,7 @@ module Actions
               host = ::Host.find(input[:host_id])
               host.subscription_facet.update_from_consumer_attributes(input[:consumer_params])
               host.subscription_facet.save!
-              input[:consumer_params][:facts] = 'TRIMMED' unless input[:consumer_params][:facts].blank?
+              input[:consumer_params][:facts] = 'TRIMMED' if input[:consumer_params].try(:[], :facts)
             end
           end
         end


### PR DESCRIPTION
To reproduce error:
1. Create a Org
2. Create 2 lifecycle env with 2 Cv's promoted
3. Create a host using 1st CV and lifecycle
4. Delete the 1st Lifecycle and CV and transfer the Created Content host to 2nd Lifecycle and CV

hammer -v -u admin -p changeme  content-view remove --system-content-view-id="2nd CV id" --system-environment-id="2nd Lifecycle ID" --environment-ids="1st Lifecycle id " --id="1st CV id"