### PR TITLE
Fixes #21665 - Override Host validate_media? properly

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -6,7 +6,7 @@ module Katello
       include ForemanTasks::Concerns::ActionSubject
 
       module Overrides
-        def validate_media
+        def validate_media?
           (content_source_id.blank? || (content_facet && content_facet.kickstart_repository.blank?)) && super
         end
 


### PR DESCRIPTION
The Host::Managed media validator has always been overridden by Katello, as Synced content does not need installation media to work.
Check out the following gif for an example:

The problem is that https://github.com/Katello/katello/commit/a32a9be522015a1ef925038ca2cf94722efb6307#diff-4a41cc0011db848f8d1bc5025f997d12R9 renamed the override from "validate_media?" to "validate_media" (no question mark).
Renaming that and adding some tests to ensure hosts with synced content.


https://gfycat.com/gifs/detail/AcademicBasicKusimanse (see what happens)