### PR TITLE
Fixes #22180 - Missing attrs in content views API

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -329,6 +329,10 @@ module Katello
       components.map(&:archived_repos).flatten
     end
 
+    def component_repository_ids
+      component_repositories.map(&:id)
+    end
+
     def repos_in_product(env, product)
       version = version(env)
       if version

--- a/app/views/katello/api/v2/content_views/base.json.rabl
+++ b/app/views/katello/api/v2/content_views/base.json.rabl
@@ -2,8 +2,7 @@ extends 'katello/api/v2/common/identifier'
 extends 'katello/api/v2/common/org_reference'
 
 attributes :composite
-attributes :repository_ids
-attributes :component_ids
+attributes :content_view_version_ids => :component_ids
 attributes :default
 attributes :force_puppet_environment
 attributes :version_count
@@ -32,10 +31,12 @@ if @object.composite?
   child :component_repositories => :repositories do
     attributes :id, :name, :label, :content_type
   end
+  attributes :component_repository_ids => :repository_ids
 else
   child :repositories => :repositories do
     attributes :id, :name, :label, :content_type
   end
+  attributes :repository_ids
 end
 
 child :puppet_modules => :puppet_modules do


### PR DESCRIPTION
component_ids were missing because an association was removed from ContentView
repository_ids were missing only for composite views, and so I added those.