### PR TITLE
Fixes #21659 - Act key subscriptions search

### DIFF
--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -145,8 +145,9 @@ module Katello
     end
 
     def self.find_by_subscription_id(_key, operator, value)
-      conditions = sanitize_sql_for_conditions(["#{Katello::Subscription.table_name}.id #{operator} ?", value_to_sql(operator, value)])
-      activation_keys = ::Katello::ActivationKey.joins(pools: :subscription).where(conditions)
+      # What we refer to as "subscriptions" is really Pools, so we search based on Pool id.
+      conditions = sanitize_sql_for_conditions(["#{Katello::Pool.table_name}.id #{operator} ?", value_to_sql(operator, value)])
+      activation_keys = ::Katello::ActivationKey.joins(:pools).where(conditions)
       return_activation_keys_by_id(activation_keys.pluck(:id))
     end
 

--- a/test/models/activation_key_test.rb
+++ b/test/models/activation_key_test.rb
@@ -7,6 +7,7 @@ module Katello
       @dev_staging_view_key = katello_activation_keys(:library_dev_staging_view_key)
       @dev_view = katello_content_views(:library_dev_view)
       @lib_view = katello_content_views(:library_view)
+      @pool_one = katello_pools(:pool_one)
     end
 
     test "can have content view" do
@@ -105,6 +106,16 @@ module Katello
     def test_search_description
       activation_keys = ActivationKey.search_for("description = \"#{@dev_staging_view_key.description}\"")
       assert_includes activation_keys, @dev_staging_view_key
+    end
+
+    def test_search_subscription_id
+      activation_keys = ActivationKey.search_for("subscription_id = \"#{@pool_one.id}\"")
+      assert_includes activation_keys, @dev_key
+    end
+
+    def test_search_subscription_name
+      activation_keys = ActivationKey.search_for("subscription_name = \"#{@pool_one.subscription.name}\"")
+      assert_includes activation_keys, @dev_key
     end
 
     def test_valid_content_override_label?


### PR DESCRIPTION
We refer to pools as subscriptions, so the
subscription_id search should really be searching
pools.

To test this attach a sub to an activation key,
go to that sub's details and click on the number
next to "Activation Keys" in the Associations
box.