### PR TITLE
Fixes #21051: warn on unregistering of host if delete enabled.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
@@ -10,13 +10,14 @@
  * @requires CurrentOrganization
  * @requires MenuExpander
  * @requires ApiErrorHandler
+ * @requires deleteHostOnUnregister
  *
  * @description
  *   Provides the functionality for the content host details action pane.
  */
 angular.module('Bastion.content-hosts').controller('ContentHostDetailsController',
-    ['$scope', '$state', '$q', 'translate', 'Host', 'HostSubscription', 'Organization', 'CurrentOrganization', 'Notification', 'MenuExpander', 'ApiErrorHandler',
-    function ($scope, $state, $q, translate, Host, HostSubscription, Organization, CurrentOrganization, Notification, MenuExpander, ApiErrorHandler) {
+    ['$scope', '$state', '$q', 'translate', 'Host', 'HostSubscription', 'Organization', 'CurrentOrganization', 'Notification', 'MenuExpander', 'ApiErrorHandler', 'deleteHostOnUnregister',
+    function ($scope, $state, $q, translate, Host, HostSubscription, Organization, CurrentOrganization, Notification, MenuExpander, ApiErrorHandler, deleteHostOnUnregister) {
         $scope.menuExpander = MenuExpander;
 
         $scope.panel = {
@@ -25,7 +26,8 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsController
         };
 
         $scope.host = Host.get({id: $scope.$stateParams.hostId}, function (host) {
-            host.unregisterDelete = !host.hasSubscription(); //default to delete if no subscription
+            host.unregisterDelete = !host.hasSubscription() || deleteHostOnUnregister;
+            host.deleteHostOnUnregister = deleteHostOnUnregister;
             $scope.panel.loading = false;
         }, function (response) {
             $scope.panel.loading = false;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-details.html
@@ -22,22 +22,30 @@
           Unregister Options:
         </p>
 
-        <p ng-show="host.hasSubscription()">
+        <p class="alert alert-warning" ng-show="host.deleteHostOnUnregister" translate>
+          This operation may also remove managed resources linked to the host such as virtual machines and DNS records.
+          Change the setting "Delete Host upon Unregister" to false on the <a href="/settings">settings page</a> to prevent this.
+        </p>
+
+        <p ng-show="host.hasSubscription()" class="radio" ng-class="{disabled: host.deleteHostOnUnregister}">
           <label>
-            <input name="delete"
+            <input name="unregister"
+                   ng-disabled="host.deleteHostOnUnregister"
                    ng-model="host.unregisterDelete"
                    ng-value="false"
                    type="radio" />
-            Unregister the host as a subscription consumer.  Provisioning and configuration information is preserved.
+            <span translate>Unregister the host as a subscription consumer.  Provisioning and configuration information is preserved.</span>
+            <span class="help-block" ng-show="host.deleteHostOnUnregister">This option is disabled because the setting "Delete Host upon unregister" is set.</span>
           </label>
         </p>
-        <p>
+
+        <p class="radio">
           <label>
             <input name="delete"
                    ng-model="host.unregisterDelete"
                    ng-value="true"
                    type="radio" />
-            Completely deletes the host record and removes all reporting, provisioning, and configuration information.
+            <span translate>Completely deletes the host record and removes all reporting, provisioning, and configuration information.</span>
           </label>
         </p>
       </div>


### PR DESCRIPTION
If the setting 'unregister_delete_host' is set then we should warn users
upon unregistering a host and selecting 'delete host record' that the
action could remove the VM.

http://projects.theforeman.org/issues/21051