### PR TITLE
Fixes #21612 - Promote op performs distro publish

### DIFF
--- a/app/lib/actions/katello/repository/clone_yum_metadata.rb
+++ b/app/lib/actions/katello/repository/clone_yum_metadata.rb
@@ -7,7 +7,8 @@ module Actions
             # Check for matching content before indexing happens, the content in pulp is
             # actually updated, but it is not reflected in the database yet.
             output = {}
-            if target_repo.environment && !options[:force_yum_metadata_regeneration]
+            if !target_repo.previous_changes.include?(:unprotected) &&
+                target_repo.environment && !options[:force_yum_metadata_regeneration]
               output = plan_action(Katello::Repository::CheckMatchingContent,
                                    :source_repo_id => source_repo.id,
                                    :target_repo_id => target_repo.id).output

--- a/test/actions/katello/repository/clone_yum_metadata_test.rb
+++ b/test/actions/katello/repository/clone_yum_metadata_test.rb
@@ -45,5 +45,19 @@ module Actions
                                 :source_repository => archive_repo,
                                 :matching_content => nil)
     end
+
+    it 'plans to clone the metadata if unprotected changed' do
+      action = create_action(action_class)
+      environment_repo.update_attributes!(:unprotected => !environment_repo.unprotected)
+      plan_action(action, archive_repo, environment_repo)
+
+      refute_action_planed(action, Katello::Repository::CheckMatchingContent)
+
+      assert_action_planed_with(action, Katello::Repository::IndexContent, :id => environment_repo.id)
+
+      assert_action_planed_with(action, Katello::Repository::MetadataGenerate, environment_repo,
+                                :source_repository => archive_repo,
+                                :matching_content => nil)
+    end
   end
 end


### PR DESCRIPTION
Previously commits added smarts on running the metadata operations on a
CV publish only if necessary. The code would match content and force a
distribution publish only if content changed. However that code does not
look for changes related to the "publish via http"/"unprotected" on a
repo. So if the "publish-via-http" option on a repo is changed, the
promote operation would not perform a distributor publish even though it
should.

This commit fixes that by making sure that "matching content" operation
happens only if the "publish-via-http"/"unprotected" attribute has not
changed.