### PR TITLE
Fixes #21719: fix organization selector page.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/organization-selector.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/organizations/organization-selector.controller.js
@@ -13,7 +13,8 @@
 
         $scope.selectedOrganization = {};
 
-        Organization.queryUnpaged(function (response) {
+        // TODO: per_page hack necessary because of http://projects.theforeman.org/issues/21800
+        Organization.queryUnpaged({'per_page': 99999999999}, function (response) {
             $scope.organizations = response.results;
         });
 


### PR DESCRIPTION
The organization selector page was only showing the first 20
organizations. This commit ensures that we show all organizations.

http://projects.theforeman.org/issues/21719