### PR TITLE
Fixes #21709 - Require bastion >= 6.1.2

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |gem|
 
   # UI
   gem.add_dependency "deface", '>= 1.0.2', '< 2.0.0'
-  gem.add_dependency "bastion", ">= 6.0.0", "< 7.0.0"
+  gem.add_dependency "bastion", ">= 6.1.2", "< 7.0.0"
 
   # Testing
   gem.add_development_dependency "factory_bot_rails", "~> 4.5"


### PR DESCRIPTION
cac97fdf63d7299f9aaba0091d3059e775fb5e26 removes markActiveMenu which is incompatible with Foremans vertical navigation.