### PR TITLE
Fixes #22562: do not truncate repository (set) titles.

### DIFF
--- a/webpack/redux/actions/RedHatRepositories/enabled.js
+++ b/webpack/redux/actions/RedHatRepositories/enabled.js
@@ -1,4 +1,5 @@
 import api, { orgId } from '../../../services/api';
+import { normalizeRepositorySets } from './helpers';
 
 import {
   ENABLED_REPOSITORIES_REQUEST,
@@ -22,7 +23,7 @@ export const loadEnabledRepos = (extendedParams = {}) => (dispatch) => {
     .then(({ data }) => {
       dispatch({
         type: ENABLED_REPOSITORIES_SUCCESS,
-        response: data,
+        response: normalizeRepositorySets(data),
         search: extendedParams.search,
       });
     })

--- a/webpack/redux/actions/RedHatRepositories/helpers.js
+++ b/webpack/redux/actions/RedHatRepositories/helpers.js
@@ -1,0 +1,9 @@
+export function normalizeRepositorySets(data) {
+  data.results.forEach((repositorySet) => {
+    /* eslint no-param-reassign: ["error", { "ignorePropertyModificationsFor": ["id"] }] */
+    repositorySet.id = parseInt(repositorySet.id, 10);
+  });
+  return data;
+}
+
+export default normalizeRepositorySets;

--- a/webpack/redux/actions/RedHatRepositories/repositorySetRepositories.js
+++ b/webpack/redux/actions/RedHatRepositories/repositorySetRepositories.js
@@ -14,8 +14,8 @@ export const setRepositoryEnabled = repository => ({
 
 export function normalizeContentSetRepositories(repos, contentId, productId) {
   return repos.map(repo => ({
-    contentId,
-    productId,
+    contentId: parseInt(contentId, 10),
+    productId: parseInt(productId, 10),
     arch: repo.substitutions.basearch,
     releasever: repo.substitutions.releasever,
     enabled: repo.enabled,

--- a/webpack/redux/actions/RedHatRepositories/sets.js
+++ b/webpack/redux/actions/RedHatRepositories/sets.js
@@ -1,4 +1,6 @@
 import api, { orgId } from '../../../services/api';
+import { normalizeRepositorySets } from './helpers';
+
 import {
   REPOSITORY_SETS_REQUEST,
   REPOSITORY_SETS_SUCCESS,
@@ -16,7 +18,7 @@ export const loadRepositorySets = (extendedParams = {}) => (dispatch) => {
     .then(({ data }) => {
       dispatch({
         type: REPOSITORY_SETS_SUCCESS,
-        response: data,
+        response: normalizeRepositorySets(data),
         search: extendedParams.search,
       });
     })

--- a/webpack/scenes/RedHatRepositories/components/EnabledRepository.js
+++ b/webpack/scenes/RedHatRepositories/components/EnabledRepository.js
@@ -4,7 +4,7 @@ import cx from 'classnames';
 import { ListView, Spinner, OverlayTrigger, Tooltip } from 'patternfly-react';
 import { connect } from 'react-redux';
 
-import { getTypeIcon } from '../../../services/index';
+import RepositoryTypeIcon from './RepositoryTypeIcon';
 import { setRepositoryDisabled } from '../../../redux/actions/RedHatRepositories/enabled';
 import api from '../../../services/api';
 
@@ -54,6 +54,8 @@ class EnabledRepository extends Component {
           // TODO: Add error component
         });
     };
+
+    this.disableTooltipId = `disable-${props.id}`;
   }
 
   render() {
@@ -67,7 +69,7 @@ class EnabledRepository extends Component {
         actions={
           <Spinner loading={this.state.loading} inline>
             <OverlayTrigger
-              overlay={<Tooltip id="disable">Disable</Tooltip>}
+              overlay={<Tooltip id={this.disableTooltipId}>{__('Disable')}</Tooltip>}
               placement="bottom"
               trigger={['hover', 'focus']}
               rootClose={false}
@@ -85,12 +87,7 @@ class EnabledRepository extends Component {
             </OverlayTrigger>
           </Spinner>
         }
-        leftContent={<ListView.Icon name={getTypeIcon(type)} />}
-        additionalInfo={[
-          <ListView.InfoItem key="1">
-            <strong>{type.toUpperCase()}</strong>
-          </ListView.InfoItem>,
-        ]}
+        leftContent={<RepositoryTypeIcon id={id} type={type} />}
         heading={__(name)}
         description={`${arch} ${releasever || ''}`}
         stacked
@@ -101,7 +98,7 @@ class EnabledRepository extends Component {
 
 EnabledRepository.propTypes = {
   id: PropTypes.number.isRequired,
-  contentId: PropTypes.string.isRequired,
+  contentId: PropTypes.number.isRequired,
   productId: PropTypes.number.isRequired,
   name: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,

--- a/webpack/scenes/RedHatRepositories/components/RepositorySet.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySet.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ListView } from 'patternfly-react';
 
-import { getTypeIcon } from '../../../services/index';
+import RepositoryTypeIcon from './RepositoryTypeIcon';
 import RepositorySetRepositories from './RepositorySetRepositories';
 
 const RepositorySet = ({
@@ -13,12 +13,7 @@ const RepositorySet = ({
     className="listViewItem--listItemVariants"
     description={__(label)}
     heading={__(name)}
-    leftContent={<ListView.Icon name={getTypeIcon(type)} />}
-    additionalInfo={[
-      <ListView.InfoItem key="1">
-        <strong>{type.toUpperCase()}</strong>
-      </ListView.InfoItem>,
-    ]}
+    leftContent={<RepositoryTypeIcon id={id} type={type} />}
     stacked
     hideCloseIcon
   >
@@ -27,13 +22,13 @@ const RepositorySet = ({
 );
 
 RepositorySet.propTypes = {
-  id: PropTypes.string.isRequired,
+  id: PropTypes.number.isRequired,
   type: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   product: PropTypes.shape({
     name: PropTypes.string.isRequired,
-    id: PropTypes.instanceOf.isRequired,
+    id: PropTypes.number.isRequired,
   }).isRequired,
 };
 

--- a/webpack/scenes/RedHatRepositories/components/RepositorySetRepositories.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySetRepositories.js
@@ -40,7 +40,7 @@ class RepositorySetRepositories extends Component {
 
 RepositorySetRepositories.propTypes = {
   loadRepositorySetRepos: PropTypes.func.isRequired,
-  contentId: PropTypes.string.isRequired,
+  contentId: PropTypes.number.isRequired,
   productId: PropTypes.number.isRequired,
   data: PropTypes.shape({
     loading: PropTypes.bool.isRequired,

--- a/webpack/scenes/RedHatRepositories/components/RepositorySetRepository.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySetRepository.js
@@ -112,7 +112,7 @@ class RepositorySetRepository extends Component {
 }
 
 RepositorySetRepository.propTypes = {
-  contentId: PropTypes.string.isRequired,
+  contentId: PropTypes.number.isRequired,
   productId: PropTypes.number.isRequired,
   arch: PropTypes.string.isRequired,
   releasever: PropTypes.string,

--- a/webpack/scenes/RedHatRepositories/components/RepositoryTypeIcon.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositoryTypeIcon.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { ListView, OverlayTrigger, Tooltip } from 'patternfly-react';
+
+import { getTypeIcon } from '../../../services/index';
+
+export default class RepositoryTypeIcon extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.tooltipId = `type-tooltip-${props.id}`;
+  }
+
+  render() {
+    return (
+      <OverlayTrigger
+        overlay={<Tooltip id={this.tooltipId}>{this.props.type}</Tooltip>}
+        placement="bottom"
+        trigger={['hover', 'focus']}
+        rootClose={false}
+      >
+        <ListView.Icon name={getTypeIcon(this.props.type)} />
+      </OverlayTrigger>
+    );
+  }
+}
+
+RepositoryTypeIcon.propTypes = {
+  id: PropTypes.number.isRequired,
+  type: PropTypes.string.isRequired,
+};

--- a/webpack/scenes/RedHatRepositories/components/__tests__/RepositoryTypeIcon.test.js
+++ b/webpack/scenes/RedHatRepositories/components/__tests__/RepositoryTypeIcon.test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+import RepositoryTypeIcon from '../RepositoryTypeIcon';
+
+describe('RepositoryTypeIcon component', () => {
+  const getBaseProps = () => ({
+    id: 123,
+    type: 'unknown-type',
+  });
+
+  describe('rendering', () => {
+    test('it should get rendered correctly', () => {
+      const component = shallow(<RepositoryTypeIcon {...getBaseProps()} />);
+
+      expect(toJson(component)).toMatchSnapshot();
+    });
+
+    test('it should get rendered correctly when type is provided', () => {
+      const props = getBaseProps();
+      props.type = 'yum';
+      const component = shallow(<RepositoryTypeIcon {...props} />);
+
+      expect(toJson(component)).toMatchSnapshot();
+    });
+  });
+});

--- a/webpack/scenes/RedHatRepositories/components/__tests__/__snapshots__/RepositoryTypeIcon.test.js.snap
+++ b/webpack/scenes/RedHatRepositories/components/__tests__/__snapshots__/RepositoryTypeIcon.test.js.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RepositoryTypeIcon component rendering it should get rendered correctly 1`] = `
+<OverlayTrigger
+  defaultOverlayShown={false}
+  overlay={
+    <Tooltip
+      bsClass="tooltip"
+      id="type-tooltip-123"
+      placement="right"
+    >
+      unknown-type
+    </Tooltip>
+  }
+  placement="bottom"
+  rootClose={false}
+  trigger={
+    Array [
+      "hover",
+      "focus",
+    ]
+  }
+>
+  <ListViewIcon
+    name="fa-2x fa fa-question"
+    size="sm"
+    type="fa"
+  />
+</OverlayTrigger>
+`;
+
+exports[`RepositoryTypeIcon component rendering it should get rendered correctly when type is provided 1`] = `
+<OverlayTrigger
+  defaultOverlayShown={false}
+  overlay={
+    <Tooltip
+      bsClass="tooltip"
+      id="type-tooltip-123"
+      placement="right"
+    >
+      yum
+    </Tooltip>
+  }
+  placement="bottom"
+  rootClose={false}
+  trigger={
+    Array [
+      "hover",
+      "focus",
+    ]
+  }
+>
+  <ListViewIcon
+    name="fa-2x pficon-bundle"
+    size="sm"
+    type="fa"
+  />
+</OverlayTrigger>
+`;

--- a/webpack/scenes/RedHatRepositories/helpers.js
+++ b/webpack/scenes/RedHatRepositories/helpers.js
@@ -24,7 +24,9 @@ export const getSetsComponent = ({ results, searchIsActive }) => {
       </p>
     );
   }
-  return <ListView>{results.map(set => <RepositorySet key={set.id} {...set} />)}</ListView>;
+  return (
+    <ListView>{results.map(set => <RepositorySet id={set.id} key={set.id} {...set} />)}</ListView>
+  );
 };
 
 getSetsComponent.propTypes = {

--- a/webpack/scenes/RedHatRepositories/index.js
+++ b/webpack/scenes/RedHatRepositories/index.js
@@ -28,7 +28,7 @@ class RedHatRepositoriesPage extends Component {
     const { enabledRepositories, repositorySets } = this.props;
 
     return (
-      <Grid bsClass="container-fluid">
+      <Grid id="redhatRepositoriesPage" bsClass="container-fluid">
         <h1>{__('Red Hat Repositories')}</h1>
 
         <Row className="toolbar-pf">

--- a/webpack/scenes/RedHatRepositories/index.scss
+++ b/webpack/scenes/RedHatRepositories/index.scss
@@ -15,3 +15,13 @@
 .small-spacer {
   margin: 10px 0;
 }
+
+#redhatRepositoriesPage {
+  .list-view-pf-description {
+    width: 100%;
+
+    .list-group-item-heading {
+      white-space: pre-wrap;
+    }
+  }
+}

--- a/webpack/services/index.js
+++ b/webpack/services/index.js
@@ -26,6 +26,9 @@ export function getTypeIcon(type) {
     case 'kickstart':
       className = 'fa fa-futbol-o';
       break;
+    case 'containerimage':
+      className = 'fa fa-cube';
+      break;
     default:
       className = 'fa fa-question';
       break;


### PR DESCRIPTION
Also fixes a few other styling issues on the page.

http://projects.theforeman.org/issues/22562

Before:
<img width="1220" alt="screen shot 2018-02-13 at 12 48 30 pm" src="https://user-images.githubusercontent.com/4116405/36165292-04d9155a-10bd-11e8-99c7-9255fae649aa.png">

After:
![screen shot 2018-02-12 at 4 59 38 pm](https://user-images.githubusercontent.com/4116405/36165303-0d21fd26-10bd-11e8-9d7c-792158a39b6e.png)

