### PR TITLE
Fixes 21822 - document katello-host-tools option

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/register.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/register.html
@@ -15,17 +15,27 @@
       </li>
       <li>
         <p translate>Install the pre-built bootstrap RPM:</p>
-        <pre><code>rpm -Uvh http://{{ noCapsulesFound ? katelloHostname : hostname(selectedCapsule.url) }}/pub/{{ consumerCertRPM }}</code></pre>
+        <pre><code>rpm -Uvh https://{{ noCapsulesFound ? katelloHostname : hostname(selectedCapsule.url) }}/pub/{{ consumerCertRPM }}</code></pre>
       </li>
       <li>
-        <p translate>Run subscription-manager in a console on the client host.  You may use an Activation Key to register:</p>
+        <p translate>Register using subscription-manager:</p>
+        <p translate>Using an Activation Key:</p>
         <pre><code>subscription-manager register --org="{{ organization.label }}" --activationkey="&ltActivation Key Name&gt"</code></pre>
-        <p translate>or authenticate with a username and password:</p>
+        <p translate>Using a username and password:</p>
         <pre><code>subscription-manager register --org="{{ organization.label }}" --environment="Library"</code></pre>
       </li>
       <li>
-        <p translate>Install katello-agent for remote actions and displaying errata information:</p>
+        <p translate>Install client package:</p>
+
+        <p translate>To report package & errata information:</p>
+        <pre><code>yum -y install katello-host-tools</code></pre>
+
+        <p translate>To optionally report tracer information:</p>
+        <pre><code>yum -y install katello-host-tools-tracer</code></pre>
+
+        <p translate>For remote actions and reporting package & errata information:</p>
         <pre><code>yum -y install katello-agent</code></pre>
+        <p translate>Learn more about these packages in the <a href="https://theforeman.org/plugins/katello/">Documentation</a> </p>
       </li>
     </ol>
   </div>


### PR DESCRIPTION
This rewords the content host -> register page and enables our sub-man snippet to install katello-host-tools.

@jlsherrill I used the original katello-host-tools issue, hopefully that is okay? because I'm lazy 😆
 
![screenshot from 2017-11-30 10-29-11](https://user-images.githubusercontent.com/13135483/33426544-1d07176e-d5ba-11e7-96c7-92c6fa5ca5a8.png)
