### PR TITLE
Fixes #21995 - Add /katello/api/gpg_keys/<id>/content

### DIFF
--- a/app/controllers/katello/api/v2/gpg_keys_controller.rb
+++ b/app/controllers/katello/api/v2/gpg_keys_controller.rb
@@ -3,8 +3,8 @@ module Katello
     include Katello::Concerns::FilteredAutoCompleteSearch
     before_action :authorize
     before_action :find_organization, :only => [:create, :index, :auto_complete_search]
-    before_action :find_gpg_key, :only => [:show, :update, :destroy, :content]
-    skip_before_action :check_content_type, :only => [:create, :content]
+    before_action :find_gpg_key, :only => [:show, :update, :destroy, :content, :set_content]
+    skip_before_action :check_content_type, :only => [:create, :content, :set_content]
 
     def_param_group :gpg_key do
       param :name, :identifier, :action_aware => true, :required => true, :desc => N_("identifier of the gpg key")
@@ -71,10 +71,16 @@ module Katello
       respond_for_destroy
     end
 
+    api :GET, "/gpg_keys/:id/content", N_("Return the content of a gpg key, used directly by yum")
+    param :id, :number, :required => true
+    def content
+      render(:plain => @gpg_key.content, :layout => false)
+    end
+
     api :POST, "/gpg_keys/:id/content", N_("Upload gpg key contents")
     param :id, :number, :desc => N_("gpg key numeric identifier"), :required => true
     param :content, File, :desc => N_("file contents"), :required => true
-    def content
+    def set_content
       filepath = params.try(:[], :content).try(:path)
 
       if filepath

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -155,7 +155,10 @@ Katello::Engine.routes.draw do
         end
 
         api_resources :gpg_keys, :only => [:index, :show, :create, :update, :destroy] do
-          post :content, :on => :member
+          member do
+            get :content
+            post :content, :action => :set_content
+          end
           get :auto_complete_search, :on => :collection
         end
 

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -145,7 +145,7 @@ module Katello
     def gpg_key_permissions
       @plugin.permission :view_gpg_keys,
                          {
-                           'katello/api/v2/gpg_keys' => [:index, :show, :auto_complete_search]
+                           'katello/api/v2/gpg_keys' => [:index, :show, :content, :auto_complete_search]
                          },
                          :resource_type => 'Katello::GpgKey'
       @plugin.permission :create_gpg_keys,
@@ -155,7 +155,7 @@ module Katello
                          :resource_type => 'Katello::GpgKey'
       @plugin.permission :edit_gpg_keys,
                          {
-                           'katello/api/v2/gpg_keys' => [:update, :content]
+                           'katello/api/v2/gpg_keys' => [:update, :set_content]
                          },
                          :resource_type => 'Katello::GpgKey'
       @plugin.permission :destroy_gpg_keys,

--- a/test/controllers/api/v2/gpg_keys_controller_test.rb
+++ b/test/controllers/api/v2/gpg_keys_controller_test.rb
@@ -42,12 +42,18 @@ module Katello
     end
 
     def test_content
+      get :content, :id => @gpg_key.id
+      assert_response :success
+      assert_equal @response.body, @gpg_key.content
+    end
+
+    def test_set_content
       @request.env["CONTENT_TYPE"] = "multipart/form"
       content = "abc123"
       temp_content_file = Tempfile.new(content)
       temp_content_file.write(content)
       temp_content_file.rewind
-      post :content, :id => @gpg_key.id, :content => Rack::Test::UploadedFile.new(temp_content_file.path, "text/plain")
+      post :set_content, :id => @gpg_key.id, :content => Rack::Test::UploadedFile.new(temp_content_file.path, "text/plain")
       assert_response :success, @response.body
       assert_equal content, @gpg_key.reload.content
     end


### PR DESCRIPTION
This will help support the use of GPG Keys that are used to sign repository metadata but not repository content.

See https://bugzilla.redhat.com/show_bug.cgi?id=1410638 and https://github.com/candlepin/subscription-manager/pull/1749 for some additional background.