### PR TITLE
Fixes #22318 - Fetches pxe files on sync

### DIFF
--- a/app/lib/actions/katello/capsule_content/sync.rb
+++ b/app/lib/actions/katello/capsule_content/sync.rb
@@ -18,6 +18,7 @@ module Actions
           ["'#{input['smart_proxy']['name']}'"] + super
         end
 
+        # rubocop:disable MethodLength
         def plan(smart_proxy, options = {})
           action_subject(smart_proxy)
           capsule_content = ::Katello::CapsuleContent.new(smart_proxy)
@@ -72,6 +73,13 @@ module Actions
                               repo,
                               capsule_id: capsule_content.capsule.id,
                               force: true)
+                end
+                if repo.is_a?(::Katello::Repository) &&
+                   repo.distribution_bootable? &&
+                   repo.download_policy == ::Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND
+                  plan_action(Katello::Repository::FetchPxeFiles,
+                              id: repo.id,
+                              capsule_id: capsule_content.capsule.id)
                 end
               end
             end

--- a/app/lib/actions/katello/repository/fetch_pxe_files.rb
+++ b/app/lib/actions/katello/repository/fetch_pxe_files.rb
@@ -1,0 +1,49 @@
+module Actions
+  module Katello
+    module Repository
+      class FetchPxeFiles < Actions::EntryAction
+        middleware.use Actions::Middleware::KeepCurrentUser
+
+        input_format do
+          param :id, Integer
+          param :capsule_id, Integer
+        end
+
+        def run
+          repository = ::Katello::Repository.find(input[:id])
+          if repository.distribution_bootable? &&
+             repository.download_policy == ::Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND
+
+            capsule = if input[:capsule_id].present?
+                        SmartProxy.unscoped.find(input[:capsule_id])
+                      else
+                        SmartProxy.default_capsule!
+                      end
+            repo_path = repository.full_path(capsule, true).chomp("/")
+
+            os = Redhat.find_or_create_operating_system(repository)
+
+            ueber_cert = ::Cert::Certs.ueber_cert(repository.organization)
+            cert = OpenSSL::X509::Certificate.new(ueber_cert[:cert])
+            key = OpenSSL::PKey::RSA.new(ueber_cert[:key])
+
+            Redhat::PXEFILES.each_key do |pxe_file|
+              fetch("#{repo_path}/#{os.url_for_boot(pxe_file)}", cert, key)
+            end
+          end
+        end
+
+        def fetch(url, cert, key)
+          RestClient::Request.execute(:method => :get,
+                                      :url => url,
+                                      :timeout => SETTINGS[:katello][:rest_client_timeout],
+                                      :ssl_client_cert => cert,
+                                      :ssl_client_key => key)
+          Rails.logger.info("retrieved #{url}")
+        rescue StandardError => e
+          Rails.logger.warn("Exception -> #{e.inspect} when retrieving #{url}")
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/repository/sync.rb
+++ b/app/lib/actions/katello/repository/sync.rb
@@ -15,6 +15,7 @@ module Actions
         # @param repo
         # @param pulp_sync_task_id in case the sync was triggered outside
         #   of Katello and we just need to finish the rest of the orchestration
+        # rubocop:disable MethodLength
         def plan(repo, pulp_sync_task_id = nil, options = {})
           action_subject(repo)
 
@@ -40,6 +41,7 @@ module Actions
             contents_changed = skip_metadata_check || output[:contents_changed]
             plan_action(Katello::Repository::IndexContent, :id => repo.id, :contents_changed => contents_changed, :full_index => skip_metadata_check)
             plan_action(Katello::Foreman::ContentUpdate, repo.environment, repo.content_view, repo)
+            plan_action(Katello::Repository::FetchPxeFiles, :id => repo.id)
             plan_action(Katello::Repository::CorrectChecksum, repo)
             concurrence do
               plan_action(Pulp::Repository::Download, :pulp_id => repo.pulp_id, :options => {:verify_all_units => true}) if validate_contents


### PR DESCRIPTION
This commit adds an extra step to the repository "sync" plan to directly
fetch  initrd/vmlinuz in the case of a bootable distribution for an
OnDemand repo. This eager fetching is done to mitigate future timeout
issues when the smart proxy requests these 2 files on provisioning.