### PR TITLE
Fixes #21712: fix double search on CH and AK pages.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/activation-keys.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/activation-keys.routes.js
@@ -1,6 +1,6 @@
 angular.module('Bastion.activation-keys').config(['$stateProvider', function ($stateProvider) {
     $stateProvider.state('activation-keys', {
-        url: '/activation_keys?search',
+        url: '/activation_keys',
         permission: 'view_activation_keys',
         template: '<div ui-view></div>',
         views: {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.routes.js
@@ -10,7 +10,7 @@
 
 angular.module('Bastion.content-hosts').config(['$stateProvider', function ($stateProvider) {
     $stateProvider.state('content-hosts', {
-        url: '/content_hosts?search',
+        url: '/content_hosts',
         permission: 'view_hosts',
         views: {
             '@': {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/subscriptions.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/subscriptions.routes.js
@@ -60,7 +60,7 @@ angular.module('Bastion.subscriptions').config(['$stateProvider', function ($sta
         }
     })
     .state('subscription.content-hosts', {
-        url: '/content-hosts?search',
+        url: '/content-hosts',
         permission: 'view_subscriptions',
         controller: 'SubscriptionContentHostsController',
         templateUrl: 'subscriptions/details/views/subscription-content-hosts.html',


### PR DESCRIPTION
This commit fixes an issue where a search was executed
twice for pages that included an unnecessary query
string parameter for search.

http://projects.theforeman.org/issues/21712