### PR TITLE
Fixes #21811 - Add Rails 5 migrations

### DIFF
--- a/db/migrate/20131014135042_katello_tables.rb
+++ b/db/migrate/20131014135042_katello_tables.rb
@@ -1,4 +1,4 @@
-class KatelloTables < ActiveRecord::Migration
+class KatelloTables < ActiveRecord::Migration[4.2]
 
   def self.up
 

--- a/db/migrate/20131014225132_add_users_fields.rb
+++ b/db/migrate/20131014225132_add_users_fields.rb
@@ -1,4 +1,4 @@
-class AddUsersFields < ActiveRecord::Migration
+class AddUsersFields < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :helptips_enabled, :boolean, :default => true
     add_column :users, :hidden, :boolean, :default => false, :null => false

--- a/db/migrate/20131016124255_add_foreign_keys_engine.rb
+++ b/db/migrate/20131016124255_add_foreign_keys_engine.rb
@@ -1,4 +1,4 @@
-class AddForeignKeysEngine < ActiveRecord::Migration
+class AddForeignKeysEngine < ActiveRecord::Migration[4.2]
   # rubocop:disable MethodLength
   def change
     add_foreign_key "katello_activation_keys", "katello_content_views", :column => 'content_view_id', :name => "activation_keys_content_view_id_fk"

--- a/db/migrate/20131120225132_add_organization_fields.rb
+++ b/db/migrate/20131120225132_add_organization_fields.rb
@@ -1,4 +1,4 @@
-class AddOrganizationFields < ActiveRecord::Migration
+class AddOrganizationFields < ActiveRecord::Migration[4.2]
   def change
     add_column :taxonomies, :description, :text unless column_exists?(:taxonomies, :description)
     add_column :taxonomies, :label, :string, :limit => 255

--- a/db/migrate/20131216212502_add_quantity_to_katello_key_pools.rb
+++ b/db/migrate/20131216212502_add_quantity_to_katello_key_pools.rb
@@ -1,4 +1,4 @@
-class AddQuantityToKatelloKeyPools < ActiveRecord::Migration
+class AddQuantityToKatelloKeyPools < ActiveRecord::Migration[4.2]
   def change
     add_column :katello_key_pools, :quantity, :integer
   end

--- a/db/migrate/20131216212621_add_cp_id_to_katello_activation_keys.rb
+++ b/db/migrate/20131216212621_add_cp_id_to_katello_activation_keys.rb
@@ -1,4 +1,4 @@
-class AddCpIdToKatelloActivationKeys < ActiveRecord::Migration
+class AddCpIdToKatelloActivationKeys < ActiveRecord::Migration[4.2]
   def change
     add_column :katello_activation_keys, :cp_id, :string, :limit => 255
     add_column :katello_activation_keys, :label, :string, :limit => 255

--- a/db/migrate/20131218174203_drop_katello_key_pools_table.rb
+++ b/db/migrate/20131218174203_drop_katello_key_pools_table.rb
@@ -1,4 +1,4 @@
-class DropKatelloKeyPoolsTable < ActiveRecord::Migration
+class DropKatelloKeyPoolsTable < ActiveRecord::Migration[4.2]
   def up
     drop_table :katello_key_pools
   end

--- a/db/migrate/20140110000001_update_environments_add_katello_id.rb
+++ b/db/migrate/20140110000001_update_environments_add_katello_id.rb
@@ -1,4 +1,4 @@
-class UpdateEnvironmentsAddKatelloId < ActiveRecord::Migration
+class UpdateEnvironmentsAddKatelloId < ActiveRecord::Migration[4.2]
   def up
     add_column :environments, :katello_id, :string, :limit => 255
     add_index :environments, :katello_id

--- a/db/migrate/20140117160939_refactor_content_views.rb
+++ b/db/migrate/20140117160939_refactor_content_views.rb
@@ -1,4 +1,4 @@
-class RefactorContentViews < ActiveRecord::Migration
+class RefactorContentViews < ActiveRecord::Migration[4.2]
   # rubocop:disable MethodLength
   def up
     remove_foreign_key "katello_component_content_views", :name => "component_content_views_content_view_definition_id_fk"

--- a/db/migrate/20140206200439_create_content_view_puppet_modules.rb
+++ b/db/migrate/20140206200439_create_content_view_puppet_modules.rb
@@ -1,4 +1,4 @@
-class CreateContentViewPuppetModules < ActiveRecord::Migration
+class CreateContentViewPuppetModules < ActiveRecord::Migration[4.2]
   def change
     create_table :katello_content_view_puppet_modules do |t|
       t.references :content_view

--- a/db/migrate/20140212131812_create_content_view_package_filter_rules.rb
+++ b/db/migrate/20140212131812_create_content_view_package_filter_rules.rb
@@ -1,4 +1,4 @@
-class CreateContentViewPackageFilterRules < ActiveRecord::Migration
+class CreateContentViewPackageFilterRules < ActiveRecord::Migration[4.2]
   def change
     create_table :katello_content_view_package_filter_rules do |t|
       t.references :content_view_filter

--- a/db/migrate/20140212143454_create_content_view_package_group_filter_rules.rb
+++ b/db/migrate/20140212143454_create_content_view_package_group_filter_rules.rb
@@ -1,4 +1,4 @@
-class CreateContentViewPackageGroupFilterRules < ActiveRecord::Migration
+class CreateContentViewPackageGroupFilterRules < ActiveRecord::Migration[4.2]
   def change
     create_table :katello_content_view_package_group_filter_rules do |t|
       t.references :content_view_filter

--- a/db/migrate/20140212143642_create_content_view_erratum_filter_rules.rb
+++ b/db/migrate/20140212143642_create_content_view_erratum_filter_rules.rb
@@ -1,4 +1,4 @@
-class CreateContentViewErratumFilterRules < ActiveRecord::Migration
+class CreateContentViewErratumFilterRules < ActiveRecord::Migration[4.2]
   def change
     create_table :katello_content_view_erratum_filter_rules do |t|
       t.references :content_view_filter

--- a/db/migrate/20140217145303_remove_changeset.rb
+++ b/db/migrate/20140217145303_remove_changeset.rb
@@ -1,4 +1,4 @@
-class RemoveChangeset < ActiveRecord::Migration
+class RemoveChangeset < ActiveRecord::Migration[4.2]
   def up
     drop_table "katello_changeset_content_views"
     drop_table "katello_changeset_users"

--- a/db/migrate/20140217160132_create_content_view_history.rb
+++ b/db/migrate/20140217160132_create_content_view_history.rb
@@ -1,4 +1,4 @@
-class CreateContentViewHistory < ActiveRecord::Migration
+class CreateContentViewHistory < ActiveRecord::Migration[4.2]
   def up
     create_table 'katello_content_view_histories' do |t|
       t.references :katello_content_view_version, :null => false

--- a/db/migrate/20140222022712_remove_provider_discovery.rb
+++ b/db/migrate/20140222022712_remove_provider_discovery.rb
@@ -1,4 +1,4 @@
-class RemoveProviderDiscovery < ActiveRecord::Migration
+class RemoveProviderDiscovery < ActiveRecord::Migration[4.2]
   def up
     remove_foreign_key "katello_providers", :name => "providers_discovery_task_id_fk"
     remove_column :katello_providers, :discovery_url

--- a/db/migrate/20140305101813_allow_null_for_repository_content_id.rb
+++ b/db/migrate/20140305101813_allow_null_for_repository_content_id.rb
@@ -1,4 +1,4 @@
-class AllowNullForRepositoryContentId < ActiveRecord::Migration
+class AllowNullForRepositoryContentId < ActiveRecord::Migration[4.2]
   def change
     change_column :katello_repositories, :content_id, :string, null: true,
       :limit => 255

--- a/db/migrate/20140306132108_create_content_view_puppet_environments.rb
+++ b/db/migrate/20140306132108_create_content_view_puppet_environments.rb
@@ -1,4 +1,4 @@
-class CreateContentViewPuppetEnvironments < ActiveRecord::Migration
+class CreateContentViewPuppetEnvironments < ActiveRecord::Migration[4.2]
   def change
     create_table :katello_content_view_puppet_environments do |t|
       t.references :content_view_version

--- a/db/migrate/20140310102051_repository_add_checksum_type.rb
+++ b/db/migrate/20140310102051_repository_add_checksum_type.rb
@@ -1,4 +1,4 @@
-class RepositoryAddChecksumType < ActiveRecord::Migration
+class RepositoryAddChecksumType < ActiveRecord::Migration[4.2]
   def up
     add_column :katello_repositories, :checksum_type, :string, :null => true,
       :limit => 255

--- a/db/migrate/20140318174203_drop_cdn_import_success_column.rb
+++ b/db/migrate/20140318174203_drop_cdn_import_success_column.rb
@@ -1,4 +1,4 @@
-class DropCdnImportSuccessColumn < ActiveRecord::Migration
+class DropCdnImportSuccessColumn < ActiveRecord::Migration[4.2]
   def up
     remove_column :katello_products, :cdn_import_success
   end

--- a/db/migrate/20140325185413_create_content_view_foreign_keys.rb
+++ b/db/migrate/20140325185413_create_content_view_foreign_keys.rb
@@ -1,4 +1,4 @@
-class CreateContentViewForeignKeys < ActiveRecord::Migration
+class CreateContentViewForeignKeys < ActiveRecord::Migration[4.2]
   def up
     add_foreign_key :katello_content_view_environments, :katello_content_view_versions,
       :name => "katello_content_view_environments_version_fk", :column => 'content_view_version_id'

