### PR TITLE
Fixes #21994 - Auto Publish composite

### DIFF
--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -20,6 +20,7 @@ module Katello
     param :version, String, :desc => N_("Filter versions by version number"), :required => false
     param :composite_version_id, :number, :desc => N_("Filter versions that are components in the specified composite version"), :required => false
     param :organization_id, :number, :desc => N_("Organization identifier")
+    param :triggered_by_id, :number, :desc => N_("Filter composite versions whose publish was triggered by the specified component version"), :required => false
     param_group :search, Api::V2::ApiController
     def index
       options = {
@@ -32,6 +33,7 @@ module Katello
     def index_relation
       version_number = params.permit(:version)[:version]
       versions = ContentViewVersion.readable
+      versions = versions.triggered_by(params[:triggered_by_id]) if params[:triggered_by_id]
       versions = versions.with_organization_id(params[:organization_id]) if params[:organization_id]
       versions = versions.where(:content_view_id => @view.id) if @view
       versions = versions.for_version(version_number) if version_number

--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -18,6 +18,7 @@ module Katello
       param :description, String, :desc => N_("Description for the content view")
       param :repository_ids, Array, :desc => N_("List of repository ids")
       param :component_ids, Array, :desc => N_("List of component content view version ids for composite views")
+      param :auto_publish, :bool, :desc => N_("Enable/Disable auto publish of composite view")
     end
 
     api :GET, "/organizations/:organization_id/content_views", N_("List content views")
@@ -209,7 +210,7 @@ module Katello
     def view_params
       attrs = [:name, :description, :force_puppet_environment, {:repository_ids => []}, {:component_ids => []}]
       attrs.push(:label, :composite) if action_name == "create"
-      attrs.push(:component_ids, :repository_ids) # For deep_munge; Remove for Rails 5
+      attrs.push(:component_ids, :repository_ids, :auto_publish) # For deep_munge; Remove for Rails 5
       params.require(:content_view).permit(*attrs).to_h
     end
 

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -53,6 +53,7 @@ module Katello
     validates :organization_id, :presence => true
     validate :check_non_composite_components
     validate :check_puppet_conflicts
+    validate :check_non_composite_auto_publish
     validates :composite, :inclusion => [true, false]
 
     validates_with Validators::KatelloNameFormatValidator, :attributes => :name
@@ -417,6 +418,12 @@ module Katello
     def check_non_composite_components
       if !composite? && components.present?
         errors.add(:base, _("Cannot add component versions to a non-composite content view"))
+      end
+    end
+
+    def check_non_composite_auto_publish
+      if !composite? && auto_publish
+        errors.add(:base, _("Cannot set auto publish to a non-composite content view"))
       end
     end
 

--- a/app/models/katello/content_view_history.rb
+++ b/app/models/katello/content_view_history.rb
@@ -5,6 +5,9 @@ module Katello
     belongs_to :environment, :class_name => "Katello::KTEnvironment", :inverse_of => :content_view_histories,
                              :foreign_key => :katello_environment_id
     belongs_to :content_view_version, :class_name => "Katello::ContentViewVersion", :foreign_key => :katello_content_view_version_id, :inverse_of => :history
+
+    belongs_to :triggered_by, :class_name => "Katello::ContentViewVersion", :inverse_of => :triggered_histories
+
     belongs_to :task, :class_name => "ForemanTasks::Task::DynflowTask", :foreign_key => :task_id
 
     IN_PROGRESS = 'in progress'.freeze

--- a/app/services/katello/ui_notifications/content_view/auto_publish_failure.rb
+++ b/app/services/katello/ui_notifications/content_view/auto_publish_failure.rb
@@ -1,0 +1,22 @@
+module Katello
+  module UINotifications
+    module ContentView
+      class AutoPublishFailure < ::UINotifications::Base
+        private
+
+        def create
+          Notification.create!(
+            subject: subject,
+            initiator: initiator,
+            audience: ::Notification::AUDIENCE_ADMIN,
+            notification_blueprint: blueprint
+          )
+        end
+
+        def blueprint
+          @blueprint ||= NotificationBlueprint.find_by(name: 'content_view_auto_publish_error')
+        end
+      end
+    end
+  end
+end

--- a/app/views/katello/api/v2/content_view_histories/show.json.rabl
+++ b/app/views/katello/api/v2/content_view_histories/show.json.rabl
@@ -18,6 +18,18 @@ node :version_id do |h|
   h.content_view_version.id
 end
 
+node :triggered_by do |h|
+  if h.triggered_by
+    h.triggered_by.name
+  end
+end
+
+node :triggered_by_id do |h|
+  if h.triggered_by
+    h.triggered_by.id
+  end
+end
+
 child :task => :task do
   extends 'foreman_tasks/api/tasks/show'
 end

--- a/app/views/katello/api/v2/content_views/base.json.rabl
+++ b/app/views/katello/api/v2/content_views/base.json.rabl
@@ -7,6 +7,7 @@ attributes :default
 attributes :force_puppet_environment
 attributes :version_count
 attributes :latest_version
+attributes :auto_publish
 
 node :next_version do |content_view|
   content_view.next_version.to_f.to_s

--- a/db/migrate/20171214050230_add_auto_publish_to_content_views.rb
+++ b/db/migrate/20171214050230_add_auto_publish_to_content_views.rb
@@ -1,0 +1,5 @@
+class AddAutoPublishToContentViews < ActiveRecord::Migration[5.1]
+  def change
+    add_column :katello_content_views, :auto_publish, :boolean, :null => false, :default => false
+  end
+end

--- a/db/migrate/20180207232901_add_triggered_by_to_content_view_history.rb
+++ b/db/migrate/20180207232901_add_triggered_by_to_content_view_history.rb
@@ -1,0 +1,7 @@
+class AddTriggeredByToContentViewHistory < ActiveRecord::Migration[5.1]
+  def change
+    add_column :katello_content_view_histories, :triggered_by_id, :integer, :null => true
+    add_foreign_key "katello_content_view_histories", "katello_content_view_versions",
+                :name => "katello_cv_history_versions_triggered_by_fk", :column => "triggered_by_id"
+  end
+end

--- a/db/seeds.d/110-content-view-autopublish.rb
+++ b/db/seeds.d/110-content-view-autopublish.rb
@@ -1,0 +1,15 @@
+# seeds UI notification blueprints that are supported by Content View.
+[
+  {
+    group: N_('Content View'),
+    name: 'content_view_auto_publish_error',
+    message: N_('Composite Content View \'%{subject}\' failed auto-publish'),
+    level: 'error',
+    actions:
+    {
+      links:
+      [
+      ]
+    }
+  }
+].each { |blueprint| UINotifications::Seed.new(blueprint).configure }

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-info.html
@@ -35,6 +35,20 @@
           With this option selected, a puppet environment will be created during publish and promote even if no puppet modules have been added to the Content View
         </p>
       </dd>
+
+      <div ng-if="contentView.composite">
+        <dt translate>Auto Publish</dt>
+        <dd>
+          <div bst-edit-checkbox="contentView.auto_publish"
+               formatter="booleanToYesNo"
+               on-save="save(contentView)"
+               readonly="denied('edit_content_views', contentView)">
+          </div>
+          <p class="help-text">
+            Applicable only for composite views. Auto publish composite view when a new version of a component content view is created. Also note auto publish will only happen when the component is marked "latest".
+          </p>
+        </dd>
+      </div>
     </dl>
   </div>
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/new/views/content-view-new.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/new/views/content-view-new.html
@@ -70,6 +70,22 @@
         <p class="help-block" translate>A composite view contains other content views.</p>
       </div>
 
+      <div bst-form-group>
+        <div class="checkbox">
+          <label for="auto_publish">
+            <input id="auto_publish"
+                   name="auto_publish"
+                   ng-model="contentView.auto_publish"
+                   type="checkbox"
+                   tabindex="5"
+                   ng-disabled="!contentView.composite"
+                   ng-checked="contentView.composite && 0"/>
+            <span translate>Auto Publish</span>
+          </label>
+        </div>
+        <p class="help-block" translate>Applicable only for composite views. Auto publish composite view when a new version of a component content view is created. Also note auto publish will only happen when the component is marked "latest".</p>
+      </div>
+
       <div bst-form-buttons
            on-cancel="transitionTo('content-views')"
            on-save="save(contentView)"


### PR DESCRIPTION
This commit contains code to auto publish a composite when a component
CV updates. 
When a component cv publishes it checks for 2 flags
1) If its composite has auto publish marked as true
2) If its composite wants the latest version of this component.
If those conditions are met then the publish tasks for the composites
are spawned. The user is notified once the operation is completed. The
'triggering' content view's version id is stored in the content view
history so that the caller can track other publishes that are happening
at the same time.

It is assumed that the composite is not getting published
else where at the same time. If that is the case the publish will error
out. 
