### PR TITLE
Fixes #21681 - CV Docker Filters selects correctly

### DIFF
--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -253,15 +253,8 @@ module Katello
       end
     end
 
-    def docker_tags
-      archived_repos.docker_type.flat_map(&:docker_tags)
-    end
-
     def docker_tag_count
-      tag_counts = repositories.archived.docker_type.map do |repo|
-        repo.docker_tags.count
-      end
-      tag_counts.sum
+      ::Katello::DockerMetaTag.where(:repository_id => repositories.archived.docker_type).count
     end
 
     def errata(errata_type = nil)

--- a/test/factories/docker_tag_factory.rb
+++ b/test/factories/docker_tag_factory.rb
@@ -13,6 +13,10 @@ FactoryBot.define do
     name "latest"
   end
 
+  trait :with_uuid do
+    uuid { SecureRandom.hex }
+  end
+
   trait :with_manifest_list do
     association :docker_taggable, :factory => :docker_manifest_list
   end

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -401,7 +401,7 @@ redis:
 
 busybox:
   name:                 busybox
-  pulp_id:              "Default_Organization-Test-busybox"
+  pulp_id:              "Default_Organization-Test-busybox-library"
   content_id:           1
   content_type:         docker
   label:                busybox
@@ -411,6 +411,23 @@ busybox:
   gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>
   unprotected:           <%= true %>
+  url:                  'http://docker.io'
+  docker_upstream_name: 'busybox'
+
+busybox2:
+  name:                 busybox
+  pulp_id:              "Default_Organization-Test-busybox2-library"
+  content_id:           1
+  content_type:         docker
+  label:                busybox
+  relative_path:        'ACME_Corporation/library/busybox'
+  environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>
+  product_id:           <%= ActiveRecord::FixtureSet.identify(:puppet_product) %>
+  gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
+  content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>
+  unprotected:           <%= true %>
+  url:                  'http://docker.io'
+  docker_upstream_name: 'busybox'
 
 busybox_view1:
   name:                 busybox

--- a/test/lib/util/docker_manifest_clause_generator_test.rb
+++ b/test/lib/util/docker_manifest_clause_generator_test.rb
@@ -16,6 +16,10 @@ module Katello
       @man2 = katello_docker_manifests(:two)
       @man3 = katello_docker_manifests(:three)
 
+      @tag1.update_attributes!(:uuid => "100011")
+      @tag2.update_attributes!(:uuid => "100012")
+      @tag3.update_attributes!(:uuid => "100013")
+
       @repo.docker_tags = [@tag1, @tag2, @tag3]
       @repo.docker_manifests = [@man1, @man2, @man3]
       @man1.docker_tags = [@tag1]
@@ -36,11 +40,11 @@ module Katello
       rule2 = FactoryBot.create(:katello_content_view_docker_filter_rule, :filter => @filter, :name => @tag2.name)
 
       clause_gen = setup_whitelist_filter([rule1, rule2])
-      expected = {"$or" => [{"name" => {"$in" => [@tag1.name, @tag2.name]}}]}
+      expected = {"$or" => [{"_id" => {"$in" => [@tag1.uuid, @tag2.uuid]}}]}
       assert_equal expected, clause_gen.copy_clause
       assert_nil clause_gen.remove_clause
 
-      blacklist_expected = {"$or" => [{"name" => {"$in" => [@tag1.name, @tag2.name]}}]}
+      blacklist_expected = {"$or" => [{"_id" => {"$in" => [@tag1.uuid, @tag2.uuid]}}]}
       clause_gen = setup_blacklist_filter([rule1, rule2])
       expected = {"$and" => [INCLUDE_ALL_TAGS, {"$nor" => [blacklist_expected]}]}
       assert_equal expected, clause_gen.copy_clause

