### PR TITLE
Refs #22287 - add compliance reasons and inst products to db

### DIFF
--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -88,7 +88,7 @@ module Katello
       rhsm_params[:facts] ||= {}
       rhsm_params[:facts]['network.hostname'] ||= rhsm_params[:name]
 
-      if params['installed_products']
+      if params['installed_products'] #convert api installed_product to candlepin params
         rhsm_params[:installedProducts] = params['installed_products'].map do |product|
           product_params = { :productId => product['product_id'], :productName => product['product_name'] }
           product_params[:arch] = product['arch'] if product['arch']

--- a/app/lib/actions/candlepin/import_pool_handler.rb
+++ b/app/lib/actions/candlepin/import_pool_handler.rb
@@ -38,6 +38,7 @@ module Actions
         if subscription_facet && sub_status
           @logger.debug "re-indexing content host #{subscription_facet.host.name}"
           subscription_facet.update_subscription_status(sub_status)
+          subscription_facet.update_compliance_reasons(message_handler.consumer_reasons)
         elsif subscription_facet.nil?
           @logger.debug "skip re-indexing of non-existent content host #{uuid}"
         elsif sub_status.nil?

--- a/app/lib/actions/katello/host/register.rb
+++ b/app/lib/actions/katello/host/register.rb
@@ -64,7 +64,7 @@ module Actions
           User.as_anonymous_admin do
             host = ::Host.find(input[:host_id])
             host.subscription_facet.update_from_consumer_attributes(host.subscription_facet.candlepin_consumer.
-                consumer_attributes.except(:installedProducts, :guestIds, :facts))
+                consumer_attributes.except(:guestIds, :facts))
             host.subscription_facet.save!
             host.subscription_facet.update_subscription_status
             host.content_facet.update_errata_status
@@ -114,7 +114,7 @@ module Actions
         def plan_subscription_facet(host, activation_keys, consumer_params)
           subscription_facet = host.subscription_facet || ::Katello::Host::SubscriptionFacet.new(:host => host)
           subscription_facet.last_checkin = Time.now
-          subscription_facet.update_from_consumer_attributes(consumer_params.except(:installedProducts, :guestIds, :facts))
+          subscription_facet.update_from_consumer_attributes(consumer_params.except(:guestIds, :facts))
           subscription_facet.save!
           subscription_facet.activation_keys = activation_keys
           subscription_facet

--- a/app/models/katello/compliance_reason.rb
+++ b/app/models/katello/compliance_reason.rb
@@ -1,0 +1,5 @@
+module Katello
+  class ComplianceReason < Katello::Model
+    belongs_to :subscription_facet, :inverse_of => :compliance_reasons, :class_name => 'Katello::Host::SubscriptionFacet'
+  end
+end

--- a/app/models/katello/installed_product.rb
+++ b/app/models/katello/installed_product.rb
@@ -1,0 +1,30 @@
+module Katello
+  class InstalledProduct < Katello::Model
+    has_many :subscription_facet_installed_products, :class_name => "Katello::SubscriptionFacetInstalledProduct", :dependent => :destroy, :inverse_of => :installed_product
+    has_many :subscription_facets, :through => :subscription_facet_installed_products, :class_name => "Katello::Host::SubscriptionFacet"
+
+    def self.find_or_create_from_consumer(consumer_attributes)
+      attributes = {
+        :arch => consumer_attributes['arch'],
+        :version => consumer_attributes['version'],
+        :name => consumer_attributes['productName'],
+        :cp_product_id => consumer_attributes['productId']
+      }
+      Katello::Util::Support.active_record_retry do
+        unless self.where(attributes).exists?
+          self.create!(attributes)
+        end
+      end
+      self.where(attributes).first
+    end
+
+    def consumer_attributes
+      {
+        :arch => arch,
+        :version => version,
+        :productName => name,
+        :productId => cp_product_id
+      }
+    end
+  end
+end

--- a/app/models/katello/subscription_facet_installed_product.rb
+++ b/app/models/katello/subscription_facet_installed_product.rb
@@ -1,0 +1,6 @@
+module Katello
+  class SubscriptionFacetInstalledProduct < Katello::Model
+    belongs_to :subscription_facet, :inverse_of => :subscription_facet_installed_products, :class_name => 'Katello::Host::SubscriptionFacet'
+    belongs_to :installed_product, :inverse_of => :subscription_facet_installed_products, :class_name => 'Katello::InstalledProduct'
+  end
+end

