### PR TITLE
Fixes #21569 - Speed up clean backend objects

### DIFF
--- a/app/services/katello/candlepin/consumer.rb
+++ b/app/services/katello/candlepin/consumer.rb
@@ -122,20 +122,6 @@ module Katello
         end
       end
 
-      def self.orphaned_consumer_ids
-        #returns consumer ids in candlepin with no matching katello entry
-        orphaned_ids = []
-        User.as_anonymous_admin do
-          cp_consumers = Organization.all.collect { |org| ::Katello::Resources::Candlepin::Consumer.get('owner' => org.label) }
-          cp_consumers.flatten!
-          cp_consumers.reject! { |consumer| consumer['type']['label'] == 'uebercert' }
-          cp_consumer_ids = cp_consumers.map { |consumer| consumer["uuid"] }
-          katello_consumer_ids = ::Katello::Host::SubscriptionFacet.pluck(:uuid)
-          orphaned_ids = cp_consumer_ids - katello_consumer_ids
-        end
-        orphaned_ids
-      end
-
       def self.distribution_to_puppet_os(name)
         return ::Operatingsystem::REDHAT_ATOMIC_HOST_OS if name == ::Operatingsystem::REDHAT_ATOMIC_HOST_DISTRO_NAME
 

--- a/config/katello.yaml.example
+++ b/config/katello.yaml.example
@@ -33,7 +33,7 @@
     # the candlepin host and the location of the copied file needs to be
     # specified here..
     :ca_cert_file:
-
+    # :bulk_load_size: 1000
   # Setup your pulp environment here
   :pulp:
     # refers to the url of the pulp

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "apipie-rails", ">= 0.5.4"
 
   # Pulp
-  gem.add_dependency "runcible", ">= 2.1.0", "< 3.0.0"
+  gem.add_dependency "runcible", ">= 2.5.0", "< 3.0.0"
   gem.add_dependency "anemone"
 
   # UI

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -38,7 +38,8 @@ module Katello
           :url => 'https://localhost:8443/candlepin',
           :oauth_key => 'katello',
           :oauth_secret => 'katello',
-          :ca_cert_file => nil
+          :ca_cert_file => nil,
+          :bulk_load_size => 1000
         }
       }
 

--- a/test/services/katello/candlepin/consumer_test.rb
+++ b/test/services/katello/candlepin/consumer_test.rb
@@ -59,20 +59,6 @@ module Katello
 
         assert_equal nil, Candlepin::Consumer.distribution_to_puppet_os('RedHot')
       end
-
-      def test_orphaned_consumer_ids
-        org = get_organization
-        Organization.stubs(:all).returns([org])
-
-        orphaned_uuid = 'annie'
-        consumer = {'type' => {'label' => nil}, 'uuid' => orphaned_uuid}
-        ueber_consumer = {'type' => {'label' => 'uebercert'}, 'uuid' => 'my_ueber_cert'}
-
-        ::Katello::Resources::Candlepin::Consumer.expects(:get).with('owner' => org.label).returns([consumer, ueber_consumer])
-        orphaned = Katello::Candlepin::Consumer.orphaned_consumer_ids
-
-        assert_equal [orphaned_uuid], orphaned
-      end
     end
   end
 end


### PR DESCRIPTION
The clean backend objects rake task would loop through every host and
figure out if the candlepin and pulp ids were valid. This meant for
every host there would be 2 rest calls for this check. On machines where
the number of hosts were in the 10 s of thousands this would mean 20K
rest calls.
On top of that the final clean "orphaned" systems, i.e.'find all systems
in candlepin that are not in katello' would potentially load up or
serialize all candlepin consumers in 1 very big json (very expensive
task) to determine if there are orphaned consumers.

This commit tries to address this load by
1) Reducing the json foot print in candlepin (just get the UUIDs and
nothing else)
2) Page the calls. (Fetch 5000 uuids at a time, dont get everything)
3) Common sense arithmetic to calculate/fetch hosts that are in Katello
but not in CP/Pulp and vice versa
4) Hopefully more modular code for readability.