### PR TITLE
Fixes #22276 - Don't pass AC::Params into actions

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -417,7 +417,7 @@ module Katello
     end
 
     def rhsm_params
-      params.slice(:name, :type, :facts, :installedProducts, :autoheal, :releaseVer, :serviceLevel, :uuid, :capabilities, :guestIds, :lastCheckin)
+      params.slice(:name, :type, :facts, :installedProducts, :autoheal, :releaseVer, :serviceLevel, :uuid, :capabilities, :guestIds, :lastCheckin).to_h
     end
 
     def logger

--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -173,7 +173,7 @@ module Katello
                              :system_environment_id,
                              :key_content_view_id,
                              :key_environment_id
-                            ).reject { |_k, v| v.nil? }
+                            ).reject { |_k, v| v.nil? }.to_unsafe_h
       options[:content_view_versions] = versions
       options[:content_view_environments] = cv_envs
 

--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -74,13 +74,13 @@ module Katello
       host = Katello::Host::SubscriptionFacet.find_or_create_host(@content_view_environment.environment.organization, rhsm_params)
       sync_task(::Actions::Katello::Host::Register, host, rhsm_params, @content_view_environment)
       host.reload
-      ::Katello::Host::SubscriptionFacet.update_facts(host, rhsm_params[:facts].to_unsafe_h) unless rhsm_params[:facts].blank?
+      ::Katello::Host::SubscriptionFacet.update_facts(host, rhsm_params[:facts]) unless rhsm_params[:facts].blank?
 
       respond_for_show(:resource => host, :template => '../../../api/v2/hosts/show')
     end
 
     def params_to_rhsm_params
-      rhsm_params = params.slice(:facts, :uuid, :name)
+      rhsm_params = params.slice(:facts, :uuid, :name).to_unsafe_h
       rhsm_params[:releaseVer] = params['release_version'] if params['release_version']
       rhsm_params[:serviceLevel] = params['service_level'] if params['service_level']
       rhsm_params[:guestIds] = params['hypervisor_guest_uuids'] if params[:hypervisor_guest_uuids]

--- a/app/controllers/katello/api/v2/package_groups_controller.rb
+++ b/app/controllers/katello/api/v2/package_groups_controller.rb
@@ -38,7 +38,8 @@ module Katello
       params[:user_visible] = ::Foreman::Cast.to_bool(params[:user_visible])
       params[:user_visible] ||= true
 
-      sync_task(::Actions::Katello::Repository::UploadPackageGroup, @repo, params)
+      create_params = params.slice(:name, :description, :user_visible, :mandatory_package_names, :optional_package_names, :conditional_package_names, :default_package_names).to_unsafe_h
+      sync_task(::Actions::Katello::Repository::UploadPackageGroup, @repo, create_params)
       render :json => {:status => "success"}
     end
 

--- a/app/controllers/katello/api/v2/repository_sets_controller.rb
+++ b/app/controllers/katello/api/v2/repository_sets_controller.rb
@@ -120,7 +120,7 @@ module Katello
     end
 
     def substitutions
-      params.slice(:basearch, :releasever)
+      params.permit(:basearch, :releasever).to_h
     end
   end
 end

--- a/app/lib/actions/katello/repository/upload_package_group.rb
+++ b/app/lib/actions/katello/repository/upload_package_group.rb
@@ -5,7 +5,6 @@ module Actions
         def plan(repository, params)
           action_subject(repository)
           unit_key = {"repo_id": repository.pulp_id, "id": params[:name].parameterize.underscore}
-          params = params.slice(:name, :description, :user_visible, :mandatory_package_names, :optional_package_names, :conditional_package_names, :default_package_names)
 
           sequence do
             upload_request = plan_action(Pulp::Repository::CreateUploadRequest)

--- a/test/controllers/api/v2/package_groups_controller_test.rb
+++ b/test/controllers/api/v2/package_groups_controller_test.rb
@@ -119,7 +119,6 @@ module Katello
       parameters = { :repository_id => @repo.id, :name => 'My_Group', :description => "My Group", :mandatory_package_names => ["katello-agent"]}
       assert_sync_task(::Actions::Katello::Repository::UploadPackageGroup) do |repository, params|
         repository.must_equal @repo
-        params[:repository_id].to_i.must_equal @repo.id.to_i
         params[:name].must_equal parameters[:name]
         params[:description].must_equal parameters[:description]
         params[:mandatory_package_names].must_equal parameters[:mandatory_package_names]


### PR DESCRIPTION
Here's how we might handle strong parameters since ActionController::Parameters is not a superset of the Hash API.

- Call .to_h on permitted params
- Call .to_unsafe_h on params with nested hashes otherwise we need to disable strong params or permit deep into the structure
- Don't pass actioncontroller::params beyond controllers - it's risky.