### PR TITLE
Fixes #22384 - turn div back into a form for rex integration

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-packages-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-packages-modal.html
@@ -30,14 +30,14 @@
       </ul>
     </span>
 
-    <div ng-form id="packageActionForm" name="packageActionForm" class="form" method="post" action="/katello/remote_execution">
+    <form id="packageActionForm" name="packageActionForm" class="form" method="post" action="/katello/remote_execution">
       <input type="hidden" name="name" ng-value="content.content"/>
       <input type="hidden" name="remote_action" ng-value="packageActionFormValues.remoteAction"/>
       <input type="hidden" name="scoped_search" ng-value="packageActionFormValues.search"/>
       <input type="hidden" name="host_ids" ng-value="packageActionFormValues.hostIds"/>
       <input type="hidden" name="authenticity_token" ng-value="packageActionFormValues.authenticityToken"/>
       <input type="hidden" name="customize" ng-value="packageActionFormValues.customize"/>
-    </div>
+    </form>
 
     <div ng-form name="systemContentForm" class="form" ng-hide="content.workingMode || denied('edit_hosts')" novalidate>
       <div>


### PR DESCRIPTION
Otherwise, the remote-execution actions don't work as expected.

Steps to reproduce:

1. got to host collections
2. select host collection and enter 'Package Installation, Removal, and Update'
3. try to peform any action via remote execution