### PR TITLE
Fixes #21788:  fix repository package links.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filter-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filter-repositories.html
@@ -94,7 +94,7 @@
             </td>
             <td bst-table-cell>
               <div ng-if="repository.content_counts.rpm && repository.content_counts.rpm > 0">
-                <a ui-sref="products.repository.manage-content.packages({productId: repository.product.id, repositoryId: repository.id})"
+                <a ui-sref="product.repository.manage-content.packages({productId: repository.product.id, repositoryId: repository.id})"
                    ng-show="repository.content_type == 'yum'"
                    translate>
                   {{ repository.content_counts.rpm }} Packages

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-repositories.html
@@ -86,7 +86,7 @@
         </td>
         <td bst-table-cell>
           <div>
-            <a ui-sref="products.repository.manage-content.packages({productId: repository.product.id, repositoryId: repository.id})"
+            <a ui-sref="product.repository.manage-content.packages({productId: repository.product.id, repositoryId: repository.id})"
                ng-show="repository.content_type == 'yum'"
                translate>
               {{ repository.content_counts.rpm }} Packages

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/views/content-view-version-yum.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/views/content-view-version-yum.html
@@ -14,7 +14,7 @@
         <td bst-table-cell>{{ repository.product.name }}</td>
         <td bst-table-cell>
           <div>
-            <a ui-sref="products.repository.manage-content.packages({productId: repository.product.id, repositoryId: repository.id})" translate>
+            <a ui-sref="product.repository.manage-content.packages({productId: repository.product.id, repositoryId: repository.id})" translate>
               {{ repository.content_counts.rpm }} Packages
             </a>
           </div>


### PR DESCRIPTION
The product repository links were incorrectly changed after the
switch to nutupane.  This commit fixes the generation of the links.

http://projects.theforeman.org/issues/21788