### PR TITLE
Fixes #21692 - DockerTag Info shows Manifest Type

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/docker-tag-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/docker-tag-details.controller.js
@@ -7,13 +7,14 @@
  * @requires DockerTag
  * @requires CurrentOrganization
  * @requires ApiErrorHandler
+ * @requires translate
  *
  * @description
  *   Provides the functionality for the docker tags details action pane.
  */
 angular.module('Bastion.docker-tags').controller('DockerTagDetailsController',
-    ['$scope', '$location', 'DockerTag', 'CurrentOrganization', 'ApiErrorHandler',
-    function ($scope, $location, DockerTag, CurrentOrganization, ApiErrorHandler) {
+    ['$scope', '$location', 'DockerTag', 'CurrentOrganization', 'ApiErrorHandler', 'translate',
+    function ($scope, $location, DockerTag, CurrentOrganization, ApiErrorHandler, translate) {
         $scope.panel = {
             error: false,
             loading: true
@@ -23,11 +24,24 @@ angular.module('Bastion.docker-tags').controller('DockerTagDetailsController',
             $scope.panel.loading = false;
         }
 
-        $scope.tag = DockerTag.get({id: $scope.$stateParams.tagId}, function () {
+        $scope.tag = DockerTag.get({id: $scope.$stateParams.tagId}, function (data) {
+            if (data.manifest_schema1) {
+                data.manifest_schema1["manifest_type_display"] = $scope.getManifestDisplayType(data.manifest_schema1);
+            }
+            if (data.manifest_schema2) {
+                data.manifest_schema2["manifest_type_display"] = $scope.getManifestDisplayType(data.manifest_schema2);
+            }
             $scope.panel.loading = false;
         }, function (response) {
             $scope.panel.loading = false;
             ApiErrorHandler.handleGETRequestErrors(response, $scope);
         });
+
+        $scope.getManifestDisplayType = function (schema) {
+            if (schema['manifest_type'] === 'image') {
+                return translate("Image");
+            }
+            return translate("List");
+        };
     }
 ]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/docker-tag-environments.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/docker-tag-environments.controller.js
@@ -6,14 +6,13 @@
  * @requires $location
  * @requires DockerTag
  * @requires CurrentOrganization
- * @requires translate
  *
  * @description
  *   Provides the functionality for the docker tags details environments list.
  */
 angular.module('Bastion.docker-tags').controller('DockerTagEnvironmentsController',
-    ['$scope', '$location', 'Nutupane', 'DockerTag', 'CurrentOrganization', 'translate',
-    function ($scope, $location, Nutupane, DockerTag, CurrentOrganization, translate) {
+    ['$scope', '$location', 'Nutupane', 'DockerTag', 'CurrentOrganization',
+    function ($scope, $location, Nutupane, DockerTag, CurrentOrganization) {
         var params = {
             'organization_id': CurrentOrganization,
             'search': $location.search().search || "",
@@ -52,13 +51,5 @@ angular.module('Bastion.docker-tags').controller('DockerTagEnvironmentsControlle
         } else {
             $scope.tag.$promise.then(renderTable);
         }
-
-        $scope.getManifestType = function (schema) {
-            if (schema['manifest_type'] === 'image') {
-                return translate("Image");
-            }
-            return translate("List");
-        };
-
     }
 ]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/views/docker-tag-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/docker-tags/details/views/docker-tag-info.html
@@ -21,13 +21,13 @@
 
   <div data-block="right-column">
     <h4 translate>Docker Manifest</h4>
-    <div ng-if="!_.isEmpty(tag.manifest_schema1)">
+    <div ng-if="tag.manifest_schema1">
       <h5 translate>Schema Version 1</h5>
       <dl class="dl-horizontal dl-horizontal-left">
 
         <dt translate>Manifest Type</dt>
         <dd>
-          {{ getManifestType(tag.manifest_schema1) }}
+          {{ tag.manifest_schema1.manifest_type_display }}
         </dd>
         <dt translate>Digest</dt>
         <dd>
@@ -35,12 +35,12 @@
         </dd>
       </dl>
     </div>
-    <div ng-if="!_.isEmpty(tag.manifest_schema2)">
+    <div ng-if="tag.manifest_schema2">
       <h5 translate>Schema Version 2</h5>
       <dl class="dl-horizontal dl-horizontal-left">
         <dt translate>Manifest Type</dt>
         <dd>
-          {{ getManifestType(tag.manifest_schema2) }}
+          {{ tag.manifest_schema2.manifest_type_display }}
         </dd>
         <dt translate>Digest</dt>
         <dd>


### PR DESCRIPTION
Commit 1fc82810ba25036abae9d7d2ce0caf5eb3b81956 introduced a minor error
in the DockerTag info screen. The Manifest Type (List/Image) were not
getting displayed and the logic that said 'do not show schema version
information if its not present' wasn't getting handled correctly. This
commit fixes that issue.