### PR TITLE
Fixes #21574 - Move patternfly dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.4.0",
     "jest": "^21.2.1",
-    "patternfly": "^3.29.5",
-    "patternfly-react": "^0.8.1",
     "prettier": "^1.7.4",
     "react-test-renderer": "^16.0.0"
   },
   "dependencies": {
+    "patternfly": "^3.29.5",
+    "patternfly-react": "^0.8.1",
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",


### PR DESCRIPTION
The patternfly dependencies should be in the regular dependencies
list not the devDependencies.

http://projects.theforeman.org/issues/21574