### PR TITLE
Fixes #22306 - Don't pass AC::Params into actions

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -129,7 +129,7 @@ module Katello
       task = User.as(login) do
         params['owner'] = @organization.label #override owner label if
         params['env'] = nil #hypervisors don't need an environment
-        sync_task(::Actions::Katello::Host::Hypervisors, params.except(:controller, :action, :format))
+        sync_task(::Actions::Katello::Host::Hypervisors, params.except(:controller, :action, :format).to_h)
       end
       render :json => task.output[:results]
     end
@@ -417,7 +417,7 @@ module Katello
     end
 
     def rhsm_params
-      params.slice(:name, :type, :facts, :installedProducts, :autoheal, :releaseVer, :serviceLevel, :uuid, :capabilities, :guestIds, :lastCheckin)
+      params.slice(:name, :type, :facts, :installedProducts, :autoheal, :releaseVer, :serviceLevel, :uuid, :capabilities, :guestIds, :lastCheckin).to_h
     end
 
     def logger

--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -320,7 +320,7 @@ module Katello
                                                           # For deep_munge; Remove for Rails 5
                                                           :host_collection_ids,
                                                           :content_overrides => [],
-                                                          :host_collection_ids => [])
+                                                          :host_collection_ids => []).to_h
 
       key_params[:environment_id] = params[:environment][:id] if params[:environment].try(:[], :id)
       key_params[:content_view_id] = params[:content_view][:id] if params[:content_view].try(:[], :id)

--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -173,7 +173,7 @@ module Katello
                              :system_environment_id,
                              :key_content_view_id,
                              :key_environment_id
-                            ).reject { |_k, v| v.nil? }
+                            ).reject { |_k, v| v.nil? }.to_unsafe_h
       options[:content_view_versions] = versions
       options[:content_view_environments] = cv_envs
 
@@ -210,7 +210,7 @@ module Katello
       attrs = [:name, :description, :force_puppet_environment, {:repository_ids => []}, {:component_ids => []}]
       attrs.push(:label, :composite) if action_name == "create"
       attrs.push(:component_ids, :repository_ids) # For deep_munge; Remove for Rails 5
-      params.require(:content_view).permit(*attrs)
+      params.require(:content_view).permit(*attrs).to_h
     end
 
     def find_environment

--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -74,13 +74,13 @@ module Katello
       host = Katello::Host::SubscriptionFacet.find_or_create_host(@content_view_environment.environment.organization, rhsm_params)
       sync_task(::Actions::Katello::Host::Register, host, rhsm_params, @content_view_environment)
       host.reload
-      ::Katello::Host::SubscriptionFacet.update_facts(host, rhsm_params[:facts].to_unsafe_h) unless rhsm_params[:facts].blank?
+      ::Katello::Host::SubscriptionFacet.update_facts(host, rhsm_params[:facts]) unless rhsm_params[:facts].blank?
 
       respond_for_show(:resource => host, :template => '../../../api/v2/hosts/show')
     end
 
     def params_to_rhsm_params
-      rhsm_params = params.slice(:facts, :uuid, :name)
+      rhsm_params = params.slice(:facts, :uuid, :name).to_unsafe_h
       rhsm_params[:releaseVer] = params['release_version'] if params['release_version']
       rhsm_params[:serviceLevel] = params['service_level'] if params['service_level']
       rhsm_params[:guestIds] = params['hypervisor_guest_uuids'] if params[:hypervisor_guest_uuids]

--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -63,7 +63,8 @@ module Katello
     param_group :resource, ::Api::V2::TaxonomiesController
     def update
       if params.key?(:redhat_repository_url)
-        sync_task(::Actions::Katello::Provider::Update, @organization.redhat_provider, params)
+        org_params = params.permit(:redhat_repository_url).to_h
+        sync_task(::Actions::Katello::Provider::Update, @organization.redhat_provider, org_params)
       end
       super
     end

--- a/app/controllers/katello/api/v2/package_groups_controller.rb
+++ b/app/controllers/katello/api/v2/package_groups_controller.rb
@@ -38,7 +38,8 @@ module Katello
       params[:user_visible] = ::Foreman::Cast.to_bool(params[:user_visible])
       params[:user_visible] ||= true
 