--- a/test/models/content_view_docker_filter_test.rb
+++ b/test/models/content_view_docker_filter_test.rb
@@ -1,0 +1,97 @@
+require 'katello_test_helper'
+
+module Katello
+  class ContentViewDockerFilterTest < ActiveSupport::TestCase
+    def setup
+      User.current = User.find(users(:admin).id)
+      @rule = FactoryBot.build(:katello_content_view_docker_filter_rule)
+    end
+
+    def test_repo_clause
+      repo = Repository.find(katello_repositories(:busybox).id)
+      schema2 = create(:docker_tag, :with_uuid, :repository => repo, :name => "latest")
+      schema1 = create(:docker_tag, :with_uuid, :schema1, :repository => repo, :name => "latest")
+
+      repo.docker_tags << schema2
+      repo.docker_tags << schema1
+      repo.docker_manifests << schema1.docker_manifest
+      repo.docker_manifests << schema2.docker_manifest
+
+      repo.save!
+      DockerMetaTag.import_meta_tags([repo])
+
+      @rule.name = "latest"
+      @rule.save!
+
+      filter = FactoryBot.build(:katello_content_view_docker_filter, :docker_rules => [@rule])
+      clauses = filter.generate_clauses(repo)
+      refute_empty clauses
+      refute_empty clauses["_id"]
+      refute_empty clauses["_id"]["$in"]
+      assert_equal 2, clauses["_id"]["$in"].size
+      assert_includes clauses["_id"]["$in"], schema1.uuid
+      assert_includes clauses["_id"]["$in"], schema2.uuid
+    end
+
+    # rubocop:disable MethodLength
+    def test_repo_intersection_clause
+      #create repo1 with tag goo
+      repo1 = Repository.find(katello_repositories(:busybox).id)
+      schema1_repo1 = create(:docker_tag, :with_uuid, :repository => repo1, :name => "latest")
+      schema2_repo1 = create(:docker_tag, :with_uuid, :schema1, :repository => repo1, :name => "latest")
+
+      # Create a docker tag goo that points to the same manifest as schema1_repo1
+      # i.e. both latest and goo point ot the same manifest
+      schema_goo_repo1 = create(:docker_tag, :with_uuid, :repository => repo1, :name => "goo")
+      schema_goo_repo1.docker_taggable = schema1_repo1.docker_manifest
+      schema_goo_repo1.save!
+
+      repo1.docker_tags << schema2_repo1
+      repo1.docker_tags << schema1_repo1
+      repo1.docker_tags << schema_goo_repo1
+
+      repo1.docker_manifests << schema1_repo1.docker_manifest
+      repo1.docker_manifests << schema2_repo1.docker_manifest
+      repo1.save!
+
+      DockerMetaTag.import_meta_tags([repo1])
+
+      # now setup repo2
+      # same manifests
+      # but different tagW as in No goo
+      repo2 = Repository.find(katello_repositories(:busybox2).id)
+      schema1_repo2 = create(:docker_tag, :with_uuid, :repository => repo1, :name => "latest")
+      schema2_repo2 = create(:docker_tag, :with_uuid, :schema1, :repository => repo1, :name => "latest")
+
+      schema1_repo2.docker_taggable = schema1_repo1.docker_manifest
+      schema2_repo2.docker_taggable = schema2_repo1.docker_manifest
+      schema1_repo2.save!
+      schema2_repo2.save!
+
+      repo2.docker_tags << schema1_repo2
+      repo2.docker_tags << schema2_repo2
+
+      repo2.docker_manifests << schema1_repo2.docker_manifest
+      repo2.docker_manifests << schema2_repo2.docker_manifest
+      repo2.save!
+      DockerMetaTag.import_meta_tags([repo2])
+
+      # search for goo in repo1
+      # should be a success
+      @rule.name = "goo"
+      @rule.save!
+
+      filter = FactoryBot.build(:katello_content_view_docker_filter, :docker_rules => [@rule])
+      clauses = filter.generate_clauses(repo1)
+
+      refute_empty clauses
+      assert_equal 2, clauses["_id"]["$in"].size
+      assert_includes clauses["_id"]["$in"], schema_goo_repo1.uuid
+      assert_includes clauses["_id"]["$in"], schema1_repo1.uuid
+
+      # now search for goo in repo2
+      # it should be nil
+      assert_nil filter.generate_clauses(repo2)
+    end
+  end
+end

--- a/test/models/content_view_version_test.rb
+++ b/test/models/content_view_version_test.rb
@@ -90,6 +90,7 @@ module Katello
         manifest_count += repo.docker_manifests.count
         tag_count += repo.docker_tags.count
       end
+      DockerMetaTag.import_meta_tags(cvv.repositories.archived.docker_type)
 
       assert cvv.repositories.archived.docker_type.count > 0
       assert_equal manifest_count, cvv.docker_manifest_count


### PR DESCRIPTION
Consider Content View with a Docker repo and Docker Tag filter that says
filter by Tag "goo". And assume that the same Manifest exists in 2
separate repositories Repo1 and Repo2 where
Repo1 =>Manifest1=>Tags [latest, goo] and
Repo2 =>Manifest1=> Tags[latest]
Now suppose the ContentView had Repo2 along with the Tag Filter to
include manifests with the name 'goo' and wanted to publish it. Our
filter should copy no Tags because there is nothing called 'goo' in
repo2.
Before this commit however this code would include goo in its clause
because of a faulty query.
This commit fixes that by improving the query to include tags in the
repository belonging to the manifest first.

This commit also fixes a "docker tag counts" issue in the content view version so
that tags with the same name for schema1 and 2 are not double counted.

Finally it removes an unused method in the content view version also
related to docker_tags