### PR TITLE
Fixes #22288 - correct json value for Component_id

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -81,6 +81,10 @@ module Katello
       hosts.count
     end
 
+    def component_ids
+      components.map(&:id)
+    end
+
     def components
       content_view_components.map(&:latest_version).compact.freeze
     end

--- a/app/views/katello/api/v2/content_views/base.json.rabl
+++ b/app/views/katello/api/v2/content_views/base.json.rabl
@@ -2,7 +2,7 @@ extends 'katello/api/v2/common/identifier'
 extends 'katello/api/v2/common/org_reference'
 
 attributes :composite
-attributes :content_view_version_ids => :component_ids
+attributes :component_ids
 attributes :default
 attributes :force_puppet_environment
 attributes :version_count


### PR DESCRIPTION
Commit 062a73e039eb62fb60e1c9e5c140ba4ebefc0c80 incorrectly associated
content_view_versions to component_ids. This commit fixes that.