### PR TITLE
Fixes #21562: add patternfly and patternfly-react to katello

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.4.0",
     "jest": "^21.2.1",
+    "patternfly": "^3.29.5",
+    "patternfly-react": "^0.8.1",
     "prettier": "^1.7.4",
     "react-test-renderer": "^16.0.0"
   },


### PR DESCRIPTION
Add patternfly and patternfly-react to katello's package.json so
that we are explicit about what packages katello requires.

http://projects.theforeman.org/issues/21562