### PR TITLE
Fixes #21931 - Add react-storybook to Katello

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,0 +1,9 @@
+import { configure } from '@storybook/react';
+
+global.__ = str => str;
+
+function loadStories() {
+  require('../webpack/stories');
+}
+
+configure(loadStories, module);

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "katello",
   "version": "1.0.0",
   "scripts": {
+    "storybook": "start-storybook -p 6007",
+    "storybook:deploy": "storybook-to-ghpages",
     "test": "jest webpack",
     "test:watch": "jest webpack --watchAll",
     "test:current": "jest webpack --watch",
@@ -17,6 +19,8 @@
     "url": "http://projects.theforeman.org/projects/katello/issues"
   },
   "devDependencies": {
+    "@storybook/react": "^3.2.17",
+    "@storybook/storybook-deployer": "^2.0.0",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",

--- a/webpack/scenes/RedHatRepositories/components/EnabledRepository.stories.js
+++ b/webpack/scenes/RedHatRepositories/components/EnabledRepository.stories.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import EnabledRepository from './EnabledRepository.js';
+
+storiesOf('RedHat Repositories Page', module).add('Enabled Repository', () => (
+  <EnabledRepository
+    id={638}
+    name="Red Hat Enterprise Linux 6 Server Kickstart x86_64 6.8"
+    releasever="6.8"
+    arch="x86_64"
+    type="rpm"
+  />
+));

--- a/webpack/stories/index.js
+++ b/webpack/stories/index.js
@@ -1,0 +1,12 @@
+import { configure } from '@storybook/react';
+
+require('patternfly/dist/css/patternfly.min.css');
+require('patternfly/dist/css/patternfly-additions.min.css');
+
+const req = require.context('../', true, /.stories.js$/);
+
+function loadStories() {
+  req.keys().forEach(filename => req(filename));
+}
+
+configure(loadStories, module);


### PR DESCRIPTION
Adds dependency for react-storybook as well as the deployer.
I've included one story as an example which can be seen [here](https://rawgit.com/danseethaler/katello/storybook-21931-stories/index.html).

http://projects.theforeman.org/issues/21931