### PR TITLE
Fixes #21667 - ProxyAPI::Pulp not found when refreshing proxy

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -1,4 +1,6 @@
-# rubocop:disable Style/MixinUsage
+require 'proxy_api'
+require 'proxy_api/pulp'
+require 'proxy_api/pulp_node'
 module Katello
   module Concerns
     module SmartProxyExtensions


### PR DESCRIPTION
For some reason ProxyAPI::Pulp and ProxyAPI::PulpNode are not available to katello/SmartProxyExtensions, which causes a ResourceNotFound error when refreshing the proxy.
Fix seems to be as simple as requiring proxy_api/pulp.