### PR TITLE
Fixes #21954 - Visual improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "bootstrap-select": "^1.12.2",
     "classnames": "^2.2.5",
     "patternfly": "^3.31.2",
-    "patternfly-react": "^0.18.2",
+    "patternfly-react": "^0.22.1",
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
     "react-bootstrap": "^0.31.5",

--- a/webpack/scenes/RedHatRepositories/components/RepositorySetRepositories.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySetRepositories.js
@@ -24,7 +24,7 @@ class RepositorySetRepositories extends Component {
 
     return (
       <Spinner loading={data.loading}>
-        <div>{data.repositories.length ? repos : <div>No repositories found.</div>}</div>
+        {data.repositories.length ? repos : <div>No repositories found.</div>}
       </Spinner>
     );
   }

--- a/webpack/scenes/RedHatRepositories/components/RepositorySetRepository.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySetRepository.js
@@ -6,6 +6,7 @@ import { ListView, Spinner, OverlayTrigger, Tooltip } from 'patternfly-react';
 import { connect } from 'react-redux';
 
 import { setRepositoryEnabled } from '../../../redux/actions/RedHatRepositories/repositorySetRepositories';
+import '../index.scss';
 
 class RepositorySetRepository extends Component {
   constructor(props) {
@@ -68,6 +69,7 @@ class RepositorySetRepository extends Component {
     return (
       <ListView.Item
         heading={`${arch} ${releasever}`}
+        className="list-item-with-divider"
         actions={
           <Spinner loading={this.state.loading} inline>
             <OverlayTrigger

--- a/webpack/scenes/RedHatRepositories/index.js
+++ b/webpack/scenes/RedHatRepositories/index.js
@@ -15,6 +15,8 @@ import RepositorySet from './components/RepositorySet';
 import EnabledRepository from './components/EnabledRepository';
 import SearchInput from '../../components/SearchInput/index';
 
+import './index.scss';
+
 class RedHatRepositoriesPage extends Component {
   componentDidMount() {
     this.loadData();
@@ -56,10 +58,11 @@ class RedHatRepositoriesPage extends Component {
             </Spinner>
           </Col>
 
-          <Col sm={6}>
+          <Col sm={6} className="background-container-gray">
             <h2>{__('Enabled Repositories')}</h2>
             <Spinner loading={enabledRepositories.loading}>
               <ListView>
+                {enabledRepositories.repositories.length ? null : <p>No repositories enabled.</p>}
                 {enabledRepositories.repositories.map(repo => (
                   <EnabledRepository key={repo.id} {...repo} />
                 ))}

--- a/webpack/scenes/RedHatRepositories/index.scss
+++ b/webpack/scenes/RedHatRepositories/index.scss
@@ -1,0 +1,9 @@
+@import '~patternfly/dist/sass/patternfly/_color-variables';
+
+.background-container-gray {
+  background-color: $color-pf-black-200;
+}
+
+.list-item-with-divider:not(:last-child) {
+  border-bottom: 1px solid $color-pf-black-200;
+}


### PR DESCRIPTION
- [x] Updates patternfly-react to fix action alignment issues
- [x] Adds background color to Enabled Repositories container
- [x] Adds divider borders between repository set repositories
- [x] Adds indication when no repositories are enabled

- [ ] ~~Remove close button from Repository Set Repositories list (Waiting on discussion [here](https://github.com/patternfly/patternfly-react/issues/153))~~ Not waiting for patternfly
  