-      sync_task(::Actions::Katello::Repository::UploadPackageGroup, @repo, params)
+      create_params = params.slice(:name, :description, :user_visible, :mandatory_package_names, :optional_package_names, :conditional_package_names, :default_package_names).to_unsafe_h
+      sync_task(::Actions::Katello::Repository::UploadPackageGroup, @repo, create_params)
       render :json => {:status => "success"}
     end
 

--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -368,7 +368,9 @@ module Katello
         fail HttpErrors::BadRequest, _('No upload param specified. Either uploads or upload_ids (deprecated) is required.')
       end
 
-      uploads = params['uploads'] || []
+      uploads = (params[:uploads] || []).map do |upload|
+        upload.permit(:id, :size, :checksum, :name).to_h
+      end
 
       if params.key?(:upload_ids)
         ::Foreman::Deprecation.api_deprecation_warning("The parameter upload_ids will be removed in Katello 3.3. Please update to use the uploads parameter.")
@@ -438,7 +440,7 @@ module Katello
       if params[:action] == 'create' || @repository.custom?
         keys += [:url, :gpg_key_id, :unprotected, :name, :checksum_type, :docker_upstream_name]
       end
-      params.require(:repository).permit(*keys)
+      params.require(:repository).permit(*keys).to_h
     end
 
     def error_on_rh_product

--- a/app/controllers/katello/api/v2/repository_sets_controller.rb
+++ b/app/controllers/katello/api/v2/repository_sets_controller.rb
@@ -120,7 +120,7 @@ module Katello
     end
 
     def substitutions
-      params.slice(:basearch, :releasever)
+      params.permit(:basearch, :releasever).to_h
     end
   end
 end

--- a/app/lib/actions/katello/repository/upload_package_group.rb
+++ b/app/lib/actions/katello/repository/upload_package_group.rb
@@ -5,7 +5,6 @@ module Actions
         def plan(repository, params)
           action_subject(repository)
           unit_key = {"repo_id": repository.pulp_id, "id": params[:name].parameterize.underscore}
-          params = params.slice(:name, :description, :user_visible, :mandatory_package_names, :optional_package_names, :conditional_package_names, :default_package_names)
 
           sequence do
             upload_request = plan_action(Pulp::Repository::CreateUploadRequest)

--- a/test/controllers/api/v2/package_groups_controller_test.rb
+++ b/test/controllers/api/v2/package_groups_controller_test.rb
@@ -119,7 +119,6 @@ module Katello
       parameters = { :repository_id => @repo.id, :name => 'My_Group', :description => "My Group", :mandatory_package_names => ["katello-agent"]}
       assert_sync_task(::Actions::Katello::Repository::UploadPackageGroup) do |repository, params|
         repository.must_equal @repo
-        params[:repository_id].to_i.must_equal @repo.id.to_i
         params[:name].must_equal parameters[:name]
         params[:description].must_equal parameters[:description]
         params[:mandatory_package_names].must_equal parameters[:mandatory_package_names]

--- a/test/support/foreman_tasks/task.rb
+++ b/test/support/foreman_tasks/task.rb
@@ -30,11 +30,17 @@ module Support
                     lambda { |*args|  args == args_expected }
                   end
 
+        valid_args = lambda do |*args|
+          msg = "ActionController::Parameters were sent to an action. Please convert to a Hash"
+          fail(msg) if args.any? { |a| a.class == ActionController::Parameters }
+          true
+        end
+
         method = async ? :async_task : :sync_task
         task_stub = build_task_stub
         @controller.
             expects(method).
-            with { |action_class, *args| expected_action_class == action_class && block.call(*args) }.
+            with { |action_class, *args| expected_action_class == action_class && block.call(*args) && valid_args.call(*args) }.
             returns(task_stub)
         return task_stub
       end


### PR DESCRIPTION
Rails 5 stuff. I don't think we should be passing ActionController::Params beyond controllers since they don't provide a superset of the Hash API.