--- a/db/migrate/20140404122011_drop_repositories_enabled_column.rb
+++ b/db/migrate/20140404122011_drop_repositories_enabled_column.rb
@@ -1,4 +1,4 @@
-class DropRepositoriesEnabledColumn < ActiveRecord::Migration
+class DropRepositoriesEnabledColumn < ActiveRecord::Migration[4.2]
   def up
     remove_column :katello_repositories, :enabled
   end

--- a/db/migrate/20140411134235_update_content_view_description_type.rb
+++ b/db/migrate/20140411134235_update_content_view_description_type.rb
@@ -1,4 +1,4 @@
-class UpdateContentViewDescriptionType < ActiveRecord::Migration
+class UpdateContentViewDescriptionType < ActiveRecord::Migration[4.2]
   def up
     change_column :katello_content_views, :description, :string, :limit => 255
   end

--- a/db/migrate/20140414214152_allow_null_content_view_to_activation_key.rb
+++ b/db/migrate/20140414214152_allow_null_content_view_to_activation_key.rb
@@ -1,4 +1,4 @@
-class AllowNullContentViewToActivationKey < ActiveRecord::Migration
+class AllowNullContentViewToActivationKey < ActiveRecord::Migration[4.2]
   def up
     change_column :katello_activation_keys, :environment_id, :integer, :null => true
   end

--- a/db/migrate/20140418124032_add_next_version_to_katello_content_views.rb
+++ b/db/migrate/20140418124032_add_next_version_to_katello_content_views.rb
@@ -1,4 +1,4 @@
-class AddNextVersionToKatelloContentViews < ActiveRecord::Migration
+class AddNextVersionToKatelloContentViews < ActiveRecord::Migration[4.2]
   def up
     add_column :katello_content_views, :next_version, :int, :null => false, :default => 1
 

--- a/db/migrate/20140422000001_update_products_add_organization.rb
+++ b/db/migrate/20140422000001_update_products_add_organization.rb
@@ -1,4 +1,4 @@
-class UpdateProductsAddOrganization < ActiveRecord::Migration
+class UpdateProductsAddOrganization < ActiveRecord::Migration[4.2]
   class Katello::Product < ApplicationRecord
     belongs_to :provider
     self.inheritance_column = nil

--- a/db/migrate/20140423191446_add_anonymous_providers_to_orgs.rb
+++ b/db/migrate/20140423191446_add_anonymous_providers_to_orgs.rb
@@ -1,4 +1,4 @@
-class AddAnonymousProvidersToOrgs < ActiveRecord::Migration
+class AddAnonymousProvidersToOrgs < ActiveRecord::Migration[4.2]
   def up
     Organization.all.each do |org|
       if org.anonymous_provider.nil?

--- a/db/migrate/20140425155126_add_host_id_to_system.rb
+++ b/db/migrate/20140425155126_add_host_id_to_system.rb
@@ -1,4 +1,4 @@
-class AddHostIdToSystem < ActiveRecord::Migration
+class AddHostIdToSystem < ActiveRecord::Migration[4.2]
   def up
     add_column :katello_systems, :host_id, :integer
     add_index :katello_systems, :host_id

--- a/db/migrate/20140429193743_add_release_version_to_activation_keys.rb
+++ b/db/migrate/20140429193743_add_release_version_to_activation_keys.rb
@@ -1,4 +1,4 @@
-class AddReleaseVersionToActivationKeys < ActiveRecord::Migration
+class AddReleaseVersionToActivationKeys < ActiveRecord::Migration[4.2]
   def change
     add_column :katello_activation_keys, :release_version, :string, :limit => 255
   end

--- a/db/migrate/20140502164009_rename_system_groups_to_host_collections.rb
+++ b/db/migrate/20140502164009_rename_system_groups_to_host_collections.rb
@@ -1,4 +1,4 @@
-class RenameSystemGroupsToHostCollections < ActiveRecord::Migration
+class RenameSystemGroupsToHostCollections < ActiveRecord::Migration[4.2]
   def change
     rename_index :katello_key_system_groups, "index_key_system_groups_on_activation_key_id", "index_key_host_collections_on_activation_key_id"
     rename_index :katello_key_system_groups, "index_key_system_groups_on_system_group_id", "index_key_host_collections_on_host_collection_id"

--- a/db/migrate/20140502174412_update_host_collections_foreign_keys.rb
+++ b/db/migrate/20140502174412_update_host_collections_foreign_keys.rb
@@ -1,4 +1,4 @@
-class UpdateHostCollectionsForeignKeys < ActiveRecord::Migration
+class UpdateHostCollectionsForeignKeys < ActiveRecord::Migration[4.2]
   def up
     remove_foreign_key "katello_key_host_collections", :name => "key_system_groups_activation_key_id_fk"
     remove_foreign_key "katello_key_host_collections", :name => "key_system_groups_system_group_id_fk"

--- a/db/migrate/20140514165842_create_capsule_lifecycle_environments.rb
+++ b/db/migrate/20140514165842_create_capsule_lifecycle_environments.rb
@@ -1,4 +1,4 @@
-class CreateCapsuleLifecycleEnvironments < ActiveRecord::Migration
+class CreateCapsuleLifecycleEnvironments < ActiveRecord::Migration[4.2]
   def change
     create_table :katello_capsule_lifecycle_environments do |t|
       t.references :capsule

--- a/db/migrate/20140531160506_package_filter_add_original_packages.rb
+++ b/db/migrate/20140531160506_package_filter_add_original_packages.rb
@@ -1,4 +1,4 @@
-class PackageFilterAddOriginalPackages < ActiveRecord::Migration
+class PackageFilterAddOriginalPackages < ActiveRecord::Migration[4.2]
   def up
     add_column :katello_content_view_filters, :original_packages, :boolean, :default => false, :null => false
   end

--- a/db/migrate/20140610083129_add_pulp_proxy_to_host.rb
+++ b/db/migrate/20140610083129_add_pulp_proxy_to_host.rb
@@ -1,4 +1,4 @@
-class AddPulpProxyToHost < ActiveRecord::Migration
+class AddPulpProxyToHost < ActiveRecord::Migration[4.2]
   def change
     add_column :hosts,      :content_source_id, :integer
     add_column :hostgroups, :content_source_id, :integer

--- a/db/migrate/20140610154745_content_view_puppet_environment_id.rb
+++ b/db/migrate/20140610154745_content_view_puppet_environment_id.rb
@@ -1,4 +1,4 @@
-class ContentViewPuppetEnvironmentId < ActiveRecord::Migration
+class ContentViewPuppetEnvironmentId < ActiveRecord::Migration[4.2]
   class ::Environment < ApplicationRecord
     def self.find_by_katello_id(org, env, content_view)
       katello_id = Environment.construct_katello_id(org, env, content_view)

--- a/db/migrate/20140610170142_add_uuid_to_content_view_package_group_filter_rule.rb
+++ b/db/migrate/20140610170142_add_uuid_to_content_view_package_group_filter_rule.rb
@@ -1,4 +1,4 @@
-class AddUuidToContentViewPackageGroupFilterRule < ActiveRecord::Migration
+class AddUuidToContentViewPackageGroupFilterRule < ActiveRecord::Migration[4.2]
   def change
     add_column :katello_content_view_package_group_filter_rules, :uuid,
       :string, :limit => 255

--- a/db/migrate/20140617100300_add_description_to_content_view_filter_rules.rb
+++ b/db/migrate/20140617100300_add_description_to_content_view_filter_rules.rb
@@ -1,4 +1,4 @@
-class AddDescriptionToContentViewFilterRules < ActiveRecord::Migration
+class AddDescriptionToContentViewFilterRules < ActiveRecord::Migration[4.2]
   def up
     add_column :katello_content_view_filters, :description, :string, :limit => 255
   end

--- a/db/migrate/20140623103442_drop_taxonomies_owner_auto_attach_all_systems_task_id_column.rb
+++ b/db/migrate/20140623103442_drop_taxonomies_owner_auto_attach_all_systems_task_id_column.rb
@@ -1,4 +1,4 @@
-class DropTaxonomiesOwnerAutoAttachAllSystemsTaskIdColumn < ActiveRecord::Migration
+class DropTaxonomiesOwnerAutoAttachAllSystemsTaskIdColumn < ActiveRecord::Migration[4.2]
   def up
     remove_column :taxonomies, :owner_auto_attach_all_systems_task_id
   end

--- a/db/migrate/20140624183938_add_foreign_keys_for_organizations.rb
+++ b/db/migrate/20140624183938_add_foreign_keys_for_organizations.rb
@@ -1,4 +1,4 @@
-class AddForeignKeysForOrganizations < ActiveRecord::Migration
+class AddForeignKeysForOrganizations < ActiveRecord::Migration[4.2]
   def up
     add_foreign_key(:katello_task_statuses, :taxonomies,
                     :name => 'katello_task_statuses_organization_fk', :column => 'organization_id')

--- a/db/migrate/20140624184401_remove_label_from_activation_key.rb
+++ b/db/migrate/20140624184401_remove_label_from_activation_key.rb
@@ -1,4 +1,4 @@
-class RemoveLabelFromActivationKey < ActiveRecord::Migration
+class RemoveLabelFromActivationKey < ActiveRecord::Migration[4.2]
   def up
     remove_column :katello_activation_keys, :label
   end

