### PR TITLE
Fixes #22241 - fix double search on Packages

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.routes.js
@@ -9,7 +9,7 @@
  */
 angular.module('Bastion.errata').config(['$stateProvider', function ($stateProvider) {
     $stateProvider.state('errata', {
-        url: '/errata?repositoryId',
+        url: '/errata',
         permission: ['view_products', 'view_content_views'],
         views: {
           '@': {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/ostree-branches/ostree-branches.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/ostree-branches/ostree-branches.routes.js
@@ -9,7 +9,7 @@
  */
 angular.module('Bastion.ostree-branches').config(['$stateProvider', function ($stateProvider) {
     $stateProvider.state('ostree-branches', {
-        url: '/ostree_branches?repositoryId',
+        url: '/ostree_branches',
         permission: ['view_products', 'view_content_views'],
         views: {
             '@': {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/packages.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/packages.routes.js
@@ -9,7 +9,7 @@
  */
 angular.module('Bastion.packages').config(['$stateProvider', function ($stateProvider) {
     $stateProvider.state('packages', {
-        url: '/packages?repositoryId',
+        url: '/packages',
         permission: ['view_products', 'view_content_views'],
         views: {
             '@': {


### PR DESCRIPTION
This commit fixes an issue where a search was executed
twice for pages that included an unnecessary query
string parameter for search (repositoryId).