### PR TITLE
Fixes #21696,#21695 - speed up composite cv publish

### DIFF
--- a/app/lib/actions/katello/repository/metadata_generate.rb
+++ b/app/lib/actions/katello/repository/metadata_generate.rb
@@ -4,12 +4,10 @@ module Actions
       class MetadataGenerate < Actions::Base
         def plan(repository, options = {})
           dependency = options.fetch(:dependency, nil)
-          source_repository = options.fetch(:source_repository, nil)
           force = options.fetch(:force, false)
+          source_repository = options.fetch(:source_repository, nil)
 
-          if source_repository.nil? && repository.yum? && repository.requires_yum_clone_distributor?
-            source_repository = repository.archived_instance
-          end
+          source_repository ||= repository.target_repository if repository.link?
 
           distributors(repository, source_repository).each do |distributor|
             plan_action(Pulp::Repository::DistributorPublish,

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -284,10 +284,18 @@ module Katello
       # is the library instance id, and the value is an array
       # of the repositories for that instance.
       repositories_to_publish.inject({}) do |result, repo|
-        result[repo.library_instance_id] ||= []
-        result[repo.library_instance_id] << repo
+        result[repo.library_instance] ||= []
+        result[repo.library_instance] << repo
         result
       end
+    end
+
+    def duplicate_repositories_to_publish
+      repositories_to_publish_by_library_instance.select { |_key, val| val.count > 1 }.keys
+    end
+
+    def components_with_repo(library_instance)
+      components.select { |component| component.repositories.where(:library_instance => library_instance).any? }
     end
 
     def publish_repositories

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -132,7 +132,7 @@ module Katello
 
     scope :has_url, -> { where('url IS NOT NULL') }
     scope :in_default_view, -> { joins(:content_view_version => :content_view).where("#{Katello::ContentView.table_name}.default" => true) }
-
+    scope :in_non_default_view, -> { joins(:content_view_version => :content_view).where("#{Katello::ContentView.table_name}.default" => false) }
     scope :yum_type, -> { where(:content_type => YUM_TYPE) }
     scope :file_type, -> { where(:content_type => FILE_TYPE) }
     scope :puppet_type, -> { where(:content_type => PUPPET_TYPE) }
@@ -678,6 +678,52 @@ module Katello
 
     def docker_meta_tag_count
       DockerMetaTag.in_repositories(self.id).count
+    end
+
+    # a master repository actually has content (rpms, errata, etc) in the pulp repository.  For these repositories, we can use the YumDistributor
+    # to generate metadata and can index the content from pulp, or for the case of content view archives without filters, can also use the YumCloneDistributor
+    #
+    def master?
+      !self.yum? || # non-yum repos
+          self.in_default_view? || # default content view repos
+          (self.archive? && !self.content_view.composite) || # non-composite content view archive repos
+          (self.content_view.composite? && self.component_source_repositories.count > 1) # composite archive repo with more than 1 source repository
+    end
+
+    # a link repository has no content in the pulp repository and serves as a shell.  It will always be empty.  Only the YumCloneDistributor can be used
+    # to publish yum metadata, and it cannot be indexed from pulp, but must have its indexed associations copied from another repository (its target).
+    def link?
+      !master?
+    end
+
+    # A link (empty repo) points to a target (a repository that actually has units in pulp).  Target repos are always archive repos of a content view version (a repo with no environment)
+    # But for composite view versions, an archive repo, usually won't be a master (but might be if multple components contain the same repo)
+    def target_repository
+      fail _("This is not a linked repository") if master?
+      return nil if self.archived_instance.nil?
+
+      #this is an environment repo, and the archived_instance is a master (not always true with composite)
+      if self.environment_id? && self.archived_instance.master?
+        self.archived_instance
+      elsif self.environment_id #this is an environment repo, but a composite who's archived_instance isn't a master
+        self.archived_instance.target_repository || self.archived_instance #to archived_instance if nil
+      else #must be a composite archive repo, with only one component repo
+        self.component_source_repositories.first
+      end
+    end
+
+    def component_source_repositories
+      #find other copies of this repositories, in the CV version's components, that are in the 'archive'
+      Katello::Repository.where(:content_view_version_id => self.content_view_version.components, :environment_id => nil,
+                                :library_instance_id => self.library_instance_id)
+    end
+
+    def self.linked_repositories
+      to_return = []
+      Katello::Repository.yum_type.in_non_default_view.find_each do |repo|
+        to_return << repo if repo.link?
+      end
+      to_return
     end
 
     protected

--- a/app/models/katello/rpm.rb
+++ b/app/models/katello/rpm.rb
@@ -95,11 +95,5 @@ module Katello
       self.joins(:content_facets).
         where("#{Katello::Host::ContentFacet.table_name}.host_id" => hosts).uniq
     end
-
-    def self.import_additional_content
-      Katello::Repository.in_published_environments.yum_type.find_each do |repo|
-        repo.index_content
-      end
-    end
   end
 end

--- a/app/views/katello/api/v2/content_views/show.json.rabl
+++ b/app/views/katello/api/v2/content_views/show.json.rabl
@@ -3,3 +3,15 @@ object @resource
 extends "katello/api/v2/content_views/base"
 
 attributes :content_host_count
+
+child :duplicate_repositories_to_publish => :duplicate_repositories_to_publish do
+  attributes :id, :name
+  node :components do |repo|
+    @resource.components_with_repo(repo).map do |component|
+      {
+        :content_view_name => component.content_view.name,
+        :content_view_version => component.version
+      }
+    end
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-details.controller.js
@@ -30,13 +30,6 @@ angular.module('Bastion.content-views').controller('ContentViewDetailsController
             loading: true
         };
 
-        $scope.contentView = ContentView.get({id: $scope.$stateParams.contentViewId}, function () {
-            $scope.panel.loading = false;
-        }, function (response) {
-            $scope.panel.loading = false;
-            ApiErrorHandler.handleGETRequestErrors(response, $scope);
-        });
-
         $scope.taskTypes = {
             publish: "Actions::Katello::ContentView::Publish",
             promotion: "Actions::Katello::ContentView::Promote",
@@ -55,6 +48,15 @@ angular.module('Bastion.content-views').controller('ContentViewDetailsController
 
         $scope.save = function (contentView) {
             return contentView.$update($scope.saveSuccess, $scope.saveError);
+        };
+
+        $scope.fetchContentView = function () {
+            $scope.contentView = ContentView.get({id: $scope.$stateParams.contentViewId}, function () {
+                $scope.panel.loading = false;
+            }, function (response) {
+                $scope.panel.loading = false;
+                ApiErrorHandler.handleGETRequestErrors(response, $scope);
+            });
         };
 
         $scope.getAvailableVersions = function (paramContentView) {
@@ -78,5 +80,7 @@ angular.module('Bastion.content-views').controller('ContentViewDetailsController
             }
             return latest.concat(paramContentView.versions.reverse());
         };
+
+        $scope.fetchContentView();
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-publish.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-publish.controller.js
@@ -40,5 +40,8 @@ angular.module('Bastion.content-views').controller('ContentViewPublishController
             ContentView.publish(data, success, failure);
         };
 
+        //Refetch the content view so that the contentView is updated for latest components
+        $scope.fetchContentView();
+
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-publish.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-publish.html
@@ -13,8 +13,19 @@
 
 <div class="row">
   <div class="col-sm-5">
-    <form name="versionForm" role="form" novalidate>
+    <div bst-alert="info" ng-show="contentView.duplicate_repositories_to_publish.length > 0">
+      You have selected more than one component Content View Version with the same repository resulting in slower publishing:
+      <ul>
+        <li ng-repeat="repository in contentView.duplicate_repositories_to_publish">
+          {{ repository.name }}
+          <ul>
+            <li ng-repeat="content_view in repository.components" >{{ content_view.content_view_name }} {{ content_view.content_view_version}}</li>
+          </ul>
+        </li>
+      </ul>
+    </div>
 
+    <form name="versionForm" role="form" novalidate>
       <div bst-form-group label="{{ 'Version' | translate }}">
         <span>{{ contentView['next_version'] }}</span>
       </div>

--- a/engines/bastion_katello/test/content-views/details/content-view-publish.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/content-view-publish.controller.test.js
@@ -15,6 +15,7 @@ describe('Controller: ContentViewPublishController', function() {
         $scope.contentView = ContentView.get({id: 1});
         $scope.contentView.versions = [];
         $scope.$stateParams = {contentViewId: 1};
+        $scope.fetchContentView = function() {};
 
         spyOn($scope, 'transitionTo');
         spyOn($scope, 'reloadVersions');

--- a/lib/katello/tasks/reimport.rake
+++ b/lib/katello/tasks/reimport.rake
@@ -41,5 +41,8 @@ namespace :katello do
     Katello::ActivationKey.all.each do |ack_key|
       ack_key.import_pools
     end
+
+    print "Importing Linked Repositories"
+    Katello::Repository.linked_repositories.each(&:index_content)
   end
 end

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -502,6 +502,21 @@ module ::Actions::Katello::Repository
                                 :id => "8")
     end
 
+    it 'plans with unit copy if needed' do
+      # required for export pre-run validation to succeed
+      Setting['pulp_export_destination'] = '/tmp'
+
+      action.stubs(:action_subject)
+      repository.stubs(:link?).returns(true)
+      repository.stubs(:target_repository).returns(custom_repository)
+
+      plan_action(action, [repository], false, nil, 0, "8")
+      assert_action_planed_with(action, ::Actions::Katello::Repository::Clear,
+                                repository)
+      assert_action_planed_with(action, ::Actions::Katello::Repository::CloneYumContent, custom_repository, repository, [], false,
+                                    :generate_metadata => false, :index_content => false)
+    end
+
     it 'plans without export destination' do
       action.stubs(:action_subject)
 

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -282,7 +282,7 @@ dev_p_forge:
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_view_version_2) %>
 
 rhel_6_x86_64_library_view_1:
-  name:                 RHEL 6 x86_64
+  name:                 RHEL 6 x86_64 library view 1
   pulp_id:              8_view1
   content_id:           1
   major:                6
@@ -293,6 +293,22 @@ rhel_6_x86_64_library_view_1:
   environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>
   product_id:           <%= ActiveRecord::FixtureSet.identify(:redhat) %>
   gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
+  library_instance_id:  <%= ActiveRecord::FixtureSet.identify(:rhel_6_x86_64) %>
+  content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_view_version_1) %>
+  download_policy: on_demand
+
+rhel_6_x86_64_library_view_1_archive:
+  name:                 RHEL 6 x86_64 library view 1 archive
+  pulp_id:              8_view1_archive
+  content_id:           1
+  major:                6
+  minor:                6Server
+  content_type:         yum
+  label:                rhel_6_x86_64_label
+  relative_path:        'ACME_Corporation/library/rhel_6_label'
+  product_id:           <%= ActiveRecord::FixtureSet.identify(:redhat) %>
+  gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
+  library_instance_id:  <%= ActiveRecord::FixtureSet.identify(:rhel_6_x86_64) %>
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_view_version_1) %>
   download_policy: on_demand
 
@@ -371,7 +387,7 @@ srpm_repo:
   relative_path:        'ACME_Corporation/library/LibraryView/source_rpm'
   environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>
   product_id:           <%= ActiveRecord::FixtureSet.identify(:puppet_product) %>
-  content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_view_version_1) %>
+  content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>
   download_policy: on_demand
 
 
