### PR TITLE
Fixes #22142 - Update templates to use host_param

### DIFF
--- a/app/views/foreman/unattended/finish-katello.erb
+++ b/app/views/foreman/unattended/finish-katello.erb
@@ -20,8 +20,8 @@ service network restart
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
   os_major = @host.operatingsystem.major.to_i
   pm_set = @host.puppetmaster.empty? ? false : true
-  puppet_enabled = pm_set || @host.params['force-puppet']
-  salt_enabled = @host.params['salt_master'] ? true : false
+  puppet_enabled = pm_set || host_param('force-puppet')
+  salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
 %>
 
@@ -33,10 +33,10 @@ service network restart
 
 # update local time
 echo "updating system time"
-/usr/sbin/ntpdate -sub <%= @host.params['ntp-server'] || '0.fedora.pool.ntp.org' %>
+/usr/sbin/ntpdate -sub <%= host_param('ntp-server') || '0.fedora.pool.ntp.org' %>
 /usr/sbin/hwclock --systohc
 
-<% if @host.info['parameters']['realm'] && @host.realm && @host.realm.realm_type == 'FreeIPA' -%>
+<% if host_param('realm') && @host.realm && @host.realm.realm_type == 'FreeIPA' -%>
 <%= snippet "freeipa_register" %>
 <% end -%>
 

--- a/app/views/foreman/unattended/kickstart-katello-atomic.erb
+++ b/app/views/foreman/unattended/kickstart-katello-atomic.erb
@@ -3,9 +3,9 @@ kind: provision
 name: Katello Atomic Kickstart default
 %>
 
-lang <%= @host.params['lang'] || 'en_US.UTF-8' %>
-keyboard <%= @host.params['keyboard'] || 'us' %>
-timezone --utc <%= @host.params['time-zone'] || 'UTC' %>
+lang <%= host_param('lang') || 'en_US.UTF-8' %>
+keyboard <%= host_param('keyboard') || 'us' %>
+timezone --utc <%= host_param('time-zone') || 'UTC' %>
 
 <% subnet = @host.subnet -%>
 <% if subnet.respond_to?(:dhcp_boot_mode?) -%>

--- a/app/views/foreman/unattended/kickstart-katello.erb
+++ b/app/views/foreman/unattended/kickstart-katello.erb
@@ -16,8 +16,8 @@ oses:
   os_major = @host.operatingsystem.major.to_i
   # safemode renderer does not support unary negation
   pm_set = @host.puppetmaster.empty? ? false : true
-  puppet_enabled = pm_set || @host.params['force-puppet']
-  salt_enabled = @host.params['salt_master'] ? true : false
+  puppet_enabled = pm_set || host_param('force-puppet')
+  salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
   section_end = (rhel_compatible && os_major <= 5) ? '' : '%end'
 %>
@@ -40,7 +40,7 @@ network --bootproto <%= dhcp ? 'dhcp' : "static --ip=#{@host.ip} --netmask=#{sub
 rootpw --iscrypted <%= root_pass %>
 firewall --<%= os_major >= 6 ? 'service=' : '' %>ssh
 authconfig --useshadow --passalgo=<%= @host.operatingsystem.password_hash || 'sha256' %> --kickstart
-timezone --utc <%= @host.params['time-zone'] || 'UTC' %>
+timezone --utc <%= host_param('time-zone') || 'UTC' %>
 
 <% if @host.operatingsystem.name == 'Fedora' and os_major <= 16 -%>
 # Bootloader exception for Fedora 16:
@@ -100,12 +100,12 @@ exec < /dev/tty3 > /dev/tty3
 
 #update local time
 echo "updating system time"
-/usr/sbin/ntpdate -sub <%= @host.params['ntp-server'] || '0.fedora.pool.ntp.org' %>
+/usr/sbin/ntpdate -sub <%= host_param('ntp-server') || '0.fedora.pool.ntp.org' %>
 /usr/sbin/hwclock --systohc
 
 <%= snippet "subscription_manager_registration" %>
 
-<% if @host.info['parameters']['realm'] && @host.realm && @host.realm.realm_type == 'FreeIPA' -%>
+<% if host_param('realm') && @host.realm && @host.realm.realm_type == 'FreeIPA' -%>
 <%= snippet "freeipa_register" %>
 <% end -%>
 

--- a/app/views/foreman/unattended/snippets/_subscription_manager_registration.erb
+++ b/app/views/foreman/unattended/snippets/_subscription_manager_registration.erb
@@ -1,4 +1,4 @@
-<% if @host.params['kt_activation_keys'] %>
+<% if host_param('kt_activation_keys') %>
   # add subscription manager
  <% if @host.operatingsystem.atomic? %>
   curl -s <%= subscription_manager_configuration_url(@host, false) %> | IS_ATOMIC=true bash
@@ -8,7 +8,7 @@
  <% end %>
 
   echo "Registering the System"
-  subscription-manager register --org="<%= @host.rhsm_organization_label %>" --name="<%= @host.name %>" --activationkey="<%= @host.params['kt_activation_keys'] %>"
+  subscription-manager register --org="<%= @host.rhsm_organization_label %>" --name="<%= @host.name %>" --activationkey="<%= host_param('kt_activation_keys') %>"
 
   <% unless @host.operatingsystem.atomic? %>
     echo "Installing Katello Agent"

--- a/app/views/foreman/unattended/userdata-katello.erb
+++ b/app/views/foreman/unattended/userdata-katello.erb
@@ -29,13 +29,13 @@ users:
    passwd: <%= @host.root_pass %>
 
 <%# Allow user to specify additional SSH key as host paramter -%>
-<% if @host.params['sshkey'].present? || @host.params['remote_execution_ssh_keys'].present? -%>
+<% if host_param('sshkey').present? || host_param('remote_execution_ssh_keys').present? -%>
 ssh_authorized_keys:
-<% if @host.params['sshkey'].present? -%>
-  - <%= @host.params['sshkey'] %>
+<% if host_param('sshkey').present? -%>
+  - <%= host_param('sshkey') %>
 <% end -%>
-<% if @host.params['remote_execution_ssh_keys'].present? -%>
-<% @host.params['remote_execution_ssh_keys'].each do |key| -%>
+<% if host_param('remote_execution_ssh_keys').present? -%>
+<% host_param('remote_execution_ssh_keys').each do |key| -%>
   - <%= key %>
 <% end -%>
 <% end -%>
@@ -48,7 +48,7 @@ write_files:
 <%= indent 4 do
       snippet 'subscription_manager_registration'
     end %>
-<% if @host.info['parameters']['realm'] && @host.realm && @host.realm.realm_type == 'FreeIPA' -%>
+<% if host_param('realm') && @host.realm && @host.realm.realm_type == 'FreeIPA' -%>
 <%= indent 4 do
       snippet 'freeipa_register'
     end %>
@@ -61,8 +61,8 @@ write_files:
   # safemode renderer does not support unary negation
   non_atomic = @host.operatingsystem.atomic? ? false : true
   pm_set = @host.puppetmaster.empty? ? false : true
-  puppet_enabled = non_atomic && (pm_set || @host.params['force-puppet'])
-  salt_enabled = non_atomic && (@host.params['salt_master'] ? true : false)
+  puppet_enabled = non_atomic && (pm_set || host_param('force-puppet'))
+  salt_enabled = non_atomic && (host_param('salt_master') ? true : false)
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
 %>
 <% if chef_enabled %>


### PR DESCRIPTION
Current templates throw an error because `@host.params` is not allowed in the Host::Jail