--- a/db/migrate/20140626055258_add_missing_foreign_keys.rb
+++ b/db/migrate/20140626055258_add_missing_foreign_keys.rb
@@ -1,4 +1,4 @@
-class AddMissingForeignKeys < ActiveRecord::Migration
+class AddMissingForeignKeys < ActiveRecord::Migration[4.2]
   def up
     add_foreign_key(:katello_capsule_lifecycle_environments, :smart_proxies,
                     :name => 'katello_capsule_lifecycle_environments_capsule_fk', :column => 'capsule_id')

--- a/db/migrate/20140626204657_add_unlimited_to_activation_keys.rb
+++ b/db/migrate/20140626204657_add_unlimited_to_activation_keys.rb
@@ -1,4 +1,4 @@
-class AddUnlimitedToActivationKeys < ActiveRecord::Migration
+class AddUnlimitedToActivationKeys < ActiveRecord::Migration[4.2]
   class ::Katello::ActivationKeys < ApplicationRecord
   end
 

--- a/db/migrate/20140626204902_add_unlimited_to_host_collection.rb
+++ b/db/migrate/20140626204902_add_unlimited_to_host_collection.rb
@@ -1,4 +1,4 @@
-class AddUnlimitedToHostCollection < ActiveRecord::Migration
+class AddUnlimitedToHostCollection < ActiveRecord::Migration[4.2]
   class ::Katello::HostCollections < ApplicationRecord
   end
 

--- a/db/migrate/20140707203534_location_add_katello_default.rb
+++ b/db/migrate/20140707203534_location_add_katello_default.rb
@@ -1,4 +1,4 @@
-class LocationAddKatelloDefault < ActiveRecord::Migration
+class LocationAddKatelloDefault < ActiveRecord::Migration[4.2]
   def up
     add_column :taxonomies, :katello_default, :boolean, :null => false, :default => false
   end

--- a/db/migrate/20140709150428_remove_deletion_task_id_from_taxonomies.rb
+++ b/db/migrate/20140709150428_remove_deletion_task_id_from_taxonomies.rb
@@ -1,4 +1,4 @@
-class RemoveDeletionTaskIdFromTaxonomies < ActiveRecord::Migration
+class RemoveDeletionTaskIdFromTaxonomies < ActiveRecord::Migration[4.2]
   def up
     remove_column :taxonomies, :deletion_task_id
   end

--- a/db/migrate/20140716211853_repo_rename_feed_to_url.rb
+++ b/db/migrate/20140716211853_repo_rename_feed_to_url.rb
@@ -1,4 +1,4 @@
-class RepoRenameFeedToUrl < ActiveRecord::Migration
+class RepoRenameFeedToUrl < ActiveRecord::Migration[4.2]
   def up
     rename_column :katello_repositories, :feed, :url
   end

--- a/db/migrate/20140807175457_remove_hidden_column_from_user.rb
+++ b/db/migrate/20140807175457_remove_hidden_column_from_user.rb
@@ -1,4 +1,4 @@
-class RemoveHiddenColumnFromUser < ActiveRecord::Migration
+class RemoveHiddenColumnFromUser < ActiveRecord::Migration[4.2]
   def up
     remove_column :users, :hidden
   end

--- a/db/migrate/20140811141742_remove_delayed_jobs.rb
+++ b/db/migrate/20140811141742_remove_delayed_jobs.rb
@@ -1,4 +1,4 @@
-class RemoveDelayedJobs < ActiveRecord::Migration
+class RemoveDelayedJobs < ActiveRecord::Migration[4.2]
   def up
     drop_table "delayed_jobs"
   end

--- a/db/migrate/20140821084214_add_sync_plan_enabled_to_sync_plan.rb
+++ b/db/migrate/20140821084214_add_sync_plan_enabled_to_sync_plan.rb
@@ -1,4 +1,4 @@
-class AddSyncPlanEnabledToSyncPlan < ActiveRecord::Migration
+class AddSyncPlanEnabledToSyncPlan < ActiveRecord::Migration[4.2]
   def up
     add_column :katello_sync_plans, :enabled, :boolean, :default => true, :null => false
   end

--- a/db/migrate/20140928210618_add_description_to_content_view_versions.rb
+++ b/db/migrate/20140928210618_add_description_to_content_view_versions.rb
@@ -1,4 +1,4 @@
-class AddDescriptionToContentViewVersions < ActiveRecord::Migration
+class AddDescriptionToContentViewVersions < ActiveRecord::Migration[4.2]
   def change
     add_column :katello_content_view_versions, :description, :text
   end

--- a/db/migrate/20140930170628_add_errata.rb
+++ b/db/migrate/20140930170628_add_errata.rb
@@ -1,4 +1,4 @@
-class AddErrata < ActiveRecord::Migration
+class AddErrata < ActiveRecord::Migration[4.2]
   # rubocop:disable MethodLength
   def up
     create_table "katello_errata" do |t|

--- a/db/migrate/20141001170628_add_system_repository.rb
+++ b/db/migrate/20141001170628_add_system_repository.rb
@@ -1,4 +1,4 @@
-class AddSystemRepository < ActiveRecord::Migration
+class AddSystemRepository < ActiveRecord::Migration[4.2]
   def up
     create_table "katello_system_repositories" do |t|
       t.references :system, :null => false

--- a/db/migrate/20141003210742_add_docker_container_registry_url_to_providers.rb
+++ b/db/migrate/20141003210742_add_docker_container_registry_url_to_providers.rb
@@ -1,4 +1,4 @@
-class AddDockerContainerRegistryUrlToProviders < ActiveRecord::Migration
+class AddDockerContainerRegistryUrlToProviders < ActiveRecord::Migration[4.2]
   def up
     add_column :katello_providers, :docker_registry_url, :string, :limit => 255
   end

--- a/db/migrate/20141015173220_add_docker_image_fields.rb
+++ b/db/migrate/20141015173220_add_docker_image_fields.rb
@@ -1,4 +1,4 @@
-class AddDockerImageFields < ActiveRecord::Migration
+class AddDockerImageFields < ActiveRecord::Migration[4.2]
   def up
     add_column :docker_images, :katello_uuid, :string, :limit => 255
     add_column :docker_images, :katello_repository_id, :integer

--- a/db/migrate/20141031150814_add_tag_repository_id_index.rb
+++ b/db/migrate/20141031150814_add_tag_repository_id_index.rb
@@ -1,4 +1,4 @@
-class AddTagRepositoryIdIndex < ActiveRecord::Migration
+class AddTagRepositoryIdIndex < ActiveRecord::Migration[4.2]
   def up
     add_index :docker_tags, [:tag, :katello_repository_id],
               :name => :katello_docker_tag_repository_id, :unique => true

--- a/db/migrate/20141112180709_add_auto_attach_to_activation_keys.rb
+++ b/db/migrate/20141112180709_add_auto_attach_to_activation_keys.rb
@@ -1,4 +1,4 @@
-class AddAutoAttachToActivationKeys < ActiveRecord::Migration
+class AddAutoAttachToActivationKeys < ActiveRecord::Migration[4.2]
   def change
     add_column :katello_activation_keys, :auto_attach, :boolean
   end

--- a/db/migrate/20141124182205_content_view_version_add_minor.rb
+++ b/db/migrate/20141124182205_content_view_version_add_minor.rb
@@ -1,4 +1,4 @@
-class ContentViewVersionAddMinor < ActiveRecord::Migration
+class ContentViewVersionAddMinor < ActiveRecord::Migration[4.2]
   def up
     add_column :katello_content_view_versions, :minor, :integer, :null => false, :default => 0
     rename_column :katello_content_view_versions, :version, :major

--- a/db/migrate/20141203123206_add_timestamps_to_repository_join_tables.rb
+++ b/db/migrate/20141203123206_add_timestamps_to_repository_join_tables.rb
@@ -1,4 +1,4 @@
-class AddTimestampsToRepositoryJoinTables < ActiveRecord::Migration
+class AddTimestampsToRepositoryJoinTables < ActiveRecord::Migration[4.2]
   def change
     change_table(:katello_repository_errata) do |t|
       t.timestamps

--- a/db/migrate/20141204203609_add_default_value_to_auto_attach.rb
+++ b/db/migrate/20141204203609_add_default_value_to_auto_attach.rb
@@ -1,4 +1,4 @@
-class AddDefaultValueToAutoAttach < ActiveRecord::Migration
+class AddDefaultValueToAutoAttach < ActiveRecord::Migration[4.2]
   def up
     change_column :katello_activation_keys, :auto_attach, :boolean, :default => true
   end

--- a/db/migrate/20141209103005_disown_foreman_templates.rb
+++ b/db/migrate/20141209103005_disown_foreman_templates.rb
@@ -1,4 +1,4 @@
-class DisownForemanTemplates < ActiveRecord::Migration
+class DisownForemanTemplates < ActiveRecord::Migration[4.2]
   class FakeConfigTemplate < ApplicationRecord
     if ActiveRecord::Base.connection.table_exists?('config_templates')
       self.table_name = 'config_templates'

--- a/db/migrate/20141210173220_create_docker_tables.rb
+++ b/db/migrate/20141210173220_create_docker_tables.rb
@@ -1,4 +1,4 @@
-class CreateDockerTables < ActiveRecord::Migration
+class CreateDockerTables < ActiveRecord::Migration[4.2]
   def up
     create_table :katello_docker_images do |t|
       t.string :image_id, :limit => 255

