### PR TITLE
Fixes #21518 - Auto complete for docker manifest

### DIFF
--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -119,7 +119,12 @@ Katello::Engine.routes.draw do
           end
         end
 
-        api_resources :docker_manifests, :only => [:index, :show]
+        api_resources :docker_manifests, :only => [:index, :show] do
+          collection do
+            get :auto_complete_search
+          end
+        end
+
         api_resources :docker_tags, :only => [:index, :show] do
           collection do
             get :auto_complete_search

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-manifests/docker-manifest.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-manifests/docker-manifest.factory.js
@@ -10,7 +10,10 @@
      */
     function DockerManifest(BastionResource) {
         return BastionResource('katello/api/v2/docker_manifests/:id',
-            {'id': '@id'}
+            {'id': '@id'},
+            {
+                'autocomplete': {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}}
+            }
         );
     }
 


### PR DESCRIPTION
This commit fixes a UI issue the Auto complete options were not getting
displayed when one clicked on the search box in the docker manifests
page