### PR TITLE
Fixes #21549 - do not actually copy units on promotion

### DIFF
--- a/app/lib/actions/katello/content_view_version/republish_repositories.rb
+++ b/app/lib/actions/katello/content_view_version/republish_repositories.rb
@@ -5,10 +5,7 @@ module Actions
         def plan(content_view_version)
           action_subject(content_view_version.content_view)
           plan_self(:version_id => content_view_version.id)
-
-          content_view_version.repositories.each do |repo|
-            plan_action(::Actions::Katello::Repository::MetadataGenerate, repo, :force => true)
-          end
+          plan_action(::Actions::Katello::Repository::BulkMetadataGenerate, content_view_version.repositories, :force => true)
 
           content_view_version.content_view_puppet_environments.each do |repo|
             plan_action(::Actions::Katello::Repository::MetadataGenerate, repo, :force => true)

--- a/app/lib/actions/katello/repository/bulk_metadata_generate.rb
+++ b/app/lib/actions/katello/repository/bulk_metadata_generate.rb
@@ -1,0 +1,15 @@
+module Actions
+  module Katello
+    module Repository
+      class BulkMetadataGenerate < Actions::Base
+        def plan(repos, options = {})
+          sequence do
+            plan_action(::Actions::BulkAction, ::Actions::Katello::Repository::MetadataGenerate, repos.in_default_view, options) if repos.in_default_view.any?
+            plan_action(::Actions::BulkAction, ::Actions::Katello::Repository::MetadataGenerate, repos.archived, options) if repos.archived.any?
+            plan_action(::Actions::BulkAction, ::Actions::Katello::Repository::MetadataGenerate, repos.in_published_environments, options) if repos.in_published_environments.any?
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/repository/check_matching_content.rb
+++ b/app/lib/actions/katello/repository/check_matching_content.rb
@@ -35,8 +35,8 @@ module Actions
         end
 
         def package_groups_match?(source_repo, target_repo)
-          source_repo_ids = source_repo.package_group_ids.sort
-          target_repo_ids = target_repo.package_group_ids.sort
+          source_repo_ids = source_repo.package_groups.order(:name).pluck(:name)
+          target_repo_ids = target_repo.package_groups.order(:name).pluck(:name)
           source_repo_ids == target_repo_ids
         end
 

--- a/app/lib/actions/katello/repository/clone_to_environment.rb
+++ b/app/lib/actions/katello/repository/clone_to_environment.rb
@@ -21,7 +21,7 @@ module Actions
             end
 
             if repository.yum?
