### PR TITLE
Fixes #21548 - use archive repo for CVV env indexing

### DIFF
--- a/app/controllers/katello/api/v2/products_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/products_bulk_actions_controller.rb
@@ -31,7 +31,7 @@ module Katello
       validate_contents = ::Foreman::Cast.to_bool(params[:validate_contents])
 
       syncable_products = @products.syncable
-      syncable_repositories = Repository.where(:product_id => syncable_products).has_url
+      syncable_repositories = Repository.where(:product_id => syncable_products).has_url.in_default_view
 
       syncable_repositories = syncable_repositories.where(:content_type => Repository::YUM_TYPE) if skip_metadata_check || validate_contents
       syncable_repositories = syncable_repositories.where.not(:download_policy => ::Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND) if validate_contents

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -139,6 +139,7 @@ module Katello
     scope :non_archived, -> { where('environment_id is not NULL') }
     scope :archived, -> { where('environment_id is NULL') }
     scope :subscribable, -> { where(content_type: SUBSCRIBABLE_TYPES) }
+    scope :in_published_environments, -> { in_content_views(Katello::ContentView.non_default).where.not(:environment_id => nil) }
 
     scoped_search :on => :name, :complete_value => true
     scoped_search :rename => :product, :on => :name, :relation => :product, :complete_value => true
@@ -493,6 +494,14 @@ module Katello
       search.in_content_views([view])
     end
 
+    def archived_instance
+      if self.environment_id.nil? || self.library_instance_id.nil?
+        self
+      else
+        self.content_view_version.archived_repos.where(:library_instance_id => self.library_instance_id).first
+      end
+    end
+
     def url?
       url.present?
     end
@@ -518,7 +527,7 @@ module Katello
     end
 
     def exist_for_environment?(environment, content_view, attribute = nil)
-      if environment.present?
+      if environment.present? && content_view.in_environment?(environment)
         repos = content_view.version(environment).repos(environment)
 
         repos.any? do |repo|

--- a/app/models/katello/rpm.rb
+++ b/app/models/katello/rpm.rb
@@ -95,5 +95,11 @@ module Katello
       self.joins(:content_facets).
         where("#{Katello::Host::ContentFacet.table_name}.host_id" => hosts).uniq
     end
+
+    def self.import_additional_content
+      Katello::Repository.in_published_environments.yum_type.find_each do |repo|
+        repo.index_content
+      end
+    end
   end
 end

--- a/test/actions/katello/content_view_version_test.rb
+++ b/test/actions/katello/content_view_version_test.rb
@@ -59,8 +59,8 @@ module ::Actions::Katello::ContentViewVersion
       katello_content_view_versions(:library_view_version_2)
     end
 
-    let(:library_repo) do
-      katello_repositories(:fedora_17_x86_64_library_view_2)
+    let(:library_repos) do
+      [katello_repositories(:rhel_6_x86_64_dev_archive), katello_repositories(:fedora_17_x86_64_library_view_2)]
     end
 
     it 'plans' do
@@ -70,7 +70,7 @@ module ::Actions::Katello::ContentViewVersion
       action.stubs(:task).returns(task)
       plan_action(action, content_view_version, false, nil, 0)
       # verify everything bubbles through to the export action as we expect
