### PR TITLE
Fixes #21307 - Pre-made role for registering hosts

### DIFF
--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -272,4 +272,14 @@ Foreman::Plugin.register :katello do
 
   Katello::PermissionCreator.new(self).define
   add_all_permissions_to_default_roles
+
+  role 'Register hosts', [
+    :view_hostgroups, :view_activation_keys, :view_hosts,
+    :create_hosts, :edit_hosts, :destroy_hosts,
+    :view_content_views, :view_gpg_keys, :view_subscriptions,
+    :attach_subscriptions, :view_host_collections,
+    :view_organizations, :view_lifecycle_environments, :view_products,
+    :view_locations, :view_domains, :view_architectures,
+    :view_operatingsystems
+  ]
 end


### PR DESCRIPTION
Because bootstrap.py requires a login and password in clear text, I
decided to create an unprivileged role to which I could assign
that user. If Katello provides it, it will save time as non-admin
users  are meant to create this to register hosts.