### PR TITLE
Fixes #22186 - Correct date format in Host Info Provider

### DIFF
--- a/app/models/katello/host/info_provider.rb
+++ b/app/models/katello/host/info_provider.rb
@@ -28,7 +28,7 @@ module Katello
           'label' => host.content_view.try(:label),
           'latest-version' => host.content_view.try(:latest_version),
           'version' => content_version.try(:version),
-          'published' => content_version.try(:created_at),
+          'published' => content_version.try(:created_at).try(:time),
           'components' => content_view_components
         }
 
@@ -43,7 +43,7 @@ module Katello
           cv_label = cv.component_version.content_view.label
           components[cv_label] = {}
           components[cv_label]['version'] = cv.component_version.try(:version)
-          components[cv_label]['published'] = cv.component_version.try(:created_at)
+          components[cv_label]['published'] = cv.component_version.try(:created_at).try(:time)
         end
         components
       end


### PR DESCRIPTION
Rails 5 changed the way ActiveSupport::TimeWithZone is serialized to YAML ... this fixes it, and keeps the prior output.

```  content_view_info:
    label: d7cbbf91-c8f4-4065-b2da-00587438b6a7
    latest-version: '1.0'
    version: '1.0'
    published: 2018-01-24 15:35:41.496951000 Z
    components: {}
```

You can verify the output by looking at a host's YAML at the details page.