### PR TITLE
Fixes #21794 - use view_hosts for rex actions

### DIFF
--- a/lib/katello/permissions/host_permissions.rb
+++ b/lib/katello/permissions/host_permissions.rb
@@ -29,9 +29,7 @@ Foreman::AccessControl.permission(:edit_hosts).actions.concat [
   'katello/api/rhsm/candlepin_proxies/regenerate_identity_certificates',
   'katello/api/rhsm/candlepin_proxies/hypervisors_update',
   'katello/api/rhsm/candlepin_proxies/async_hypervisors_update',
-  'katello/api/rhsm/candlepin_proxies/upload_tracer_profile',
-  'katello/remote_execution/new',
-  'katello/remote_execution/create'
+  'katello/api/rhsm/candlepin_proxies/upload_tracer_profile'
 ]
 
 Foreman::AccessControl.permission(:view_hosts).actions.concat [
@@ -48,7 +46,9 @@ Foreman::AccessControl.permission(:view_hosts).actions.concat [
   'katello/api/v2/hosts_bulk_actions/installable_errata',
   'katello/api/v2/hosts_bulk_actions/available_incremental_updates',
   'katello/api/v2/host_packages/index',
-  'katello/api/v2/host_tracer/index'
+  'katello/api/v2/host_tracer/index',
+  'katello/remote_execution/new',
+  'katello/remote_execution/create'
 ]
 
 Foreman::AccessControl.permission(:destroy_hosts).actions.concat [


### PR DESCRIPTION
The Remote Execution User needs just view_hosts (side by side to
execute_job_invocation) permission and there is no reason at all
to use edit_hosts permission for this purposes in Katello.

This way, the `Remote Execution User` role will work correctly
for Katello use-cases as well, which was not the case, when using
`edit_hosts` permission.