### PR TITLE
Add in string extract logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,10 +23,12 @@ tmp
 *~
 config/katello.yml
 *.iml
-locale/*/LC_MESSAGES
+locale/*.mo
 locale/*/*.edit.po
 locale/*/*.po.time_stamp
 locale/.cache/*
+locale/*/*.pox
+locale/*/LC_MESSAGES
 .yardoc
 yardoc
 doc/apidoc*

--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,14 @@
 [main]
-host = https://www.transifex.net
+host = https://www.transifex.com
 
-[katello.katello]
-file_filter = locale/<lang>/katello.po
+[foreman.katello]
+file_filter = locale/<lang>/katello.edit.po
 source_file = locale/katello.pot
 source_lang = en
+type = PO
+
+[foreman.bastion_katello]
+file_filter = engines/bastion_katello/app/assets/javascripts/bastion_katello/i18n/locale/<lang>.po
+source_file = engines/bastion_katello/app/assets/javascripts/bastion_katello/i18n/bastion_katello.pot
+source_lang = en
+type = PO

--- a/locale/Makefile
+++ b/locale/Makefile
@@ -1,33 +1,40 @@
 #
-# Makefile for PO merging and MO generation
+# Makefile for PO merging and MO generation. More info in the README.
 #
-
-POTFILE = katello.pot
-POFILES = $(shell find . -name '*.po')
+# make all-mo (default) - generate MO files
+# make check - check translations using translate-tool
+# make tx-update - download and merge translations from Transifex
+# make clean - clean everything
+#
+DOMAIN = katello
+VERSION = $(shell git describe --abbrev=0 --tags)
+POTFILE = $(DOMAIN).pot
+MOFILE = $(DOMAIN).mo
+POFILES = $(shell find . -name '$(DOMAIN).po')
 MOFILES = $(patsubst %.po,%.mo,$(POFILES))
 POXFILES = $(patsubst %.po,%.pox,$(POFILES))
+EDITFILES = $(patsubst %.po,%.edit.po,$(POFILES))
 
 %.mo: %.po
-	msgfmt -o $@ $<
+	mkdir -p $(shell dirname $@)/LC_MESSAGES
+	msgfmt -o $(shell dirname $@)/LC_MESSAGES/$(MOFILE) $<
+	touch $(shell dirname $@)/LC_MESSAGES/$(MOFILE)
 
 # Generate MO files from PO files
 all-mo: $(MOFILES)
 
 # Check for malformed strings
-# TODO - enable endwhitespace, endpunc, puncspacing, options filters
 %.pox: %.po
 	msgfmt -c $<
 	pofilter --nofuzzy -t variables -t blank -t urls -t emails -t long -t newlines \
-		-t options -t printf -t validchars --gnome $< > $@
+		-t endwhitespace -t endpunc -t puncspacing -t options -t printf -t validchars --gnome $< > $@
+	cat $@
 	! grep -q msgid $@
 
-check: $(POXFILES)
+%.edit.po:
+	touch $@
 
-# Merge PO files
-update-po:
-	for f in $(shell find ./ -name "*.po") ; do \
-		msgmerge -N --backup=none -U $$f ${POTFILE} ; \
-	done
+check: $(POXFILES)
 
 # Unify duplicate translations
 uniq-po:
@@ -35,7 +42,35 @@ uniq-po:
 		msguniq $$f -o $$f ; \
 	done
 
-# Remove all MO files
-clean:
-	-rm -f messages.mo
-	find . \( -name "*.mo" -o -name "*.pox" \) -exec rm -f '{}' ';'
+tx-pull: $(EDITFILES)
+	tx pull -f
+	for f in $(EDITFILES) ; do \
+		sed -i 's/^\("Project-Id-Version: \).*$$/\1$(DOMAIN) $(VERSION)\\n"/' $$f; \
+	done
+
+tx-update: tx-pull
+	@echo
+	@echo Run rake plugin:gettext[$(DOMAIN)] from the Foreman installation, then make -C locale mo-files to finish
+	@echo
+
+mo-files: $(MOFILES)
+	git add $(POFILES) $(POTFILE) ../locale/*/LC_MESSAGES
+	git commit -m "i18n - pulling from tx"
+	@echo
+	@echo Changes commited!
+	@echo
+
+# Workaround when rake task fails (https://github.com/ruby/rake/pull/182)
+extract:
+	rxgettext \
+		--sort-output \
+		--sort-by-msgid \
+		--no-wrap \
+		--no-location \
+		-o ${DOMAIN}.pot \
+		--package-name=${DOMAIN} \
+		--package-version="${VERSION}" \
+		--msgid-bugs-address=foreman-dev@googlegroups.com \
+		--copyright-holder="Foreman developers" \
+		--copyright-year=$(shell date +%Y) \
+		$(shell find ../app -type f -name \*.rb -o -name \*.erb)

--- a/locale/update-i18n
+++ b/locale/update-i18n
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+FOREMAN_DIR="../../foreman"
+BASTION_DIR="../engines/bastion_katello"
+
+#this actuall pulls the strings from transifex for both directions
+make -C locale tx-update
+
+#Extract the main strings
+pushd $FOREMAN_DIR
+bundle exec rake plugin:gettext[katello]
+popd
+
+# Now extract the bastion files
+pushd $BASTION_DIR
+bundle exec grunt i18n:extract
+bundle exec grunt i18n:compile
+popd
+
+# This step creates the mo files and does the commit
+make -C locale mo-files
+


### PR DESCRIPTION
This is 4 commits that do the following:
1) Extract the strings and translations for the main code base.
2) Add automation to do (1)
3) Extract the strings and translations for the bastion bits
4) Adds automation for all of the above.
I dont like  the bastion automation since it does not use edit files like the other bits, but I think it is ok. I have copied the items for (1) from the work @lzap did in foreman_discovery. Once this is commited, I will set up transifex to pull from this repo and then ask that every release of katello extract strings and translations as part of the release process. I will set up a seperate process to push downstream strings into trransifex.