--- a/db/migrate/20141215213720_track_version_components.rb
+++ b/db/migrate/20141215213720_track_version_components.rb
@@ -1,4 +1,4 @@
-class TrackVersionComponents < ActiveRecord::Migration
+class TrackVersionComponents < ActiveRecord::Migration[4.2]
   def change
     create_table "katello_content_view_version_components" do |t|
       t.integer :component_version_id, :null => false

--- a/db/migrate/20141222151001_add_host_content_view_environment.rb
+++ b/db/migrate/20141222151001_add_host_content_view_environment.rb
@@ -1,4 +1,4 @@
-class AddHostContentViewEnvironment < ActiveRecord::Migration
+class AddHostContentViewEnvironment < ActiveRecord::Migration[4.2]
   def up
     add_column :hosts, :content_view_id, :integer, :null => true
     add_column :hosts, :lifecycle_environment_id, :integer, :null => true

--- a/db/migrate/20150109012657_add_capsule_id_to_container.rb
+++ b/db/migrate/20150109012657_add_capsule_id_to_container.rb
@@ -1,4 +1,4 @@
-class AddCapsuleIdToContainer < ActiveRecord::Migration
+class AddCapsuleIdToContainer < ActiveRecord::Migration[4.2]
   def up
     add_column :containers, :capsule_id, :integer
     add_foreign_key :containers, :smart_proxies, :column => "capsule_id"

--- a/db/migrate/20150114225023_add_upstream_name_to_repository.rb
+++ b/db/migrate/20150114225023_add_upstream_name_to_repository.rb
@@ -1,4 +1,4 @@
-class AddUpstreamNameToRepository < ActiveRecord::Migration
+class AddUpstreamNameToRepository < ActiveRecord::Migration[4.2]
   def up
     add_column :katello_repositories, :docker_upstream_name, :string, :limit => 255
     Katello::Repository.docker_type.each do |repo|

--- a/db/migrate/20150119153452_update_promote_errata_email_description.rb
+++ b/db/migrate/20150119153452_update_promote_errata_email_description.rb
@@ -1,4 +1,4 @@
-class UpdatePromoteErrataEmailDescription < ActiveRecord::Migration
+class UpdatePromoteErrataEmailDescription < ActiveRecord::Migration[4.2]
   def up
     notification = MailNotification.find_by(:name => :katello_promote_errata)
 

--- a/db/migrate/20150224083608_remove_docker_registry_url.rb
+++ b/db/migrate/20150224083608_remove_docker_registry_url.rb
@@ -1,4 +1,4 @@
-class RemoveDockerRegistryUrl < ActiveRecord::Migration
+class RemoveDockerRegistryUrl < ActiveRecord::Migration[4.2]
   def up
     remove_column :katello_providers, :docker_registry_url
   end

--- a/db/migrate/20150227213850_change_descriptions_to_text_fields.rb
+++ b/db/migrate/20150227213850_change_descriptions_to_text_fields.rb
@@ -1,4 +1,4 @@
-class ChangeDescriptionsToTextFields < ActiveRecord::Migration
+class ChangeDescriptionsToTextFields < ActiveRecord::Migration[4.2]
   def change
     change_column :katello_content_view_filters, :description, :text
     change_column :katello_content_views, :description, :text

--- a/db/migrate/20150423134004_add_content_host_id_to_smart_proxy.rb
+++ b/db/migrate/20150423134004_add_content_host_id_to_smart_proxy.rb
@@ -1,4 +1,4 @@
-class AddContentHostIdToSmartProxy < ActiveRecord::Migration
+class AddContentHostIdToSmartProxy < ActiveRecord::Migration[4.2]
   def change
     add_column :smart_proxies, :content_host_id, :integer
     add_foreign_key :smart_proxies, :katello_systems, :column => "content_host_id"

--- a/db/migrate/20150505180030_change_errata_timestamps_to_dates.rb
+++ b/db/migrate/20150505180030_change_errata_timestamps_to_dates.rb
@@ -1,4 +1,4 @@
-class ChangeErrataTimestampsToDates < ActiveRecord::Migration
+class ChangeErrataTimestampsToDates < ActiveRecord::Migration[4.2]
   def up
     change_column(:katello_errata, :issued, :date)
     change_column(:katello_errata, :updated, :date)

--- a/db/migrate/20150507131145_update_composite_default_for_content_view.rb
+++ b/db/migrate/20150507131145_update_composite_default_for_content_view.rb
@@ -1,4 +1,4 @@
-class UpdateCompositeDefaultForContentView < ActiveRecord::Migration
+class UpdateCompositeDefaultForContentView < ActiveRecord::Migration[4.2]
   class Katello::ContentView
   end
 

--- a/db/migrate/20150513034751_add_ostree_branches.rb
+++ b/db/migrate/20150513034751_add_ostree_branches.rb
@@ -1,4 +1,4 @@
-class AddOstreeBranches < ActiveRecord::Migration
+class AddOstreeBranches < ActiveRecord::Migration[4.2]
   def up
     create_table :katello_ostree_branches do |t|
       t.string :name, :null => false, :limit => 255

--- a/db/migrate/20150602153753_remove_help_tips.rb
+++ b/db/migrate/20150602153753_remove_help_tips.rb
@@ -1,4 +1,4 @@
-class RemoveHelpTips < ActiveRecord::Migration
+class RemoveHelpTips < ActiveRecord::Migration[4.2]
   def up
     drop_table :katello_help_tips
   end

--- a/db/migrate/20150602153754_remove_search_histories.rb
+++ b/db/migrate/20150602153754_remove_search_histories.rb
@@ -1,4 +1,4 @@
-class RemoveSearchHistories < ActiveRecord::Migration
+class RemoveSearchHistories < ActiveRecord::Migration[4.2]
   def up
     drop_table :katello_search_histories
   end

--- a/db/migrate/20150602153755_remove_search_favorites.rb
+++ b/db/migrate/20150602153755_remove_search_favorites.rb
@@ -1,4 +1,4 @@
-class RemoveSearchFavorites < ActiveRecord::Migration
+class RemoveSearchFavorites < ActiveRecord::Migration[4.2]
   def up
     drop_table :katello_search_favorites
   end

--- a/db/migrate/20150602153756_remove_user_notices.rb
+++ b/db/migrate/20150602153756_remove_user_notices.rb
@@ -1,4 +1,4 @@
-class RemoveUserNotices < ActiveRecord::Migration
+class RemoveUserNotices < ActiveRecord::Migration[4.2]
   def up
     drop_table :katello_user_notices
   end

--- a/db/migrate/20150602153757_remove_notices.rb
+++ b/db/migrate/20150602153757_remove_notices.rb
@@ -1,4 +1,4 @@
-class RemoveNotices < ActiveRecord::Migration
+class RemoveNotices < ActiveRecord::Migration[4.2]
   def up
     drop_table :katello_notices
   end

--- a/db/migrate/20150603045418_remove_user_fields.rb
+++ b/db/migrate/20150603045418_remove_user_fields.rb
@@ -1,4 +1,4 @@
-class RemoveUserFields < ActiveRecord::Migration
+class RemoveUserFields < ActiveRecord::Migration[4.2]
   def up
     remove_column :users, :helptips_enabled
     remove_column :users, :page_size

--- a/db/migrate/20150606021722_create_puppet_modules.rb
+++ b/db/migrate/20150606021722_create_puppet_modules.rb
@@ -1,4 +1,4 @@
-class CreatePuppetModules < ActiveRecord::Migration
+class CreatePuppetModules < ActiveRecord::Migration[4.2]
   # rubocop:disable MethodLength
   def up
     create_table 'katello_puppet_modules' do |t|

--- a/db/migrate/20150611140455_remove_default_and_custom_info.rb
+++ b/db/migrate/20150611140455_remove_default_and_custom_info.rb
@@ -1,4 +1,4 @@
-class RemoveDefaultAndCustomInfo < ActiveRecord::Migration
+class RemoveDefaultAndCustomInfo < ActiveRecord::Migration[4.2]
   def change
     remove_column :taxonomies, :default_info
   end

--- a/db/migrate/20150613134559_add_rpm.rb
+++ b/db/migrate/20150613134559_add_rpm.rb
@@ -1,4 +1,4 @@
-class AddRpm < ActiveRecord::Migration
+class AddRpm < ActiveRecord::Migration[4.2]
   def up
     create_table "katello_rpms" do |t|
       t.string "uuid", :null => false, :limit => 255

--- a/db/migrate/20150623135424_create_package_groups.rb
+++ b/db/migrate/20150623135424_create_package_groups.rb
@@ -1,4 +1,4 @@
-class CreatePackageGroups < ActiveRecord::Migration
+class CreatePackageGroups < ActiveRecord::Migration[4.2]
   def change
     create_table "katello_package_groups" do |t|
       t.string "name", :limit => 255

--- a/db/migrate/20150715142649_assign_content_host_to_smart_proxies.rb
+++ b/db/migrate/20150715142649_assign_content_host_to_smart_proxies.rb
@@ -1,4 +1,4 @@
-class AssignContentHostToSmartProxies < ActiveRecord::Migration
+class AssignContentHostToSmartProxies < ActiveRecord::Migration[4.2]
   def up
     SmartProxy.reset_column_information
 

--- a/db/migrate/20150717142559_add_distributions_to_repository.rb
+++ b/db/migrate/20150717142559_add_distributions_to_repository.rb
@@ -1,4 +1,4 @@
-class AddDistributionsToRepository < ActiveRecord::Migration
+class AddDistributionsToRepository < ActiveRecord::Migration[4.2]
   def change
     add_column :katello_repositories, :distribution_version, :string, :limit => 255
     add_column :katello_repositories, :distribution_arch, :string, :limit => 255

