### PR TITLE
Fixes #22240 - fix repo sets for akeys and content hosts

### DIFF
--- a/app/lib/actions/katello/product/content_create.rb
+++ b/app/lib/actions/katello/product/content_create.rb
@@ -51,7 +51,8 @@ module Actions
                                                content_url: content_url(repository),
                                                vendor: ::Katello::Provider::CUSTOM)
 
-          ::Katello::ProductContent.create!(product: repository.product, content: content)
+          #custom product content is always enabled by default
+          ::Katello::ProductContent.create!(product: repository.product, content: content, enabled: true)
         end
 
         private

--- a/app/models/katello/glue/candlepin/product.rb
+++ b/app/models/katello/glue/candlepin/product.rb
@@ -67,6 +67,7 @@ module Katello
         # otherwise create a reference to existing content OR new content altogether
         if (existing = product.product_content_by_id(pc[:id]))
           existing.content.update_attributes!(content_attrs)
+          existing.update_attributes(enabled: params['enabled'])
         else
           content = ::Katello::Content.find_by_cp_content_id(pc[:id])
           content ||= ::Katello::Content.create!(content_attrs)

--- a/app/views/katello/api/v2/activation_keys/product_content.json.rabl
+++ b/app/views/katello/api/v2/activation_keys/product_content.json.rabl
@@ -8,7 +8,7 @@ child @collection[:results] => :results do
   end
 
   child :content => :content do
-    attributes :id, :name, :label, :vendor, :content_type, :content_url, :gpg_url, :modified_product_ids
+    attributes :id, :name, :label, :vendor, :content_type, :content_url, :gpg_url
   end
 
   node :override do |pc|

--- a/app/views/katello/api/v2/host_subscriptions/product_content.json.rabl
+++ b/app/views/katello/api/v2/host_subscriptions/product_content.json.rabl
@@ -8,7 +8,7 @@ child @collection[:results] => :results do
   end
 
   child :content => :content do
-    attributes :id, :name, :label, :vendor, :content_type, :content_url, :gpg_url, :modified_product_ids
+    attributes :id, :name, :label, :vendor, :content_type, :content_url, :gpg_url
   end
 
   child :content_overrides => :overrides do

--- a/lib/katello/tasks/reimport.rake
+++ b/lib/katello/tasks/reimport.rake
@@ -29,7 +29,8 @@ namespace :katello do
               Katello::DockerManifest,
               Katello::DockerManifestList,
               Katello::DockerTag,
-              Katello::ContentViewPuppetEnvironment]
+              Katello::ContentViewPuppetEnvironment,
+              Katello::Content]
 
     models << Katello::OstreeBranch if Katello::RepositoryTypeManager.find(Katello::Repository::OSTREE_TYPE).present?
 

--- a/lib/katello/tasks/upgrades/3.6/import_product_content.rake
+++ b/lib/katello/tasks/upgrades/3.6/import_product_content.rake
@@ -5,19 +5,7 @@ namespace :katello do
       task :import_product_content => %w(environment check_ping) do
         User.current = User.anonymous_admin
 
-        Organization.all.each do |org|
-          org.products.each do |product|
-            begin
-              product_json = Katello::Resources::Candlepin::Product.get(org.label,
-                                                                    product.cp_id,
-                                                                    %w(productContent)).first
-              product_content_attrs = product_json['productContent']
-              Katello::Glue::Candlepin::Product.import_product_content(product, product_content_attrs)
-            rescue RestClient::NotFound
-              puts "Product with ID #{product.cp_id} not found in Candlepin. Skipping content import for it."
-            end
-          end
-        end
+        Katello::Content.import_all
       end
     end
   end

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -7,16 +7,20 @@ module Katello
     include Support::ForemanTasks::Task
 
     def models
-      ActivationKey.any_instance.stubs(:valid_content_override_label?).returns(true)
-      ActivationKey.any_instance.stubs(:content_overrides).returns([])
-      ActivationKey.any_instance.stubs(:products).returns([])
-      ActivationKey.any_instance.stubs(:all_products).returns([])
-
       @organization = get_organization
       @activation_key = ActivationKey.find(katello_activation_keys(:simple_key).id)
       @view = katello_content_views(:library_view)
       @acme_view = katello_content_views(:acme_default)
       @library = @organization.library