@@ -482,6 +498,23 @@ rhel_6_x86_64_composite_view_version_1:
   environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>
   product_id:           <%= ActiveRecord::FixtureSet.identify(:redhat) %>
   gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
+  library_instance_id:  <%= ActiveRecord::FixtureSet.identify(:rhel_6_x86_64) %>
+  content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:composite_view_version_1) %>
+  download_policy: on_demand
+
+
+rhel_6_x86_64_composite_view_version_1_archive:
+  name:                 RHEL 6 x86_64
+  pulp_id:              8_composite_version1_archive
+  content_id:           69
+  major:                6
+  minor:                6Server
+  content_type:         yum
+  label:                rhel_6_x86_64_label_composite_view_version_1
+  relative_path:        'ACME_Corporation/library/composite/rhel_6_label'
+  product_id:           <%= ActiveRecord::FixtureSet.identify(:redhat) %>
+  gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
+  library_instance_id:  <%= ActiveRecord::FixtureSet.identify(:rhel_6_x86_64) %>
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:composite_view_version_1) %>
   download_policy: on_demand
 

--- a/test/glue/pulp/repository_test.rb
+++ b/test/glue/pulp/repository_test.rb
@@ -63,6 +63,22 @@ module Katello
       @new_error_task = {'finish_time' => '2017-06-20T14:52:17Z', 'error' => 'bad_error' }
     end
 