--- a/db/migrate/20150813185339_create_subscriptions.rb
+++ b/db/migrate/20150813185339_create_subscriptions.rb
@@ -1,4 +1,4 @@
-class CreateSubscriptions < ActiveRecord::Migration
+class CreateSubscriptions < ActiveRecord::Migration[4.2]
   # rubocop:disable MethodLength
   def change
     create_table "katello_subscriptions" do |t|

--- a/db/migrate/20150826165942_add_subscription_facet.rb
+++ b/db/migrate/20150826165942_add_subscription_facet.rb
@@ -1,4 +1,4 @@
-class AddSubscriptionFacet < ActiveRecord::Migration
+class AddSubscriptionFacet < ActiveRecord::Migration[4.2]
   def change
     create_table "katello_subscription_facets" do |t|
       t.references 'host', :null => false

--- a/db/migrate/20150826170004_add_content_facet.rb
+++ b/db/migrate/20150826170004_add_content_facet.rb
@@ -1,4 +1,4 @@
-class AddContentFacet < ActiveRecord::Migration
+class AddContentFacet < ActiveRecord::Migration[4.2]
   # rubocop:disable MethodLength
   def change
     create_table "katello_content_facets" do |t|

--- a/db/migrate/20150901213759_remove_distributors.rb
+++ b/db/migrate/20150901213759_remove_distributors.rb
@@ -1,4 +1,4 @@
-class RemoveDistributors < ActiveRecord::Migration
+class RemoveDistributors < ActiveRecord::Migration[4.2]
   class Katello::Distributor < ApplicationRecord
     self.table_name = 'katello_distributors'
   end

--- a/db/migrate/20150902164543_remove_apply_info_task_id_from_taxonomies.rb
+++ b/db/migrate/20150902164543_remove_apply_info_task_id_from_taxonomies.rb
@@ -1,4 +1,4 @@
-class RemoveApplyInfoTaskIdFromTaxonomies < ActiveRecord::Migration
+class RemoveApplyInfoTaskIdFromTaxonomies < ActiveRecord::Migration[4.2]
   def change
     remove_column :taxonomies, :apply_info_task_id
   end

--- a/db/migrate/20150908222711_drop_marketing_engineering_products.rb
+++ b/db/migrate/20150908222711_drop_marketing_engineering_products.rb
@@ -1,4 +1,4 @@
-class DropMarketingEngineeringProducts < ActiveRecord::Migration
+class DropMarketingEngineeringProducts < ActiveRecord::Migration[4.2]
   class Katello::MarketingProduct < ApplicationRecord
     self.table_name = "katello_products"
   end

--- a/db/migrate/20150928221648_update_location_katello_default.rb
+++ b/db/migrate/20150928221648_update_location_katello_default.rb
@@ -1,4 +1,4 @@
-class UpdateLocationKatelloDefault < ActiveRecord::Migration
+class UpdateLocationKatelloDefault < ActiveRecord::Migration[4.2]
   def up
     change_column_default :taxonomies, :katello_default, false
   end

--- a/db/migrate/20150930183738_migrate_content_hosts.rb
+++ b/db/migrate/20150930183738_migrate_content_hosts.rb
@@ -1,4 +1,4 @@
-class MigrateContentHosts < ActiveRecord::Migration
+class MigrateContentHosts < ActiveRecord::Migration[4.2]
   HYPERVISOR_CLASS = 'Katello::Hypervisor'.freeze
 
   class Location < ApplicationRecord

--- a/db/migrate/20151014144004_host_collection_to_hosts.rb
+++ b/db/migrate/20151014144004_host_collection_to_hosts.rb
@@ -1,4 +1,4 @@
-class HostCollectionToHosts < ActiveRecord::Migration
+class HostCollectionToHosts < ActiveRecord::Migration[4.2]
   class Host < ApplicationRecord
     self.table_name = "hosts"
   end

--- a/db/migrate/20151015152947_add_virt_only_to_katello_pools.rb
+++ b/db/migrate/20151015152947_add_virt_only_to_katello_pools.rb
@@ -1,4 +1,4 @@
-class AddVirtOnlyToKatelloPools < ActiveRecord::Migration
+class AddVirtOnlyToKatelloPools < ActiveRecord::Migration[4.2]
   def up
     add_column :katello_pools, :virt_only, :boolean, :default => false, :null => false
     add_column :katello_pools, :unmapped_guest, :boolean, :default => false, :null => false

--- a/db/migrate/20151203230940_add_date_type_to_content_view_erratum_filter_rules.rb
+++ b/db/migrate/20151203230940_add_date_type_to_content_view_erratum_filter_rules.rb
@@ -1,4 +1,4 @@
-class AddDateTypeToContentViewErratumFilterRules < ActiveRecord::Migration
+class AddDateTypeToContentViewErratumFilterRules < ActiveRecord::Migration[4.2]
   def change
     add_column :katello_content_view_erratum_filter_rules, :date_type, :string,
       :default => "updated", :null => false, :limit => 255

--- a/db/migrate/20151219152536_rename_index_repository_errata.rb
+++ b/db/migrate/20151219152536_rename_index_repository_errata.rb
@@ -1,4 +1,4 @@
-class RenameIndexRepositoryErrata < ActiveRecord::Migration
+class RenameIndexRepositoryErrata < ActiveRecord::Migration[4.2]
   def change
     original_name = 'index_katello_repository_errata_on_erratum_id_and_repository_id'
     shorter_name = 'index_katello_repository_errata_on_erratum_id_and_repo_id'

--- a/db/migrate/20151219203225_rename_index_repository_puppet_module.rb
+++ b/db/migrate/20151219203225_rename_index_repository_puppet_module.rb
@@ -1,4 +1,4 @@
-class RenameIndexRepositoryPuppetModule < ActiveRecord::Migration
+class RenameIndexRepositoryPuppetModule < ActiveRecord::Migration[4.2]
   def change
     original_name = 'index_katello_repository_puppet_module_on_module_id_and_repo_id'
     shorter_name = 'index_katello_repo_puppet_module_on_module_id_and_repo_id'

--- a/db/migrate/20160114200145_add_mirror_on_sync_to_repositories.rb
+++ b/db/migrate/20160114200145_add_mirror_on_sync_to_repositories.rb
@@ -1,4 +1,4 @@
-class AddMirrorOnSyncToRepositories < ActiveRecord::Migration
+class AddMirrorOnSyncToRepositories < ActiveRecord::Migration[4.2]
   class RepositoryMirrorOnSync < ApplicationRecord
     self.table_name = "katello_repositories"
   end

--- a/db/migrate/20160129192548_add_docker_v2_schema.rb
+++ b/db/migrate/20160129192548_add_docker_v2_schema.rb
@@ -1,4 +1,4 @@
-class AddDockerV2Schema < ActiveRecord::Migration
+class AddDockerV2Schema < ActiveRecord::Migration[4.2]
   def up
     create_table :katello_docker_manifests do |t|
       t.string :name, :limit => 255

--- a/db/migrate/20160131182301_add_download_policy_to_katello_repositories.rb
+++ b/db/migrate/20160131182301_add_download_policy_to_katello_repositories.rb
@@ -1,4 +1,4 @@
-class AddDownloadPolicyToKatelloRepositories < ActiveRecord::Migration
+class AddDownloadPolicyToKatelloRepositories < ActiveRecord::Migration[4.2]
   class DownloadPolicyRepository < ApplicationRecord
     self.table_name = "katello_repositories"
   end

--- a/db/migrate/20160203195736_remove_docker_image_schema.rb
+++ b/db/migrate/20160203195736_remove_docker_image_schema.rb
@@ -1,4 +1,4 @@
-class RemoveDockerImageSchema < ActiveRecord::Migration
+class RemoveDockerImageSchema < ActiveRecord::Migration[4.2]
   def up
     if foreign_key_exists?(:katello_docker_tags, :name => "katello_docker_tags_docker_image_id_fk")
       remove_foreign_key :katello_docker_tags, :name => "katello_docker_tags_docker_image_id_fk"

--- a/db/migrate/20160211134035_remove_system_errata.rb
+++ b/db/migrate/20160211134035_remove_system_errata.rb
@@ -1,4 +1,4 @@
-class RemoveSystemErrata < ActiveRecord::Migration
+class RemoveSystemErrata < ActiveRecord::Migration[4.2]
   def up
     drop_table "katello_system_errata"
   end

--- a/db/migrate/20160222143432_move_system_description_to_host.rb
+++ b/db/migrate/20160222143432_move_system_description_to_host.rb
@@ -1,4 +1,4 @@
-class MoveSystemDescriptionToHost < ActiveRecord::Migration
+class MoveSystemDescriptionToHost < ActiveRecord::Migration[4.2]
   class Host < ApplicationRecord
     self.table_name = "hosts"
   end

--- a/db/migrate/20160224155909_add_registered_at_to_subscription_facet.rb
+++ b/db/migrate/20160224155909_add_registered_at_to_subscription_facet.rb
@@ -1,4 +1,4 @@
-class AddRegisteredAtToSubscriptionFacet < ActiveRecord::Migration
+class AddRegisteredAtToSubscriptionFacet < ActiveRecord::Migration[4.2]
   def up
     add_column(:katello_subscription_facets, :registered_at, :datetime, :null => false, :default => Time.now)
   end

