### PR TITLE
Fixes #21607 - docker-tag auto name completion

### DIFF
--- a/app/controllers/katello/api/v2/docker_tags_controller.rb
+++ b/app/controllers/katello/api/v2/docker_tags_controller.rb
@@ -9,7 +9,7 @@ module Katello
       page_size = Katello::Concerns::FilteredAutoCompleteSearch::PAGE_SIZE
       tags = Katello::DockerMetaTag.in_repositories(@repositories)
       col = "#{Katello::DockerMetaTag.table_name}.name"
-      tags = tags.where("#{Katello::DockerTag.table_name}.name ILIKE ?", "#{params[:term]}%").select(col).group(col).order(col).limit(page_size)
+      tags = tags.where("#{col} ILIKE ?", "#{params[:term]}%").select(col).group(col).order(col).limit(page_size)
       render :json => tags.pluck(col)
     end
 

--- a/test/controllers/api/v2/docker_tags_controller_test.rb
+++ b/test/controllers/api/v2/docker_tags_controller_test.rb
@@ -14,6 +14,13 @@ module Katello
       models
     end
 
+    def test_autocomplete_name
+      response = get :auto_complete_name, :repoids => [@repo.id], :term => @tag.name
+
+      assert_response :success
+      assert_includes JSON.parse(response.body), @tag.name
+    end
+
     def test_index
       get :index, :repository_id => @repo.id
       assert_response :success


### PR DESCRIPTION
This commit addresses a bug where the docker tag name was not gettign
autocompleted when requested from the UI. The Table referenced in the
autocomplete did not point DockerMetaTag and instead pointed to
DockerTag breaking this.