### PR TITLE
fixes #22446 - use relative_url for file repo paths

### DIFF
--- a/app/lib/actions/pulp/repository/create.rb
+++ b/app/lib/actions/pulp/repository/create.rb
@@ -170,9 +170,11 @@ module Actions
         end
 
         def iso_distributor
-          Runcible::Models::IsoDistributor.new(true, true).tap do |dist|
-            dist.auto_publish = true
-          end
+          options = { auto_publish: true }
+          Runcible::Models::IsoDistributor.new(input[:path],
+                                               input[:unprotected] || true,
+                                               true,
+                                               options)
         end
 
         def puppet_distributor

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -288,8 +288,7 @@ module Katello
           distributors = [yum_dist, export_dist]
           distributors << clone_dist if capsule.default_capsule?
         when Repository::FILE_TYPE
-          dist = Runcible::Models::IsoDistributor.new(true, true)
-          dist.auto_publish = true
+          dist = Runcible::Models::IsoDistributor.new(self.relative_path, self.unprotected, true, auto_publish: true)
           distributors = [dist]
         when Repository::PUPPET_TYPE
           capsule ||= SmartProxy.default_capsule!
@@ -765,7 +764,7 @@ module Katello
       if docker?
         "#{pulp_uri.host.downcase}:#{Setting['pulp_docker_registry_port']}/#{container_repository_name}"
       elsif file?
-        "#{scheme}://#{pulp_uri.host.downcase}/pulp/isos/#{pulp_id}/"
+        "#{scheme}://#{pulp_uri.host.downcase}/pulp/isos/#{relative_path}/"
       elsif puppet?
         "#{scheme}://#{pulp_uri.host.downcase}/pulp/puppet/#{pulp_id}/"
       elsif ostree?

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -184,7 +184,7 @@
       </div>
     </div>
 
-    <div ng-show="repository.content_type === 'yum' || repository.content_type === 'puppet' || repository.content_type === 'deb'">
+    <div ng-show="repository.content_type === 'yum' || repository.content_type === 'puppet' || repository.content_type === 'deb' || repository.content_type === 'file'">
       <h4 ng-show="repository.content_type !== undefined" translate> Published Repository Information </h4>
 
       <div bst-form-group label="{{ 'Checksum' | translate }}" ng-show="repository.content_type === 'yum'">

--- a/lib/katello/tasks/clean_old_file_repos.rake
+++ b/lib/katello/tasks/clean_old_file_repos.rake
@@ -1,0 +1,33 @@
+namespace :katello do
+  desc "Cleans up file repos that were moved to /pulp/isos/<org name>/"
+  task :clean_old_file_repos => ['environment'] do
+    User.current = User.anonymous_admin
+    PUB_DIR = '/var/www/pub'.freeze
+    SCRIPT_PATH = '/tmp/delete_old_file_repos.sh'.freeze
+    delete = []
+
+    %w(http https).each do |proto|
+      dir = "#{PUB_DIR}/#{proto}/isos/"
+      if File.directory?(dir)
+        Dir.foreach(dir) do |entry|
+          # If directory is a file repo, then it was published using
+          # the UUID.  It's a target for deletion.
+          if (repo = Katello::Repository.find_by(pulp_id: File.basename(entry)))
+            if repo.content_type == Katello::Repository::FILE_TYPE
+              delete << "#{dir}#{entry}"
+            end
+          end
+        end
+      end
+    end
+
+    if delete.empty?
+      puts "There are no directories to delete."
+    else
+      open(SCRIPT_PATH, 'w') { |f| f << "rm -rf #{delete.join " \\\n "}\n" }
+      puts "To clean up the directories, please run the following as root:\n# bash #{SCRIPT_PATH}"
+    end
+
+    puts "Rake task completed."
+  end
+end

--- a/lib/katello/tasks/upgrades/3.6/republish_file_repos.rake
+++ b/lib/katello/tasks/upgrades/3.6/republish_file_repos.rake
@@ -1,0 +1,16 @@
+namespace :katello do
+  namespace :upgrades do
+    namespace '3.6' do
+      desc "Republish FILE repos with relative paths including organization name"
+      task :republish_file_repos => %w(environment check_ping) do
+        User.current = User.anonymous_admin
+
+        Katello::Repository.where(:content_type => Katello::Repository::FILE_TYPE).each do |repo|
+          puts "Republishing file repo #{repo.name} (#{repo.id})..."
+          ForemanTasks.sync_task(::Actions::Pulp::Repository::Refresh, repo)
+          ForemanTasks.sync_task(::Actions::Katello::Repository::MetadataGenerate, repo)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Needs https://github.com/Katello/runcible/pull/201.

Capsule syncs use the RHSM ueber certificate for an organization, RHSM is validating access to paths based on `org name` being the path prefix.  We don't publish file repos that way right now, this changes it to use the right path, and as part of the upgrade for 3.6, it republishes the file repos to the right places.

Should we clean up the old ones?

Should we make the old ones symlinks to the new location on disk?
