### PR TITLE
Fixes #21855 - Give EventQueue Time objects instead of DateTime

### DIFF
--- a/app/lib/actions/katello/event_queue/suspended_action.rb
+++ b/app/lib/actions/katello/event_queue/suspended_action.rb
@@ -7,7 +7,7 @@ module Actions
         end
 
         def notify_queue_item(event_type, object_id, created_at)
-          @suspended_action << Monitor::Event[event_type, object_id, created_at.to_datetime]
+          @suspended_action << Monitor::Event[event_type, object_id, created_at]
         end
 
         def notify_ready


### PR DESCRIPTION
The time format passed from event_queue/suspended_action.rb was not matching what was expected in event_queue/monitor.rb

Before checking the code out, inspect your queue size: 

`irb(main):003:0> Katello::Event.all.size                 
=> 195`

If it's 0, do something like importing a manifest and you should see a positive number which does not decrease. Restarting the app with this change should get the events flowing once more.

`irb(main):015:0> Katello::Event.all.size                 
=> 0`