-              plan_action(Repository::CloneYumContent, repository, clone, [], false,
+              plan_action(Repository::CloneYumMetadata, repository, clone,
                           :force_yum_metadata_regeneration => options[:force_yum_metadata_regeneration])
             elsif repository.docker?
               plan_action(Repository::CloneDockerContent, repository, clone, [])

--- a/app/lib/actions/katello/repository/clone_yum_metadata.rb
+++ b/app/lib/actions/katello/repository/clone_yum_metadata.rb
@@ -1,0 +1,27 @@
+module Actions
+  module Katello
+    module Repository
+      class CloneYumMetadata < Actions::Base
+        def plan(source_repo, target_repo, options = {})
+          sequence do
+            # Check for matching content before indexing happens, the content in pulp is
+            # actually updated, but it is not reflected in the database yet.
+            output = {}
+            if target_repo.environment && !options[:force_yum_metadata_regeneration]
+              output = plan_action(Katello::Repository::CheckMatchingContent,
+                                   :source_repo_id => source_repo.id,
+                                   :target_repo_id => target_repo.id).output
+            end
+
+            plan_action(Katello::Repository::IndexContent, id: target_repo.id)
+
+            plan_action(Katello::Repository::MetadataGenerate,
+                        target_repo,
+                        :source_repository => source_repo,
+                        :matching_content => output[:matching_content])
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/repository/metadata_generate.rb
+++ b/app/lib/actions/katello/repository/metadata_generate.rb
@@ -7,6 +7,10 @@ module Actions
           source_repository = options.fetch(:source_repository, nil)
           force = options.fetch(:force, false)
 
+          if source_repository.nil? && repository.yum? && repository.requires_yum_clone_distributor?
+            source_repository = repository.archived_instance
+          end
+
           distributors(repository, source_repository).each do |distributor|
             plan_action(Pulp::Repository::DistributorPublish,
                         :pulp_id => repository.pulp_id,

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -502,6 +502,10 @@ module Katello
       end
     end
 
+    def requires_yum_clone_distributor?
+      self.yum? && self.environment_id && !self.in_default_view?
+    end
+
     def url?
       url.present?
     end

--- a/lib/katello/tasks/repository.rake
+++ b/lib/katello/tasks/repository.rake
@@ -11,7 +11,7 @@ namespace :katello do
         begin
           if repo.needs_metadata_publish?
             Rails.logger.error("Repository metadata for #{repo.name} (#{repo.id}) is out of date, regenerating.")
-            needing_publish << repo
+            needing_publish << repo.id
           end
         rescue => e
           puts "Failed to check repository #{repo.id}: #{e}"
@@ -19,7 +19,7 @@ namespace :katello do
       end
     end
     if needing_publish.any?
-      ForemanTasks.async_task(::Actions::BulkAction, ::Actions::Katello::Repository::MetadataGenerate, needing_publish)
+      ForemanTasks.async_task(::Actions::Katello::Repository::BulkMetadataGenerate, Katello::Repository.where(:id => needing_publish))
     end
   end
 
@@ -29,7 +29,7 @@ namespace :katello do
     repos = lookup_repositories
 
     if repos.any?
-      task = ForemanTasks.async_task(::Actions::BulkAction, Actions::Katello::Repository::MetadataGenerate, repos.all.sort)
+      task = ForemanTasks.async_task(Actions::Katello::Repository::BulkMetadataGenerate, repos.all.sort)
       puts "Regenerating #{repos.count} repositories.  You can monitor these on task id #{task.id}\n"
     else
       puts "No repositories found for regeneration."

--- a/test/actions/katello/content_view_version/republish_repositories_test.rb
+++ b/test/actions/katello/content_view_version/republish_repositories_test.rb
@@ -20,9 +20,7 @@ module Katello::Host
 
         plan_action(action, @version)
 
-        @version.repositories.each do |repo|
-          assert_action_planed_with(action, Actions::Katello::Repository::MetadataGenerate, repo, :force => true)
-        end
+        assert_action_planed_with(action, ::Actions::Katello::Repository::BulkMetadataGenerate, @version.repositories, :force => true)
 
         @version.content_view_puppet_environments.each do |cvpe|
           assert_action_planed_with(action, Actions::Katello::Repository::MetadataGenerate, cvpe, :force => true)

--- a/test/actions/katello/repository/bulk_metadata_generate_test.rb
+++ b/test/actions/katello/repository/bulk_metadata_generate_test.rb
@@ -1,0 +1,25 @@
+require 'katello_test_helper'
+
+module Actions
+  describe Katello::Repository::BulkMetadataGenerate do
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+    include FactoryBot::Syntax::Methods
+
+    let(:action_class) { ::Actions::Katello::Repository::BulkMetadataGenerate }
+    let(:metadata_gen) { ::Actions::Katello::Repository::MetadataGenerate }
+    let(:bulk_action) { ::Actions::BulkAction }
+    let(:yum_repo) { katello_repositories(:rhel_6_x86_64_dev) }
+    let(:yum_repo2) { katello_repositories(:rhel_6_x86_64_dev_archive) }
+
+    it 'plans a yum refresh' do
+      action = create_action(action_class)
+      query = ::Katello::Repository.where(:id => [yum_repo.id, yum_repo2.id])
+
+      plan_action(action, query, :force => true)
+
+      assert_action_planed_with(action, bulk_action, metadata_gen, query.archived, :force => true)
+      assert_action_planed_with(action, bulk_action, metadata_gen, query.in_published_environments, :force => true)
+    end
+  end
+end

--- a/test/actions/katello/repository/clone_yum_metadata_test.rb
+++ b/test/actions/katello/repository/clone_yum_metadata_test.rb
@@ -1,0 +1,49 @@
+require 'katello_test_helper'
+
+module Actions
+  describe Katello::Repository::CloneYumMetadata do
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+    include FactoryBot::Syntax::Methods
+
+    let(:action_class) { ::Actions::Katello::Repository::CloneYumMetadata }
+    let(:metadata_gen) { ::Actions::Katello::Repository::MetadataGenerate }
+    let(:bulk_action) { ::Actions::BulkAction }
+    let(:environment_repo) { katello_repositories(:rhel_6_x86_64_dev) }
+    let(:archive_repo) { katello_repositories(:rhel_6_x86_64_dev_archive) }
+
+    it 'plans to clone the metadata' do
+      action = create_action(action_class)
+
+      action.execution_plan.stub_planned_action(Katello::Repository::CheckMatchingContent) do |matching|
+        matching.stubs(output: { :matching_content => false})
+      end
+
+      plan_action(action, archive_repo, environment_repo)
+
+      matching_action = assert_action_planed_with(action, Katello::Repository::CheckMatchingContent,
+                                :source_repo_id => archive_repo.id,
+                                :target_repo_id => environment_repo.id)
+
+      assert_action_planed_with(action, Katello::Repository::IndexContent, :id => environment_repo.id)
+
+      assert_action_planed_with(action, Katello::Repository::MetadataGenerate, environment_repo,
+                                :source_repository => archive_repo,
+                                :matching_content => matching_action[0].output[:matching_content])
+    end
+
+    it 'plans to clone the metadata with force_yum_metadata_regeneration' do
+      action = create_action(action_class)
+
+      plan_action(action, archive_repo, environment_repo, :force_yum_metadata_regeneration => true)
+
+      refute_action_planed(action, Katello::Repository::CheckMatchingContent)
+
+      assert_action_planed_with(action, Katello::Repository::IndexContent, :id => environment_repo.id)
+
+      assert_action_planed_with(action, Katello::Repository::MetadataGenerate, environment_repo,
+                                :source_repository => archive_repo,
+                                :matching_content => nil)
+    end
+  end
+end

--- a/test/lib/tasks/repository_test.rb
+++ b/test/lib/tasks/repository_test.rb
@@ -31,7 +31,7 @@ module Katello
     end
 
     def test_regenerate_repo_metadata
-      ForemanTasks.expects(:async_task).with(::Actions::BulkAction, Actions::Katello::Repository::MetadataGenerate,
+      ForemanTasks.expects(:async_task).with(::Actions::Katello::Repository::BulkMetadataGenerate,
                                              Katello::Repository.all.sort).returns(ForemanTasks::Task.new)
 
       Rake.application.invoke_task('katello:regenerate_repo_metadata')
@@ -41,7 +41,7 @@ module Katello
       ENV['LIFECYCLE_ENVIRONMENT'] = @library_repo.environment.name
 
       expected_repos = Katello::Repository.joins(:environment).where('katello_environments.name' => @library_repo.environment.name)
-      ForemanTasks.expects(:async_task).with(::Actions::BulkAction, Actions::Katello::Repository::MetadataGenerate,
+      ForemanTasks.expects(:async_task).with(::Actions::Katello::Repository::BulkMetadataGenerate,
                                              expected_repos.sort).returns(ForemanTasks::Task.new)
 
       Rake.application.invoke_task('katello:regenerate_repo_metadata')
@@ -49,7 +49,7 @@ module Katello
 
     def test_regenerate_repo_metadata_cv
       ENV['CONTENT_VIEW'] = @cv_repo.content_view.name
-      ForemanTasks.expects(:async_task).with(::Actions::BulkAction, Actions::Katello::Repository::MetadataGenerate,
+      ForemanTasks.expects(:async_task).with(::Actions::Katello::Repository::BulkMetadataGenerate,
                                              [@cv_repo]).returns(ForemanTasks::Task.new)
 
       Rake.application.invoke_task('katello:regenerate_repo_metadata')


### PR DESCRIPTION
this change modifies promotions and the 2nd half
of content view publishes to not actually copy any units
to the target repositories.  This works fine, but breaks the rule
that we can simply republish a repository to get its content.

Now, since the repositories in pulp have no actual content
we have to always use the yum_clone_distributor when generating
metadata via the various methods of doing that.

The benefit is a decrease in promotion time down to
seconds, and and a decrease in publish time by approximately
50%