### PR TITLE
Fixes #21845 - Removes docker blobs on promotion

### DIFF
--- a/app/lib/actions/katello/repository/clear.rb
+++ b/app/lib/actions/katello/repository/clear.rb
@@ -11,7 +11,9 @@ module Actions
            Pulp::Repository::RemoveFile,
            Pulp::Repository::RemovePuppetModule,
            Pulp::Repository::RemoveDockerManifest,
-           Pulp::Repository::RemoveDockerManifestList].each do |action_class|
+           Pulp::Repository::RemoveDockerManifestList,
+           Pulp::Repository::RemoveDockerTag,
+           Pulp::Repository::RemoveDockerBlob].each do |action_class|
             plan_action(action_class, pulp_id: repo.pulp_id)
           end
         end

--- a/app/lib/actions/pulp/repository/remove_docker_blob.rb
+++ b/app/lib/actions/pulp/repository/remove_docker_blob.rb
@@ -1,0 +1,11 @@
+module Actions
+  module Pulp
+    module Repository
+      class RemoveDockerBlob < Pulp::Repository::AbstractRemoveContent
+        def content_extension
+          pulp_extensions.docker_blob
+        end
+      end
+    end
+  end
+end

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "apipie-rails", ">= 0.5.4"
 
   # Pulp
-  gem.add_dependency "runcible", ">= 2.5.0", "< 3.0.0"
+  gem.add_dependency "runcible", ">= 2.6.0", "< 3.0.0"
   gem.add_dependency "anemone"
 
   # UI


### PR DESCRIPTION
Before this commit

During promotion one of the pulp docker content types 'DockerBlob' did not cleared when the 'clear' operation was run.

After this commit

DockerBlob get wiped out on 'clear' operation.