### PR TITLE
fixes #21961 - fix host collection check during register

### DIFF
--- a/app/lib/actions/katello/host/register.rb
+++ b/app/lib/actions/katello/host/register.rb
@@ -83,7 +83,8 @@ module Actions
 
           host_collection_ids.each do |host_collection_id|
             host_collection = ::Katello::HostCollection.find(host_collection_id)
-            if !host_collection.unlimited_hosts && host_collection.max_hosts >= 0
+            if !host_collection.unlimited_hosts && host_collection.max_hosts >= 0 &&
+              host_collection.hosts.length >= host_collection.max_hosts
               fail _("Host collection '%{name}' exceeds maximum usage limit of '%{limit}'") %
                        {:limit => host_collection.max_hosts, :name => host_collection.name}
             end


### PR DESCRIPTION
This commit is to put back the logic removed with commit
91599327 that removed the check of the host collection hosts
against the host collection max_hosts.