### PR TITLE
Fixes #21808 - Correct DockerTag unit import

### DIFF
--- a/app/models/katello/docker_tag.rb
+++ b/app/models/katello/docker_tag.rb
@@ -56,6 +56,7 @@ module Katello
     end
 
     def self.import_all(uuids = nil, options = {})
+      ::Katello::DockerTag.destroy_all if uuids.blank?
       super
       ::Katello::DockerTag.where(:repository_id => nil).destroy_all
       if uuids
@@ -64,6 +65,11 @@ module Katello
       else
         ::Katello::DockerMetaTag.import_meta_tags(::Katello::Repository.docker_type)
       end
+    end
+
+    def self.import_for_repository(repository)
+      ::Katello::DockerTag.where(:repository_id => repository).destroy_all
+      super(repository, true)
     end
 
     def self.manage_repository_association

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -772,7 +772,7 @@ module Katello
       elsif self.docker?
         Katello::DockerManifest.import_for_repository(self)
         Katello::DockerManifestList.import_for_repository(self)
-        Katello::DockerTag.import_for_repository(self, true)
+        Katello::DockerTag.import_for_repository(self)
       elsif self.puppet?
         Katello::PuppetModule.import_for_repository(self)
       elsif self.ostree?


### PR DESCRIPTION
Before This commit

::Katello::DockerTag.import_for_repository(repo)
would not update an existing repo. It would not clear the prior
tags before importing new ones from pulp.
This call in particular is used by the promotion operations to update
tags in a CVE repository.

After This commit

This operation is now fixed because the import for repository forcibly
clears out existing tags in the repo before the import actually starts.