### PR TITLE
Fixes #22276 - Make errata apply via REX respond

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
@@ -31,6 +31,14 @@
     </p>
   </div>
 
+  <form id="errataActionForm" method="post" action="/katello/remote_execution">
+    <input type="hidden" name="remote_action" value="errata_install"/>
+    <input type="hidden" name="name" ng-value="errataActionFormValues.errata"/>
+    <input type="hidden" name="host_ids" ng-value="errataActionFormValues.hostIds"/>
+    <input type="hidden" name="customize" ng-value="errataActionFormValues.customize"/>
+    <input type="hidden" name="authenticity_token" ng-value="errataActionFormValues.authenticityToken"/>
+  </form>
+
   <div data-extend-template="layouts/partials/table.html">
     <span data-block="search-filter" bst-feature-flag="remote_actions">
       <label class="sr-only" translate>
@@ -43,14 +51,6 @@
               ng-options="option.label as option.name for option in errataOptions | orderBy: 'order'">
       </select>
     </span>
-
-    <form id="errataActionForm" method="post" action="/katello/remote_execution">
-      <input type="hidden" name="remote_action" value="errata_install"/>
-      <input type="hidden" name="name" ng-value="errataActionFormValues.errata"/>
-      <input type="hidden" name="host_ids" ng-value="errataActionFormValues.hostIds"/>
-      <input type="hidden" name="customize" ng-value="errataActionFormValues.customize"/>
-      <input type="hidden" name="authenticity_token" ng-value="errataActionFormValues.authenticityToken"/>
-    </form>
 
     <span data-block="list-actions" ng-hide="contentHost.readonly">
       <div bst-modal="applySelected()" model="host">


### PR DESCRIPTION
Clicking the apply button wasn't submitting the form from the content host Errata tab. The form I moved was not in the DOM at all.

I think it was because something changed in table.html or the plugin which enables data-extend-template and we were not specifying a data-block which made it be ignored. I checked other forms using the remote_execution action and we should be good. It's now consistent with https://github.com/Katello/katello/blob/e7271788929064baed059fa54fedbaa20298eac3/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-traces.html#L19

You'll see the task is now created. If you want to end-to-end test you'll need to configure your environment with the REX plugin. Can provide the details if you want to embark on that. I was able to apply errata successfully.