### PR TITLE
Fixes #22157 - Including RemoveDockerTag

### DIFF
--- a/app/lib/actions/pulp/repository/remove_docker_tag.rb
+++ b/app/lib/actions/pulp/repository/remove_docker_tag.rb
@@ -1,0 +1,11 @@
+module Actions
+  module Pulp
+    module Repository
+      class RemoveDockerTag < Pulp::Repository::AbstractRemoveContent
+        def content_extension
+          pulp_extensions.docker_tag
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Commit a0e098cded383b65b09100a971570b7194bbd9b7 was incomplete. The
remove_docker_tag file was not submitted as a part of the merge and
hence we hit an error saying "RemoveDockerTag not found" when
republishing a content view with docker repos.

This commit fixes that