+    def test_index_linked_repo
+      archive = @fedora_17_x86_64_dev.archived_instance
+
+      archive.rpms = [katello_rpms(:one)]
+      archive.errata = [katello_errata(:security)]
+      archive.package_groups = [katello_package_groups(:server_pg)]
+      archive.distribution_variant = 'varied variant'
+      archive.save
+      @fedora_17_x86_64_dev.index_linked_repo
+
+      assert_equal archive.rpms, @fedora_17_x86_64_dev.rpms
+      assert_equal archive.errata, @fedora_17_x86_64_dev.errata
+      assert_equal archive.package_groups, @fedora_17_x86_64_dev.package_groups
+      assert_equal archive.distribution_variant, @fedora_17_x86_64_dev.distribution_variant
+    end
+
     def test_needs_metadata_publish_true
       @fedora_17_x86_64.stubs(:last_publish_task).returns(@old_task)
       @fedora_17_x86_64.stubs(:last_sync_task).returns(@new_task)

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -226,6 +226,7 @@ module Katello
 
       assert composite.update_attributes(component_ids: [v1.id, v2.id])
       assert_equal 0, composite.errors.count # docker and yum repos
+      refute_empty composite.duplicate_repositories_to_publish
     end
 
     def test_puppet_module_conflicts

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -302,6 +302,39 @@ module Katello
       @repo.ostree_upstream_sync_depth = sync_depth
       assert_equal sync_depth, @repo.compute_ostree_upstream_sync_depth
     end