--- a/app/services/katello/candlepin/consumer.rb
+++ b/app/services/katello/candlepin/consumer.rb
@@ -117,7 +117,11 @@ module Katello
       end
 
       def compliance_reasons
-        Resources::Candlepin::Consumer.compliance(uuid)['reasons'].map do |reason|
+        self.class.friendly_compliance_reasons(Resources::Candlepin::Consumer.compliance(uuid)['reasons'])
+      end
+
+      def self.friendly_compliance_reasons(candlepin_reasons)
+        candlepin_reasons.map do |reason|
           "#{reason['attributes']['name']}: #{reason['message']}"
         end
       end

--- a/app/services/katello/candlepin/message_handler.rb
+++ b/app/services/katello/candlepin/message_handler.rb
@@ -39,12 +39,19 @@ module Katello
         end
       end
 
-      def consumer_uuid
+      def entity
         entity = self.new_entity || self.old_entity
         if entity
-          parsed = JSON.parse(entity)
-          parsed['consumer']['uuid']
+          JSON.parse(entity)
         end
+      end
+
+      def consumer_reasons
+        entity['status']['reasons']
+      end
+
+      def consumer_uuid
+        entity['consumer']['uuid'] if entity
       end
 
       def subscription_facet

--- a/app/views/katello/api/v2/subscription_facet/show.json.rabl
+++ b/app/views/katello/api/v2/subscription_facet/show.json.rabl
@@ -1,25 +1,21 @@
-child :subscription_facet => :subscription_facet_attributes do |facet|
+child :subscription_facet => :subscription_facet_attributes do |_facet|
   extends 'katello/api/v2/subscription_facet/base'
-  consumer = Katello::Candlepin::Consumer.new(facet.uuid, facet.host.organization.label)
 
-  node :compliance_reasons do
-    consumer.compliance_reasons
+  node :compliance_reasons do |sub_facet|
+    sub_facet.compliance_reasons.pluck(:reason)
   end
 
-  node :virtual_host do |_subscription_facet|
-    if (host = consumer.virtual_host)
-      {:name => host.name, :id => host.id}
-    end
+  child :hypervisor_host => :virtual_host do
+    attributes :id, :name
   end
 
-  node :virtual_guests do |_subscription_facet|
-    consumer.virtual_guests.map do |guest|
-      {:name => guest.name, :id => guest.id}
-    end
+  child :virtual_guests => :virtual_guests do
+    attributes :id, :name
   end
 
-  node :installed_products do
-    consumer.installed_products
+  child :installed_products => :installed_products do
+    attributes :name => :productName, :cp_product_id => :productId
+    attributes :arch, :version
   end
 
   child :activation_keys => :activation_keys do

--- a/db/migrate/20180117202932_sub_facet_add_installed_products.rb
+++ b/db/migrate/20180117202932_sub_facet_add_installed_products.rb
@@ -1,0 +1,20 @@
+class SubFacetAddInstalledProducts < ActiveRecord::Migration[5.1]
+  def change
+    create_table :katello_installed_products do |t|
+      t.string :name
+      t.string :cp_product_id
+      t.string :arch
+      t.string :version
+    end
+
+    create_table :katello_subscription_facet_installed_products do |t|
+      t.references :installed_product, :index => {:name => :katello_sub_facet_installed_products_ipid}
+      t.references :subscription_facet, :index => {:name => :katello_sub_facet_installed_products_sfid}
+    end
+
+    add_foreign_key "katello_subscription_facet_installed_products", "katello_subscription_facets",
+                        :name => "katello_sub_facet_installed_product_facet_id", :column => "subscription_facet_id"
+    add_foreign_key "katello_subscription_facet_installed_products", "katello_installed_products",
+                        :name => "katello_sub_facet_installed_product_product_id", :column => "installed_product_id"
+  end
+end

--- a/db/migrate/20180119152210_add_compliance_reasons.rb
+++ b/db/migrate/20180119152210_add_compliance_reasons.rb
@@ -1,0 +1,11 @@
+class AddComplianceReasons < ActiveRecord::Migration[5.1]
+  def change
+    create_table :katello_compliance_reasons do |t|
+      t.string :reason
+      t.references :subscription_facet
+    end
+
+    add_foreign_key "katello_compliance_reasons", "katello_subscription_facets",
+                        :name => "katello_compliance_reasons_facet_id", :column => "subscription_facet_id"
+  end
+end

