### PR TITLE
Fixes #21660 - Subscription's "guests of" link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,6 @@ bundler.d/local*.rb
 config/initializers/_local*.rb
 config/initializers/local*.rb
 lib/tasks/local*.rb
-test/fixtures/all_fixtures
 doc/graphs/*.svg
 .ruby-version
 .ruby-gemset

--- a/app/models/katello/glue/candlepin/pool.rb
+++ b/app/models/katello/glue/candlepin/pool.rb
@@ -9,7 +9,7 @@ module Katello
         lazy_accessor :pool_facts, :initializer => lambda { |_s| self.import_lazy_attributes }
         lazy_accessor :subscription_facts, :initializer => lambda { |_s| self.subscription ? self.subscription.attributes : {} }
 
-        lazy_accessor :pool_derived, :owner, :source_pool_id, :host_id, :virt_limit, :arch, :description,
+        lazy_accessor :pool_derived, :owner, :source_pool_id, :virt_limit, :arch, :description,
           :product_family, :variant, :suggested_quantity, :support_type, :product_id, :type,
           :initializer => :pool_facts
 
@@ -49,8 +49,6 @@ module Katello
         pool_attributes.each do |attr|
           json[attr["name"]] = attr["value"]
           case attr["name"]
-          when 'requires_host'
-            json["host_id"] = attr['value']
           when 'virt_limit'
             json["virt_limit"] = attr['value'].to_i
           when 'support_type'
@@ -121,7 +119,11 @@ module Katello
         if pool_attributes.key?(:virtual)
           pool_attributes[:virt_only] = pool_attributes["virtual"] == 'true'
         end
-        pool_attributes[:host_id] = pool_attributes["requiresHost"] if pool_attributes.key?("requiresHost")
+
+        if pool_attributes.key?("requires_host")
+          pool_attributes[:hypervisor_id] = ::Katello::Host::SubscriptionFacet.find_by(:uuid => pool_attributes["requires_host"])
+                                                                              .try(:host_id)
+        end
 
         if pool_attributes.key?(:unmapped_guests_only) && pool_attributes[:unmapped_guests_only] == 'true'
           pool_attributes[:unmapped_guest] = true
@@ -169,7 +171,7 @@ module Katello
       end
 
       def hypervisor
-        ::Katello::Host::SubscriptionFacet.find_by(:uuid => host_id).try(:host) if host_id
+        ::Host.find_by(id: self.hypervisor_id) if self.hypervisor_id
       end
     end
   end

--- a/app/models/katello/pool.rb
+++ b/app/models/katello/pool.rb
@@ -64,10 +64,6 @@ module Katello
       self.subscription.products if self.subscription
     end
 
-    def host
-      Katello::Host::SubscriptionFacet.find_by_uuid(host_id).try(:host) if host_id
-    end
-
     private
 
     def default_sort

--- a/app/views/katello/api/v2/subscriptions/base.json.rabl
+++ b/app/views/katello/api/v2/subscriptions/base.json.rabl
@@ -16,3 +16,10 @@ attributes :name => :product_name
 attributes :unmapped_guest
 attributes :virt_only
 attributes :virt_who
+
+node :hypervisor, :if => lambda { |sub| sub && sub.respond_to?(:hypervisor) && sub.hypervisor_id } do |subscription|
+  {
+    id: subscription.hypervisor.id,
+    name: subscription.hypervisor.name
+  }
+end

--- a/db/migrate/20171114183353_add_hypervisor_id_to_katello_pools.rb
+++ b/db/migrate/20171114183353_add_hypervisor_id_to_katello_pools.rb
@@ -1,0 +1,9 @@
+class AddHypervisorIdToKatelloPools < ActiveRecord::Migration
+  def up
+    add_column :katello_pools, :hypervisor_id, :integer
+  end
+
+  def down
+    remove_column :katello_pools, :hypervisor_id
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/subscription-type.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/subscription-type.html
@@ -2,7 +2,7 @@
 <div ng-if="subscription.virt_only === false">
   {{ 'Physical' | translate }}
 </div>
-<div ng-if="subscription.virt_only === true && !subscription.host">
+<div ng-if="subscription.virt_only === true && !subscription.hypervisor">
   <div ng-if="subscription.unmapped_guest !== true">
     {{ 'Virtual' | translate }}
   </div>
@@ -10,9 +10,9 @@
     {{ 'Temporary' | translate }}
   </div>
 </div>
-<div ng-if="subscription.virt_only === true && subscription.host">
+<div ng-if="subscription.virt_only === true && subscription.hypervisor">
   <span translate> Guests of </span>
-  <a ui-sref="content-hosts.details.info({hostId: subscription.host.id })">
-    {{ subscription.host.name }}
+  <a ui-sref="content-host.info({hostId: subscription.hypervisor.id })">
+    {{ subscription.hypervisor.name }}
   </a>
 </div>

--- a/engines/bastion_katello/test/subscriptions/subscription-type.directive.test.js
+++ b/engines/bastion_katello/test/subscriptions/subscription-type.directive.test.js
@@ -40,7 +40,7 @@ describe('Directive: subscriptionType', function() {
     });
 
     it("subscription type Guest when host", function() {
-        $scope.subscription = {virt_only: true, host: {id: 123, name: "hypervisor"}};
+        $scope.subscription = {virt_only: true, hypervisor: {id: 123, name: "hypervisor"}};
         element = '<div subscription-type="subscription"></div>';
         element = $compile(element)($scope);
         $scope.$digest();

--- a/test/fixtures/models/hosts.yml
+++ b/test/fixtures/models/hosts.yml
@@ -1,23 +1,23 @@
 one:
-  organization: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
-  location: <%= ActiveRecord::FixtureSet.identify(:location1) %>
+  organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
+  location_id: <%= ActiveRecord::FixtureSet.identify(:location1) %>
   name: "Host1.example.com"
   type: 'Host::Managed'
 
 two:
-  organization: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
-  location: <%= ActiveRecord::FixtureSet.identify(:location1) %>
+  organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
+  location_id: <%= ActiveRecord::FixtureSet.identify(:location1) %>
   name: "Host2.example.com"
   type: 'Host::Managed'
 
 without_content_facet:
-  organization: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
-  location: <%= ActiveRecord::FixtureSet.identify(:location1) %>
+  organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
+  location_id: <%= ActiveRecord::FixtureSet.identify(:location1) %>
   name: "Host3.example.com"
   type: 'Host::Managed'
 
 without_errata:
-  organization: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
-  location: <%= ActiveRecord::FixtureSet.identify(:location1) %>
+  organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
+  location_id: <%= ActiveRecord::FixtureSet.identify(:location1) %>
   name: "Host4.example.com"
   type: 'Host::Managed'

--- a/test/fixtures/models/katello_pools.yml
+++ b/test/fixtures/models/katello_pools.yml
@@ -13,6 +13,7 @@ pool_one:
   multi_entitlement: true
   consumed: 1
   virt_who: true
+  hypervisor_id: <%= ActiveRecord::FixtureSet.identify(:one) %>
 
 pool_two:
   cp_id: "xyz123"

--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -75,7 +75,9 @@ module FixtureTestCase
 
     Katello::FixturesSupport.set_fixture_classes(self)
 
-    self.fixture_path = "#{Katello::Engine.root}/test/fixtures/all_fixtures/"
+    # Fixtures are copied into a separate path to combine with Foreman fixtures. This directory
+    # is kept out of version control.
+    self.fixture_path = "#{Rails.root}/tmp/combined_fixtures/"
     FileUtils.rm_rf(self.fixture_path) if File.directory?(self.fixture_path)
     Dir.mkdir(self.fixture_path)
     FileUtils.cp(Dir.glob("#{Katello::Engine.root}/test/fixtures/models/*"), self.fixture_path)
@@ -197,6 +199,8 @@ class ActiveSupport::TestCase
     organization = Organization.find(taxonomies(org.to_sym).id)
     organization.stubs(:label_not_changed).returns(true)
     organization.setup_label_from_name
+    location = Location.where(name: "Location 1").first
+    organization.locations << location
     organization.save!
     User.current = saved_user
     organization

--- a/test/models/foreman/location_test.rb
+++ b/test/models/foreman/location_test.rb
@@ -35,9 +35,11 @@ module Katello
 
       test 'renaming location should update settings' do
         loc = Location.first
+        org = Organization.first
         Setting[:default_location_subscribed_hosts] = loc.title
         Setting[:default_location_puppet_content] = loc.title
 
+        loc.organizations << org
         loc.update_attributes!(:name => 'foo_bar')
         assert_equal 'foo_bar', Setting[:default_location_subscribed_hosts]
         assert_equal 'foo_bar', Setting[:default_location_puppet_content]

--- a/test/models/pool_test.rb
+++ b/test/models/pool_test.rb
@@ -56,6 +56,10 @@ module Katello
       assert_equal @pool_one.hosts, [@host_one]
     end
 
+    def test_hypervisors
+      assert_equal @pool_one.hypervisor, @host_one
+    end
+
     def test_search_consumed
       subscriptions = Pool.search_for("consumed = \"#{@pool_one.consumed}\"")
       assert_includes subscriptions, @pool_one


### PR DESCRIPTION
The "guests of <hypervisor>" link was broken because
we changed the subscription API to no longer return hosts.
This commit will grab the "requires_host" value from
candlepin and adds that to a new field on the pools table,
"hypervisor_id". This can then be referenced by UI, which
will display the associated hypervisor.

To test you will need to register a VDC subscription and a
hypervisor running virt-who w/ guests.