--- a/db/migrate/20160301070319_add_version_ostree_branches.rb
+++ b/db/migrate/20160301070319_add_version_ostree_branches.rb
@@ -1,4 +1,4 @@
-class AddVersionOstreeBranches < ActiveRecord::Migration
+class AddVersionOstreeBranches < ActiveRecord::Migration[4.2]
   def up
     drop_table :katello_ostree_branches if ActiveRecord::Base.connection.table_exists? "katello_ostree_branches"
 

--- a/db/migrate/20160317171813_change_activation_key_column_names.rb
+++ b/db/migrate/20160317171813_change_activation_key_column_names.rb
@@ -1,4 +1,4 @@
-class ChangeActivationKeyColumnNames < ActiveRecord::Migration
+class ChangeActivationKeyColumnNames < ActiveRecord::Migration[4.2]
   def self.up
     rename_column :katello_activation_keys, :max_content_hosts, :max_hosts
     rename_column :katello_activation_keys, :unlimited_content_hosts, :unlimited_hosts

--- a/db/migrate/20160323065901_increase_cdn_length.rb
+++ b/db/migrate/20160323065901_increase_cdn_length.rb
@@ -1,4 +1,4 @@
-class IncreaseCdnLength < ActiveRecord::Migration
+class IncreaseCdnLength < ActiveRecord::Migration[4.2]
   def up
     change_column :katello_providers, :repository_url, :string, :limit => 1024
     change_column :katello_repositories, :url, :string, :limit => 1024

--- a/db/migrate/20160404132250_remove_katello_from_notification_name.rb
+++ b/db/migrate/20160404132250_remove_katello_from_notification_name.rb
@@ -1,4 +1,4 @@
-class RemoveKatelloFromNotificationName < ActiveRecord::Migration
+class RemoveKatelloFromNotificationName < ActiveRecord::Migration[4.2]
   class FakeMailNotification < ApplicationRecord
     self.table_name = 'mail_notifications'
   end

--- a/db/migrate/20160413230128_add_kickstart_repository_to_hosts_and_hostgroups.rb
+++ b/db/migrate/20160413230128_add_kickstart_repository_to_hosts_and_hostgroups.rb
@@ -1,4 +1,4 @@
-class AddKickstartRepositoryToHostsAndHostgroups < ActiveRecord::Migration
+class AddKickstartRepositoryToHostsAndHostgroups < ActiveRecord::Migration[4.2]
   def change
     add_column :katello_content_facets, :kickstart_repository_id, :integer, :null => true
     add_foreign_key :katello_content_facets, :katello_repositories, :column => :kickstart_repository_id

--- a/db/migrate/20160426145517_move_host_description_to_host_comment.rb
+++ b/db/migrate/20160426145517_move_host_description_to_host_comment.rb
@@ -1,4 +1,4 @@
-class MoveHostDescriptionToHostComment < ActiveRecord::Migration
+class MoveHostDescriptionToHostComment < ActiveRecord::Migration[4.2]
   class Host < ApplicationRecord
     self.table_name = "hosts"
   end

--- a/db/migrate/20160505181337_rename_katello_settings.rb
+++ b/db/migrate/20160505181337_rename_katello_settings.rb
@@ -1,4 +1,4 @@
-class RenameKatelloSettings < ActiveRecord::Migration
+class RenameKatelloSettings < ActiveRecord::Migration[4.2]
   def up
     Setting.where(category: 'Setting::Katello').update_all(:category => 'Setting::Content')
   end

--- a/db/migrate/20160520175340_add_host_applicable_package.rb
+++ b/db/migrate/20160520175340_add_host_applicable_package.rb
@@ -1,4 +1,4 @@
-class AddHostApplicablePackage < ActiveRecord::Migration
+class AddHostApplicablePackage < ActiveRecord::Migration[4.2]
   def change
     create_table "katello_content_facet_applicable_rpms" do |t|
       t.references 'content_facet', :null => false

--- a/db/migrate/20160530184400_add_repo_id_indexes.rb
+++ b/db/migrate/20160530184400_add_repo_id_indexes.rb
@@ -1,4 +1,4 @@
-class AddRepoIdIndexes < ActiveRecord::Migration
+class AddRepoIdIndexes < ActiveRecord::Migration[4.2]
   def change
     add_index :katello_repository_docker_manifests, :repository_id
     add_index :katello_repository_errata, :repository_id

--- a/db/migrate/20160605160933_remove_jobs.rb
+++ b/db/migrate/20160605160933_remove_jobs.rb
@@ -1,4 +1,4 @@
-class RemoveJobs < ActiveRecord::Migration
+class RemoveJobs < ActiveRecord::Migration[4.2]
   def up
     drop_table :katello_job_tasks
     drop_table :katello_jobs

--- a/db/migrate/20160605162929_remove_system_smart_proxy.rb
+++ b/db/migrate/20160605162929_remove_system_smart_proxy.rb
@@ -1,4 +1,4 @@
-class RemoveSystemSmartProxy < ActiveRecord::Migration
+class RemoveSystemSmartProxy < ActiveRecord::Migration[4.2]
   def change
     remove_column :smart_proxies, :content_host_id, :integer
   end

--- a/db/migrate/20160613150922_add_event_queue.rb
+++ b/db/migrate/20160613150922_add_event_queue.rb
@@ -1,4 +1,4 @@
-class AddEventQueue < ActiveRecord::Migration
+class AddEventQueue < ActiveRecord::Migration[4.2]
   def change
     create_table :katello_events, :force => true do |t|
       t.integer :object_id, :null => false

--- a/db/migrate/20160617124149_remove_duplicate_view_filters.rb
+++ b/db/migrate/20160617124149_remove_duplicate_view_filters.rb
@@ -1,4 +1,4 @@
-class RemoveDuplicateViewFilters < ActiveRecord::Migration
+class RemoveDuplicateViewFilters < ActiveRecord::Migration[4.2]
   class Role < ApplicationRecord
   end
 

--- a/db/migrate/20160619223332_fix_viewer_role.rb
+++ b/db/migrate/20160619223332_fix_viewer_role.rb
@@ -1,4 +1,4 @@
-class FixViewerRole < ActiveRecord::Migration
+class FixViewerRole < ActiveRecord::Migration[4.2]
   class Role < ApplicationRecord
     has_many :filters
   end

--- a/db/migrate/20160627125310_delete_system.rb
+++ b/db/migrate/20160627125310_delete_system.rb
@@ -1,4 +1,4 @@
-class DeleteSystem < ActiveRecord::Migration
+class DeleteSystem < ActiveRecord::Migration[4.2]
   def change
     drop_table :katello_system_activation_keys
     drop_table :katello_system_repositories

--- a/db/migrate/20160701180402_add_sortable_version_to_puppet_modules.rb
+++ b/db/migrate/20160701180402_add_sortable_version_to_puppet_modules.rb
@@ -1,4 +1,4 @@
-class AddSortableVersionToPuppetModules < ActiveRecord::Migration
+class AddSortableVersionToPuppetModules < ActiveRecord::Migration[4.2]
   class PuppetModule < ApplicationRecord
     self.table_name = "katello_puppet_modules"
   end

--- a/db/migrate/20160722193256_add_verify_ssl_on_sync_to_repository.rb
+++ b/db/migrate/20160722193256_add_verify_ssl_on_sync_to_repository.rb
@@ -1,4 +1,4 @@
-class AddVerifySslOnSyncToRepository < ActiveRecord::Migration
+class AddVerifySslOnSyncToRepository < ActiveRecord::Migration[4.2]
   def up
     add_column :katello_repositories, :verify_ssl_on_sync, :boolean, :null => false, :default => true
   end

--- a/db/migrate/20160727144242_add_registered_through_to_katello_subscription_facets.rb
+++ b/db/migrate/20160727144242_add_registered_through_to_katello_subscription_facets.rb
@@ -1,4 +1,4 @@
-class AddRegisteredThroughToKatelloSubscriptionFacets < ActiveRecord::Migration
+class AddRegisteredThroughToKatelloSubscriptionFacets < ActiveRecord::Migration[4.2]
   def change
     add_column :katello_subscription_facets, :registered_through, :string
   end

--- a/db/migrate/20160728005028_add_latest_version_to_content_view_component.rb
+++ b/db/migrate/20160728005028_add_latest_version_to_content_view_component.rb
@@ -1,4 +1,4 @@
-class AddLatestVersionToContentViewComponent < ActiveRecord::Migration
+class AddLatestVersionToContentViewComponent < ActiveRecord::Migration[4.2]
   def change
     rename_column :katello_content_view_components, :content_view_id, :composite_content_view_id
     change_column_null :katello_content_view_components, :content_view_version_id, :integer, true

--- a/db/migrate/20160808002834_add_files.rb
+++ b/db/migrate/20160808002834_add_files.rb
@@ -1,4 +1,4 @@
-class AddFiles < ActiveRecord::Migration
+class AddFiles < ActiveRecord::Migration[4.2]
   def change
     create_table "katello_files" do |t|
       t.timestamps

--- a/db/migrate/20160906181923_add_puppet_path_to_smart_proxy.rb
+++ b/db/migrate/20160906181923_add_puppet_path_to_smart_proxy.rb
@@ -1,4 +1,4 @@
-class AddPuppetPathToSmartProxy < ActiveRecord::Migration
+class AddPuppetPathToSmartProxy < ActiveRecord::Migration[4.2]
   def change
     add_column :smart_proxies, :puppet_path, :text
   end

