### PR TITLE
Fixes #21670 - Allow non RH hosts to NOT have content views

### DIFF
--- a/app/lib/katello/validators/content_view_environment_validator.rb
+++ b/app/lib/katello/validators/content_view_environment_validator.rb
@@ -6,9 +6,9 @@ module Katello
         environment_id = record.respond_to?(:lifecycle_environment_id) ? record.lifecycle_environment_id : record.environment_id
 
         if record.content_view_id && environment_id
-          view = ContentView.find(record.content_view_id)
-          env = KTEnvironment.find(environment_id)
-          unless view.in_environment?(env)
+          view = ContentView.where(:id => record.content_view_id).first
+          env = KTEnvironment.where(:id => environment_id).first
+          unless view.blank? || env.blank? || view.in_environment?(env)
             record.errors[:base] << _("Content view '%{view}' is not in environment '%{env}'") %
                                       {:view => view.name, :env => env.name}
           end

--- a/app/models/katello/concerns/content_facet_host_extensions.rb
+++ b/app/models/katello/concerns/content_facet_host_extensions.rb
@@ -49,7 +49,7 @@ module Katello
         )
 
         def content_facet_ignore_update?(attributes)
-          self.content_facet.blank? && attributes.blank?
+          self.content_facet.blank? && attributes.values.all?(&:blank?)
         end
       end
 

--- a/test/controllers/foreman/hosts_controller_test.rb
+++ b/test/controllers/foreman/hosts_controller_test.rb
@@ -18,10 +18,21 @@ class HostsControllerTest < ActionController::TestCase
     permissions
   end
 
-  def test_puppet_environment_for_content_view
+  test 'puppet environment for content_view' do
     get :puppet_environment_for_content_view, :content_view_id => @library_dev_staging_view.id, :lifecycle_environment_id => @library.id
 
     assert_response :success
+  end
+
+  test 'empty content facet parameters are removed' do
+    post :create, { :host => {
+      :name => 'test_content',
+      :content_facet_attributes => {
+        :lifecycle_environment_id => "",
+        :content_source_id => ""
+      }
+    } }, set_session_user
+    assert_empty assigns('host').content_facet
   end
 
   context 'csv' do

--- a/test/models/concerns/content_facet_host_extensions_test.rb
+++ b/test/models/concerns/content_facet_host_extensions_test.rb
@@ -49,11 +49,11 @@ module Katello
       empty_host.reload
       assert_nil empty_host.content_facet
 
-      empty_host.update_attributes!(:content_facet_attributes => {})
+      empty_host.update_attributes(:content_facet_attributes => {})
       empty_host.reload
       assert_nil empty_host.content_facet
 
-      empty_host.update_attributes!(:content_facet_attributes => { :lifecycle_environment_id => library.id, :content_view_id => view.id })
+      empty_host.update_attributes(:content_facet_attributes => { :lifecycle_environment_id => library.id, :content_view_id => view.id })
       empty_host.reload.content_facet.reload
       refute_nil empty_host.content_facet # not reset to nil
     end


### PR DESCRIPTION
Currently the Content View and Lifecycle Environment are fields of a
Content Facet. These fields have a NOT-NULL constraint, so they are
validated on every host. This means that if I'm trying to create a
CentOS, or Debian host, it will ask for a Content View and Lifecycle -
which I may not want for hosts that don't use subscription-manager.

In fact for the CentOS case, it's harmful: having a Content View for a
CentOS host changes the @mediapath variable (the parameter sent to --url
in the kickstart) to point to Pulp, which means you're pointing to
Red Hat and installing Red Hat instead of CentOS (unless you've synced
CentOS).