+      @product = katello_products(:fedora)
+
+      ActivationKey.any_instance.stubs(:valid_content_override_label?).returns(true)
+      ActivationKey.any_instance.stubs(:content_overrides).returns([])
+      ActivationKey.any_instance.stubs(:products).returns([@product])
+      ActivationKey.any_instance.stubs(:all_products).returns([@product])
+
+      #@content = FactoryBot.create(:katello_content, cp_content_id: @content_id)
+      #@product_content = FactoryBot.create(:katello_product_content, content: @content, product: @product)
     end
 
     def permissions
@@ -193,8 +197,9 @@ module Katello
     end
 
     def test_product_content
-      get :product_content, params: { :id => @activation_key.id, :organization_id => @organization.id }
+      response = get :product_content, params: { :id => @activation_key.id, :organization_id => @organization.id }
 
+      refute_empty JSON.parse(response.body)['results']
       assert_response :success
       assert_template 'api/v2/activation_keys/product_content'
     end

--- a/test/controllers/api/v2/host_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/host_subscriptions_controller_test.rb
@@ -23,7 +23,6 @@ module Katello
     end
 
     def backend_stubs
-      Katello::Content.any_instance.stubs(:modified_product_ids).returns([])
       Katello::Pool.any_instance.stubs(:pool_facts).returns({})
       Katello::Candlepin::Consumer.any_instance.stubs(:entitlements).returns(@entitlements)
     end

--- a/test/fixtures/models/katello_contents.yml
+++ b/test/fixtures/models/katello_contents.yml
@@ -1,0 +1,3 @@
+some_content:
+  name:         Fedora
+  cp_content_id: 1

--- a/test/fixtures/models/katello_product_contents.yml
+++ b/test/fixtures/models/katello_product_contents.yml
@@ -1,0 +1,3 @@
+fedora_17_x86_64_content:
+  content_id:           <%= ActiveRecord::FixtureSet.identify(:some_content) %>
+  product_id:           <%= ActiveRecord::FixtureSet.identify(:fedora) %>

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -160,9 +160,7 @@ module Katello
       fedora = katello_repositories(:fedora_17_x86_64)
       puppet = katello_repositories(:p_forge)
 
-      content = FactoryBot.create(:katello_content, cp_content_id: fedora.content_id)
-      fedora_content = FactoryBot.create(:katello_product_content, content: content, product: product)
-
+      fedora_content = product.product_contents.to_a
       puppet.update_attributes(content_id: 2)
 
       content = FactoryBot.create(:katello_content, cp_content_id: puppet.content_id)
@@ -171,7 +169,7 @@ module Katello
       Repository.any_instance.stubs(:exist_for_environment?).returns(true)
       product.repositories = [fedora, puppet]
 
-      assert_equal [fedora_content], product.available_content
+      assert_equal fedora_content, product.available_content
     end
   end
 end

--- a/test/services/product_content_finder_test.rb
+++ b/test/services/product_content_finder_test.rb
@@ -10,7 +10,8 @@ module Katello
       @repo2 = katello_repositories(:rhel_7_x86_64)
       @repo2_cv = katello_repositories(:rhel_6_x86_64_composite_view_version_1)
 
-      [@repo1, @repo2].each do |repo|
+      #@repo1's content is already in fixtures
+      [@repo2].each do |repo|
         content = FactoryBot.create(:katello_content,
                                     name: repo.name,
                                     label: repo.label,

--- a/test/support/fixtures_support.rb
+++ b/test/support/fixtures_support.rb
@@ -2,6 +2,7 @@ module Katello
   module FixturesSupport
     FIXTURE_CLASSES = {
       :katello_activation_keys => Katello::ActivationKey,
+      :katello_contents => Katello::Content,
       :katello_content_views => Katello::ContentView,
       :katello_content_view_environments => Katello::ContentViewEnvironment,
       :katello_content_view_filters => Katello::ContentViewFilter,
@@ -20,6 +21,7 @@ module Katello
       :katello_repository_package_groups => Katello::RepositoryPackageGroup,
       :katello_pools => Katello::Pool,
       :katello_products => Katello::Product,
+      :katello_product_contents => Katello::ProductContent,
       :katello_providers => Katello::Provider,
       :katello_puppet_modules => Katello::PuppetModule,
       :katello_repository_puppet_modules => Katello::RepositoryPuppetModule,


### PR DESCRIPTION
in addition, correctly save custom content
to be known to be enabled by default. Also
provides a way to reimport content and product content