-      assert_action_planed_with(action, ::Actions::Katello::Repository::Export, [library_repo],
+      assert_action_planed_with(action, ::Actions::Katello::Repository::Export, library_repos,
                                 false, nil, 0, "-published_library_view-v2.0")
     end
 
@@ -81,7 +81,7 @@ module ::Actions::Katello::ContentViewVersion
       action.stubs(:task).returns(task)
       # the date should not be converted to an iso8601 when fed to Repository::Export.
       plan_action(action, content_view_version, false, '1841-01-01', 0)
-      assert_action_planed_with(action, ::Actions::Katello::Repository::Export, [library_repo],
+      assert_action_planed_with(action, ::Actions::Katello::Repository::Export, library_repos,
                                 false, '1841-01-01', 0, "-published_library_view-v2.0")
     end
   end

--- a/test/controllers/api/v2/products_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/products_bulk_actions_controller_test.rb
@@ -55,7 +55,7 @@ module Katello
     def test_sync
       assert_async_task(::Actions::BulkAction) do |action_class, repos|
         action_class.must_equal ::Actions::Katello::Repository::Sync
-        repos.size.must_equal 9
+        repos.size.must_equal 5
       end
 
       put :sync_products, :ids => @products.collect(&:id), :organization_id => @organization.id

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -140,7 +140,7 @@ module Katello
     end
 
     def test_index_with_content_view_id_and_environment_id
-      ids = @fedora_dev.content_view_version.repositories.pluck(:id)
+      ids = @fedora_dev.content_view_version.repositories.where(:environment_id => @fedora_dev.environment_id).pluck(:id)
 
       response =  get :index, :content_view_id => @fedora_dev.content_view_version.content_view_id, :environment_id => @fedora_dev.environment_id,
                   :organization_id => @organization.id
@@ -162,7 +162,7 @@ module Katello
 
     def test_index_with_content_view_version_id_and_environment
       repo = Repository.find(katello_repositories(:fedora_17_x86_64_dev).id)
-      ids = repo.content_view_version.repository_ids
+      ids = repo.content_view_version.repositories.where(:environment_id => repo.environment.id).map(&:id)
 
       response =  get :index, :content_view_version_id => repo.content_view_version.id,
                   :environment_id => repo.environment_id,

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -39,9 +39,30 @@ fedora_17_x86_64_dev:
   distribution_uuid: 'xyz123'
   download_policy: immediate
 
+fedora_17_x86_64_dev_archive:
+  name:                 Fedora 17 x86_64 dev
+  pulp_id:              2_archive
+  content_id:           1
+  content_type:         yum
+  library_instance:     fedora_17_x86_64
+  label:                fedora_17_x86_64_dev_label
+  relative_path:        'ACME_Corporation/dev/fedora_17_dev_label'
+  environment_id:
+  product_id:           <%= ActiveRecord::FixtureSet.identify(:fedora) %>
+  gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
+  content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_dev_view_version) %>
+  url:                 "http://myrepo.com"
+  distribution_arch: "x86_64"
+  distribution_version: "2.1"
+  distribution_family: "Test Family"
+  distribution_variant: "TestVariant"
+  distribution_bootable: false
+  distribution_uuid: 'xyz123'
+  download_policy: immediate
+
 fedora_17_x86_64_duplicate:
   name:                 Fedora 17 x86_64 duplicate
-  pulp_id:              2
+  pulp_id:              2_duplicate
   content_id:           1
   content_type:         yum
   label:                fedora_17_x86_64_duplicate_label
@@ -168,6 +189,23 @@ rhel_6_x86_64_dev:
   url:                 'https://cdn.example.com/rhel/6/os'
   download_policy: on_demand
 
+rhel_6_x86_64_dev_archive:
+  name:                 RHEL 6 x86_64
+  pulp_id:              8_arch
+  content_id:           69
+  major:                6
+  minor:                6Server
+  content_type:         yum
+  label:                rhel_6_x86_64_label
+  relative_path:        'ACME_Corporation/library/rhel_6_label'
+  url:                 'https://cdn.example.com/rhel/6/os'
+  product_id:           <%= ActiveRecord::FixtureSet.identify(:redhat) %>
+  gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
+  library_instance_id:  <%= ActiveRecord::FixtureSet.identify(:rhel_6_x86_64) %>
+  content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_view_version_2) %>
+  url:                 'https://cdn.example.com/rhel/6/os'
+  download_policy: on_demand
+
 fedora_17_no_arch:
   name:                 Fedora 17 no arch
   pulp_id:              1
@@ -188,7 +226,7 @@ fedora_17_no_arch:
 
 rhel_7_no_arch:
   name:                 RHEL 7 no_arch
-  pulp_id:              9
+  pulp_id:              9_noarch
   content_id:           1
   major:                7
   minor:                7Server
@@ -245,7 +283,7 @@ dev_p_forge:
 
 rhel_6_x86_64_library_view_1:
   name:                 RHEL 6 x86_64
-  pulp_id:              8
+  pulp_id:              8_view1
   content_id:           1
   major:                6
   minor:                6Server
@@ -260,7 +298,7 @@ rhel_6_x86_64_library_view_1:
 
 fedora_17_x86_64_library_view_1:
   name:                 Fedora 17 x86_64 lib view 1
-  pulp_id:              3
+  pulp_id:              3_view1
   content_id:           1
   label:                fedora_17_x86_64_label
   library_instance:     fedora_17_x86_64
@@ -273,7 +311,7 @@ fedora_17_x86_64_library_view_1:
 
 fedora_17_x86_64_library_view_2:
   name:                 Fedora 17 x86_64 lib view 2
-  pulp_id:              3
+  pulp_id:              3_view2
   content_id:           1
   label:                fedora_17_x86_64_label
   library_instance:     fedora_17_x86_64
@@ -286,7 +324,7 @@ fedora_17_x86_64_library_view_2:
 
 fedora_17_x86_64_library_view_2_library:
   name:                 Fedora 17 x86_64 lib view 2 lib
-  pulp_id:              3
+  pulp_id:              3_view2_library
   content_id:           1
   label:                fedora_17_x86_64_label
   library_instance:     fedora_17_x86_64
@@ -404,7 +442,7 @@ busybox_view2:
 
 rhel_6_x86_64_composite_view_version_1:
   name:                 RHEL 6 x86_64
-  pulp_id:              8
+  pulp_id:              8_composite_version1
   content_id:           69
   major:                6
   minor:                6Server

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -168,6 +168,16 @@ module Katello
       end
     end
 
+    def test_archived_instance
+      archived_repo = katello_repositories(:fedora_17_x86_64_dev_archive)
+      env_repo = katello_repositories(:fedora_17_x86_64_dev)
+
+      assert_equal archived_repo, env_repo.archived_instance
+      assert_equal archived_repo, archived_repo.archived_instance
+
+      assert_equal @fedora_17_x86_64, @fedora_17_x86_64.archived_instance
+    end
+
     def test_content_type
       @repo.content_type = "puppet"
       @repo.download_policy = nil


### PR DESCRIPTION
this commit changes the way to we index repositories
that are published in a content view within the lifecycle
environment.  Previously we went to pulp to fetch the uuids.
Now we base it off the "archive" copy of that repository.

This may be slightly faster (or much faster if pulp/mongo
is under heavy load), but will facilitate even faster publishes
in the future by not copying any actual units to the repo.