--- a/lib/katello/tasks/upgrades/3.6/import_backend_consumer_attributes.rake
+++ b/lib/katello/tasks/upgrades/3.6/import_backend_consumer_attributes.rake
@@ -1,0 +1,32 @@
+namespace :katello do
+  namespace :upgrades do
+    namespace '3.6' do
+      desc "Import product content from Candlepin to improve API performance and enhance searching"
+      task :import_backend_consumer_attributes => %w(environment check_ping) do
+        def log_message(org, count, total)
+          if count % 25 == 1 || count == total
+            puts "Importing consumer: #{org.name}: #{count}/#{total}"
+          end
+        end
+
+        User.current = User.anonymous_admin
+        Organization.all.each do |org|
+          consumers = ::Katello::Resources::Candlepin::Consumer.get(:owner => org.label,
+                                                                     :include_only => %w(uuid installedProducts.productId
+                                                                                         installedProducts.productName installedProducts.version
+                                                                                         installedProducts.arch))
+          consumer_count = 1
+          consumers.each do |consumer|
+            log_message(org, consumer_count, consumers.count)
+            facet = Katello::Host::SubscriptionFacet.find_by(:uuid => consumer['uuid'])
+            if facet
+              facet.update_installed_products(consumer['installedProducts'])
+              facet.update_compliance_reasons(Katello::Resources::Candlepin::Consumer.compliance(facet.uuid)['reasons'])
+            end
+            consumer_count += 1
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -17,19 +17,14 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     get :index
     assert_response :success
 
-    Katello::Candlepin::Consumer.any_instance.stubs(:compliance_reasons).returns([])
-    Katello::Candlepin::Consumer.any_instance.stubs(:installed_products).returns([])
-
     get :show, params: { :id => host.id }
     assert_response :success
   end
 
   def host_show(host, smart_proxy)
-    Katello::Candlepin::Consumer.any_instance.stubs(:compliance_reasons).returns([])
-    Katello::Candlepin::Consumer.any_instance.stubs(:installed_products).returns([])
-
     get :show, params: { :id => host.id }
     response = ActiveSupport::JSON.decode(@response.body)
+
     assert_equal smart_proxy.id, response["content_facet_attributes"]["content_source_id"]
     assert_response :success
   end

--- a/test/models/host/subscription_facet_test.rb
+++ b/test/models/host/subscription_facet_test.rb
@@ -81,6 +81,31 @@ module Katello
       assert_equal '7Server', subscription_facet.release_version
     end
 
+    def test_update_installed_products
+      assert_empty subscription_facet.installed_products
+      subscription_facet.update_installed_products([{
+                                                     :arch => 'x86_64',
+                                                     :version => '77.7',
+                                                     :productName => 'super great enterprise os/2',
+                                                     :productId => '108' }])
+      refute_empty subscription_facet.installed_products
+    end
+
+    def test_update_compliance_reasons
+      reason_one = {'message' => 'b', 'attributes' => {'name' => 'a'}}
+      reason_two = {'message' => 'd', 'attributes' => {'name' => 'c'}}
+      assert_empty subscription_facet.compliance_reasons.pluck(:reason)
+
+      subscription_facet.update_compliance_reasons([reason_one])
+      assert_equal ['a: b'], subscription_facet.compliance_reasons.pluck(:reason)
+
+      subscription_facet.update_compliance_reasons([reason_one, reason_two])
+      assert_equal ['a: b', 'c: d'].sort, subscription_facet.compliance_reasons.pluck(:reason).sort
+
+      subscription_facet.update_compliance_reasons([reason_two])
+      assert_equal ['c: d'], subscription_facet.compliance_reasons.pluck(:reason)
+    end
+
     def test_candlepin_environment_id
       assert_equal subscription_facet.candlepin_environment_id, ContentViewEnvironment.where(:content_view_id => view, :environment_id => library).first.cp_id
     end


### PR DESCRIPTION
This adds installed products and compliance reasons to
the subscription facet object to eliminate the need to
reach out to candlepin when doing a host show