--- a/db/migrate/20160907231049_add_username_password_to_repository.rb
+++ b/db/migrate/20160907231049_add_username_password_to_repository.rb
@@ -1,4 +1,4 @@
-class AddUsernamePasswordToRepository < ActiveRecord::Migration
+class AddUsernamePasswordToRepository < ActiveRecord::Migration[4.2]
   def change
     add_column :katello_repositories, :upstream_username, :string, :limit => 255
     add_column :katello_repositories, :upstream_password, :string, :limit => 255

--- a/db/migrate/20160908234510_add_rpm_nvra.rb
+++ b/db/migrate/20160908234510_add_rpm_nvra.rb
@@ -1,4 +1,4 @@
-class AddRpmNvra < ActiveRecord::Migration
+class AddRpmNvra < ActiveRecord::Migration[4.2]
   def up
     add_column :katello_rpms, :nvra, :string, :limit => 1020
     Katello::Rpm.find_each { |r| r.update_attributes!(:nvra => r.build_nvra) }

--- a/db/migrate/20160923143611_add_action_to_content_view_histories.rb
+++ b/db/migrate/20160923143611_add_action_to_content_view_histories.rb
@@ -1,4 +1,4 @@
-class AddActionToContentViewHistories < ActiveRecord::Migration
+class AddActionToContentViewHistories < ActiveRecord::Migration[4.2]
   def up
     add_column :katello_content_view_histories, :action, :integer, default: 0
 

--- a/db/migrate/20160924213020_change_katello_widget_names.rb
+++ b/db/migrate/20160924213020_change_katello_widget_names.rb
@@ -1,4 +1,4 @@
-class ChangeKatelloWidgetNames < ActiveRecord::Migration
+class ChangeKatelloWidgetNames < ActiveRecord::Migration[4.2]
   class Widget < ApplicationRecord
     self.table_name = "widgets"
   end

--- a/db/migrate/20160930121245_content_view_force_puppet_env.rb
+++ b/db/migrate/20160930121245_content_view_force_puppet_env.rb
@@ -1,4 +1,4 @@
-class ContentViewForcePuppetEnv < ActiveRecord::Migration
+class ContentViewForcePuppetEnv < ActiveRecord::Migration[4.2]
   def change
     add_column :katello_content_views, :force_puppet_environment, :boolean, :default => false
   end

--- a/db/migrate/20160930150810_add_smart_proxy_download_policy.rb
+++ b/db/migrate/20160930150810_add_smart_proxy_download_policy.rb
@@ -1,4 +1,4 @@
-class AddSmartProxyDownloadPolicy < ActiveRecord::Migration
+class AddSmartProxyDownloadPolicy < ActiveRecord::Migration[4.2]
   def up
     #set default to on_demand, but update existing proxies to inherit
     add_column :smart_proxies, :download_policy, :string, :null => true

--- a/db/migrate/20161003130853_add_architecture_to_katello_content_view_package_filter_rule.rb
+++ b/db/migrate/20161003130853_add_architecture_to_katello_content_view_package_filter_rule.rb
@@ -1,4 +1,4 @@
-class AddArchitectureToKatelloContentViewPackageFilterRule < ActiveRecord::Migration
+class AddArchitectureToKatelloContentViewPackageFilterRule < ActiveRecord::Migration[4.2]
   def change
     add_column :katello_content_view_package_filter_rules, :architecture, :string
   end

--- a/db/migrate/20161003204325_add_user_to_katello_subscription_facets.rb
+++ b/db/migrate/20161003204325_add_user_to_katello_subscription_facets.rb
@@ -1,4 +1,4 @@
-class AddUserToKatelloSubscriptionFacets < ActiveRecord::Migration
+class AddUserToKatelloSubscriptionFacets < ActiveRecord::Migration[4.2]
   def change
     add_column :katello_subscription_facets, :user_id, :integer
     add_index :katello_subscription_facets, [:user_id], :unique => true

--- a/db/migrate/20161014133811_move_content_view_version_description_to_histories.rb
+++ b/db/migrate/20161014133811_move_content_view_version_description_to_histories.rb
@@ -1,4 +1,4 @@
-class MoveContentViewVersionDescriptionToHistories < ActiveRecord::Migration
+class MoveContentViewVersionDescriptionToHistories < ActiveRecord::Migration[4.2]
   class FakeContentViewVersion < ApplicationRecord
     self.table_name = 'katello_content_view_versions'
     has_many :history, :class_name => "CVHistory", :inverse_of => :content_view_version,

--- a/db/migrate/20161021072346_fix_subscription_permissions.rb
+++ b/db/migrate/20161021072346_fix_subscription_permissions.rb
@@ -1,4 +1,4 @@
-class FixSubscriptionPermissions < ActiveRecord::Migration
+class FixSubscriptionPermissions < ActiveRecord::Migration[4.2]
   def up
     permission_names = [:view_subscriptions, :attach_subscriptions, :unattach_subscriptions, :import_manifest, :delete_manifest]
     Permission.where(:resource_type => 'Organization', :name => permission_names).update_all(resource_type: 'Katello::Subscription')

--- a/db/migrate/20161026191118_fix_invalid_interfaces.rb
+++ b/db/migrate/20161026191118_fix_invalid_interfaces.rb
@@ -1,4 +1,4 @@
-class FixInvalidInterfaces < ActiveRecord::Migration
+class FixInvalidInterfaces < ActiveRecord::Migration[4.2]
   class FakeNic < ApplicationRecord
     self.table_name = 'nics'
 

--- a/db/migrate/20161028153131_sub_facet_user_index_not_uniq.rb
+++ b/db/migrate/20161028153131_sub_facet_user_index_not_uniq.rb
@@ -1,4 +1,4 @@
-class SubFacetUserIndexNotUniq < ActiveRecord::Migration
+class SubFacetUserIndexNotUniq < ActiveRecord::Migration[4.2]
   def up
     remove_index :katello_subscription_facets, [:user_id]
     add_index :katello_subscription_facets, [:user_id], :unique => false

--- a/db/migrate/20161031204903_add_tracer_support.rb
+++ b/db/migrate/20161031204903_add_tracer_support.rb
@@ -1,4 +1,4 @@
-class AddTracerSupport < ActiveRecord::Migration
+class AddTracerSupport < ActiveRecord::Migration[4.2]
   def change
     create_table :katello_host_tracers do |t|
       t.references 'host', :null => false, :index => true

--- a/db/migrate/20161102194100_create_content_view_docker_filter_rules.rb
+++ b/db/migrate/20161102194100_create_content_view_docker_filter_rules.rb
@@ -1,4 +1,4 @@
-class CreateContentViewDockerFilterRules < ActiveRecord::Migration
+class CreateContentViewDockerFilterRules < ActiveRecord::Migration[4.2]
   def change
     create_table :katello_content_view_docker_filter_rules do |t|
       t.references :content_view_filter

--- a/db/migrate/20161209162947_add_virt_who_to_katello_pools.rb
+++ b/db/migrate/20161209162947_add_virt_who_to_katello_pools.rb
@@ -1,4 +1,4 @@
-class AddVirtWhoToKatelloPools < ActiveRecord::Migration
+class AddVirtWhoToKatelloPools < ActiveRecord::Migration[4.2]
   def up
     add_column :katello_pools, :virt_who, :boolean, :default => false, :null => false
   end

--- a/db/migrate/20161214151548_move_content_source_id_to_content_facets.rb
+++ b/db/migrate/20161214151548_move_content_source_id_to_content_facets.rb
@@ -1,4 +1,4 @@
-class MoveContentSourceIdToContentFacets < ActiveRecord::Migration
+class MoveContentSourceIdToContentFacets < ActiveRecord::Migration[4.2]
   def up
     add_column :katello_content_facets, :content_source_id, :integer
     add_index :katello_content_facets, :content_source_id

--- a/db/migrate/20170114051758_add_depth_to_repositories.rb
+++ b/db/migrate/20170114051758_add_depth_to_repositories.rb
@@ -1,4 +1,4 @@
-class AddDepthToRepositories < ActiveRecord::Migration
+class AddDepthToRepositories < ActiveRecord::Migration[4.2]
   def change
     add_column :katello_repositories, :ostree_upstream_sync_policy, :string, :limit => 25
     add_column :katello_repositories, :ostree_upstream_sync_depth, :integer

--- a/db/migrate/20170122204325_add_hypervisor_to_subscription_facets.rb
+++ b/db/migrate/20170122204325_add_hypervisor_to_subscription_facets.rb
@@ -1,4 +1,4 @@
-class AddHypervisorToSubscriptionFacets < ActiveRecord::Migration
+class AddHypervisorToSubscriptionFacets < ActiveRecord::Migration[4.2]
   def change
     add_column :katello_subscription_facets, :hypervisor, :boolean, :default => false
     add_column :katello_subscription_facets, :hypervisor_host_id, :integer

--- a/db/migrate/20170125152421_move_default_location_to_settings.rb
+++ b/db/migrate/20170125152421_move_default_location_to_settings.rb
@@ -1,4 +1,4 @@
-class MoveDefaultLocationToSettings < ActiveRecord::Migration
+class MoveDefaultLocationToSettings < ActiveRecord::Migration[4.2]
   DEFAULT_LOCATION_SETTINGS = ['default_location_subscribed_hosts',
                                'default_location_puppet_content'].freeze
   def up