+
+    def test_master_link
+      assert @puppet_forge.master?
+
+      assert @fedora_17_x86_64.master?
+      refute @fedora_17_x86_64.link?
+
+      assert @fedora_17_x86_64_dev.link?
+      refute @fedora_17_x86_64_dev.master?
+      assert_equal @fedora_17_x86_64_dev.target_repository, katello_repositories(:fedora_17_x86_64_dev_archive)
+
+      archive = katello_repositories(:fedora_17_x86_64_dev_archive)
+      assert archive.master?
+      refute archive.link?
+    end
+
+    def test_master_link_composite
+      version = katello_content_view_versions(:composite_view_version_1)
+      version_env_repo = katello_repositories(:rhel_6_x86_64_composite_view_version_1)
+      version_archive_repo = version_env_repo.archived_instance
+
+      assert version_env_repo.link?
+      assert_equal version_archive_repo.target_repository, version_env_repo.target_repository
+
+      assert version_archive_repo.link?
+      assert_equal version_env_repo.content_view_version.components.first.repositories.where(:library_instance_id => version_env_repo.library_instance_id,
+                                                                                             :environment_id => nil).first,
+                   version_archive_repo.target_repository
+
+      #now add a 2nd component to make the archive a "master", due to 'conflicting' repos
+      version.components << katello_content_view_versions(:library_view_version_2)
+      assert version_archive_repo.master?
+    end
   end
 
   class RepositoryGeneratedIdsTest < RepositoryTestBase

--- a/test/models/rpm_test.rb
+++ b/test/models/rpm_test.rb
@@ -64,6 +64,18 @@ module Katello
     def test_build_nvre
       assert_equal "#{@rpm_one.name}-#{@rpm_one.version}-#{@rpm_one.release}.#{@rpm_one.arch}", @rpm_one.build_nvra
     end
+
+    def test_copy_repository_associations
+      repo_one = @repo
+      repo_two = katello_repositories(:fedora_17_x86_64_dev)
+
+      repo_one.rpms = [@rpm_one]
+      repo_two.rpms = [@rpm_two]
+
+      Katello::Rpm.copy_repository_associations(repo_one, repo_two)
+
+      assert_equal [@rpm_one], repo_two.reload.rpms
+    end
   end
 
   class ApplicablityTest < RpmTestBase


### PR DESCRIPTION
This enhances composite content view publish by not
actually copying units into the composite view archive
repos.  We can only do that for Library repos that are
only represented once in a component view.

It also introduces two new terms for repos, links and targets.
Links have no content within the pulp repository, but have
metadata on the filesystem for them.  Links copy metadata from
their targets, and copy indexed units from their targets.

This also adds a warning when publishing a composite view
if the composite has more than one component that includes
a particular repository, since publishing will be slower.

Exporting a composite content view version will not work in
this case since it relies on content actually being in these
repositories, so this modifies exporting to copy units over to it
if needed prior to exporting.  This will make the exporting process
somewhat slower, but it is already very slow and happens less
frequently than publishing.