### PR TITLE
Fixes #22116 - Remove disable_dynflow from import_product_content.rake

### DIFF
--- a/lib/katello/tasks/upgrades/3.6/import_product_content.rake
+++ b/lib/katello/tasks/upgrades/3.6/import_product_content.rake
@@ -2,7 +2,7 @@ namespace :katello do
   namespace :upgrades do
     namespace '3.6' do
       desc "Import product content from Candlepin to improve API performance and enhance searching"
-      task :import_product_content => %w(environment disable_dynflow check_ping) do
+      task :import_product_content => %w(environment check_ping) do
         User.current = User.anonymous_admin
 
         Organization.all.each do |org|


### PR DESCRIPTION
This was preventing the task from being run which makes it pretty useless!