### PR TITLE
Fixes #22305: Unscope Host find on create via sub

### DIFF
--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -192,7 +192,7 @@ module Katello
 
       def self.find_host(facts, organization)
         host_name = propose_existing_hostname(facts)
-        hosts = ::Host.where(:name => host_name)
+        hosts = ::Host.unscoped.where(:name => host_name)
 
         return nil if hosts.empty? #no host exists
         if hosts.where("organization_id = #{organization.id} OR organization_id is NULL").empty? #not in the correct org

--- a/test/controllers/foreman/organizations_controller_test.rb
+++ b/test/controllers/foreman/organizations_controller_test.rb
@@ -26,7 +26,7 @@ class OrganizationsControllerTest < ActionController::TestCase
 
     org = Organization.find_by(:name => name)
     assert org
-    assert_redirected_to edit_organization_path(:id => org.to_param)
+    assert_redirected_to step2_organization_path(:id => org.to_param)
     assert_equal session[:organization_id], org.id
   end
 end

--- a/test/fixtures/models/hosts.yml
+++ b/test/fixtures/models/hosts.yml
@@ -21,3 +21,7 @@ without_errata:
   location_id: <%= ActiveRecord::FixtureSet.identify(:location1) %>
   name: "Host4.example.com"
   type: 'Host::Managed'
+
+without_organization:
+  name: "host5.example.com"
+  type: "Host::Managed"

--- a/test/models/host/subscription_facet_test.rb
+++ b/test/models/host/subscription_facet_test.rb
@@ -10,6 +10,7 @@ module Katello
     let(:empty_host) { ::Host::Managed.create!(:name => 'foobar', :managed => false) }
     let(:basic_subscription) { katello_subscriptions(:basic_subscription) }
     let(:host_one) { hosts(:one) }
+    let(:host_without_org) { hosts(:without_organization) }
     let(:host) do
       FactoryBot.create(:host, :with_content, :with_subscription, :content_view => view,
                                      :lifecycle_environment => library, :organization => org)
@@ -111,6 +112,9 @@ module Katello
       org2 = taxonomies(:organization2)
       assert_equal host, Katello::Host::SubscriptionFacet.find_host({'network.hostname' => host.name}, host.organization)
       assert_equal host, Katello::Host::SubscriptionFacet.find_host({'network.hostname' => host.name.upcase}, host.organization)
+      Organization.current = org # simulate user setting default org
+      assert_equal host_without_org, Katello::Host::SubscriptionFacet.find_host({'network.hostname' => host_without_org.name.upcase}, org)
+      Organization.current = nil
       assert_nil Host::SubscriptionFacet.find_host({'network.hostname' => "the hostest with the mostest"}, host.organization)
       assert_raises(RuntimeError) { Katello::Host::SubscriptionFacet.find_host({'network.hostname' => host.name.upcase}, org2) }
     end


### PR DESCRIPTION
#### To Test

In rake console:
```rb
Host.new(name: 'devel.example.com').save!
```

Try to register `devel.example.com` via subscription-manager.