### PR TITLE
Fixes #21388 - Filters for DockerManifestList

### DIFF
--- a/app/lib/actions/katello/repository/clear.rb
+++ b/app/lib/actions/katello/repository/clear.rb
@@ -9,7 +9,8 @@ module Actions
            Pulp::Repository::RemoveDistribution,
            Pulp::Repository::RemoveFile,
            Pulp::Repository::RemovePuppetModule,
-           Pulp::Repository::RemoveDockerManifest].each do |action_class|
+           Pulp::Repository::RemoveDockerManifest,
+           Pulp::Repository::RemoveDockerManifestList].each do |action_class|
             plan_action(action_class, pulp_id: repo.pulp_id)
           end
         end

--- a/app/lib/actions/pulp/repository/remove_docker_manifest_list.rb
+++ b/app/lib/actions/pulp/repository/remove_docker_manifest_list.rb
@@ -1,0 +1,11 @@
+module Actions
+  module Pulp
+    module Repository
+      class RemoveDockerManifestList < Pulp::Repository::AbstractRemoveContent
+        def content_extension
+          pulp_extensions.docker_manifest_list
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds code to set up docker content view filters that should work with
docker manifest lists. Also fixes a couple of bugs related to the docker
manifests filter generation code.