### PR TITLE
Fixes #21593 - CV Puppet Env handles mirror on syc

### DIFF
--- a/app/models/katello/content_view_puppet_environment.rb
+++ b/app/models/katello/content_view_puppet_environment.rb
@@ -38,6 +38,10 @@ module Katello
       false
     end
 
+    def mirror_on_sync?
+      true
+    end
+
     def node_syncable?
       environment
     end

--- a/test/models/content_view_puppet_environment_test.rb
+++ b/test/models/content_view_puppet_environment_test.rb
@@ -53,6 +53,17 @@ module Katello
       @puppet_env.save!
       assert @puppet_env.pulp_id
     end
+
+    def test_puppet_importer_values_for_mirror_on_sync
+      assert_equal true, @puppet_env.mirror_on_sync?
+      capsule = OpenStruct.new(:default_capsule? => true)
+      @puppet_env.expects(:mirror_on_sync?).returns(true)
+      @puppet_env.expects(:importer_ssl_options).returns({}).at_least_once
+
+      assert_equal true, @puppet_env.generate_importer(capsule).remove_missing
+      other_capsule = OpenStruct.new(:default_capsule? => false)
+      assert_equal true, @puppet_env.generate_importer(other_capsule).remove_missing
+    end
   end
 
   class ContentViewPuppetEnvironmentPulpIdTest < ActiveSupport::TestCase


### PR DESCRIPTION
A prior commit 4ba82967fe4efe2e60c4fe7dc82e02f7f6f90cca added mirror on
sync options for puppet repo but did not handle the case of
ContentViewPuppetEnvironment. This commit remedies that issue by making
CVPE always choose mirror on sync to be true (since it would always want
mirror what is in the master repo)