### PR TITLE
Fixes #22262 - Remove modified_product_ids from API

### DIFF
--- a/app/views/katello/api/v2/activation_keys/product_content.json.rabl
+++ b/app/views/katello/api/v2/activation_keys/product_content.json.rabl
@@ -8,7 +8,7 @@ child @collection[:results] => :results do
   end
 
   child :content => :content do
-    attributes :id, :name, :label, :vendor, :content_type, :content_url, :gpg_url, :modified_product_ids
+    attributes :id, :name, :label, :vendor, :content_type, :content_url, :gpg_url
   end
 
   node :override do |pc|

--- a/app/views/katello/api/v2/host_subscriptions/product_content.json.rabl
+++ b/app/views/katello/api/v2/host_subscriptions/product_content.json.rabl
@@ -8,7 +8,7 @@ child @collection[:results] => :results do
   end
 
   child :content => :content do
-    attributes :id, :name, :label, :vendor, :content_type, :content_url, :gpg_url, :modified_product_ids
+    attributes :id, :name, :label, :vendor, :content_type, :content_url, :gpg_url
   end
 
   child :content_overrides => :overrides do


### PR DESCRIPTION
I added these keys recently, and they're breaking the API. Rather than fixing I am removing as they were not part of the requirements.