--- a/db/migrate/20170208215148_add_docker_repo_name.rb
+++ b/db/migrate/20170208215148_add_docker_repo_name.rb
@@ -1,4 +1,4 @@
-class AddDockerRepoName < ActiveRecord::Migration
+class AddDockerRepoName < ActiveRecord::Migration[4.2]
   def up
     add_column :katello_repositories, :container_repository_name, :string
 

--- a/db/migrate/20170220679403_remove_system_permissions.rb
+++ b/db/migrate/20170220679403_remove_system_permissions.rb
@@ -1,4 +1,4 @@
-class RemoveSystemPermissions < ActiveRecord::Migration
+class RemoveSystemPermissions < ActiveRecord::Migration[4.2]
   def up
     system_permissions = Permission.where(:resource_type => 'Katello::System')
     system_permissions.flat_map(&:filters).map(&:destroy!)

--- a/db/migrate/20170222131211_change_pool_columns_to_dates.rb
+++ b/db/migrate/20170222131211_change_pool_columns_to_dates.rb
@@ -1,4 +1,4 @@
-class ChangePoolColumnsToDates < ActiveRecord::Migration
+class ChangePoolColumnsToDates < ActiveRecord::Migration[4.2]
   def up
     unless connection.adapter_name.downcase.include?('sqlite')
       change_column(:katello_pools, :start_date, 'timestamp USING CAST(start_date AS timestamp without time zone)')

--- a/db/migrate/20170321012632_fill_in_content_view_components.rb
+++ b/db/migrate/20170321012632_fill_in_content_view_components.rb
@@ -1,4 +1,4 @@
-class FillInContentViewComponents < ActiveRecord::Migration
+class FillInContentViewComponents < ActiveRecord::Migration[4.2]
   class FakeContentView < ApplicationRecord
     self.table_name = 'katello_content_views'
 

--- a/db/migrate/20170523182831_create_docker_meta_tag.rb
+++ b/db/migrate/20170523182831_create_docker_meta_tag.rb
@@ -1,4 +1,4 @@
-class CreateDockerMetaTag < ActiveRecord::Migration
+class CreateDockerMetaTag < ActiveRecord::Migration[4.2]
   def change
     create_table :katello_docker_meta_tags do |t|
       t.integer  "schema1_id"

--- a/db/migrate/20170718142148_create_katello_subscription_facet_pools.rb
+++ b/db/migrate/20170718142148_create_katello_subscription_facet_pools.rb
@@ -1,4 +1,4 @@
-class CreateKatelloSubscriptionFacetPools < ActiveRecord::Migration
+class CreateKatelloSubscriptionFacetPools < ActiveRecord::Migration[4.2]
   def change
     create_table :katello_subscription_facet_pools do |t|
       t.column :subscription_facet_id, :integer, required: true

--- a/db/migrate/20170821170915_add_index_to_installed_packages.rb
+++ b/db/migrate/20170821170915_add_index_to_installed_packages.rb
@@ -1,4 +1,4 @@
-class AddIndexToInstalledPackages < ActiveRecord::Migration
+class AddIndexToInstalledPackages < ActiveRecord::Migration[4.2]
   def change
     add_index :katello_installed_packages, [:name, :nvra]
   end

--- a/db/migrate/20170821170916_add_nvra_index_to_installed_packages.rb
+++ b/db/migrate/20170821170916_add_nvra_index_to_installed_packages.rb
@@ -1,4 +1,4 @@
-class AddNvraIndexToInstalledPackages < ActiveRecord::Migration
+class AddNvraIndexToInstalledPackages < ActiveRecord::Migration[4.2]
   def change
     add_index :katello_installed_packages, [:nvra]
   end

--- a/db/migrate/20170822104447_add_katello_content_to_image.rb
+++ b/db/migrate/20170822104447_add_katello_content_to_image.rb
@@ -1,4 +1,4 @@
-class AddKatelloContentToImage < ActiveRecord::Migration
+class AddKatelloContentToImage < ActiveRecord::Migration[4.2]
   def change
     add_column :docker_container_wizard_states_images, :katello_content, :text
   end

--- a/db/migrate/20170913183848_add_errata_counts.rb
+++ b/db/migrate/20170913183848_add_errata_counts.rb
@@ -1,4 +1,4 @@
-class AddErrataCounts < ActiveRecord::Migration
+class AddErrataCounts < ActiveRecord::Migration[4.2]
   def up
     add_column :katello_content_facets, :installable_security_errata_count, :integer, :null => false, :default => 0
     add_column :katello_content_facets, :installable_enhancement_errata_count, :integer, :null => false, :default => 0

--- a/db/migrate/20171010170443_add_index_to_katello_content_facet_errata.rb
+++ b/db/migrate/20171010170443_add_index_to_katello_content_facet_errata.rb
@@ -1,4 +1,4 @@
-class AddIndexToKatelloContentFacetErrata < ActiveRecord::Migration
+class AddIndexToKatelloContentFacetErrata < ActiveRecord::Migration[4.2]
   def change
     add_index :katello_content_facet_errata, :content_facet_id, using: 'btree'
   end

--- a/db/migrate/20171010172724_add_docker_manifest_list.rb
+++ b/db/migrate/20171010172724_add_docker_manifest_list.rb
@@ -1,4 +1,4 @@
-class AddDockerManifestList < ActiveRecord::Migration
+class AddDockerManifestList < ActiveRecord::Migration[4.2]
   def up
     create_table :katello_docker_manifest_lists do |t|
       t.integer :schema_version

--- a/db/migrate/20171011175510_add_srpm.rb
+++ b/db/migrate/20171011175510_add_srpm.rb
@@ -1,4 +1,4 @@
-class AddSrpm < ActiveRecord::Migration
+class AddSrpm < ActiveRecord::Migration[4.2]
   def up
     create_table "katello_srpms" do |t|
       t.string "uuid", :null => false, :limit => 255

--- a/db/migrate/20171014051810_remove_docker_manifest_name.rb
+++ b/db/migrate/20171014051810_remove_docker_manifest_name.rb
@@ -1,4 +1,4 @@
-class RemoveDockerManifestName < ActiveRecord::Migration
+class RemoveDockerManifestName < ActiveRecord::Migration[4.2]
   def up
     remove_column :katello_docker_manifests, :name
   end

--- a/db/migrate/20171025163149_remove_use_pulp_oauth_setting.rb
+++ b/db/migrate/20171025163149_remove_use_pulp_oauth_setting.rb
@@ -1,4 +1,4 @@
-class RemoveUsePulpOauthSetting < ActiveRecord::Migration
+class RemoveUsePulpOauthSetting < ActiveRecord::Migration[4.2]
   def up
     Setting.where(:name => 'use_pulp_oauth', :category => 'Setting::Content').delete_all
   end

--- a/db/migrate/20171112174357_create_katello_content.rb
+++ b/db/migrate/20171112174357_create_katello_content.rb
@@ -1,4 +1,4 @@
-class CreateKatelloContent < ActiveRecord::Migration
+class CreateKatelloContent < ActiveRecord::Migration[4.2]
   def change
     create_table :katello_contents do |t|
       t.string :cp_content_id, :index => true, :unique => true

--- a/db/migrate/20171112174358_create_katello_product_content.rb
+++ b/db/migrate/20171112174358_create_katello_product_content.rb
@@ -1,4 +1,4 @@
-class CreateKatelloProductContent < ActiveRecord::Migration
+class CreateKatelloProductContent < ActiveRecord::Migration[4.2]
   def change
     create_table :katello_product_contents do |t|
       t.integer :product_id, :required => true

--- a/db/migrate/20171114150937_cleanup_installed_packages.rb
+++ b/db/migrate/20171114150937_cleanup_installed_packages.rb
@@ -1,4 +1,4 @@
-class CleanupInstalledPackages < ActiveRecord::Migration
+class CleanupInstalledPackages < ActiveRecord::Migration[4.2]
   def up
     create_table "katello_installed_packages_new", force: :cascade do |t|
       t.string "name", limit: 255, null: false

--- a/db/migrate/20171114183353_add_hypervisor_id_to_katello_pools.rb
+++ b/db/migrate/20171114183353_add_hypervisor_id_to_katello_pools.rb
@@ -1,4 +1,4 @@
-class AddHypervisorIdToKatelloPools < ActiveRecord::Migration
+class AddHypervisorIdToKatelloPools < ActiveRecord::Migration[4.2]
   def up
     add_column :katello_pools, :hypervisor_id, :integer
   end

--- a/db/migrate/20171120144843_add_repository_ignore_proxy.rb
+++ b/db/migrate/20171120144843_add_repository_ignore_proxy.rb
@@ -1,4 +1,4 @@
-class AddRepositoryIgnoreProxy < ActiveRecord::Migration
+class AddRepositoryIgnoreProxy < ActiveRecord::Migration[4.2]
   def change
     add_column :katello_repositories, :ignore_global_proxy, :boolean, :null => false, :default => false
   end

--- a/db/migrate/20171211124439_add_uuid_index_to_katello_subscription_facets.rb
+++ b/db/migrate/20171211124439_add_uuid_index_to_katello_subscription_facets.rb
@@ -1,4 +1,4 @@
-class AddUuidIndexToKatelloSubscriptionFacets < ActiveRecord::Migration
+class AddUuidIndexToKatelloSubscriptionFacets < ActiveRecord::Migration[4.2]
   def change
     add_index :katello_subscription_facets, :uuid
   end


### PR DESCRIPTION
Modify migrations to be Rails 5 style and fixes the issue with foreign key for docker tags